### PR TITLE
Disable retries on Anthropic HTTP client

### DIFF
--- a/internal/anthropic/client.go
+++ b/internal/anthropic/client.go
@@ -33,11 +33,12 @@ func New() (*Client, error) {
 	}
 
 	c := httpcl.New(httpcl.Config{
-		BaseURL:    baseURL,
-		AuthToken:  key,
-		AuthHeader: "x-api-key",
-		UserAgent:  "chunk-cli",
-		Timeout:    5 * time.Minute,
+		BaseURL:        baseURL,
+		AuthToken:      key,
+		AuthHeader:     "x-api-key",
+		UserAgent:      "chunk-cli",
+		Timeout:        5 * time.Minute,
+		DisableRetries: true,
 	})
 
 	return &Client{http: c}, nil

--- a/internal/httpcl/client.go
+++ b/internal/httpcl/client.go
@@ -31,6 +31,9 @@ type Config struct {
 	UserAgent string
 	// Timeout is the per-request timeout. Defaults to 30s.
 	Timeout time.Duration
+	// DisableRetries disables automatic retries. By default requests are
+	// retried up to 3 times with exponential backoff.
+	DisableRetries bool
 	// Transport overrides the HTTP transport (useful for testing).
 	Transport http.RoundTripper
 }
@@ -54,6 +57,9 @@ func New(cfg Config) *Client {
 
 	rc := retryablehttp.NewClient()
 	rc.RetryMax = 3
+	if cfg.DisableRetries {
+		rc.RetryMax = 0
+	}
 	rc.RetryWaitMin = 50 * time.Millisecond
 	rc.RetryWaitMax = 2 * time.Second
 	rc.Logger = nil // suppress default log output

--- a/internal/httpcl/client_test.go
+++ b/internal/httpcl/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
@@ -72,6 +73,29 @@ func TestCallHTTPError(t *testing.T) {
 	}
 	if !httpcl.HasStatusCode(err, http.StatusNotFound) {
 		t.Fatalf("expected HTTPError with 404, got %v", err)
+	}
+}
+
+func TestDisableRetries(t *testing.T) {
+	var attempts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := httpcl.New(httpcl.Config{
+		BaseURL:        srv.URL,
+		DisableRetries: true,
+	})
+
+	_, err := c.Call(context.Background(), httpcl.NewRequest("GET", "/"))
+	if err == nil {
+		t.Fatal("expected error for 503 response")
+	}
+	if n := attempts.Load(); n != 1 {
+		t.Fatalf("expected exactly 1 attempt with retries disabled, got %d", n)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `DisableRetries` option to `httpcl.Config`; when set, `RetryMax` is 0
- Set `DisableRetries: true` on the Anthropic client — the 5-minute timeout is sufficient without retries, and retrying large LLM requests wastes time when the context deadline wraps the full retry loop