### PR TITLE
Extract newCircleCIClient() and add token validation

### DIFF
--- a/internal/cmd/circleci_client.go
+++ b/internal/cmd/circleci_client.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+)
+
+// newCircleCIClient resolves a CircleCI token (env vars then config file) and
+// returns a ready-to-use client. Token resolution and base URL reading belong
+// in the cmd layer, not in the circleci leaf package.
+func newCircleCIClient() (*circleci.Client, error) {
+	token := os.Getenv("CIRCLE_TOKEN")
+	if token == "" {
+		token = os.Getenv("CIRCLECI_TOKEN")
+	}
+	if token == "" {
+		cfg, _ := config.Load()
+		token = cfg.CircleCIToken
+	}
+	if token == "" {
+		return nil, fmt.Errorf("circleci token not found: set CIRCLE_TOKEN or run 'chunk auth set'")
+	}
+	return circleci.NewClientWithToken(token, os.Getenv("CIRCLECI_BASE_URL"))
+}

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/chunk-cli/envbuilder"
-	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/sandbox"
@@ -67,7 +66,7 @@ func newSandboxListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}
@@ -103,7 +102,7 @@ func newSandboxCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}
@@ -134,7 +133,7 @@ func newSandboxExecCmd() *cobra.Command {
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}
@@ -173,7 +172,7 @@ func newSandboxAddSSHKeyCmd() *cobra.Command {
 		Short: "Add an SSH public key to a sandbox",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}
@@ -204,7 +203,7 @@ func newSandboxSSHCmd() *cobra.Command {
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			authSock := os.Getenv("SSH_AUTH_SOCK")
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}
@@ -259,7 +258,7 @@ func newSandboxSyncCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 			authSock := os.Getenv("SSH_AUTH_SOCK")
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/task.go
+++ b/internal/cmd/task.go
@@ -38,7 +38,7 @@ func newTaskRunCmd() *cobra.Command {
 		Use:   "run",
 		Short: "Trigger a task run",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}
@@ -99,7 +99,7 @@ func newTaskConfigCmd() *cobra.Command {
 			io := iostream.FromCmd(cmd)
 			ctx := cmd.Context()
 
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/sandbox"
@@ -92,7 +91,7 @@ func newValidateCmd() *cobra.Command {
 			}
 
 			if sandboxID != "" {
-				client, err := circleci.NewClient()
+				client, err := newCircleCIClient()
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
## Summary
- Add `NewClientWithToken()` and `GetCurrentUser()` to the CircleCI client for token validation
- Extract `newCircleCIClient()` helper in `cmd/` that resolves tokens from env vars and config
- Update all command callers (`task`, `sandbox`, `validate`) to use the new helper

## Test plan
- [ ] `task build` compiles cleanly
- [ ] `task test` passes (new client + fake tests)
- [ ] Commands that create CircleCI clients still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> [!NOTE]
> Part 2 of 3 — stacked on #210. Merge that first.