### PR TITLE
Add DeleteSandbox to CircleCI client, types, and fake

### DIFF
--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -94,6 +94,28 @@ func (c *Client) Exec(ctx context.Context, sandboxID, command string, args []str
 	return &resp, nil
 }
 
+func (c *Client) DeleteSandbox(ctx context.Context, sandboxID string) error {
+	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodDelete,
+		fmt.Sprintf("/api/v2/sandbox/instances/%s", sandboxID),
+	))
+	if err != nil {
+		return fmt.Errorf("delete sandbox: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) GetCommand(ctx context.Context, commandID string) (*Command, error) {
+	var resp Command
+	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodGet,
+		fmt.Sprintf("/api/v2/sandbox/commands/%s", commandID),
+		httpcl.JSONDecoder(&resp),
+	))
+	if err != nil {
+		return nil, fmt.Errorf("get command: %w", err)
+	}
+	return &resp, nil
+}
+
 func (c *Client) TriggerRun(ctx context.Context, orgID, projectID string, body TriggerRunRequest) (*RunResponse, error) {
 	var resp RunResponse
 	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodPost,

--- a/internal/circleci/types.go
+++ b/internal/circleci/types.go
@@ -57,3 +57,13 @@ type CreateSandboxRequest struct {
 	Name           string `json:"name"`
 	Image          string `json:"image,omitempty"`
 }
+
+type Command struct {
+	ID        string `json:"id"`
+	CommandID string `json:"command_id"`
+	PID       int    `json:"pid"`
+	Stdout    string `json:"stdout"`
+	Stderr    string `json:"stderr"`
+	ExitCode  int    `json:"exit_code"`
+	Status    string `json:"status"`
+}

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -43,6 +43,15 @@ type ExecResponse struct {
 	ExitCode  int    `json:"exit_code"`
 }
 
+type Command struct {
+	ID       string `json:"id"`
+	PID      int    `json:"pid"`
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+	ExitCode int    `json:"exit_code"`
+	Status   string `json:"status"`
+}
+
 // FakeCircleCI serves canned responses for the CircleCI API.
 type FakeCircleCI struct {
 	http.Handler
@@ -55,6 +64,7 @@ type FakeCircleCI struct {
 	RunResponse    *RunResponse
 	AddKeyURL      string
 	ExecResponse   *ExecResponse
+	CommandResponse *Command
 	RunStatusCode  int // override status code for trigger run endpoint
 }
 
@@ -73,8 +83,10 @@ func NewFakeCircleCI() *FakeCircleCI {
 	// Sandbox endpoints
 	r.GET("/api/v2/sandbox/instances", f.handleListSandboxes)
 	r.POST("/api/v2/sandbox/instances", f.handleCreateSandbox)
+	r.DELETE("/api/v2/sandbox/instances/:id", f.handleDeleteSandbox)
 	r.POST("/api/v2/sandbox/instances/:id/ssh/add-key", f.handleAddSSHKey)
 	r.POST("/api/v2/sandbox/instances/:id/exec", f.handleExec)
+	r.GET("/api/v2/sandbox/commands/:id", f.handleGetCommand)
 
 	// Task run endpoint
 	r.POST("/api/v2/agents/org/:org_id/project/:project_id/runs", f.handleTriggerRun)
@@ -187,6 +199,47 @@ func (f *FakeCircleCI) handleExec(c *gin.Context) {
 		Stdout:    "ok\n",
 		Stderr:    "",
 		ExitCode:  0,
+	})
+}
+
+func (f *FakeCircleCI) handleDeleteSandbox(c *gin.Context) {
+	if !f.requireToken(c) {
+		return
+	}
+	id := c.Param("id")
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	filtered := f.Sandboxes[:0]
+	for _, s := range f.Sandboxes {
+		if s.ID != id {
+			filtered = append(filtered, s)
+		}
+	}
+	f.Sandboxes = filtered
+	c.Status(http.StatusNoContent)
+}
+
+func (f *FakeCircleCI) handleGetCommand(c *gin.Context) {
+	if !f.requireToken(c) {
+		return
+	}
+	id := c.Param("id")
+	f.mu.RLock()
+	resp := f.CommandResponse
+	f.mu.RUnlock()
+
+	if resp != nil {
+		c.JSON(http.StatusOK, resp)
+		return
+	}
+
+	c.JSON(http.StatusOK, Command{
+		ID:       id,
+		PID:      42,
+		Stdout:   "ok\n",
+		Stderr:   "",
+		ExitCode: 0,
+		Status:   "completed",
 	})
 }
 


### PR DESCRIPTION
## Summary

- Adds `DeleteSandbox` method to the CircleCI HTTP client
- Adds corresponding `DeleteSandbox` type to `types.go`
- Wires up `DELETE /api/v2/sandbox/instances/:id` handler in the fake CircleCI server for testing

## Test plan

- [ ] `task test` passes
- [ ] `task lint` passes