### PR TITLE
Update default Claude models to 4.6

### DIFF
--- a/acceptance/build_prompt_test.go
+++ b/acceptance/build_prompt_test.go
@@ -1070,22 +1070,22 @@ func TestBuildPromptDefaultModels(t *testing.T) {
 	messageReqs := filterByPath(anthropicReqs, "/v1/messages")
 	assert.Equal(t, len(messageReqs), 2, "expected 2 Anthropic /v1/messages requests")
 
-	// First request: analysis step uses AnalyzeModel (claude-sonnet-4-5-20250929)
+	// First request: analysis step uses AnalyzeModel (claude-sonnet-4-6)
 	var analysisBody struct {
 		Model string `json:"model"`
 	}
 	err := json.Unmarshal(messageReqs[0].Body, &analysisBody)
 	assert.NilError(t, err)
-	assert.Equal(t, analysisBody.Model, "claude-sonnet-4-5-20250929",
+	assert.Equal(t, analysisBody.Model, "claude-sonnet-4-6",
 		"expected default analyze model")
 
-	// Second request: prompt step uses PromptModel (claude-opus-4-5-20251101)
+	// Second request: prompt step uses PromptModel (claude-opus-4-6)
 	var promptBody struct {
 		Model string `json:"model"`
 	}
 	err = json.Unmarshal(messageReqs[1].Body, &promptBody)
 	assert.NilError(t, err)
-	assert.Equal(t, promptBody.Model, "claude-opus-4-5-20251101",
+	assert.Equal(t, promptBody.Model, "claude-opus-4-6",
 		"expected default prompt model")
 }
 

--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -35,7 +35,7 @@ func TestConfigShowDefaults(t *testing.T) {
 
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "claude-sonnet-4-5-20250929"),
+	assert.Assert(t, strings.Contains(combined, "claude-sonnet-4-6"),
 		"expected default model value in config show, got: %s", combined)
 	assert.Assert(t, strings.Contains(combined, "Default"),
 		"expected '(Default)' source annotation, got: %s", combined)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,8 +96,8 @@ Three-step pipeline orchestrated by `buildprompt.Run()`:
 
 ### Model defaults
 
-- Analysis step: `claude-sonnet-4-5-20250929`
-- Generation step: `claude-opus-4-5-20251101`
+- Analysis step: `claude-sonnet-4-6`
+- Generation step: `claude-opus-4-6`
 - Overridable via `--analyze-model` / `--prompt-model` flags
 
 ## Configuration Resolution
@@ -107,7 +107,7 @@ User config lives at `~/.chunk/config.json`:
 ```json
 {
   "apiKey": "sk-...",
-  "model": "claude-sonnet-4-5-20250929"
+  "model": "claude-sonnet-4-6"
 }
 ```
 

--- a/internal/anthropic/anthropic_test.go
+++ b/internal/anthropic/anthropic_test.go
@@ -212,7 +212,7 @@ func TestAnalyzeReviews(t *testing.T) {
 	assert.Equal(t, len(reqs), 1)
 	var body messagesRequest
 	assert.NilError(t, json.Unmarshal(reqs[0].Body, &body))
-	assert.Equal(t, body.Model, "claude-sonnet-4-5-20250929") // config.AnalyzeModel
+	assert.Equal(t, body.Model, "claude-sonnet-4-6") // config.AnalyzeModel
 	assert.Equal(t, body.MaxTokens, 16000)
 }
 
@@ -245,7 +245,7 @@ func TestGenerateReviewPrompt(t *testing.T) {
 	assert.Equal(t, len(reqs), 1)
 	var body messagesRequest
 	assert.NilError(t, json.Unmarshal(reqs[0].Body, &body))
-	assert.Equal(t, body.Model, "claude-opus-4-5-20251101") // config.PromptModel
+	assert.Equal(t, body.Model, "claude-opus-4-6") // config.PromptModel
 	assert.Equal(t, body.MaxTokens, 8000)
 
 	// Verify the prompt includes the analysis and no-attribution instruction.

--- a/internal/buildprompt/buildprompt_test.go
+++ b/internal/buildprompt/buildprompt_test.go
@@ -55,8 +55,8 @@ func TestRunHappyPath(t *testing.T) {
 		Top:          5,
 		Since:        time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 		OutputPath:   outputPath,
-		AnalyzeModel: "claude-sonnet-4-5-20250929",
-		PromptModel:  "claude-sonnet-4-5-20250929",
+		AnalyzeModel: "claude-sonnet-4-6",
+		PromptModel:  "claude-sonnet-4-6",
 	}, streams)
 	assert.NilError(t, err)
 
@@ -150,8 +150,8 @@ func TestRunSkipsRepoResolutionErrors(t *testing.T) {
 		Repos:        []string{"good-repo", "bad-repo"},
 		Top:          5,
 		OutputPath:   outputPath,
-		AnalyzeModel: "claude-sonnet-4-5-20250929",
-		PromptModel:  "claude-sonnet-4-5-20250929",
+		AnalyzeModel: "claude-sonnet-4-6",
+		PromptModel:  "claude-sonnet-4-6",
 	}, streams)
 	assert.NilError(t, err)
 	assert.Assert(t, strings.Contains(stderr.String(), "Skipping bad-repo"))
@@ -188,8 +188,8 @@ func TestRunWithMaxComments(t *testing.T) {
 		Top:          5,
 		MaxComments:  1,
 		OutputPath:   outputPath,
-		AnalyzeModel: "claude-sonnet-4-5-20250929",
-		PromptModel:  "claude-sonnet-4-5-20250929",
+		AnalyzeModel: "claude-sonnet-4-6",
+		PromptModel:  "claude-sonnet-4-6",
 	}, streams)
 	assert.NilError(t, err)
 
@@ -232,8 +232,8 @@ func TestRunRetryOnTokenLimit(t *testing.T) {
 		Top:          5,
 		Since:        time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 		OutputPath:   outputPath,
-		AnalyzeModel: "claude-sonnet-4-5-20250929",
-		PromptModel:  "claude-sonnet-4-5-20250929",
+		AnalyzeModel: "claude-sonnet-4-6",
+		PromptModel:  "claude-sonnet-4-6",
 	}, streams)
 	assert.NilError(t, err)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,9 +10,9 @@ import (
 
 // Model constants define the Claude models used for different operations.
 const (
-	DefaultModel    = "claude-sonnet-4-5-20250929"
-	AnalyzeModel    = "claude-sonnet-4-5-20250929"
-	PromptModel     = "claude-opus-4-5-20251101"
+	DefaultModel    = "claude-sonnet-4-6"
+	AnalyzeModel    = "claude-sonnet-4-6"
+	PromptModel     = "claude-opus-4-6"
 	ValidationModel = "claude-haiku-4-5-20251001"
 	dirPermission   = 0o700
 	filePermission  = 0o600

--- a/internal/testing/fakes/anthropic.go
+++ b/internal/testing/fakes/anthropic.go
@@ -97,7 +97,7 @@ func (f *FakeAnthropic) handleMessages(c *gin.Context) {
 		"id":          fmt.Sprintf("msg_%03d", idx),
 		"type":        "message",
 		"role":        "assistant",
-		"model":       "claude-sonnet-4-5-20250929",
+		"model":       "claude-sonnet-4-6",
 		"stop_reason": "end_turn",
 		"content": []gin.H{
 			{"type": "text", "text": text},


### PR DESCRIPTION
Bumps `DefaultModel` and `AnalyzeModel` from `claude-sonnet-4-5-20250929` to `claude-sonnet-4-6`
Bumps `PromptModel` from `claude-opus-4-5-20251101` to `claude-opus-4-6`