### PR TITLE
Replace config.json circleci.orgId with CIRCLECI_ORG_ID env var

### DIFF
--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -159,10 +159,10 @@ func TestInitExistingConfigWithForce(t *testing.T) {
 func TestInitForcePreservesSkippedSections(t *testing.T) {
 	workDir := gitrepo.SetupGitRepo(t, "new-org", "new-repo")
 
-	// Write existing config with VCS, CircleCI, and Commands.
+	// Write existing config with VCS and Commands.
 	chunkDir := filepath.Join(workDir, ".chunk")
 	assert.NilError(t, os.MkdirAll(chunkDir, 0o755))
-	existing := `{"vcs":{"org":"old-org","repo":"old-repo"},"circleci":{"orgId":"abc-123"},"commands":[{"name":"test","run":"echo test"}]}`
+	existing := `{"vcs":{"org":"old-org","repo":"old-repo"},"commands":[{"name":"test","run":"echo test"}]}`
 	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), []byte(existing), 0o644))
 
 	env := testenv.NewTestEnv(t)
@@ -186,11 +186,6 @@ func TestInitForcePreservesSkippedSections(t *testing.T) {
 	assert.Assert(t, ok, "expected vcs section, got: %s", string(data))
 	assert.Equal(t, vcs["org"], "new-org")
 	assert.Equal(t, vcs["repo"], "new-repo")
-
-	// CircleCI should be preserved (--skip-circleci).
-	cci, ok := cfg["circleci"].(map[string]interface{})
-	assert.Assert(t, ok, "expected circleci section preserved, got: %s", string(data))
-	assert.Equal(t, cci["orgId"], "abc-123")
 
 	// Commands should be preserved (--skip-validate).
 	cmds, ok := cfg["commands"].([]interface{})
@@ -518,11 +513,12 @@ func TestInitCircleCISingleOrgAutoSelect(t *testing.T) {
 
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 
-	cfg := readInitConfig(t, workDir)
-
-	cciCfg, ok := cfg["circleci"].(map[string]interface{})
-	assert.Assert(t, ok, "expected circleci config when single org is available")
-	assert.Equal(t, cciCfg["orgId"], "org-aaa")
+	// init no longer writes circleci to config.json; it prints env var instructions
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "CIRCLECI_ORG_ID"),
+		"expected CIRCLECI_ORG_ID export instructions, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "org-aaa"),
+		"expected org ID in export instructions, got: %s", combined)
 }
 
 func TestInitCircleCINoToken(t *testing.T) {

--- a/acceptance/sandbox_gaps_test.go
+++ b/acceptance/sandbox_gaps_test.go
@@ -201,12 +201,12 @@ func TestSandboxCreateOrgIDFromConfig(t *testing.T) {
 	defer srv.Close()
 
 	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
-	writeChunkConfig(t, workDir, "org-from-config")
 
 	env := testenv.NewTestEnv(t)
 	env.CircleCIURL = srv.URL
+	env.Extra["CIRCLECI_ORG_ID"] = "org-from-config"
 
-	// No --org-id flag; should read from config
+	// No --org-id flag; should read from CIRCLECI_ORG_ID
 	result := binary.RunCLI(t, []string{
 		"sandbox", "create",
 		"--name", "config-sandbox",

--- a/acceptance/sandbox_test.go
+++ b/acceptance/sandbox_test.go
@@ -647,6 +647,7 @@ func TestSandboxesUseCommand(t *testing.T) {
 	assert.Assert(t, strings.Contains(combined, "sb-manual"),
 		"expected sb-manual in current output, got: %s", combined)
 }
+
 // filterByMethod returns requests matching both method and path prefix.
 func filterByMethod(reqs []recorder.RecordedRequest, method, pathPrefix string) []recorder.RecordedRequest {
 	var out []recorder.RecordedRequest

--- a/acceptance/sandbox_test.go
+++ b/acceptance/sandbox_test.go
@@ -431,12 +431,12 @@ func TestSandboxesListFromConfig(t *testing.T) {
 	defer srv.Close()
 
 	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
-	writeChunkConfig(t, workDir, "org-from-config")
 
 	env := testenv.NewTestEnv(t)
 	env.CircleCIURL = srv.URL
+	env.Extra["CIRCLECI_ORG_ID"] = "org-from-config"
 
-	// No --org-id flag; should read from config
+	// No --org-id flag; should read from CIRCLECI_ORG_ID
 	result := binary.RunCLI(t, []string{"sandbox", "list"}, env, workDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
@@ -647,19 +647,6 @@ func TestSandboxesUseCommand(t *testing.T) {
 	assert.Assert(t, strings.Contains(combined, "sb-manual"),
 		"expected sb-manual in current output, got: %s", combined)
 }
-
-func writeChunkConfig(t *testing.T, workDir, orgID string) {
-	t.Helper()
-	chunkDir := filepath.Join(workDir, ".chunk")
-	if err := os.MkdirAll(chunkDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	content := `{"commands":[],"circleci":{"orgId":"` + orgID + `"}}`
-	if err := os.WriteFile(filepath.Join(chunkDir, "config.json"), []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
-}
-
 // filterByMethod returns requests matching both method and path prefix.
 func filterByMethod(reqs []recorder.RecordedRequest, method, pathPrefix string) []recorder.RecordedRequest {
 	var out []recorder.RecordedRequest

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -182,7 +182,7 @@ commands, and generates hook config files.`,
 			// Guard: exit cleanly if config exists and --force not set
 			existingCfg, loadErr := config.LoadProjectConfig(workDir)
 			if loadErr == nil && !force {
-				hasData := existingCfg.HasCommands() || existingCfg.VCS != nil || existingCfg.CircleCI != nil
+				hasData := existingCfg.HasCommands() || existingCfg.VCS != nil
 				if hasData {
 					streams.ErrPrintln("Config already exists at .chunk/config.json")
 					streams.ErrPrintln(ui.Dim("To overwrite: chunk init --force"))
@@ -208,8 +208,10 @@ commands, and generates hook config files.`,
 			// Step 2: CircleCI org picker
 			if !skipCircleCI {
 				if orgID, orgName := pickCircleCIOrg(ctx, streams); orgID != "" {
-					cfg.CircleCI = &config.CircleCIConfig{OrgID: orgID}
 					streams.ErrPrintf("Selected organization: %s\n", ui.Bold(orgName))
+					if os.Getenv("CIRCLECI_ORG_ID") != orgID {
+						streams.ErrPrintf("\nSet your org ID as an environment variable:\n  export CIRCLECI_ORG_ID=%s\n\nAdd it to your shell profile (~/.zshrc or ~/.bashrc) to persist it.\n\n", orgID)
+					}
 				}
 			}
 

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/envbuilder"
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
-	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/sandbox"
 	"github.com/CircleCI-Public/chunk-cli/internal/secrets"
@@ -59,19 +58,15 @@ func resolveSandboxID(sandboxID *string) error {
 }
 
 // resolveOrgID returns orgID from the flag if set, otherwise falls back to
-// circleci.orgId in .chunk/config.json. Returns an error if neither is set.
+// the CIRCLECI_ORG_ID env var. Returns an error if neither is set.
 func resolveOrgID(orgID string) (string, error) {
 	if orgID != "" {
 		return orgID, nil
 	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("get working directory: %w", err)
+	if envID := os.Getenv("CIRCLECI_ORG_ID"); envID != "" {
+		return envID, nil
 	}
-	if projCfg, loadErr := config.LoadProjectConfig(cwd); loadErr == nil && projCfg.CircleCI != nil && projCfg.CircleCI.OrgID != "" {
-		return projCfg.CircleCI.OrgID, nil
-	}
-	return "", fmt.Errorf("--org-id is required: pass --org-id or run 'chunk init' to store it in .chunk/config.json")
+	return "", fmt.Errorf("--org-id is required: pass --org-id or set CIRCLECI_ORG_ID")
 }
 
 func newSandboxListCmd() *cobra.Command {

--- a/internal/cmd/task.go
+++ b/internal/cmd/task.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
-	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/task"
@@ -224,13 +223,11 @@ func newTaskConfigCmd() *cobra.Command {
 				}
 			}
 
-			// Warn if selected org differs from stored circleci.orgId
-			if projCfg, loadErr := config.LoadProjectConfig(repoRoot); loadErr == nil &&
-				projCfg.CircleCI != nil && projCfg.CircleCI.OrgID != "" &&
-				projCfg.CircleCI.OrgID != orgID {
+			// Warn if selected org differs from CIRCLECI_ORG_ID
+			if envOrgID := os.Getenv("CIRCLECI_ORG_ID"); envOrgID != "" && envOrgID != orgID {
 				_, _ = fmt.Fprintln(io.Err, ui.Warning(fmt.Sprintf(
-					"Warning: selected project org (%s) differs from stored circleci.orgId (%s) in .chunk/config.json",
-					orgID, projCfg.CircleCI.OrgID,
+					"Warning: selected project org (%s) differs from CIRCLECI_ORG_ID (%s)",
+					orgID, envOrgID,
 				)))
 			}
 

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -41,18 +41,12 @@ type VCSConfig struct {
 	Repo string `json:"repo,omitempty"`
 }
 
-// CircleCIConfig holds CircleCI configuration for the project.
-type CircleCIConfig struct {
-	OrgID string `json:"orgId,omitempty"`
-}
-
 // ProjectConfig is the per-repo configuration stored in .chunk/config.json.
 type ProjectConfig struct {
 	Commands []Command             `json:"commands,omitempty"`
 	Triggers map[string][]string   `json:"triggers,omitempty"`
 	Tasks    map[string]TaskConfig `json:"tasks,omitempty"`
 	VCS      *VCSConfig            `json:"vcs,omitempty"`
-	CircleCI *CircleCIConfig       `json:"circleci,omitempty"`
 }
 
 // LoadProjectConfig reads .chunk/config.json from workDir.


### PR DESCRIPTION
## Summary

- Org ID is a user/machine-level credential (like `CIRCLE_TOKEN`) and shouldn't be stored in per-repo `.chunk/config.json`
- `chunk init` now prints `export CIRCLECI_ORG_ID=<uuid>` instructions instead of writing to config
- `resolveOrgID()` falls back to `CIRCLECI_ORG_ID` env var instead of config.json
- Org mismatch warning in `chunk task config` reads from `CIRCLECI_ORG_ID` instead of config
- Removed `CircleCIConfig` struct and `CircleCI` field from `ProjectConfig`

## Test plan

- [ ] `task build` compiles cleanly
- [ ] `task test` all tests pass
- [ ] `task lint` no lint errors
- [ ] `chunk init` in a test repo shows `export CIRCLECI_ORG_ID=...` output
- [ ] `chunk sandbox list` without `--org-id` reads from `CIRCLECI_ORG_ID` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)