### PR TITLE
Track active sandbox across commands via .chunk/sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,8 @@ PLANS.md
 # sandbox sync scratch files
 .chunk/sandbox*.patch
 
+# active sandbox tracking
+.chunk/sandbox
+
 # unikraft
 .unikraft/

--- a/acceptance/sandbox_test.go
+++ b/acceptance/sandbox_test.go
@@ -484,6 +484,170 @@ func TestSandboxesSSHEnvFlag(t *testing.T) {
 	})
 }
 
+func TestSandboxesCreateSetsActiveSandbox(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	workDir := t.TempDir()
+
+	result := binary.RunCLI(t, []string{
+		"sandbox", "create",
+		"--org-id", "org-aaa",
+		"--name", "my-new-sandbox",
+	}, env, workDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "Set sandbox-new-123 as active sandbox"),
+		"expected active sandbox message, got: %s", result.Stderr)
+
+	// current should show the sandbox set by create
+	result = binary.RunCLI(t, []string{"sandbox", "current"}, env, workDir)
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "sandbox-new-123"),
+		"expected sandbox ID from current, got: %s", combined)
+}
+
+func TestSandboxesExecUsesActiveSandbox(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.ExecResponse = &fakes.ExecResponse{
+		CommandID: "cmd-1",
+		PID:       1,
+		Stdout:    "active sandbox output\n",
+		ExitCode:  0,
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	workDir := t.TempDir()
+
+	// create sets the active sandbox
+	result := binary.RunCLI(t, []string{
+		"sandbox", "create",
+		"--org-id", "org-aaa",
+		"--name", "test-box",
+	}, env, workDir)
+	assert.Equal(t, result.ExitCode, 0, "create stderr: %s", result.Stderr)
+
+	// exec without --sandbox-id should succeed using active sandbox
+	result = binary.RunCLI(t, []string{
+		"sandbox", "exec",
+		"--command", "echo",
+	}, env, workDir)
+	assert.Equal(t, result.ExitCode, 0, "exec stderr: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stdout, "active sandbox output"),
+		"expected output, got: %s", result.Stdout)
+}
+
+func TestSandboxesForgetClearsActiveSandbox(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	workDir := t.TempDir()
+
+	// create sets active sandbox
+	result := binary.RunCLI(t, []string{
+		"sandbox", "create",
+		"--org-id", "org-aaa",
+		"--name", "temp-box",
+	}, env, workDir)
+	assert.Equal(t, result.ExitCode, 0, "create stderr: %s", result.Stderr)
+
+	// forget clears it
+	result = binary.RunCLI(t, []string{"sandbox", "forget"}, env, workDir)
+	assert.Equal(t, result.ExitCode, 0, "forget stderr: %s", result.Stderr)
+
+	// exec without --sandbox-id should now fail
+	result = binary.RunCLI(t, []string{
+		"sandbox", "exec",
+		"--command", "echo",
+	}, env, workDir)
+	assert.Assert(t, result.ExitCode != 0, "expected failure after forget")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "sandbox-id") || strings.Contains(combined, "active sandbox"),
+		"expected missing sandbox error, got: %s", combined)
+}
+
+func TestSandboxesExplicitIDOverridesActive(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.ExecResponse = &fakes.ExecResponse{
+		CommandID: "cmd-2",
+		PID:       2,
+		Stdout:    "explicit output\n",
+		ExitCode:  0,
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	workDir := t.TempDir()
+
+	// Set active sandbox to something
+	result := binary.RunCLI(t, []string{
+		"sandbox", "create",
+		"--org-id", "org-aaa",
+		"--name", "default-box",
+	}, env, workDir)
+	assert.Equal(t, result.ExitCode, 0, "create stderr: %s", result.Stderr)
+
+	// exec with explicit --sandbox-id should use it (not the active one)
+	result = binary.RunCLI(t, []string{
+		"sandbox", "exec",
+		"--sandbox-id", "sb-explicit",
+		"--command", "echo",
+	}, env, workDir)
+	assert.Equal(t, result.ExitCode, 0, "exec stderr: %s", result.Stderr)
+
+	reqs := cci.Recorder.AllRequests()
+	execReqs := filterByPath(reqs, "/api/v2/sandbox/instances/sb-explicit/exec")
+	assert.Assert(t, len(execReqs) >= 1, "expected exec request to use explicit sandbox ID, got requests: %v", reqs)
+}
+
+func TestSandboxesCurrentNoActive(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	workDir := t.TempDir()
+
+	result := binary.RunCLI(t, []string{"sandbox", "current"}, env, workDir)
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "No active sandbox"),
+		"expected no active message, got: %s", combined)
+}
+
+func TestSandboxesUseCommand(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.ExecResponse = &fakes.ExecResponse{
+		CommandID: "cmd-3",
+		PID:       3,
+		Stdout:    "use output\n",
+		ExitCode:  0,
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	workDir := t.TempDir()
+
+	result := binary.RunCLI(t, []string{"sandbox", "use", "sb-manual"}, env, workDir)
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	result = binary.RunCLI(t, []string{"sandbox", "current"}, env, workDir)
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "sb-manual"),
+		"expected sb-manual in current output, got: %s", combined)
+}
+
 func writeChunkConfig(t *testing.T, workDir, orgID string) {
 	t.Helper()
 	chunkDir := filepath.Join(workDir, ".chunk")

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -35,8 +35,27 @@ func newSandboxCmd() *cobra.Command {
 	cmd.AddCommand(newSandboxSyncCmd())
 	cmd.AddCommand(newSandboxEnvCmd())
 	cmd.AddCommand(newSandboxBuildCmd())
+	cmd.AddCommand(newSandboxUseCmd())
+	cmd.AddCommand(newSandboxCurrentCmd())
+	cmd.AddCommand(newSandboxForgetCmd())
 
 	return cmd
+}
+
+// resolveSandboxID fills in sandboxID from the active sandbox file if it is empty.
+func resolveSandboxID(sandboxID *string) error {
+	if *sandboxID != "" {
+		return nil
+	}
+	active, err := sandbox.LoadActive()
+	if err != nil {
+		return fmt.Errorf("load active sandbox: %w", err)
+	}
+	if active == nil {
+		return fmt.Errorf("--sandbox-id is required (no active sandbox set; run 'chunk sandbox use <id>' or 'chunk sandbox create')")
+	}
+	*sandboxID = active.SandboxID
+	return nil
 }
 
 // resolveOrgID returns orgID from the flag if set, otherwise falls back to
@@ -125,6 +144,11 @@ environment variable (e.g. CHUNK_SANDBOX_PROVIDER=unikraft).`,
 				return err
 			}
 			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Created sandbox %s (%s)", sb.Name, sb.ID)))
+			if err := sandbox.SaveActive(sandbox.ActiveSandbox{SandboxID: sb.ID, Name: sb.Name}); err != nil {
+				io.ErrPrintf("warning: could not save active sandbox: %v\n", err)
+			} else {
+				io.ErrPrintf("Set %s as active sandbox\n", sb.ID)
+			}
 			return nil
 		},
 	}
@@ -147,6 +171,9 @@ func newSandboxExecCmd() *cobra.Command {
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
+			if err := resolveSandboxID(&sandboxID); err != nil {
+				return err
+			}
 			client, err := circleci.NewClient()
 			if err != nil {
 				return err
@@ -169,10 +196,9 @@ func newSandboxExecCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID")
+	cmd.Flags().StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID (defaults to active sandbox)")
 	cmd.Flags().StringVar(&command, "command", "", "Command to execute")
 	cmd.Flags().StringArrayVar(&execArgs, "args", nil, "Command arguments")
-	_ = cmd.MarkFlagRequired("sandbox-id")
 	_ = cmd.MarkFlagRequired("command")
 
 	return cmd
@@ -186,6 +212,9 @@ func newSandboxAddSSHKeyCmd() *cobra.Command {
 		Short: "Add an SSH public key to a sandbox",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
+			if err := resolveSandboxID(&sandboxID); err != nil {
+				return err
+			}
 			client, err := circleci.NewClient()
 			if err != nil {
 				return err
@@ -199,10 +228,9 @@ func newSandboxAddSSHKeyCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID")
+	cmd.Flags().StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID (defaults to active sandbox)")
 	cmd.Flags().StringVar(&publicKey, "public-key", "", "SSH public key string")
 	cmd.Flags().StringVar(&publicKeyFile, "public-key-file", "", "Path to SSH public key file")
-	_ = cmd.MarkFlagRequired("sandbox-id")
 
 	return cmd
 }
@@ -216,6 +244,9 @@ func newSandboxSSHCmd() *cobra.Command {
 		Short: "SSH into a sandbox",
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := resolveSandboxID(&sandboxID); err != nil {
+				return err
+			}
 			authSock := os.Getenv("SSH_AUTH_SOCK")
 			client, err := circleci.NewClient()
 			if err != nil {
@@ -253,12 +284,11 @@ func newSandboxSSHCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID")
+	cmd.Flags().StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID (defaults to active sandbox)")
 	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file")
 	cmd.Flags().StringArrayVarP(&envVarsFlag, "env", "e", nil, "KEY=VALUE pairs to set in the remote session (repeatable)")
 	cmd.Flags().StringVar(&envFile, "env-file", "", "Env file to load (default .env.local when flag is present)")
 	cmd.Flags().Lookup("env-file").NoOptDefVal = ".env.local"
-	_ = cmd.MarkFlagRequired("sandbox-id")
 
 	return cmd
 }
@@ -271,6 +301,9 @@ func newSandboxSyncCmd() *cobra.Command {
 		Short: "Sync files to a sandbox",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
+			if err := resolveSandboxID(&sandboxID); err != nil {
+				return err
+			}
 			authSock := os.Getenv("SSH_AUTH_SOCK")
 			client, err := circleci.NewClient()
 			if err != nil {
@@ -280,12 +313,66 @@ func newSandboxSyncCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID")
+	cmd.Flags().StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID (defaults to active sandbox)")
 	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file")
 	cmd.Flags().StringVar(&workdir, "workdir", "", "Destination path on sandbox (auto-detected as /workspace/<repo> when omitted)")
-	_ = cmd.MarkFlagRequired("sandbox-id")
 
 	return cmd
+}
+
+func newSandboxUseCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "use <sandbox-id>",
+		Short: "Set the active sandbox for this project",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			io := iostream.FromCmd(cmd)
+			if err := sandbox.SaveActive(sandbox.ActiveSandbox{SandboxID: args[0]}); err != nil {
+				return err
+			}
+			io.ErrPrintf("Set %s as active sandbox\n", args[0])
+			return nil
+		},
+	}
+}
+
+func newSandboxCurrentCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "current",
+		Short: "Show the active sandbox",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			io := iostream.FromCmd(cmd)
+			active, err := sandbox.LoadActive()
+			if err != nil {
+				return err
+			}
+			if active == nil {
+				io.ErrPrintln("No active sandbox")
+				return nil
+			}
+			if active.Name != "" {
+				io.Printf("%s  %s\n", active.Name, active.SandboxID)
+			} else {
+				io.Printf("%s\n", active.SandboxID)
+			}
+			return nil
+		},
+	}
+}
+
+func newSandboxForgetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "forget",
+		Short: "Clear the active sandbox",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			io := iostream.FromCmd(cmd)
+			if err := sandbox.ClearActive(); err != nil {
+				return err
+			}
+			io.ErrPrintln("Active sandbox cleared")
+			return nil
+		},
+	}
 }
 
 var validDockerTag = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/\-]*(:[a-zA-Z0-9._\-]+)?$`)

--- a/internal/sandbox/active.go
+++ b/internal/sandbox/active.go
@@ -13,7 +13,15 @@ type ActiveSandbox struct {
 	Name      string `json:"name,omitempty"`
 }
 
-const sandboxFile = "sandbox"
+// sandboxFileName returns the name of the sandbox state file. When
+// CLAUDE_SESSION_ID is set the file is keyed to that session so concurrent
+// Claude sessions in the same repo each maintain their own active sandbox.
+func sandboxFileName() string {
+	if id := os.Getenv("CLAUDE_SESSION_ID"); id != "" {
+		return "sandbox." + id
+	}
+	return "sandbox"
+}
 
 // LoadActive walks up from cwd looking for .chunk/sandbox. Returns nil if not found.
 func LoadActive() (*ActiveSandbox, error) {
@@ -50,7 +58,7 @@ func SaveActive(a ActiveSandbox) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dir, sandboxFile), data, 0o644)
+	return os.WriteFile(filepath.Join(dir, sandboxFileName()), data, 0o644)
 }
 
 // saveDir returns the .chunk directory to write into. It prefers an existing
@@ -116,7 +124,7 @@ func findSandboxFile() (string, error) {
 	}
 	gitRoot, _ := findGitRoot()
 	for {
-		candidate := filepath.Join(dir, ".chunk", sandboxFile)
+		candidate := filepath.Join(dir, ".chunk", sandboxFileName())
 		if _, err := os.Stat(candidate); err == nil {
 			return candidate, nil
 		} else if !errors.Is(err, os.ErrNotExist) {

--- a/internal/sandbox/active.go
+++ b/internal/sandbox/active.go
@@ -54,7 +54,8 @@ func SaveActive(a ActiveSandbox) error {
 }
 
 // saveDir returns the .chunk directory to write into. It prefers an existing
-// .chunk/sandbox found by walking upward; falls back to cwd/.chunk.
+// .chunk/sandbox found by walking upward; otherwise walks up to find the git
+// root and uses that; falls back to cwd/.chunk when not in a git repo.
 func saveDir() (string, error) {
 	existing, err := findSandboxFile()
 	if err != nil {
@@ -63,11 +64,33 @@ func saveDir() (string, error) {
 	if existing != "" {
 		return filepath.Dir(existing), nil
 	}
+	if root, err := findGitRoot(); err == nil && root != "" {
+		return filepath.Join(root, ".chunk"), nil
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(cwd, ".chunk"), nil
+}
+
+// findGitRoot walks up from cwd and returns the first directory containing .git,
+// or "" if none is found.
+func findGitRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", nil
+		}
+		dir = parent
+	}
 }
 
 // ClearActive removes the .chunk/sandbox file found by walking up from cwd.
@@ -83,17 +106,25 @@ func ClearActive() error {
 }
 
 // findSandboxFile walks up from cwd looking for .chunk/sandbox, returning the path or "".
+// When inside a git repository the walk is bounded by the repository root (the directory
+// containing .git); files above that root are never considered. When not inside any git
+// repository only the current directory is checked.
 func findSandboxFile() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
 		return "", err
 	}
+	gitRoot, _ := findGitRoot()
 	for {
 		candidate := filepath.Join(dir, ".chunk", sandboxFile)
 		if _, err := os.Stat(candidate); err == nil {
 			return candidate, nil
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return "", err
+		}
+		// Stop at the git root (or immediately if not in a git repo).
+		if gitRoot == "" || dir == gitRoot {
+			return "", nil
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {

--- a/internal/sandbox/active.go
+++ b/internal/sandbox/active.go
@@ -1,0 +1,104 @@
+package sandbox
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// ActiveSandbox holds the currently active sandbox for a project.
+type ActiveSandbox struct {
+	SandboxID string `json:"sandbox_id"`
+	Name      string `json:"name,omitempty"`
+}
+
+const sandboxFile = "sandbox"
+
+// LoadActive walks up from cwd looking for .chunk/sandbox. Returns nil if not found.
+func LoadActive() (*ActiveSandbox, error) {
+	path, err := findSandboxFile()
+	if err != nil {
+		return nil, err
+	}
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var a ActiveSandbox
+	if err := json.Unmarshal(data, &a); err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+// SaveActive writes .chunk/sandbox. If a .chunk/sandbox already exists in a
+// parent directory it is updated in place; otherwise the file is created in
+// cwd's .chunk/ directory.
+func SaveActive(a ActiveSandbox) error {
+	dir, err := saveDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(a)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, sandboxFile), data, 0o644)
+}
+
+// saveDir returns the .chunk directory to write into. It prefers an existing
+// .chunk/sandbox found by walking upward; falls back to cwd/.chunk.
+func saveDir() (string, error) {
+	existing, err := findSandboxFile()
+	if err != nil {
+		return "", err
+	}
+	if existing != "" {
+		return filepath.Dir(existing), nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cwd, ".chunk"), nil
+}
+
+// ClearActive removes the .chunk/sandbox file found by walking up from cwd.
+func ClearActive() error {
+	path, err := findSandboxFile()
+	if err != nil {
+		return err
+	}
+	if path == "" {
+		return nil
+	}
+	return os.Remove(path)
+}
+
+// findSandboxFile walks up from cwd looking for .chunk/sandbox, returning the path or "".
+func findSandboxFile() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		candidate := filepath.Join(dir, ".chunk", sandboxFile)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", nil
+		}
+		dir = parent
+	}
+}

--- a/internal/sandbox/active_test.go
+++ b/internal/sandbox/active_test.go
@@ -1,0 +1,103 @@
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSaveAndLoadActive(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	want := ActiveSandbox{SandboxID: "sb-abc", Name: "my-box"}
+	err := SaveActive(want)
+	assert.NilError(t, err)
+
+	got, err := LoadActive()
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil, "expected non-nil ActiveSandbox")
+	assert.Equal(t, got.SandboxID, want.SandboxID)
+	assert.Equal(t, got.Name, want.Name)
+}
+
+func TestLoadActiveReturnsNilWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	got, err := LoadActive()
+	assert.NilError(t, err)
+	assert.Assert(t, got == nil, "expected nil when no active sandbox file")
+}
+
+func TestLoadActiveWalksUpToParent(t *testing.T) {
+	parent := t.TempDir()
+	child := filepath.Join(parent, "sub", "dir")
+	assert.NilError(t, os.MkdirAll(child, 0o755))
+
+	// Write .chunk/sandbox in parent
+	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".chunk"), 0o755))
+	data := []byte(`{"sandbox_id":"sb-parent","name":"parent-box"}`)
+	assert.NilError(t, os.WriteFile(filepath.Join(parent, ".chunk", "sandbox"), data, 0o644))
+
+	// cd into child — should still find the parent's file
+	t.Chdir(child)
+
+	got, err := LoadActive()
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+	assert.Equal(t, got.SandboxID, "sb-parent")
+}
+
+func TestClearActive(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	assert.NilError(t, SaveActive(ActiveSandbox{SandboxID: "sb-xyz"}))
+
+	// File should exist
+	got, err := LoadActive()
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+
+	assert.NilError(t, ClearActive())
+
+	// Should be gone now
+	got, err = LoadActive()
+	assert.NilError(t, err)
+	assert.Assert(t, got == nil)
+}
+
+func TestClearActiveNoopWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	assert.NilError(t, ClearActive())
+}
+
+func TestSaveActiveUpdatesParentFile(t *testing.T) {
+	parent := t.TempDir()
+	child := filepath.Join(parent, "sub")
+	assert.NilError(t, os.MkdirAll(child, 0o755))
+
+	// Write an existing .chunk/sandbox in parent
+	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".chunk"), 0o755))
+	initial := []byte(`{"sandbox_id":"sb-old"}`)
+	assert.NilError(t, os.WriteFile(filepath.Join(parent, ".chunk", "sandbox"), initial, 0o644))
+
+	// Save from child — should update parent's file, not create child's
+	t.Chdir(child)
+	assert.NilError(t, SaveActive(ActiveSandbox{SandboxID: "sb-new"}))
+
+	// Child should have no .chunk dir
+	_, err := os.Stat(filepath.Join(child, ".chunk"))
+	assert.Assert(t, os.IsNotExist(err), "expected no .chunk in child")
+
+	// Parent's file should be updated
+	got, err := LoadActive()
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+	assert.Equal(t, got.SandboxID, "sb-new")
+}

--- a/internal/sandbox/active_test.go
+++ b/internal/sandbox/active_test.go
@@ -115,6 +115,35 @@ func TestClearActive(t *testing.T) {
 	assert.Assert(t, got == nil)
 }
 
+func TestSessionKeyedSandbox(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Save without a session — generic file.
+	assert.NilError(t, SaveActive(ActiveSandbox{SandboxID: "sb-generic"}))
+
+	// With a session ID set, load should return nil (isolated from the generic file).
+	t.Setenv("CLAUDE_SESSION_ID", "sess-abc")
+	got, err := LoadActive()
+	assert.NilError(t, err)
+	assert.Assert(t, got == nil, "session-keyed load should not see generic file")
+
+	// Save under the session.
+	assert.NilError(t, SaveActive(ActiveSandbox{SandboxID: "sb-session"}))
+
+	got, err = LoadActive()
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+	assert.Equal(t, got.SandboxID, "sb-session")
+
+	// Without the session env var, the original generic file is still intact.
+	t.Setenv("CLAUDE_SESSION_ID", "")
+	got, err = LoadActive()
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+	assert.Equal(t, got.SandboxID, "sb-generic")
+}
+
 func TestClearActiveNoopWhenMissing(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/internal/sandbox/active_test.go
+++ b/internal/sandbox/active_test.go
@@ -37,6 +37,9 @@ func TestLoadActiveWalksUpToParent(t *testing.T) {
 	child := filepath.Join(parent, "sub", "dir")
 	assert.NilError(t, os.MkdirAll(child, 0o755))
 
+	// Mark parent as a git root so the walk doesn't escape it.
+	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".git"), 0o755))
+
 	// Write .chunk/sandbox in parent
 	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".chunk"), 0o755))
 	data := []byte(`{"sandbox_id":"sb-parent","name":"parent-box"}`)
@@ -49,6 +52,48 @@ func TestLoadActiveWalksUpToParent(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 	assert.Equal(t, got.SandboxID, "sb-parent")
+}
+
+func TestLoadActiveStopsAtGitRoot(t *testing.T) {
+	// grandparent has .chunk/sandbox; parent has .git; cwd is child of parent.
+	// The walk should stop at parent and not find grandparent's file.
+	grandparent := t.TempDir()
+	parent := filepath.Join(grandparent, "repo")
+	child := filepath.Join(parent, "sub")
+	assert.NilError(t, os.MkdirAll(child, 0o755))
+
+	// .git lives in parent (the repo root)
+	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".git"), 0o755))
+
+	// .chunk/sandbox lives in grandparent (above the repo root)
+	assert.NilError(t, os.MkdirAll(filepath.Join(grandparent, ".chunk"), 0o755))
+	data := []byte(`{"sandbox_id":"sb-grandparent"}`)
+	assert.NilError(t, os.WriteFile(filepath.Join(grandparent, ".chunk", "sandbox"), data, 0o644))
+
+	t.Chdir(child)
+
+	got, err := LoadActive()
+	assert.NilError(t, err)
+	assert.Assert(t, got == nil, "walk should not cross the git root boundary")
+}
+
+func TestLoadActiveNoGitRepo(t *testing.T) {
+	// No .git anywhere — only the cwd itself is checked.
+	parent := t.TempDir()
+	child := filepath.Join(parent, "sub")
+	assert.NilError(t, os.MkdirAll(child, 0o755))
+
+	// .chunk/sandbox in parent but no .git anywhere
+	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".chunk"), 0o755))
+	data := []byte(`{"sandbox_id":"sb-parent"}`)
+	assert.NilError(t, os.WriteFile(filepath.Join(parent, ".chunk", "sandbox"), data, 0o644))
+
+	t.Chdir(child)
+
+	// Without .git the walk stops at cwd, so the parent file is not found.
+	got, err := LoadActive()
+	assert.NilError(t, err)
+	assert.Assert(t, got == nil, "without a git repo the walk should not go above cwd")
 }
 
 func TestClearActive(t *testing.T) {
@@ -81,6 +126,9 @@ func TestSaveActiveUpdatesParentFile(t *testing.T) {
 	parent := t.TempDir()
 	child := filepath.Join(parent, "sub")
 	assert.NilError(t, os.MkdirAll(child, 0o755))
+
+	// Mark parent as the git root so the walk can reach it.
+	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".git"), 0o755))
 
 	// Write an existing .chunk/sandbox in parent
 	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".chunk"), 0o755))


### PR DESCRIPTION
After `sandbox create`, subsequent commands (`exec`, `ssh`, `sync`, `add-ssh-key`) automatically use the active sandbox without re-specifying `--sandbox-id`. The active sandbox is stored in `.chunk/sandbox` (gitignored) with walk-up directory discovery, so nested worktrees resolve naturally. Adds `sandbox use <id>`, `sandboxes current`, and `sandbox forget` for manual management. Explicit `--sandbox-id` always overrides the active sandbox.