### PR TITLE
Switch SSH tunnel to WebSocket; default sandbox provider to e2b

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.1.0
 	charm.land/bubbletea/v2 v2.0.2
 	github.com/BurntSushi/toml v1.6.0
+	github.com/coder/websocket v1.8.14
 	github.com/gin-gonic/gin v1.12.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJ
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/curioswitch/go-reassign v0.3.0 h1:dh3kpQHuADL3cobV/sSGETA8DOv457dwl+fbBAhrQPs=
 github.com/curioswitch/go-reassign v0.3.0/go.mod h1:nApPCCTtqLJN/s8HfItCcKV0jIPwluBOvZP+dsJGA88=

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -91,12 +91,21 @@ func newSandboxListCmd() *cobra.Command {
 	return cmd
 }
 
+const (
+	defaultProvider = "e2b"
+	providerEnvVar  = "CHUNK_SANDBOX_PROVIDER"
+)
+
 func newSandboxCreateCmd() *cobra.Command {
 	var orgID, name, image string
 
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a sandbox",
+		Long: `Create a sandbox.
+
+The sandbox backend defaults to e2b. Override with the CHUNK_SANDBOX_PROVIDER
+environment variable (e.g. CHUNK_SANDBOX_PROVIDER=unikraft).`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 			resolvedOrgID, err := resolveOrgID(orgID)
@@ -107,7 +116,11 @@ func newSandboxCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sb, err := sandbox.Create(cmd.Context(), client, resolvedOrgID, name, image)
+			provider := os.Getenv(providerEnvVar)
+			if provider == "" {
+				provider = defaultProvider
+			}
+			sb, err := sandbox.Create(cmd.Context(), client, resolvedOrgID, name, provider, image)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -92,7 +92,7 @@ func newSandboxListCmd() *cobra.Command {
 }
 
 func newSandboxCreateCmd() *cobra.Command {
-	var orgID, name, provider, image string
+	var orgID, name, image string
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -107,7 +107,7 @@ func newSandboxCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sb, err := sandbox.Create(cmd.Context(), client, resolvedOrgID, name, provider, image)
+			sb, err := sandbox.Create(cmd.Context(), client, resolvedOrgID, name, image)
 			if err != nil {
 				return err
 			}
@@ -118,8 +118,7 @@ func newSandboxCreateCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&orgID, "org-id", "", "Organization ID")
 	cmd.Flags().StringVar(&name, "name", "", "Sandbox name")
-	cmd.Flags().StringVar(&provider, "provider", "", `Sandbox provider ("unikraft" or "e2b")`)
-	cmd.Flags().StringVar(&image, "image", "", `Container image (unikraft) or E2B template ID (e2b)`)
+	cmd.Flags().StringVar(&image, "image", "", "E2B template ID or container image")
 	_ = cmd.MarkFlagRequired("name")
 
 	return cmd

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -14,7 +14,17 @@ func List(ctx context.Context, client *circleci.Client, orgID string) ([]circlec
 	return client.ListSandboxes(ctx, orgID)
 }
 
-func Create(ctx context.Context, client *circleci.Client, orgID, name, provider, image string) (*circleci.Sandbox, error) {
+const defaultProvider = "e2b"
+
+// providerEnvVar is the environment variable users can set to override the
+// sandbox backend. Defaults to "e2b" when unset.
+const providerEnvVar = "CHUNK_SANDBOX_PROVIDER"
+
+func Create(ctx context.Context, client *circleci.Client, orgID, name, image string) (*circleci.Sandbox, error) {
+	provider := os.Getenv(providerEnvVar)
+	if provider == "" {
+		provider = defaultProvider
+	}
 	return client.CreateSandbox(ctx, orgID, name, provider, image)
 }
 

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -14,17 +14,7 @@ func List(ctx context.Context, client *circleci.Client, orgID string) ([]circlec
 	return client.ListSandboxes(ctx, orgID)
 }
 
-const defaultProvider = "e2b"
-
-// providerEnvVar is the environment variable users can set to override the
-// sandbox backend. Defaults to "e2b" when unset.
-const providerEnvVar = "CHUNK_SANDBOX_PROVIDER"
-
-func Create(ctx context.Context, client *circleci.Client, orgID, name, image string) (*circleci.Sandbox, error) {
-	provider := os.Getenv(providerEnvVar)
-	if provider == "" {
-		provider = defaultProvider
-	}
+func Create(ctx context.Context, client *circleci.Client, orgID, name, provider, image string) (*circleci.Sandbox, error) {
 	return client.CreateSandbox(ctx, orgID, name, provider, image)
 }
 

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -80,7 +80,7 @@ func TestCreate(t *testing.T) {
 	cl := newClient(t, srv.URL)
 	ctx := context.Background()
 
-	sb, err := sandbox.Create(ctx, cl, "org-1", "my-sandbox", "ubuntu:22.04")
+	sb, err := sandbox.Create(ctx, cl, "org-1", "my-sandbox", "e2b", "ubuntu:22.04")
 	assert.NilError(t, err)
 	assert.Equal(t, sb.ID, "sandbox-new-123")
 	assert.Equal(t, sb.Name, "my-sandbox")

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -80,7 +80,7 @@ func TestCreate(t *testing.T) {
 	cl := newClient(t, srv.URL)
 	ctx := context.Background()
 
-	sb, err := sandbox.Create(ctx, cl, "org-1", "my-sandbox", "", "ubuntu:22.04")
+	sb, err := sandbox.Create(ctx, cl, "org-1", "my-sandbox", "ubuntu:22.04")
 	assert.NilError(t, err)
 	assert.Equal(t, sb.ID, "sandbox-new-123")
 	assert.Equal(t, sb.Name, "my-sandbox")

--- a/internal/sandbox/session.go
+++ b/internal/sandbox/session.go
@@ -18,7 +18,6 @@ import (
 const (
 	defaultKeyName = "chunk_ai"
 	defaultSSHUser = "user"
-	defaultSSHPort = 2222
 	knownHostsFile = "chunk_ai_known_hosts"
 )
 
@@ -26,7 +25,7 @@ const (
 // It is a plain value type with no open connections or resources to close.
 // Each call to ExecOverSSH opens and closes its own SSH connection.
 type Session struct {
-	URL          string // sandbox domain
+	URL          string // WebSocket tunnel URL (ws:// or wss://)
 	IdentityFile string // path to SSH private key (empty when using agent)
 	KnownHosts   string // path to known_hosts file
 	UseAgent     bool   // true when authenticating via ssh-agent

--- a/internal/sandbox/ssh.go
+++ b/internal/sandbox/ssh.go
@@ -61,6 +61,39 @@ func (c *sshConn) Close() error {
 	return err
 }
 
+// toWebSocketURL normalises a sandbox URL into a WebSocket URL with the
+// /ssh/tunnel path appended.
+//
+// The API may return bare hostnames, http://, or https:// URLs depending on
+// the provider (e.g. e2b returns "https://<host>"). This converts:
+//
+//	http://host  →  ws://host/ssh/tunnel
+//	https://host →  wss://host/ssh/tunnel
+//	ws://host    →  ws://host/ssh/tunnel
+//	wss://host   →  wss://host/ssh/tunnel
+func toWebSocketURL(raw string) (string, error) {
+	// url.Parse rejects bare host:port strings (no scheme) with "first path
+	// segment cannot contain colon". Prepend ws:// so it parses correctly; the
+	// scheme will be overwritten below if an explicit one was already present.
+	if !strings.Contains(raw, "://") {
+		raw = "ws://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse URL: %w", err)
+	}
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	}
+	if !strings.HasSuffix(u.Path, "/ssh/tunnel") {
+		u.Path = strings.TrimRight(u.Path, "/") + "/ssh/tunnel"
+	}
+	return u.String(), nil
+}
+
 // dialSSH establishes an SSH client connection to the sandbox over a WebSocket tunnel.
 // The caller must close the returned sshConn.
 func dialSSH(ctx context.Context, session *Session) (*sshConn, error) {
@@ -69,8 +102,13 @@ func dialSSH(ctx context.Context, session *Session) (*sshConn, error) {
 		return nil, err
 	}
 
-	// Parse host from WebSocket URL for SSH host key TOFU verification.
-	u, err := url.Parse(session.URL)
+	wsURL, err := toWebSocketURL(session.URL)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("build tunnel URL: %w", err)
+	}
+
+	u, err := url.Parse(wsURL)
 	if err != nil {
 		cleanup()
 		return nil, fmt.Errorf("parse tunnel URL: %w", err)
@@ -90,10 +128,10 @@ func dialSSH(ctx context.Context, session *Session) (*sshConn, error) {
 		}
 	}
 
-	wsConn, _, err := websocket.Dial(ctx, session.URL, dialOpts)
+	wsConn, _, err := websocket.Dial(ctx, wsURL, dialOpts)
 	if err != nil {
 		cleanup()
-		return nil, fmt.Errorf("WebSocket connect to %s: %w", session.URL, err)
+		return nil, fmt.Errorf("WebSocket connect to %s: %w", wsURL, err)
 	}
 
 	netConn := websocket.NetConn(ctx, wsConn, websocket.MessageBinary)

--- a/internal/sandbox/ssh.go
+++ b/internal/sandbox/ssh.go
@@ -62,7 +62,8 @@ func (c *sshConn) Close() error {
 }
 
 // toWebSocketURL normalises a sandbox URL into a WebSocket URL with the
-// /ssh/tunnel path appended.
+// /ssh/tunnel path appended. It returns the normalised URL string and the
+// hostname (for SSH host key TOFU), avoiding a second url.Parse in the caller.
 //
 // The API may return bare hostnames, http://, or https:// URLs depending on
 // the provider (e.g. e2b returns "https://<host>"). This converts:
@@ -71,7 +72,7 @@ func (c *sshConn) Close() error {
 //	https://host →  wss://host/ssh/tunnel
 //	ws://host    →  ws://host/ssh/tunnel
 //	wss://host   →  wss://host/ssh/tunnel
-func toWebSocketURL(raw string) (string, error) {
+func toWebSocketURL(raw string) (wsURL, host string, err error) {
 	// url.Parse rejects bare host:port strings (no scheme) with "first path
 	// segment cannot contain colon". Prepend ws:// so it parses correctly; the
 	// scheme will be overwritten below if an explicit one was already present.
@@ -80,7 +81,7 @@ func toWebSocketURL(raw string) (string, error) {
 	}
 	u, err := url.Parse(raw)
 	if err != nil {
-		return "", fmt.Errorf("parse URL: %w", err)
+		return "", "", fmt.Errorf("parse URL: %w", err)
 	}
 	switch u.Scheme {
 	case "http":
@@ -91,7 +92,7 @@ func toWebSocketURL(raw string) (string, error) {
 	if !strings.HasSuffix(u.Path, "/ssh/tunnel") {
 		u.Path = strings.TrimRight(u.Path, "/") + "/ssh/tunnel"
 	}
-	return u.String(), nil
+	return u.String(), u.Hostname(), nil
 }
 
 // dialSSH establishes an SSH client connection to the sandbox over a WebSocket tunnel.
@@ -102,23 +103,16 @@ func dialSSH(ctx context.Context, session *Session) (*sshConn, error) {
 		return nil, err
 	}
 
-	wsURL, err := toWebSocketURL(session.URL)
+	wsURL, host, err := toWebSocketURL(session.URL)
 	if err != nil {
 		cleanup()
 		return nil, fmt.Errorf("build tunnel URL: %w", err)
 	}
 
-	u, err := url.Parse(wsURL)
-	if err != nil {
-		cleanup()
-		return nil, fmt.Errorf("parse tunnel URL: %w", err)
-	}
-	host := u.Hostname()
-
 	// Dial the WebSocket tunnel. For wss:// URLs, skip TLS verification since
 	// trust is established via SSH host key pinning (TOFU) below.
 	dialOpts := &websocket.DialOptions{}
-	if u.Scheme == "wss" {
+	if strings.HasPrefix(wsURL, "wss://") {
 		dialOpts.HTTPClient = &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{

--- a/internal/sandbox/ssh.go
+++ b/internal/sandbox/ssh.go
@@ -122,8 +122,12 @@ func dialSSH(ctx context.Context, session *Session) (*sshConn, error) {
 		}
 	}
 
-	wsConn, _, err := websocket.Dial(ctx, wsURL, dialOpts)
+	wsConn, resp, err := websocket.Dial(ctx, wsURL, dialOpts)
 	if err != nil {
+		if resp != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
 		cleanup()
 		return nil, fmt.Errorf("WebSocket connect to %s: %w", wsURL, err)
 	}

--- a/internal/sandbox/ssh.go
+++ b/internal/sandbox/ssh.go
@@ -10,12 +10,14 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 
+	"github.com/coder/websocket"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/term"
 
@@ -51,7 +53,7 @@ type sshConn struct {
 
 func (c *sshConn) Close() error {
 	// ssh.Client.Close closes the underlying ssh.Conn, which in turn
-	// closes the TLS transport we passed to ssh.NewClientConn.
+	// closes the WebSocket transport we passed to ssh.NewClientConn.
 	err := c.Client.Close()
 	if c.cleanup != nil {
 		c.cleanup()
@@ -59,7 +61,7 @@ func (c *sshConn) Close() error {
 	return err
 }
 
-// dialSSH establishes an SSH client connection to the sandbox over TLS.
+// dialSSH establishes an SSH client connection to the sandbox over a WebSocket tunnel.
 // The caller must close the returned sshConn.
 func dialSSH(ctx context.Context, session *Session) (*sshConn, error) {
 	authMethod, cleanup, err := sshAuth(ctx, session)
@@ -67,34 +69,43 @@ func dialSSH(ctx context.Context, session *Session) (*sshConn, error) {
 		return nil, err
 	}
 
-	// Parse host and port from session.URL. Production URLs are bare hostnames,
-	// but tests may include a port (e.g. "127.0.0.1:54321").
-	host, port, splitErr := net.SplitHostPort(session.URL)
-	if splitErr != nil {
-		host = session.URL
-		port = strconv.Itoa(defaultSSHPort)
-	}
-	addr := net.JoinHostPort(host, port)
-
-	// TLS dial — self-signed cert on sandbox hosts, so skip verification.
-	// Trust is established via SSH host key pinning (TOFU) below.
-	tlsConn, err := tls.Dial("tcp", addr, &tls.Config{
-		InsecureSkipVerify: true, //nolint:gosec // sandbox uses self-signed certs; trust via SSH host key TOFU
-	})
+	// Parse host from WebSocket URL for SSH host key TOFU verification.
+	u, err := url.Parse(session.URL)
 	if err != nil {
 		cleanup()
-		return nil, fmt.Errorf("TLS connect to %s: %w", addr, err)
+		return nil, fmt.Errorf("parse tunnel URL: %w", err)
+	}
+	host := u.Hostname()
+
+	// Dial the WebSocket tunnel. For wss:// URLs, skip TLS verification since
+	// trust is established via SSH host key pinning (TOFU) below.
+	dialOpts := &websocket.DialOptions{}
+	if u.Scheme == "wss" {
+		dialOpts.HTTPClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true, //nolint:gosec // sandbox uses self-signed certs; trust via SSH host key TOFU
+				},
+			},
+		}
 	}
 
+	wsConn, _, err := websocket.Dial(ctx, session.URL, dialOpts)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("WebSocket connect to %s: %w", session.URL, err)
+	}
+
+	netConn := websocket.NetConn(ctx, wsConn, websocket.MessageBinary)
 	hostKeyCallback := tofuHostKeyCallback(session.KnownHosts, host)
 
-	conn, chans, reqs, err := ssh.NewClientConn(tlsConn, host, &ssh.ClientConfig{
+	conn, chans, reqs, err := ssh.NewClientConn(netConn, host, &ssh.ClientConfig{
 		User:            defaultSSHUser,
 		Auth:            []ssh.AuthMethod{authMethod},
 		HostKeyCallback: hostKeyCallback,
 	})
 	if err != nil {
-		_ = tlsConn.Close()
+		_ = netConn.Close()
 		cleanup()
 		return nil, fmt.Errorf("SSH handshake: %w", err)
 	}

--- a/internal/sandbox/ssh_test.go
+++ b/internal/sandbox/ssh_test.go
@@ -33,7 +33,7 @@ func TestToWebSocketURL(t *testing.T) {
 		{"https://host/already/has/path", "wss://host/already/has/path/ssh/tunnel"},
 	}
 	for _, tc := range cases {
-		got, err := toWebSocketURL(tc.in)
+		got, _, err := toWebSocketURL(tc.in)
 		assert.NilError(t, err, "input: %s", tc.in)
 		assert.Equal(t, got, tc.want, "input: %s", tc.in)
 	}

--- a/internal/sandbox/ssh_test.go
+++ b/internal/sandbox/ssh_test.go
@@ -19,6 +19,26 @@ func TestShellJoin(t *testing.T) {
 	assert.Equal(t, ShellJoin([]string{"echo", "hello world"}), "'echo' 'hello world'")
 }
 
+func TestToWebSocketURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"https://8000-abc.e2b.app", "wss://8000-abc.e2b.app/ssh/tunnel"},
+		{"http://localhost:8000", "ws://localhost:8000/ssh/tunnel"},
+		{"wss://host.example.com", "wss://host.example.com/ssh/tunnel"},
+		{"ws://127.0.0.1:9000", "ws://127.0.0.1:9000/ssh/tunnel"},
+		{"ws://127.0.0.1:9000/ssh/tunnel", "ws://127.0.0.1:9000/ssh/tunnel"},
+		{"127.0.0.1:9000", "ws://127.0.0.1:9000/ssh/tunnel"},
+		{"https://host/already/has/path", "wss://host/already/has/path/ssh/tunnel"},
+	}
+	for _, tc := range cases {
+		got, err := toWebSocketURL(tc.in)
+		assert.NilError(t, err, "input: %s", tc.in)
+		assert.Equal(t, got, tc.want, "input: %s", tc.in)
+	}
+}
+
 func TestTofuHostKeyCallback(t *testing.T) {
 	dir := t.TempDir()
 	knownHosts := filepath.Join(dir, "known_hosts")

--- a/internal/sandbox/ssh_ws_test.go
+++ b/internal/sandbox/ssh_ws_test.go
@@ -2,14 +2,6 @@ package sandbox_test
 
 import (
 	"context"
-	"crypto/ed25519"
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/binary"
-	"encoding/hex"
-	"encoding/pem"
-	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,180 +9,42 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/coder/websocket"
-	"golang.org/x/crypto/ssh"
 	"gotest.tools/v3/assert"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/sandbox"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 )
 
-// startWebSocketSSHServer starts a test HTTP server that upgrades connections
-// to WebSocket at /ssh/tunnel and serves a minimal SSH server on each one.
-//
-// Returns:
-//   - wsURL: the ws:// URL to dial (e.g. ws://127.0.0.1:PORT/ssh/tunnel)
-//   - knownHostsPath: pre-populated known_hosts with the server's host fingerprint
-//   - identityFile: client private key file the server will accept
-func startWebSocketSSHServer(t *testing.T) (wsURL, knownHostsPath, identityFile string) {
-	t.Helper()
-
-	// Generate SSH host key for the server.
-	_, hostPriv, err := ed25519.GenerateKey(rand.Reader)
-	assert.NilError(t, err)
-	hostSigner, err := ssh.NewSignerFromKey(hostPriv)
-	assert.NilError(t, err)
-
-	// Generate client keypair; the server accepts only this key.
-	clientPub, clientPriv, err := ed25519.GenerateKey(rand.Reader)
-	assert.NilError(t, err)
-	authorizedKey, err := ssh.NewPublicKey(clientPub)
-	assert.NilError(t, err)
-
-	serverCfg := &ssh.ServerConfig{
-		PublicKeyCallback: func(_ ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
-			if string(key.Marshal()) == string(authorizedKey.Marshal()) {
-				return &ssh.Permissions{}, nil
-			}
-			return nil, fmt.Errorf("unauthorized key")
-		},
-	}
-	serverCfg.AddHostKey(hostSigner)
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/ssh/tunnel", func(w http.ResponseWriter, r *http.Request) {
-		ws, wsErr := websocket.Accept(w, r, nil)
-		if wsErr != nil {
-			t.Logf("websocket accept: %v", wsErr)
-			return
-		}
-		// Use context.Background() so the SSH session outlives the HTTP handler.
-		// r.Context() is cancelled when the handler returns, which would prematurely
-		// close the WebSocket before the SSH session completes.
-		go serveSSH(t, websocket.NetConn(context.Background(), ws, websocket.MessageBinary), serverCfg)
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-
-	dir := t.TempDir()
-
-	// Write client private key file.
-	identityFile = filepath.Join(dir, "id_ed25519")
-	privBlock, err := ssh.MarshalPrivateKey(clientPriv, "")
-	assert.NilError(t, err)
-	err = os.WriteFile(identityFile, pem.EncodeToMemory(privBlock), 0o600)
-	assert.NilError(t, err)
-
-	// Pre-populate known_hosts. The TOFU callback keys on the hostname from the URL.
-	host := strings.SplitN(strings.TrimPrefix(srv.URL, "http://"), ":", 2)[0]
-	fp := sha256.Sum256(hostSigner.PublicKey().Marshal())
-	knownHostsPath = filepath.Join(dir, "known_hosts")
-	err = os.WriteFile(knownHostsPath, []byte(host+" "+hex.EncodeToString(fp[:])+"\n"), 0o600)
-	assert.NilError(t, err)
-
-	wsURL = "ws://" + strings.TrimPrefix(srv.URL, "http://") + "/ssh/tunnel"
-	return wsURL, knownHostsPath, identityFile
-}
-
-// serveSSH performs the SSH server handshake on conn then dispatches session channels.
-// Runs in a goroutine; it logs unexpected errors but does not call t.Fatal — the
-// client-side error is what test assertions check.
-func serveSSH(t *testing.T, conn net.Conn, cfg *ssh.ServerConfig) {
-	t.Helper()
-	defer conn.Close() //nolint:errcheck
-
-	srvConn, chans, reqs, err := ssh.NewServerConn(conn, cfg)
-	if err != nil {
-		t.Logf("SSH server handshake: %v", err)
-		return
-	}
-	defer srvConn.Close()
-	go ssh.DiscardRequests(reqs)
-
-	for newChan := range chans {
-		if newChan.ChannelType() != "session" {
-			_ = newChan.Reject(ssh.UnknownChannelType, "unsupported channel type")
-			continue
-		}
-		ch, sessionReqs, acceptErr := newChan.Accept()
-		if acceptErr != nil {
-			t.Logf("accept session channel: %v", acceptErr)
-			return
-		}
-		go handleSessionRequests(ch, sessionReqs)
-	}
-}
-
-// handleSessionRequests handles "env" and "exec" requests on an SSH session channel.
-// For exec it writes "ran: <command>\n" to stdout and sends exit-status 0.
-func handleSessionRequests(ch ssh.Channel, reqs <-chan *ssh.Request) {
-	defer ch.Close()
-	for req := range reqs {
-		switch req.Type {
-		case "env":
-			_ = req.Reply(true, nil)
-		case "exec":
-			_ = req.Reply(true, nil)
-			// SSH exec payload encodes the command as a uint32 length + bytes.
-			cmd := ""
-			if len(req.Payload) >= 4 {
-				n := binary.BigEndian.Uint32(req.Payload[:4])
-				if int(n) <= len(req.Payload[4:]) {
-					cmd = string(req.Payload[4 : 4+n])
-				}
-			}
-			_, _ = ch.Write([]byte("ran: " + cmd + "\n"))
-			// Exit-status payload: uint32 big-endian exit code (0 = success).
-			_, _ = ch.SendRequest("exit-status", false, make([]byte, 4))
-			return
-		default:
-			if req.WantReply {
-				_ = req.Reply(false, nil)
-			}
-		}
-	}
-}
-
-// writeTestIdentityFile generates a throwaway ed25519 private key and writes it to
-// a temp file, returning the path.
-func writeTestIdentityFile(t *testing.T) string {
-	t.Helper()
-	_, priv, err := ed25519.GenerateKey(rand.Reader)
-	assert.NilError(t, err)
-	block, err := ssh.MarshalPrivateKey(priv, "")
-	assert.NilError(t, err)
-	path := filepath.Join(t.TempDir(), "id_ed25519")
-	err = os.WriteFile(path, pem.EncodeToMemory(block), 0o600)
-	assert.NilError(t, err)
-	return path
-}
-
-// TestExecOverSSHViaWebSocket verifies the happy path: a command executes successfully
-// through a WebSocket tunnel and returns output with exit code 0.
+// TestExecOverSSHViaWebSocket verifies the happy path: a command executes
+// successfully through a WebSocket tunnel and returns output with exit code 0.
 func TestExecOverSSHViaWebSocket(t *testing.T) {
-	wsURL, knownHostsPath, identityFile := startWebSocketSSHServer(t)
+	keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+	sshSrv := fakes.NewSSHServer(t, pubKey)
+	sshSrv.SetResult("hello from sandbox\n", 0)
 
 	session := &sandbox.Session{
-		URL:          wsURL,
-		IdentityFile: identityFile,
-		KnownHosts:   knownHostsPath,
+		URL:          sshSrv.Addr(),
+		IdentityFile: keyFile,
+		KnownHosts:   filepath.Join(t.TempDir(), "known_hosts"),
 	}
 
 	result, err := sandbox.ExecOverSSH(context.Background(), session, "echo hello", nil, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, result.ExitCode, 0)
-	assert.Assert(t, strings.Contains(result.Stdout, "echo hello"),
-		"expected stdout to contain the command, got: %q", result.Stdout)
+	assert.Equal(t, result.Stdout, "hello from sandbox\n")
 }
 
-// TestExecOverSSHViaWebSocketEnvVars verifies that environment variables are forwarded
-// without error.
+// TestExecOverSSHViaWebSocketEnvVars verifies that environment variables are
+// forwarded to the session without error.
 func TestExecOverSSHViaWebSocketEnvVars(t *testing.T) {
-	wsURL, knownHostsPath, identityFile := startWebSocketSSHServer(t)
+	keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+	sshSrv := fakes.NewSSHServer(t, pubKey)
+	sshSrv.SetResult("bar\n", 0)
 
 	session := &sandbox.Session{
-		URL:          wsURL,
-		IdentityFile: identityFile,
-		KnownHosts:   knownHostsPath,
+		URL:          sshSrv.Addr(),
+		IdentityFile: keyFile,
+		KnownHosts:   filepath.Join(t.TempDir(), "known_hosts"),
 	}
 
 	result, err := sandbox.ExecOverSSH(context.Background(), session, "printenv FOO", nil,
@@ -200,17 +54,20 @@ func TestExecOverSSHViaWebSocketEnvVars(t *testing.T) {
 	assert.Equal(t, result.ExitCode, 0)
 }
 
-// TestDialSSHWebSocketConnectionRefused verifies that a clear error is returned when
-// the WebSocket server is unreachable.
+// TestDialSSHWebSocketConnectionRefused verifies that a clear error is returned
+// when the WebSocket server is unreachable.
 func TestDialSSHWebSocketConnectionRefused(t *testing.T) {
-	// Grab a port via a real server, then immediately close it so connections are refused.
+	keyFile, _ := fakes.GenerateSSHKeypair(t)
+
+	// Grab a port via a real server, then immediately close it so connections
+	// to that address are refused.
 	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	wsURL := "ws://" + strings.TrimPrefix(srv.URL, "http://") + "/ssh/tunnel"
+	closedURL := "ws://" + strings.TrimPrefix(srv.URL, "http://") + "/ssh/tunnel"
 	srv.Close()
 
 	session := &sandbox.Session{
-		URL:          wsURL,
-		IdentityFile: writeTestIdentityFile(t),
+		URL:          closedURL,
+		IdentityFile: keyFile,
 		KnownHosts:   filepath.Join(t.TempDir(), "known_hosts"),
 	}
 
@@ -220,21 +77,22 @@ func TestDialSSHWebSocketConnectionRefused(t *testing.T) {
 		"expected WebSocket connect error, got: %v", err)
 }
 
-// TestDialSSHWebSocketHostKeyMismatch verifies that a tampered known_hosts entry
-// causes the connection to be rejected with a host key mismatch error.
+// TestDialSSHWebSocketHostKeyMismatch verifies that a tampered known_hosts
+// entry causes the connection to be rejected with a host key mismatch error.
 func TestDialSSHWebSocketHostKeyMismatch(t *testing.T) {
-	wsURL, knownHostsPath, identityFile := startWebSocketSSHServer(t)
+	keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+	sshSrv := fakes.NewSSHServer(t, pubKey)
 
-	// Overwrite known_hosts with a wrong fingerprint.
-	host := strings.SplitN(strings.TrimPrefix(wsURL, "ws://"), ":", 2)[0]
-	err := os.WriteFile(knownHostsPath,
-		[]byte(host+" "+strings.Repeat("aa", 32)+"\n"), 0o600)
+	// Write a wrong fingerprint for the server's host before the first connect.
+	host := strings.SplitN(sshSrv.Addr(), ":", 2)[0]
+	knownHosts := filepath.Join(t.TempDir(), "known_hosts")
+	err := os.WriteFile(knownHosts, []byte(host+" "+strings.Repeat("aa", 32)+"\n"), 0o600)
 	assert.NilError(t, err)
 
 	session := &sandbox.Session{
-		URL:          wsURL,
-		IdentityFile: identityFile,
-		KnownHosts:   knownHostsPath,
+		URL:          sshSrv.Addr(),
+		IdentityFile: keyFile,
+		KnownHosts:   knownHosts,
 	}
 
 	_, err = sandbox.ExecOverSSH(context.Background(), session, "echo hi", nil, nil)

--- a/internal/sandbox/ssh_ws_test.go
+++ b/internal/sandbox/ssh_ws_test.go
@@ -1,0 +1,244 @@
+package sandbox_test
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/coder/websocket"
+	"golang.org/x/crypto/ssh"
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/sandbox"
+)
+
+// startWebSocketSSHServer starts a test HTTP server that upgrades connections
+// to WebSocket at /ssh/tunnel and serves a minimal SSH server on each one.
+//
+// Returns:
+//   - wsURL: the ws:// URL to dial (e.g. ws://127.0.0.1:PORT/ssh/tunnel)
+//   - knownHostsPath: pre-populated known_hosts with the server's host fingerprint
+//   - identityFile: client private key file the server will accept
+func startWebSocketSSHServer(t *testing.T) (wsURL, knownHostsPath, identityFile string) {
+	t.Helper()
+
+	// Generate SSH host key for the server.
+	_, hostPriv, err := ed25519.GenerateKey(rand.Reader)
+	assert.NilError(t, err)
+	hostSigner, err := ssh.NewSignerFromKey(hostPriv)
+	assert.NilError(t, err)
+
+	// Generate client keypair; the server accepts only this key.
+	clientPub, clientPriv, err := ed25519.GenerateKey(rand.Reader)
+	assert.NilError(t, err)
+	authorizedKey, err := ssh.NewPublicKey(clientPub)
+	assert.NilError(t, err)
+
+	serverCfg := &ssh.ServerConfig{
+		PublicKeyCallback: func(_ ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+			if string(key.Marshal()) == string(authorizedKey.Marshal()) {
+				return &ssh.Permissions{}, nil
+			}
+			return nil, fmt.Errorf("unauthorized key")
+		},
+	}
+	serverCfg.AddHostKey(hostSigner)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ssh/tunnel", func(w http.ResponseWriter, r *http.Request) {
+		ws, wsErr := websocket.Accept(w, r, nil)
+		if wsErr != nil {
+			t.Logf("websocket accept: %v", wsErr)
+			return
+		}
+		// Use context.Background() so the SSH session outlives the HTTP handler.
+		// r.Context() is cancelled when the handler returns, which would prematurely
+		// close the WebSocket before the SSH session completes.
+		go serveSSH(t, websocket.NetConn(context.Background(), ws, websocket.MessageBinary), serverCfg)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	dir := t.TempDir()
+
+	// Write client private key file.
+	identityFile = filepath.Join(dir, "id_ed25519")
+	privBlock, err := ssh.MarshalPrivateKey(clientPriv, "")
+	assert.NilError(t, err)
+	err = os.WriteFile(identityFile, pem.EncodeToMemory(privBlock), 0o600)
+	assert.NilError(t, err)
+
+	// Pre-populate known_hosts. The TOFU callback keys on the hostname from the URL.
+	host := strings.SplitN(strings.TrimPrefix(srv.URL, "http://"), ":", 2)[0]
+	fp := sha256.Sum256(hostSigner.PublicKey().Marshal())
+	knownHostsPath = filepath.Join(dir, "known_hosts")
+	err = os.WriteFile(knownHostsPath, []byte(host+" "+hex.EncodeToString(fp[:])+"\n"), 0o600)
+	assert.NilError(t, err)
+
+	wsURL = "ws://" + strings.TrimPrefix(srv.URL, "http://") + "/ssh/tunnel"
+	return wsURL, knownHostsPath, identityFile
+}
+
+// serveSSH performs the SSH server handshake on conn then dispatches session channels.
+// Runs in a goroutine; it logs unexpected errors but does not call t.Fatal — the
+// client-side error is what test assertions check.
+func serveSSH(t *testing.T, conn net.Conn, cfg *ssh.ServerConfig) {
+	t.Helper()
+	defer conn.Close() //nolint:errcheck
+
+	srvConn, chans, reqs, err := ssh.NewServerConn(conn, cfg)
+	if err != nil {
+		t.Logf("SSH server handshake: %v", err)
+		return
+	}
+	defer srvConn.Close()
+	go ssh.DiscardRequests(reqs)
+
+	for newChan := range chans {
+		if newChan.ChannelType() != "session" {
+			_ = newChan.Reject(ssh.UnknownChannelType, "unsupported channel type")
+			continue
+		}
+		ch, sessionReqs, acceptErr := newChan.Accept()
+		if acceptErr != nil {
+			t.Logf("accept session channel: %v", acceptErr)
+			return
+		}
+		go handleSessionRequests(ch, sessionReqs)
+	}
+}
+
+// handleSessionRequests handles "env" and "exec" requests on an SSH session channel.
+// For exec it writes "ran: <command>\n" to stdout and sends exit-status 0.
+func handleSessionRequests(ch ssh.Channel, reqs <-chan *ssh.Request) {
+	defer ch.Close()
+	for req := range reqs {
+		switch req.Type {
+		case "env":
+			_ = req.Reply(true, nil)
+		case "exec":
+			_ = req.Reply(true, nil)
+			// SSH exec payload encodes the command as a uint32 length + bytes.
+			cmd := ""
+			if len(req.Payload) >= 4 {
+				n := binary.BigEndian.Uint32(req.Payload[:4])
+				if int(n) <= len(req.Payload[4:]) {
+					cmd = string(req.Payload[4 : 4+n])
+				}
+			}
+			_, _ = ch.Write([]byte("ran: " + cmd + "\n"))
+			// Exit-status payload: uint32 big-endian exit code (0 = success).
+			_, _ = ch.SendRequest("exit-status", false, make([]byte, 4))
+			return
+		default:
+			if req.WantReply {
+				_ = req.Reply(false, nil)
+			}
+		}
+	}
+}
+
+// writeTestIdentityFile generates a throwaway ed25519 private key and writes it to
+// a temp file, returning the path.
+func writeTestIdentityFile(t *testing.T) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	assert.NilError(t, err)
+	block, err := ssh.MarshalPrivateKey(priv, "")
+	assert.NilError(t, err)
+	path := filepath.Join(t.TempDir(), "id_ed25519")
+	err = os.WriteFile(path, pem.EncodeToMemory(block), 0o600)
+	assert.NilError(t, err)
+	return path
+}
+
+// TestExecOverSSHViaWebSocket verifies the happy path: a command executes successfully
+// through a WebSocket tunnel and returns output with exit code 0.
+func TestExecOverSSHViaWebSocket(t *testing.T) {
+	wsURL, knownHostsPath, identityFile := startWebSocketSSHServer(t)
+
+	session := &sandbox.Session{
+		URL:          wsURL,
+		IdentityFile: identityFile,
+		KnownHosts:   knownHostsPath,
+	}
+
+	result, err := sandbox.ExecOverSSH(context.Background(), session, "echo hello", nil, nil)
+	assert.NilError(t, err)
+	assert.Equal(t, result.ExitCode, 0)
+	assert.Assert(t, strings.Contains(result.Stdout, "echo hello"),
+		"expected stdout to contain the command, got: %q", result.Stdout)
+}
+
+// TestExecOverSSHViaWebSocketEnvVars verifies that environment variables are forwarded
+// without error.
+func TestExecOverSSHViaWebSocketEnvVars(t *testing.T) {
+	wsURL, knownHostsPath, identityFile := startWebSocketSSHServer(t)
+
+	session := &sandbox.Session{
+		URL:          wsURL,
+		IdentityFile: identityFile,
+		KnownHosts:   knownHostsPath,
+	}
+
+	result, err := sandbox.ExecOverSSH(context.Background(), session, "printenv FOO", nil,
+		map[string]string{"FOO": "bar"},
+	)
+	assert.NilError(t, err)
+	assert.Equal(t, result.ExitCode, 0)
+}
+
+// TestDialSSHWebSocketConnectionRefused verifies that a clear error is returned when
+// the WebSocket server is unreachable.
+func TestDialSSHWebSocketConnectionRefused(t *testing.T) {
+	// Grab a port via a real server, then immediately close it so connections are refused.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	wsURL := "ws://" + strings.TrimPrefix(srv.URL, "http://") + "/ssh/tunnel"
+	srv.Close()
+
+	session := &sandbox.Session{
+		URL:          wsURL,
+		IdentityFile: writeTestIdentityFile(t),
+		KnownHosts:   filepath.Join(t.TempDir(), "known_hosts"),
+	}
+
+	_, err := sandbox.ExecOverSSH(context.Background(), session, "echo hi", nil, nil)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, strings.Contains(err.Error(), "WebSocket connect"),
+		"expected WebSocket connect error, got: %v", err)
+}
+
+// TestDialSSHWebSocketHostKeyMismatch verifies that a tampered known_hosts entry
+// causes the connection to be rejected with a host key mismatch error.
+func TestDialSSHWebSocketHostKeyMismatch(t *testing.T) {
+	wsURL, knownHostsPath, identityFile := startWebSocketSSHServer(t)
+
+	// Overwrite known_hosts with a wrong fingerprint.
+	host := strings.SplitN(strings.TrimPrefix(wsURL, "ws://"), ":", 2)[0]
+	err := os.WriteFile(knownHostsPath,
+		[]byte(host+" "+strings.Repeat("aa", 32)+"\n"), 0o600)
+	assert.NilError(t, err)
+
+	session := &sandbox.Session{
+		URL:          wsURL,
+		IdentityFile: identityFile,
+		KnownHosts:   knownHostsPath,
+	}
+
+	_, err = sandbox.ExecOverSSH(context.Background(), session, "echo hi", nil, nil)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, strings.Contains(err.Error(), "host key mismatch"),
+		"expected host key mismatch error, got: %v", err)
+}

--- a/internal/testing/fakes/ssh.go
+++ b/internal/testing/fakes/ssh.go
@@ -2,28 +2,29 @@ package fakes
 
 import (
 	"bytes"
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/binary"
 	"encoding/pem"
-	"math/big"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
-	"time"
 
+	"github.com/coder/websocket"
 	"golang.org/x/crypto/ssh"
 )
 
-// SSHServer is a TLS+SSH server for testing SSH-based sandbox interactions.
+// SSHServer is a WebSocket+SSH server for testing SSH-based sandbox interactions.
 // It accepts a single authorized public key and records exec requests.
 type SSHServer struct {
-	listener net.Listener
+	srv      *httptest.Server
 	mu       sync.Mutex
 	stdout   string
 	exitCode int
@@ -67,20 +68,13 @@ func GenerateSSHKeypair(t *testing.T) (keyFile string, pubKey ssh.PublicKey) {
 	return keyPath, sshPub
 }
 
-// NewSSHServer starts a TLS+SSH server that accepts connections authenticated
-// with authorizedKey. The server is shut down automatically when the test ends.
+// NewSSHServer starts a WebSocket+SSH server that accepts connections
+// authenticated with authorizedKey. The server is shut down automatically
+// when the test ends.
 func NewSSHServer(t *testing.T, authorizedKey ssh.PublicKey) *SSHServer {
 	t.Helper()
 
-	tlsCert := generateSelfSignedCert(t)
 	hostSigner := generateHostKey(t)
-
-	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
-		Certificates: []tls.Certificate{tlsCert},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	sshCfg := &ssh.ServerConfig{
 		PublicKeyCallback: func(_ ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
@@ -92,16 +86,31 @@ func NewSSHServer(t *testing.T, authorizedKey ssh.PublicKey) *SSHServer {
 	}
 	sshCfg.AddHostKey(hostSigner)
 
-	srv := &SSHServer{listener: listener}
-	go srv.serve(sshCfg)
-	t.Cleanup(func() { _ = listener.Close() })
+	srv := &SSHServer{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ssh/tunnel", func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Logf("websocket accept: %v", err)
+			return
+		}
+		// Use context.Background() so the SSH session outlives the HTTP handler.
+		conn := websocket.NetConn(context.Background(), ws, websocket.MessageBinary)
+		go srv.handleConn(conn, sshCfg)
+	})
+
+	srv.srv = httptest.NewServer(mux)
+	t.Cleanup(srv.srv.Close)
 
 	return srv
 }
 
 // Addr returns the "host:port" address the server is listening on.
+// sandbox.OpenSession stores this as Session.URL; toWebSocketURL converts it
+// to ws://host:port/ssh/tunnel before dialling.
 func (s *SSHServer) Addr() string {
-	return s.listener.Addr().String()
+	return strings.TrimPrefix(s.srv.URL, "http://")
 }
 
 // SetResult configures the stdout output and exit code returned for exec requests.
@@ -121,18 +130,8 @@ func (s *SSHServer) Commands() []string {
 	return out
 }
 
-func (s *SSHServer) serve(cfg *ssh.ServerConfig) {
-	for {
-		conn, err := s.listener.Accept()
-		if err != nil {
-			return // listener closed
-		}
-		go s.handleConn(conn, cfg)
-	}
-}
-
 func (s *SSHServer) handleConn(conn net.Conn, cfg *ssh.ServerConfig) {
-	defer func() { _ = conn.Close() }()
+	defer conn.Close() //nolint:errcheck
 
 	sshConn, chans, reqs, err := ssh.NewServerConn(conn, cfg)
 	if err != nil {
@@ -159,7 +158,13 @@ func (s *SSHServer) handleSession(ch ssh.Channel, requests <-chan *ssh.Request) 
 	defer func() { _ = ch.Close() }()
 
 	for req := range requests {
-		if req.Type != "exec" {
+		switch req.Type {
+		case "env":
+			_ = req.Reply(true, nil)
+			continue
+		case "exec":
+			// handled below
+		default:
 			if req.WantReply {
 				_ = req.Reply(false, nil)
 			}
@@ -190,50 +195,14 @@ func (s *SSHServer) handleSession(ch ssh.Channel, requests <-chan *ssh.Request) 
 		if req.WantReply {
 			_ = req.Reply(true, nil)
 		}
-
 		if stdout != "" {
 			_, _ = ch.Write([]byte(stdout))
 		}
-
 		exitPayload := make([]byte, 4)
 		binary.BigEndian.PutUint32(exitPayload, uint32(exitCode)) //nolint:gosec // exit codes are 0-255
 		_, _ = ch.SendRequest("exit-status", false, exitPayload)
 		return // one exec per session
 	}
-}
-
-func generateSelfSignedCert(t *testing.T) tls.Certificate {
-	t.Helper()
-
-	pub, priv, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "test"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(24 * time.Hour),
-	}
-	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cert, err := tls.X509KeyPair(
-		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}),
-		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return cert
 }
 
 func generateHostKey(t *testing.T) ssh.Signer {


### PR DESCRIPTION
## Summary

- **WebSocket tunnel**: Replaces the direct TLS dial with a WebSocket connection to `ws[s]://host/ssh/tunnel`. A new `toWebSocketURL` helper normalises any URL format the API returns (bare `host:port`, `http://`, `https://`, or already `ws[s]://`) into the correct WebSocket URL with `/ssh/tunnel` appended.
- **Provider default**: Removes the `--provider` CLI flag. The sandbox backend is now controlled by the `CHUNK_SANDBOX_PROVIDER` env var, defaulting to `e2b` — users don't need to think about it.
- **Test infrastructure**: Updates the fake SSH server (`fakes.SSHServer`) from a raw TLS listener to a `httptest.Server` + WebSocket upgrade. SSH public key authentication is unchanged — it remains the access control mechanism.
- **New tests**: WebSocket SSH integration tests covering happy path, env var forwarding, connection refused, and host key mismatch.

## Test plan

- [ ] `task test` passes (all packages green)
- [ ] `chunk sandbox create --name foo` creates an e2b sandbox without needing `--provider`
- [ ] `CHUNK_SANDBOX_PROVIDER=unikraft chunk sandbox create --name foo` still works for override
- [ ] SSH into a sandbox connects via `wss://<host>/ssh/tunnel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)