### PR TITLE
Support private registries in sandbox build via BuildKit secrets

### DIFF
--- a/acceptance/sandboxes_build_e2e_test.go
+++ b/acceptance/sandboxes_build_e2e_test.go
@@ -15,6 +15,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/CircleCI-Public/chunk-cli/envbuilder"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/binary"
 )
 
@@ -140,6 +141,20 @@ func TestSandboxesBuildEndToEnd(t *testing.T) {
 
 			_, err := os.Stat(cloneDir + "/Dockerfile.test")
 			assert.NilError(t, err, "Dockerfile.test not created")
+
+			dfContent, err := os.ReadFile(cloneDir + "/Dockerfile.test")
+			assert.NilError(t, err, "read Dockerfile.test")
+			var parsedEnv envbuilder.Environment
+			if jsonErr := json.Unmarshal([]byte(envJSON), &parsedEnv); jsonErr == nil {
+				if envbuilder.NeedsNPMRC(parsedEnv.Stack) {
+					assert.Assert(t, strings.Contains(string(dfContent), "--mount=type=secret,id=npmrc"),
+						"Dockerfile.test missing npmrc secret mount for stack %q", parsedEnv.Stack)
+				}
+				if envbuilder.NeedsNetRC(parsedEnv.Stack) {
+					assert.Assert(t, strings.Contains(string(dfContent), "--mount=type=secret,id=netrc"),
+						"Dockerfile.test missing netrc secret mount for stack %q", parsedEnv.Stack)
+				}
+			}
 
 			t.Log("Running tests in container...")
 			testsOK, testOutput := e2eDockerRun(t, tag)

--- a/envbuilder/envbuilder.go
+++ b/envbuilder/envbuilder.go
@@ -47,7 +47,6 @@ type Environment struct {
 	SystemDeps   []string `json:"system_deps"`
 	Image        string   `json:"image"`
 	ImageVersion string   `json:"image_version"`
-	NeedsNPMRC   bool     `json:"needs_npmrc,omitempty"`
 }
 
 func fileExists(dir, name string) bool {
@@ -567,7 +566,7 @@ func dockerfileContent(dir string, env *Environment) string { //nolint:gocyclo
 	// an existing node_modules directory and no TTY is present (i.e. inside Docker).
 	// Setting CI=true suppresses the interactive prompt. This is harmless for other
 	// JS/TS package managers and is a standard signal for CI environments.
-	if env.NeedsNPMRC {
+	if env.Stack == stackJavaScript || env.Stack == stackTypeScript {
 		sb.WriteString("\nENV CI=true\n")
 	}
 	// For .NET projects, the dotnet/sdk:N image on ARM64 only ships the N.0
@@ -622,7 +621,7 @@ func dockerfileContent(dir string, env *Environment) string { //nolint:gocyclo
 	// Go and Ruby already emitted their install steps inside the split-COPY
 	// block above.
 	if env.Stack != stackGo && env.Stack != stackRuby {
-		if env.NeedsNPMRC {
+		if env.Stack == stackJavaScript || env.Stack == stackTypeScript {
 			// Mount ~/.npmrc as a BuildKit secret so private registry credentials
 			// are available during install without being baked into the image layer.
 			// required=false means the build succeeds even when no secret is provided
@@ -1956,7 +1955,6 @@ func DetectEnvironment(ctx context.Context, dir string) (*Environment, error) {
 		SystemDeps:   systemDeps,
 		Image:        image,
 		ImageVersion: imageVersion,
-		NeedsNPMRC:   stack == stackJavaScript || stack == stackTypeScript,
 	}, nil
 }
 

--- a/envbuilder/envbuilder.go
+++ b/envbuilder/envbuilder.go
@@ -513,7 +513,12 @@ func dockerfileContent(dir string, env *Environment) string { //nolint:gocyclo
 			chown = "--chown=circleci:circleci "
 		}
 		sb.WriteString("COPY " + chown + "go.mod go.sum ./\n")
-		sb.WriteString("RUN " + env.Install + "\n")
+		// Mount ~/.netrc as a BuildKit secret so private module credentials are
+		// available during download without being baked into the image layer.
+		// GONOSUMDB=* skips the checksum database for private modules that are
+		// not listed there. GOAUTH=netrc:... (Go 1.22+) tells the go command
+		// where to find the credentials file regardless of the container user.
+		fmt.Fprintf(&sb, "RUN --mount=type=secret,id=netrc,required=false,mode=0444 GONOSUMDB=* GOAUTH=netrc:/run/secrets/netrc %s\n", env.Install)
 		sb.WriteString("\nCOPY " + chown + ". .\n")
 	case stackRuby:
 		// Use the split-COPY pattern (mirrors the Go approach) to avoid
@@ -621,7 +626,8 @@ func dockerfileContent(dir string, env *Environment) string { //nolint:gocyclo
 	// Go and Ruby already emitted their install steps inside the split-COPY
 	// block above.
 	if env.Stack != stackGo && env.Stack != stackRuby {
-		if env.Stack == stackJavaScript || env.Stack == stackTypeScript {
+		switch env.Stack {
+		case stackJavaScript, stackTypeScript:
 			// Mount ~/.npmrc as a BuildKit secret so private registry credentials
 			// are available during install without being baked into the image layer.
 			// required=false means the build succeeds even when no secret is provided
@@ -630,7 +636,13 @@ func dockerfileContent(dir string, env *Environment) string { //nolint:gocyclo
 			// mount path (/run/secrets/npmrc) so the credential lookup works regardless
 			// of which user the container runs as.
 			fmt.Fprintf(&sb, "\nRUN --mount=type=secret,id=npmrc,required=false,mode=0444 NPM_CONFIG_USERCONFIG=/run/secrets/npmrc %s\n", env.Install)
-		} else {
+		case stackPython:
+			// Mount ~/.netrc as a BuildKit secret for private PyPI credentials.
+			// pip (via the requests library) and uv both respect the NETRC env var
+			// to locate the credentials file, making this work regardless of which
+			// user the container runs as.
+			fmt.Fprintf(&sb, "\nRUN --mount=type=secret,id=netrc,required=false,mode=0444 NETRC=/run/secrets/netrc %s\n", env.Install)
+		default:
 			sb.WriteString("\nRUN " + env.Install + "\n")
 		}
 	}

--- a/envbuilder/envbuilder.go
+++ b/envbuilder/envbuilder.go
@@ -47,6 +47,7 @@ type Environment struct {
 	SystemDeps   []string `json:"system_deps"`
 	Image        string   `json:"image"`
 	ImageVersion string   `json:"image_version"`
+	NeedsNPMRC   bool     `json:"needs_npmrc,omitempty"`
 }
 
 func fileExists(dir, name string) bool {
@@ -562,6 +563,13 @@ func dockerfileContent(dir string, env *Environment) string { //nolint:gocyclo
 			sb.WriteString("COPY . .\n")
 		}
 	}
+	// pnpm aborts with ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY when there is
+	// an existing node_modules directory and no TTY is present (i.e. inside Docker).
+	// Setting CI=true suppresses the interactive prompt. This is harmless for other
+	// JS/TS package managers and is a standard signal for CI environments.
+	if env.NeedsNPMRC {
+		sb.WriteString("\nENV CI=true\n")
+	}
 	// For .NET projects, the dotnet/sdk:N image on ARM64 only ships the N.0
 	// runtime — it does NOT bundle previous runtimes (contrary to the AMD64
 	// behaviour).  When global.json forces SDK version N but the test project
@@ -614,7 +622,18 @@ func dockerfileContent(dir string, env *Environment) string { //nolint:gocyclo
 	// Go and Ruby already emitted their install steps inside the split-COPY
 	// block above.
 	if env.Stack != stackGo && env.Stack != stackRuby {
-		sb.WriteString("\nRUN " + env.Install + "\n")
+		if env.NeedsNPMRC {
+			// Mount ~/.npmrc as a BuildKit secret so private registry credentials
+			// are available during install without being baked into the image layer.
+			// required=false means the build succeeds even when no secret is provided
+			// (public-only repos don't need credentials).
+			// NPM_CONFIG_USERCONFIG points npm/pnpm/yarn at the secret's default
+			// mount path (/run/secrets/npmrc) so the credential lookup works regardless
+			// of which user the container runs as.
+			fmt.Fprintf(&sb, "\nRUN --mount=type=secret,id=npmrc,required=false,mode=0444 NPM_CONFIG_USERCONFIG=/run/secrets/npmrc %s\n", env.Install)
+		} else {
+			sb.WriteString("\nRUN " + env.Install + "\n")
+		}
 	}
 
 	// Elixir-specific fixups applied after deps are fetched:
@@ -1937,6 +1956,7 @@ func DetectEnvironment(ctx context.Context, dir string) (*Environment, error) {
 		SystemDeps:   systemDeps,
 		Image:        image,
 		ImageVersion: imageVersion,
+		NeedsNPMRC:   stack == stackJavaScript || stack == stackTypeScript,
 	}, nil
 }
 

--- a/envbuilder/envbuilder.go
+++ b/envbuilder/envbuilder.go
@@ -51,6 +51,30 @@ func NeedsNetRC(stack string) bool {
 	return stack == stackPython || stack == stackGo
 }
 
+// DockerBuildSecrets returns docker --secret flag values needed for the
+// environment's stack, based on credential files present on the host.
+// Returns pairs like "id=npmrc,src=/Users/x/.npmrc".
+func DockerBuildSecrets(env *Environment) []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	var secrets []string
+	if NeedsNPMRC(env.Stack) {
+		p := filepath.Join(home, ".npmrc")
+		if _, err := os.Stat(p); err == nil {
+			secrets = append(secrets, "id=npmrc,src="+p)
+		}
+	}
+	if NeedsNetRC(env.Stack) {
+		p := filepath.Join(home, ".netrc")
+		if _, err := os.Stat(p); err == nil {
+			secrets = append(secrets, "id=netrc,src="+p)
+		}
+	}
+	return secrets
+}
+
 // Environment describes the detected tech stack and build configuration for a repository.
 type Environment struct {
 	Stack        string   `json:"stack"`

--- a/envbuilder/envbuilder.go
+++ b/envbuilder/envbuilder.go
@@ -39,6 +39,18 @@ const (
 	toolPytest  = "pytest"
 )
 
+// NeedsNPMRC reports whether the given stack requires an .npmrc secret mount
+// for private registry authentication during dependency installation.
+func NeedsNPMRC(stack string) bool {
+	return stack == stackJavaScript || stack == stackTypeScript
+}
+
+// NeedsNetRC reports whether the given stack requires a .netrc secret mount
+// for private dependency authentication during installation.
+func NeedsNetRC(stack string) bool {
+	return stack == stackPython || stack == stackGo
+}
+
 // Environment describes the detected tech stack and build configuration for a repository.
 type Environment struct {
 	Stack        string   `json:"stack"`
@@ -515,10 +527,12 @@ func dockerfileContent(dir string, env *Environment) string { //nolint:gocyclo
 		sb.WriteString("COPY " + chown + "go.mod go.sum ./\n")
 		// Mount ~/.netrc as a BuildKit secret so private module credentials are
 		// available during download without being baked into the image layer.
-		// GONOSUMDB=* skips the checksum database for private modules that are
-		// not listed there. GOAUTH=netrc:... (Go 1.22+) tells the go command
-		// where to find the credentials file regardless of the container user.
-		fmt.Fprintf(&sb, "RUN --mount=type=secret,id=netrc,required=false,mode=0444 GONOSUMDB=* GOAUTH=netrc:/run/secrets/netrc %s\n", env.Install)
+		// GONOSUMDB defaults to * (skip checksum DB for all modules) but respects
+		// any narrower value already set via ENV in the base image, so users with
+		// GOPRIVATE or a scoped GONOSUMDB keep their tighter policy.
+		// GOAUTH=netrc:... (Go 1.22+) tells the go command where to find the
+		// credentials file regardless of the container user.
+		fmt.Fprintf(&sb, "RUN --mount=type=secret,id=netrc,required=false,mode=0444 GONOSUMDB=${GONOSUMDB:-*} GOAUTH=netrc:/run/secrets/netrc %s\n", env.Install)
 		sb.WriteString("\nCOPY " + chown + ". .\n")
 	case stackRuby:
 		// Use the split-COPY pattern (mirrors the Go approach) to avoid

--- a/envbuilder/envbuilder_test.go
+++ b/envbuilder/envbuilder_test.go
@@ -808,6 +808,22 @@ members = ["crates/mypkg"]
 		assertContains(t, content, "ENV UV_CACHE_DIR=/tmp/uv-cache")
 	})
 
+	t.Run("js/ts stack sets CI=true and uses npmrc secret mount", func(t *testing.T) {
+		t.Parallel()
+		env := &Environment{
+			Stack:        stackTypeScript,
+			Install:      "pnpm install",
+			Test:         "pnpm test",
+			SystemDeps:   []string{"node", "pnpm"},
+			Image:        "cimg/node",
+			ImageVersion: "22.0",
+			NeedsNPMRC:   true,
+		}
+		content := dockerfileContent(t.TempDir(), env)
+		assertContains(t, content, "ENV CI=true")
+		assertContains(t, content, "--mount=type=secret,id=npmrc,required=false,mode=0444 NPM_CONFIG_USERCONFIG=/run/secrets/npmrc pnpm install")
+	})
+
 	t.Run("sudo apt-get for cimg system deps", func(t *testing.T) {
 		t.Parallel()
 		env := &Environment{

--- a/envbuilder/envbuilder_test.go
+++ b/envbuilder/envbuilder_test.go
@@ -753,7 +753,7 @@ func TestDockerfileContent(t *testing.T) {
 		// Split-COPY pattern: go.mod/go.sum first so the download layer is
 		// cached independently of source changes (e.g. Dockerfile.test, env.json).
 		assertContains(t, content, "COPY --chown=circleci:circleci go.mod go.sum ./")
-		assertContains(t, content, "RUN go mod download")
+		assertContains(t, content, "RUN --mount=type=secret,id=netrc,required=false,mode=0444 GONOSUMDB=* GOAUTH=netrc:/run/secrets/netrc go mod download")
 		assertContains(t, content, "COPY --chown=circleci:circleci . .")
 		// Dep-ordered per-package loop to bound peak GOTMPDIR usage.
 		assertContains(t, content, "go list -deps ./... | grep -Fxf")

--- a/envbuilder/envbuilder_test.go
+++ b/envbuilder/envbuilder_test.go
@@ -817,7 +817,6 @@ members = ["crates/mypkg"]
 			SystemDeps:   []string{"node", "pnpm"},
 			Image:        "cimg/node",
 			ImageVersion: "22.0",
-			NeedsNPMRC:   true,
 		}
 		content := dockerfileContent(t.TempDir(), env)
 		assertContains(t, content, "ENV CI=true")

--- a/envbuilder/envbuilder_test.go
+++ b/envbuilder/envbuilder_test.go
@@ -753,7 +753,7 @@ func TestDockerfileContent(t *testing.T) {
 		// Split-COPY pattern: go.mod/go.sum first so the download layer is
 		// cached independently of source changes (e.g. Dockerfile.test, env.json).
 		assertContains(t, content, "COPY --chown=circleci:circleci go.mod go.sum ./")
-		assertContains(t, content, "RUN --mount=type=secret,id=netrc,required=false,mode=0444 GONOSUMDB=* GOAUTH=netrc:/run/secrets/netrc go mod download")
+		assertContains(t, content, "RUN --mount=type=secret,id=netrc,required=false,mode=0444 GONOSUMDB=${GONOSUMDB:-*} GOAUTH=netrc:/run/secrets/netrc go mod download")
 		assertContains(t, content, "COPY --chown=circleci:circleci . .")
 		// Dep-ordered per-package loop to bound peak GOTMPDIR usage.
 		assertContains(t, content, "go list -deps ./... | grep -Fxf")
@@ -821,6 +821,19 @@ members = ["crates/mypkg"]
 		content := dockerfileContent(t.TempDir(), env)
 		assertContains(t, content, "ENV CI=true")
 		assertContains(t, content, "--mount=type=secret,id=npmrc,required=false,mode=0444 NPM_CONFIG_USERCONFIG=/run/secrets/npmrc pnpm install")
+	})
+
+	t.Run("python stack uses netrc secret mount", func(t *testing.T) {
+		t.Parallel()
+		env := &Environment{
+			Stack:        stackPython,
+			Install:      "pip install -r requirements.txt",
+			Test:         "pytest",
+			Image:        "cimg/python",
+			ImageVersion: "3.12.0",
+		}
+		content := dockerfileContent(t.TempDir(), env)
+		assertContains(t, content, "--mount=type=secret,id=netrc,required=false,mode=0444 NETRC=/run/secrets/netrc pip install -r requirements.txt")
 	})
 
 	t.Run("sudo apt-get for cimg system deps", func(t *testing.T) {

--- a/harness/environment.py
+++ b/harness/environment.py
@@ -59,6 +59,13 @@ ENVBUILDER_SOURCE = REPO_ROOT / "internal" / "envbuilder" / "envbuilder.go"
 MAX_ITERATIONS = 5
 MAX_OUTPUT_CHARS = 40_000
 
+EXPECTED_SECRET_MOUNTS = {
+    "javascript": "--mount=type=secret,id=npmrc",
+    "typescript": "--mount=type=secret,id=npmrc",
+    "python":     "--mount=type=secret,id=netrc",
+    "go":         "--mount=type=secret,id=netrc",
+}
+
 # Only one Claude agent may edit envbuilder.go at a time.
 _envbuilder_lock = threading.Lock()
 
@@ -103,6 +110,7 @@ class IterationRecord:
     tests_ok: bool
     test_output: str
     envbuilder_updated: bool
+    secret_mount_errors: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -209,6 +217,17 @@ def read_dockerfile(repo: TargetRepo, cache_dir: Path) -> str:
     if path.exists():
         return path.read_text()
     return "(Dockerfile.test not found)"
+
+
+def validate_dockerfile_secrets(dockerfile: str, env: dict) -> list[str]:
+    """Return error strings if expected secret mounts are missing from the Dockerfile."""
+    stack = (env or {}).get("stack", "")
+    expected = EXPECTED_SECRET_MOUNTS.get(stack)
+    if expected is None:
+        return []
+    if expected not in dockerfile:
+        return [f"Dockerfile missing expected secret mount for stack '{stack}': {expected}"]
+    return []
 
 
 # ---------------------------------------------------------------------------
@@ -478,6 +497,20 @@ def run_repo(repo: TargetRepo, timeout: int, max_iterations: int, persistent_cac
             tests_ok, test_output = run_acceptance_test(repo, cache_dir, timeout)
             dockerfile = read_dockerfile(repo, cache_dir)
 
+            # Read the env.json written by the acceptance test (fall back to
+            # the cached spec) so we can validate Dockerfile secret mounts.
+            env_json_path = clone_dir / "env.json"
+            try:
+                current_env = json.loads(env_json_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                current_env = repo.env or {}
+
+            secret_errors = validate_dockerfile_secrets(dockerfile, current_env)
+            if secret_errors:
+                print("  Secret mount validation errors:\n  " + "\n  ".join(secret_errors))
+                test_output = test_output + "\n" + "\n".join(secret_errors)
+                tests_ok = False
+
             if tests_ok:
                 print(f"\n✓ [{repo.name}] Tests passed on iteration {iteration}!")
                 record.passed = True
@@ -487,14 +520,8 @@ def run_repo(repo: TargetRepo, timeout: int, max_iterations: int, persistent_cac
                     tests_ok=True,
                     test_output=test_output,
                     envbuilder_updated=False,
+                    secret_mount_errors=secret_errors,
                 ))
-                # Read the env.json the acceptance test just wrote — this
-                # reflects any envbuilder fixes applied during the loop.
-                env_json_path = clone_dir / "env.json"
-                try:
-                    current_env = json.loads(env_json_path.read_text())
-                except (OSError, json.JSONDecodeError):
-                    pass
                 if normalize_env(current_env) != normalize_env(repo.env or {}):
                     update_repos_json(repo.name, current_env)
                     repo.env = current_env
@@ -511,6 +538,7 @@ def run_repo(repo: TargetRepo, timeout: int, max_iterations: int, persistent_cac
                 tests_ok=False,
                 test_output=test_output,
                 envbuilder_updated=updated,
+                secret_mount_errors=secret_errors,
             ))
     finally:
         if own_cache:
@@ -546,6 +574,10 @@ def print_report(records: list[RepoRecord]) -> None:
             print("\n    Dockerfile.test:")
             for line in it.dockerfile.strip().splitlines():
                 print(f"      {line}")
+
+            if it.secret_mount_errors:
+                print("\n    Secret mount validation errors:\n      " +
+                      "\n      ".join(it.secret_mount_errors))
 
             if not it.tests_ok and it.test_output:
                 snippet = it.test_output.strip().splitlines()[-15:]

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -360,7 +360,7 @@ Example:
 			if tag != "" {
 				args = append(args, "-t", tag)
 			}
-			if env.NeedsNPMRC {
+			if env.Stack == "javascript" || env.Stack == "typescript" {
 				if home, err := os.UserHomeDir(); err == nil {
 					npmrcPath := filepath.Join(home, ".npmrc")
 					if _, statErr := os.Stat(npmrcPath); statErr == nil {

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -361,13 +361,13 @@ Example:
 				args = append(args, "-t", tag)
 			}
 			if home, err := os.UserHomeDir(); err == nil {
-				if env.Stack == "javascript" || env.Stack == "typescript" {
+				if envbuilder.NeedsNPMRC(env.Stack) {
 					npmrcPath := filepath.Join(home, ".npmrc")
 					if _, statErr := os.Stat(npmrcPath); statErr == nil {
 						args = append(args, "--secret", "id=npmrc,src="+npmrcPath)
 					}
 				}
-				if env.Stack == "python" || env.Stack == "go" {
+				if envbuilder.NeedsNetRC(env.Stack) {
 					netrcPath := filepath.Join(home, ".netrc")
 					if _, statErr := os.Stat(netrcPath); statErr == nil {
 						args = append(args, "--secret", "id=netrc,src="+netrcPath)

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -360,6 +360,14 @@ Example:
 			if tag != "" {
 				args = append(args, "-t", tag)
 			}
+			if env.NeedsNPMRC {
+				if home, err := os.UserHomeDir(); err == nil {
+					npmrcPath := filepath.Join(home, ".npmrc")
+					if _, statErr := os.Stat(npmrcPath); statErr == nil {
+						args = append(args, "--secret", "id=npmrc,src="+npmrcPath)
+					}
+				}
+			}
 			args = append(args, ".")
 
 			dockerCmd := exec.CommandContext(cmd.Context(), "docker", args...)

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -360,11 +360,17 @@ Example:
 			if tag != "" {
 				args = append(args, "-t", tag)
 			}
-			if env.Stack == "javascript" || env.Stack == "typescript" {
-				if home, err := os.UserHomeDir(); err == nil {
+			if home, err := os.UserHomeDir(); err == nil {
+				if env.Stack == "javascript" || env.Stack == "typescript" {
 					npmrcPath := filepath.Join(home, ".npmrc")
 					if _, statErr := os.Stat(npmrcPath); statErr == nil {
 						args = append(args, "--secret", "id=npmrc,src="+npmrcPath)
+					}
+				}
+				if env.Stack == "python" || env.Stack == "go" {
+					netrcPath := filepath.Join(home, ".netrc")
+					if _, statErr := os.Stat(netrcPath); statErr == nil {
+						args = append(args, "--secret", "id=netrc,src="+netrcPath)
 					}
 				}
 			}

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -360,19 +360,8 @@ Example:
 			if tag != "" {
 				args = append(args, "-t", tag)
 			}
-			if home, err := os.UserHomeDir(); err == nil {
-				if envbuilder.NeedsNPMRC(env.Stack) {
-					npmrcPath := filepath.Join(home, ".npmrc")
-					if _, statErr := os.Stat(npmrcPath); statErr == nil {
-						args = append(args, "--secret", "id=npmrc,src="+npmrcPath)
-					}
-				}
-				if envbuilder.NeedsNetRC(env.Stack) {
-					netrcPath := filepath.Join(home, ".netrc")
-					if _, statErr := os.Stat(netrcPath); statErr == nil {
-						args = append(args, "--secret", "id=netrc,src="+netrcPath)
-					}
-				}
+			for _, secret := range envbuilder.DockerBuildSecrets(&env) {
+				args = append(args, "--secret", secret)
 			}
 			args = append(args, ".")
 


### PR DESCRIPTION
## Summary

Mounts host credential files as BuildKit secrets during `sandbox build` so private dependencies can be fetched without baking credentials into image layers.

- **JS/TS** (`~/.npmrc`): `NPM_CONFIG_USERCONFIG=/run/secrets/npmrc` — works for npm, pnpm, and yarn regardless of container user
- **Python** (`~/.netrc`): `NETRC=/run/secrets/netrc` — respected by pip (via requests) and uv
- **Go** (`~/.netrc`): `GONOSUMDB=* GOAUTH=netrc:/run/secrets/netrc` — private module auth (Go 1.22+) with checksum DB bypass
- Sets `CI=true` for JS/TS to suppress pnpm's no-TTY interactive prompt
- Secrets are passed automatically when the credential file exists on the host; `required=false` ensures builds still succeed for public repos

## Test plan

- [ ] `task build`
- [ ] JS/TS repo with private scoped packages: `dist/chunk sandbox env --dir <repo> | dist/chunk sandbox build --dir <repo>`
- [ ] Python repo with private PyPI index: same pipeline
- [ ] Go repo with private modules: same pipeline
- [ ] Public repo (no credentials needed): verify build still succeeds with no `~/.npmrc` / `~/.netrc` present
- [ ] `go test -race ./internal/envbuilder/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)