### PR TITLE
Increase Anthropic client timeout to 5 minutes

### DIFF
--- a/internal/anthropic/client.go
+++ b/internal/anthropic/client.go
@@ -37,7 +37,7 @@ func New() (*Client, error) {
 		AuthToken:  key,
 		AuthHeader: "x-api-key",
 		UserAgent:  "chunk-cli",
-		Timeout:    120 * time.Second,
+		Timeout:    5 * time.Minute,
 	})
 
 	return &Client{http: c}, nil


### PR DESCRIPTION
## Summary

- Bumps the Anthropic HTTP client timeout from 120s to 5 minutes
- `build-prompt` on repos with 233+ comments (~103k tokens) was hitting the deadline on the first attempt, preventing any retries

## Context

The `context.WithTimeout` in `httpcl.Call()` wraps the entire `retryablehttp` retry loop. Once it expires, the context is cancelled and retries are impossible — hence "giving up after 1 attempt(s): context deadline exceeded". The previous fix (PR #206) bumped 30s → 120s for typical payloads; this extends it further for large repos.

## Test plan

- [ ] Run `chunk build-prompt` on a repo with 200+ review comments and confirm it completes
- [ ] Existing tests pass: `task test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)