### PR TITLE
Redesign auth commands for multi-provider support

### DIFF
--- a/acceptance/auth_test.go
+++ b/acceptance/auth_test.go
@@ -3,6 +3,8 @@ package acceptance
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -13,6 +15,8 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 )
 
+// --- auth status ---
+
 func TestAuthStatusWithEnvKey(t *testing.T) {
 	anthropic := fakes.NewFakeAnthropic()
 	srv := httptest.NewServer(anthropic)
@@ -20,6 +24,7 @@ func TestAuthStatusWithEnvKey(t *testing.T) {
 
 	env := testenv.NewTestEnv(t)
 	env.AnthropicURL = srv.URL
+	env.CircleToken = "" // Anthropic-only test
 
 	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
 
@@ -28,22 +33,28 @@ func TestAuthStatusWithEnvKey(t *testing.T) {
 	assert.Assert(t,
 		strings.Contains(combined, "Environment variable") || strings.Contains(combined, "environment variable"),
 		"expected output to mention environment variable, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "API key is valid"),
+	assert.Assert(t, strings.Contains(combined, "Valid"),
 		"expected validation success message, got: %s", combined)
 }
 
 func TestAuthStatusNoKey(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.AnthropicKey = ""
+	env.CircleToken = ""
 
 	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "Not authenticated") || strings.Contains(combined, "not authenticated"),
-		"expected output to indicate no auth, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "chunk auth login"),
-		"expected help text about login command, got: %s", combined)
+	// All three sections are always shown, each reporting "Not set" when unconfigured
+	assert.Assert(t, strings.Contains(combined, "CircleCI"),
+		"expected CircleCI section, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "Anthropic"),
+		"expected Anthropic section, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "GitHub"),
+		"expected GitHub section, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "Not set"),
+		"expected Not set in output, got: %s", combined)
 }
 
 func TestAuthStatusInvalidKey(t *testing.T) {
@@ -58,6 +69,7 @@ func TestAuthStatusInvalidKey(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.AnthropicURL = srv.URL
 	env.AnthropicKey = "sk-ant-invalid-key-0000"
+	env.CircleToken = "" // Anthropic-only test
 
 	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
 
@@ -74,6 +86,7 @@ func TestAuthStatusShowsHeader(t *testing.T) {
 
 	env := testenv.NewTestEnv(t)
 	env.AnthropicURL = srv.URL
+	env.CircleToken = "" // Anthropic-only test
 
 	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
 
@@ -92,6 +105,7 @@ func TestAuthStatusEnvOverridesConfig(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.AnthropicURL = srv.URL
 	env.AnthropicKey = "sk-ant-env-key-EEEE"
+	env.CircleToken = "" // Anthropic-only test
 
 	// Store a different key in config file
 	setResult := binary.RunCLI(t, []string{"config", "set", "apiKey", "sk-ant-config-key-CCCC"}, env, env.HomeDir)
@@ -115,8 +129,8 @@ func TestAuthStatusMaskExactlyFourChars(t *testing.T) {
 
 	env := testenv.NewTestEnv(t)
 	env.AnthropicURL = srv.URL
-	// Key where last-4 and chars-5-to-8-from-end are distinct
 	env.AnthropicKey = "sk-ant-AAAA-BBBB-CCCC-DDDD"
+	env.CircleToken = "" // Anthropic-only test
 
 	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
@@ -128,33 +142,6 @@ func TestAuthStatusMaskExactlyFourChars(t *testing.T) {
 		"expected chars 5-8 from end to be masked, got: %s", combined)
 }
 
-func TestAuthLogoutNoStoredKey(t *testing.T) {
-	env := testenv.NewTestEnv(t)
-	env.AnthropicKey = ""
-
-	result := binary.RunCLI(t, []string{"auth", "logout"}, env, env.HomeDir)
-
-	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
-	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "No API key"),
-		"expected output to indicate no stored key, got: %s", combined)
-}
-
-func TestAuthLogoutNoStoredKeyWithEnvVar(t *testing.T) {
-	env := testenv.NewTestEnv(t)
-	env.AnthropicKey = "sk-ant-env-only-key"
-
-	// No config file key, but env var is set
-	result := binary.RunCLI(t, []string{"auth", "logout"}, env, env.HomeDir)
-
-	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
-	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "No API key"),
-		"expected no stored key message, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "ANTHROPIC_API_KEY"),
-		"expected env var note, got: %s", combined)
-}
-
 // auth status reads key from config file when no env var is set
 func TestAuthStatusFromConfigFile(t *testing.T) {
 	anthropic := fakes.NewFakeAnthropic()
@@ -164,6 +151,7 @@ func TestAuthStatusFromConfigFile(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.AnthropicURL = srv.URL
 	env.AnthropicKey = "" // no env var
+	env.CircleToken = ""  // Anthropic-only test
 
 	// Store key in config file
 	setResult := binary.RunCLI(t, []string{"config", "set", "apiKey", "sk-ant-config-only-XYZW"}, env, env.HomeDir)
@@ -175,7 +163,7 @@ func TestAuthStatusFromConfigFile(t *testing.T) {
 	combined := result.Stdout + result.Stderr
 	assert.Assert(t, strings.Contains(combined, "Config file"),
 		"expected config file source, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "API key is valid"),
+	assert.Assert(t, strings.Contains(combined, "Valid"),
 		"expected key valid message, got: %s", combined)
 	// Last 4 chars visible
 	assert.Assert(t, strings.Contains(combined, "XYZW"),
@@ -190,6 +178,7 @@ func TestAuthStatusUsesCountTokensEndpoint(t *testing.T) {
 
 	env := testenv.NewTestEnv(t)
 	env.AnthropicURL = srv.URL
+	env.CircleToken = "" // Anthropic-only test
 
 	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
@@ -204,10 +193,76 @@ func TestAuthStatusUsesCountTokensEndpoint(t *testing.T) {
 	}
 }
 
-// auth logout with a stored config key prompts for confirmation.
-// Without a TTY the confirmation prompt fails and logout is cancelled,
-// but the output shows the config file path, proving the key was detected.
-func TestAuthLogoutWithStoredKey(t *testing.T) {
+// auth status with all three providers configured shows all sections
+func TestAuthStatusAllProviders(t *testing.T) {
+	anthropic := fakes.NewFakeAnthropic()
+	anthropicSrv := httptest.NewServer(anthropic)
+	defer anthropicSrv.Close()
+
+	circleci := fakes.NewFakeCircleCI()
+	circleCISrv := httptest.NewServer(circleci)
+	defer circleCISrv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.AnthropicURL = anthropicSrv.URL
+	env.CircleCIURL = circleCISrv.URL
+
+	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "CircleCI"),
+		"expected CircleCI section, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "Anthropic"),
+		"expected Anthropic section, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "GitHub"),
+		"expected GitHub section, got: %s", combined)
+}
+
+// auth set with an unrecognised provider prints an error and exits non-zero
+func TestAuthSetInvalidProvider(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+
+	result := binary.RunCLI(t, []string{"auth", "set", "invalid-provider"}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for invalid provider")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "unknown provider"),
+		"expected error about unknown provider, got: %s", combined)
+}
+
+// --- auth remove ---
+
+func TestAuthRemoveNoStoredKey(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{"auth", "remove", "anthropic"}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "No API key"),
+		"expected output to indicate no stored key, got: %s", combined)
+}
+
+func TestAuthRemoveNoStoredKeyWithEnvVar(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = "sk-ant-env-only-key"
+
+	// No config file key, but env var is set
+	result := binary.RunCLI(t, []string{"auth", "remove", "anthropic"}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "No API key"),
+		"expected no stored key message, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "ANTHROPIC_API_KEY"),
+		"expected env var note, got: %s", combined)
+}
+
+// auth remove anthropic with a stored config key prompts for confirmation.
+// Without a TTY the confirmation prompt fails and remove is cancelled.
+func TestAuthRemoveWithStoredKey(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.AnthropicKey = "" // no env var
 
@@ -215,27 +270,26 @@ func TestAuthLogoutWithStoredKey(t *testing.T) {
 	setResult := binary.RunCLI(t, []string{"config", "set", "apiKey", "sk-ant-stored-key-1234"}, env, env.HomeDir)
 	assert.Equal(t, setResult.ExitCode, 0, "config set failed: %s", setResult.Stderr)
 
-	result := binary.RunCLI(t, []string{"auth", "logout"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"auth", "remove", "anthropic"}, env, env.HomeDir)
 
-	// Without a TTY, confirm prompt returns error and logout is cancelled
+	// Without a TTY, confirm prompt returns error and remove is cancelled
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 	combined := result.Stdout + result.Stderr
 	// The command should detect the stored key and mention the config path
 	assert.Assert(t,
-		strings.Contains(combined, "remove") || strings.Contains(combined, "cancelled"),
+		strings.Contains(combined, "remove") || strings.Contains(combined, "Cancelled"),
 		"expected removal prompt or cancellation, got: %s", combined)
 	assert.Assert(t, strings.Contains(combined, env.HomeDir), "expected config path in output, got: %s", combined)
 
-	// Key should not have been removed — cancelled logout leaves config intact.
+	// Key should not have been removed — cancelled remove leaves config intact.
 	showResult := binary.RunCLI(t, []string{"config", "show"}, env, env.HomeDir)
-	assert.Equal(t, showResult.ExitCode, 0, "config show failed after cancelled logout: %s", showResult.Stderr)
+	assert.Equal(t, showResult.ExitCode, 0, "config show failed after cancelled remove: %s", showResult.Stderr)
 	assert.Assert(t, strings.Contains(showResult.Stdout, "1234"), "expected stored key (masked) in config output, got: %s", showResult.Stdout)
 }
 
-// auth logout with both env var and config key: running logout shows
-// the stored key and (if confirmed) removes config key but env var remains.
-// Without a TTY the confirmation fails, but the output proves both were detected.
-func TestAuthLogoutWithEnvAndConfigKey(t *testing.T) {
+// auth remove with both env var and config key.
+// Without a TTY the confirmation fails, but the output proves the stored key was detected.
+func TestAuthRemoveWithEnvAndConfigKey(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.AnthropicKey = "sk-ant-env-key-EEEE"
 
@@ -243,32 +297,96 @@ func TestAuthLogoutWithEnvAndConfigKey(t *testing.T) {
 	setResult := binary.RunCLI(t, []string{"config", "set", "apiKey", "sk-ant-config-key-CCCC"}, env, env.HomeDir)
 	assert.Equal(t, setResult.ExitCode, 0, "config set failed: %s", setResult.Stderr)
 
-	result := binary.RunCLI(t, []string{"auth", "logout"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"auth", "remove", "anthropic"}, env, env.HomeDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 	combined := result.Stdout + result.Stderr
-	// Should detect the stored config key and show removal prompt
 	assert.Assert(t,
-		strings.Contains(combined, "remove") || strings.Contains(combined, "cancelled"),
+		strings.Contains(combined, "remove") || strings.Contains(combined, "Cancelled"),
 		"expected removal prompt or cancellation, got: %s", combined)
 	assert.Assert(t, strings.Contains(combined, env.HomeDir), "expected config path in output, got: %s", combined)
 
-	// Key should not have been removed — cancelled logout leaves config intact.
+	// Key should not have been removed — cancelled remove leaves config intact.
 	showResult := binary.RunCLI(t, []string{"config", "show"}, env, env.HomeDir)
-	assert.Equal(t, showResult.ExitCode, 0, "config show failed after cancelled logout: %s", showResult.Stderr)
+	assert.Equal(t, showResult.ExitCode, 0, "config show failed after cancelled remove: %s", showResult.Stderr)
 	assert.Assert(t, strings.Contains(showResult.Stdout, "EEEE"), "expected env key (masked) in config output, got: %s", showResult.Stdout)
 }
 
-// auth login without TTY: prompts for key but bubbletea fails without terminal,
-// so command exits cleanly without storing anything.
-func TestAuthLoginNoTTYExitsCleanly(t *testing.T) {
+// auth remove requires a provider argument
+func TestAuthRemoveRequiresProvider(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+
+	result := binary.RunCLI(t, []string{"auth", "remove"}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit when provider omitted")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "remove") || strings.Contains(combined, "accepts"),
+		"expected usage error, got: %s", combined)
+}
+
+// auth remove circleci removes a stored CircleCI token (cancelled without TTY)
+func TestAuthRemoveCircleCI(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	env.CircleToken = "" // no env var
+
+	// Store a CircleCI token directly in the config file
+	configDir := filepath.Join(env.HomeDir, ".config", "chunk")
+	assert.NilError(t, os.MkdirAll(configDir, 0o700))
+	assert.NilError(t, os.WriteFile(
+		filepath.Join(configDir, "config.json"),
+		[]byte(`{"circleCIToken":"circle-tok-1234"}`),
+		0o600,
+	))
+
+	result := binary.RunCLI(t, []string{"auth", "remove", "circleci"}, env, env.HomeDir)
+
+	// Without a TTY, confirm prompt cancels
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t,
+		strings.Contains(combined, "remove") || strings.Contains(combined, "Cancelled"),
+		"expected removal prompt or cancellation, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, env.HomeDir), "expected config path in output, got: %s", combined)
+}
+
+// --- auth set ---
+
+// auth set without TTY exits cleanly (defaults to circleci)
+func TestAuthSetNoTTYExitsCleanly(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.AnthropicKey = ""
 
-	result := binary.RunCLI(t, []string{"auth", "login"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"auth", "set"}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "CircleCI Token Setup"),
+		"expected CircleCI setup header, got: %s", combined)
+}
+
+// auth set anthropic without TTY exits cleanly
+func TestAuthSetAnthropicNoTTYExitsCleanly(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{"auth", "set", "anthropic"}, env, env.HomeDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 	combined := result.Stdout + result.Stderr
 	assert.Assert(t, strings.Contains(combined, "API Key Setup"),
-		"expected login header, got: %s", combined)
+		"expected Anthropic login header, got: %s", combined)
+}
+
+// auth set circleci without TTY exits cleanly
+func TestAuthSetCircleCI(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	env.CircleToken = ""
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{"auth", "set", "circleci"}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "CircleCI Token Setup"),
+		"expected CircleCI setup header, got: %s", combined)
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -97,7 +97,7 @@ chunk
 - `build-prompt --since` defaults to 3 months before the current date.
 - `task run` defaults to pipeline-as-tool mode; use `--no-pipeline-as-tool`
   to disable.
-- `config set` accepts `model`, `apiKey`, and `circleCIToken` as keys.
+- `config set` accepts only `model` and `apiKey` as keys.
 - `chunk init` uses Claude to auto-detect the test command for the project.
 - `validate --check`, `--no-check`, `--task`, and `--sync` flags activate hook
   mode for IDE lifecycle integration. See **[docs/HOOKS.md](HOOKS.md)**.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -7,8 +7,9 @@ Complete command reference for the `chunk` CLI.
 ```
 chunk
 ├── auth
-│   ├── status                      # Check authentication status
-│   └── logout                      # Clear stored API key
+│   ├── set [provider]              # Store credential (default: circleci)
+│   ├── status                      # Check authentication status (CircleCI, Anthropic, GitHub)
+│   └── remove <provider>           # Remove stored credential (circleci | anthropic)
 │
 ├── build-prompt                    # Mine PR comments → analyze → generate prompt
 │   --org <org>                     # GitHub org (auto-detected from git remote)
@@ -96,7 +97,7 @@ chunk
 - `build-prompt --since` defaults to 3 months before the current date.
 - `task run` defaults to pipeline-as-tool mode; use `--no-pipeline-as-tool`
   to disable.
-- `config set` accepts only `model` and `apiKey` as keys.
+- `config set` accepts `model`, `apiKey`, and `circleCIToken` as keys.
 - `chunk init` uses Claude to auto-detect the test command for the project.
 - `validate --check`, `--no-check`, `--task`, and `--sync` flags activate hook
   mode for IDE lifecycle integration. See **[docs/HOOKS.md](HOOKS.md)**.

--- a/internal/circleci/circleci_test.go
+++ b/internal/circleci/circleci_test.go
@@ -73,6 +73,34 @@ func TestNewClient(t *testing.T) {
 	})
 }
 
+func TestNewClientWithToken(t *testing.T) {
+	t.Run("creates client with provided token", func(t *testing.T) {
+		c, err := NewClientWithToken("explicit-token", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c == nil {
+			t.Fatal("expected non-nil client")
+		}
+	})
+
+	t.Run("uses provided base URL", func(t *testing.T) {
+		fake := fakes.NewFakeCircleCI()
+		srv := httptest.NewServer(fake)
+		defer srv.Close()
+
+		c, err := NewClientWithToken("test-token", srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		ctx := context.Background()
+		if err := c.GetCurrentUser(ctx); err != nil {
+			t.Fatalf("GetCurrentUser failed: %v", err)
+		}
+	})
+}
+
 func TestListSandboxes(t *testing.T) {
 	fake := fakes.NewFakeCircleCI()
 	fake.Sandboxes = []fakes.Sandbox{

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -19,10 +19,14 @@ func NewClient() (*Client, error) {
 		token = os.Getenv("CIRCLECI_TOKEN")
 	}
 	if token == "" {
-		return nil, fmt.Errorf("CIRCLE_TOKEN or CIRCLECI_TOKEN environment variable is required")
+		return nil, fmt.Errorf("circleci token not found: set CIRCLE_TOKEN or run 'chunk auth set'")
 	}
+	return NewClientWithToken(token, os.Getenv("CIRCLECI_BASE_URL"))
+}
 
-	baseURL := os.Getenv("CIRCLECI_BASE_URL")
+// NewClientWithToken creates a Client using the provided token and base URL.
+// If baseURL is empty it defaults to "https://circleci.com".
+func NewClientWithToken(token, baseURL string) (*Client, error) {
 	if baseURL == "" {
 		baseURL = "https://circleci.com"
 	}
@@ -34,6 +38,12 @@ func NewClient() (*Client, error) {
 	})
 
 	return &Client{cl: cl}, nil
+}
+
+// GetCurrentUser calls GET /api/v2/me to validate the token.
+func (c *Client) GetCurrentUser(ctx context.Context) error {
+	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v2/me"))
+	return err
 }
 
 func (c *Client) ListSandboxes(ctx context.Context, orgID string) ([]Sandbox, error) {

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
@@ -18,15 +20,120 @@ import (
 
 const apiKeySourceEnvVar = "Environment variable"
 
+// ErrSilent is returned when a command has already reported its error to the user
+// and wants to exit non-zero without printing anything further.
+var ErrSilent = errors.New("silent")
+
 func newAuthCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "Manage authentication",
 	}
+	cmd.AddCommand(newAuthSetCmd())
 	cmd.AddCommand(newAuthLoginCmd())
 	cmd.AddCommand(newAuthStatusCmd())
 	cmd.AddCommand(newAuthLogoutCmd())
 	return cmd
+}
+
+func newAuthSetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:       "set <provider>",
+		Short:     "Store credentials for a provider",
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: []string{"circleci"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := args[0]
+			io := iostream.FromCmd(cmd)
+			switch provider {
+			case "circleci":
+				return authSetCircleCI(cmd.Context(), io)
+			default:
+				return fmt.Errorf("unknown provider %q: valid providers are circleci", provider)
+			}
+		},
+	}
+}
+
+func authSetCircleCI(ctx context.Context, io iostream.Streams) error {
+	io.Println("")
+	io.Println(ui.Bold("Chunk CLI - CircleCI Token Setup"))
+	io.Println("")
+	io.Println("Create a CircleCI token at https://app.circleci.com/settings/user/tokens")
+	io.Println("")
+
+	if os.Getenv("CIRCLE_TOKEN") != "" || os.Getenv("CIRCLECI_TOKEN") != "" {
+		io.Println(ui.Warning("A CircleCI token is set in environment variables (CIRCLE_TOKEN/CIRCLECI_TOKEN)."))
+		io.Println(ui.Dim("Environment variables take precedence over stored config."))
+		io.Println("")
+	}
+
+	cfg, _ := config.Load()
+	if cfg.CircleCIToken != "" {
+		io.Printf("A CircleCI token is already stored in config.\n")
+		replace, err := tui.Confirm("Do you want to replace it?", false)
+		if err != nil {
+			io.Println("Cancelled.")
+			return nil
+		}
+		if !replace {
+			io.Println("Keeping existing token.")
+			return nil
+		}
+	}
+
+	token, err := tui.PromptHidden("CircleCI Token")
+	if err != nil {
+		return nil
+	}
+
+	token = strings.TrimSpace(token)
+	if token == "" {
+		io.ErrPrintln(ui.FormatError("Token cannot be empty.", "", "Create a token at https://app.circleci.com/settings/user/tokens"))
+		return ErrSilent
+	}
+
+	if err := saveCircleCIToken(ctx, token, io); err != nil {
+		return ErrSilent
+	}
+	return nil
+}
+
+// saveCircleCIToken validates and saves a CircleCI token to user config.
+func saveCircleCIToken(ctx context.Context, token string, streams iostream.Streams) error {
+	streams.ErrPrintln(ui.Dim("Validating CircleCI token..."))
+	if err := validateCircleCIToken(ctx, token); err != nil {
+		streams.ErrPrintln(ui.FormatError("CircleCI token validation failed.", "", "Check that your token is correct."))
+		return fmt.Errorf("validate token: %w", err)
+	}
+
+	cfg, _ := config.Load()
+	cfg.CircleCIToken = token
+	if err := config.Save(cfg); err != nil {
+		streams.ErrPrintln(ui.FormatError("Failed to save CircleCI token.", "", "Check that your config file is writable."))
+		return fmt.Errorf("save token: %w", err)
+	}
+
+	cfgPath, err := config.Path()
+	if err != nil {
+		return err
+	}
+	streams.ErrPrintf("\n%s\n", ui.Success(fmt.Sprintf("CircleCI token validated and saved to %s", cfgPath)))
+	return nil
+}
+
+func validateCircleCIToken(ctx context.Context, token string) error {
+	cl, err := circleci.NewClientWithToken(token, os.Getenv("CIRCLECI_BASE_URL"))
+	if err != nil {
+		return err
+	}
+	if err := cl.GetCurrentUser(ctx); err != nil {
+		if httpcl.HasStatusCode(err, http.StatusTooManyRequests) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func newAuthLoginCmd() *cobra.Command {

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -18,7 +18,11 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
 
-const apiKeySourceEnvVar = "Environment variable"
+const (
+	apiKeySourceEnvVar = "Environment variable"
+	providerCircleCI   = "circleci"
+	providerAnthropic  = "anthropic"
+)
 
 // ErrSilent is returned when a command has already reported its error to the user
 // and wants to exit non-zero without printing anything further.
@@ -30,26 +34,30 @@ func newAuthCmd() *cobra.Command {
 		Short: "Manage authentication",
 	}
 	cmd.AddCommand(newAuthSetCmd())
-	cmd.AddCommand(newAuthLoginCmd())
 	cmd.AddCommand(newAuthStatusCmd())
-	cmd.AddCommand(newAuthLogoutCmd())
+	cmd.AddCommand(newAuthRemoveCmd())
 	return cmd
 }
 
 func newAuthSetCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:       "set <provider>",
-		Short:     "Store credentials for a provider",
-		Args:      cobra.ExactArgs(1),
-		ValidArgs: []string{"circleci"},
+		Use:       "set [provider]",
+		Short:     "Store credentials (default: circleci)",
+		Args:      cobra.MaximumNArgs(1),
+		ValidArgs: []string{"circleci", "anthropic"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			provider := args[0]
+			provider := providerCircleCI
+			if len(args) > 0 {
+				provider = args[0]
+			}
 			io := iostream.FromCmd(cmd)
 			switch provider {
-			case "circleci":
+			case providerCircleCI:
 				return authSetCircleCI(cmd.Context(), io)
+			case providerAnthropic:
+				return authSetAnthropic(cmd.Context(), io)
 			default:
-				return fmt.Errorf("unknown provider %q: valid providers are circleci", provider)
+				return fmt.Errorf("unknown provider %q: valid providers are circleci, anthropic", provider)
 			}
 		},
 	}
@@ -99,7 +107,66 @@ func authSetCircleCI(ctx context.Context, io iostream.Streams) error {
 	return nil
 }
 
+func authSetAnthropic(ctx context.Context, io iostream.Streams) error {
+	io.Println("")
+	io.Println(ui.Bold("Chunk CLI - Anthropic API Key Setup"))
+	io.Println("")
+	io.Println("Enter your Anthropic API key (starts with sk-ant-).")
+	io.Println(ui.Dim("The key will be stored securely and never displayed."))
+	io.Println("")
+
+	rc := config.Resolve("", "")
+	if rc.APIKey != "" {
+		io.Printf("An API key is already configured (source: %s)\n", sourceLabel(rc.APIKeySource))
+		replace, err := tui.Confirm("Do you want to replace it?", false)
+		if err != nil {
+			return nil
+		}
+		if !replace {
+			io.Println("Keeping existing API key.")
+			return nil
+		}
+	}
+
+	key, err := tui.PromptHidden("API Key")
+	if err != nil {
+		return nil
+	}
+
+	key = strings.TrimSpace(key)
+	if key == "" {
+		io.ErrPrintln(ui.FormatError("API key cannot be empty.", "", "Get an API key from https://console.anthropic.com/"))
+		return ErrSilent
+	}
+
+	if !strings.HasPrefix(key, "sk-ant-") {
+		io.ErrPrintln(ui.FormatError("Invalid API key format.", "Keys should start with \"sk-ant-\".", "Get a valid API key from https://console.anthropic.com/"))
+		return ErrSilent
+	}
+
+	io.ErrPrintln(ui.Dim("Validating API key..."))
+	if err := validateAPIKey(ctx, key); err != nil {
+		io.ErrPrintln(ui.FormatError("API key validation failed.", "", "Check that your key is correct and has not been revoked."))
+		return ErrSilent
+	}
+
+	cfg, _ := config.Load()
+	cfg.APIKey = key
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("save API key: %w", err)
+	}
+
+	cfgPath, err := config.Path()
+	if err != nil {
+		return err
+	}
+	io.Printf("\n%s\n", ui.Success(fmt.Sprintf("API key validated and saved to %s", cfgPath)))
+	io.Println(ui.Dim("You can now run code reviews with: chunk build-prompt"))
+	return nil
+}
+
 // saveCircleCIToken validates and saves a CircleCI token to user config.
+// It prints status messages to streams and returns an error if anything fails.
 func saveCircleCIToken(ctx context.Context, token string, streams iostream.Streams) error {
 	streams.ErrPrintln(ui.Dim("Validating CircleCI token..."))
 	if err := validateCircleCIToken(ctx, token); err != nil {
@@ -136,72 +203,190 @@ func validateCircleCIToken(ctx context.Context, token string) error {
 	return nil
 }
 
-func newAuthLoginCmd() *cobra.Command {
+func newAuthStatusCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "login",
-		Short: "Store API key for authentication",
+		Use:   "status",
+		Short: "Check authentication status",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 
 			io.Println("")
-			io.Println(ui.Bold("Chunk CLI - API Key Setup"))
-			io.Println("")
-			io.Println("Enter your Anthropic API key (starts with sk-ant-).")
-			io.Println(ui.Dim("The key will be stored securely and never displayed."))
+			io.Println(ui.Bold("Chunk CLI - Authentication Status"))
 			io.Println("")
 
-			// Check for existing key
 			rc := config.Resolve("", "")
-			if rc.APIKey != "" {
-				io.Printf("An API key is already configured (source: %s)\n",
-					sourceLabel(rc.APIKeySource))
-				replace, err := tui.Confirm("Do you want to replace it?", false)
-				if err != nil {
-					return nil
+
+			hasFailure := false
+
+			// CircleCI section
+			io.Println(ui.Bold("CircleCI"))
+			if rc.CircleCIToken == "" {
+				io.Println("  Not set")
+			} else {
+				io.Printf("  Source: %s\n", rc.CircleCITokenSource)
+				io.Printf("  Token:  %s\n", config.MaskAPIKey(rc.CircleCIToken))
+				io.ErrPrintln(ui.Dim("Validating CircleCI token..."))
+				if err := validateCircleCIToken(cmd.Context(), rc.CircleCIToken); err != nil {
+					io.ErrPrintln(ui.FormatError(
+						"CircleCI token validation failed.",
+						"",
+						"Run `chunk auth set circleci` to set a new token.",
+					))
+					hasFailure = true
+				} else {
+					io.Println(ui.Success("Valid"))
 				}
-				if !replace {
-					io.Println("Keeping existing API key.")
-					return nil
+			}
+			io.Println("")
+
+			// Anthropic section
+			io.Println(ui.Bold("Anthropic"))
+			if rc.APIKey == "" {
+				io.Println("  Not set")
+			} else {
+				io.Printf("  Source: %s\n", sourceLabel(rc.APIKeySource))
+				io.Printf("  Key:    %s\n", config.MaskAPIKey(rc.APIKey))
+				io.ErrPrintln(ui.Dim("Validating API key..."))
+				if err := validateAPIKey(cmd.Context(), rc.APIKey); err != nil {
+					io.ErrPrintln(ui.FormatError(
+						"API key validation failed.",
+						"The API key could not be validated with the Anthropic API.",
+						"Run `chunk auth set anthropic` to set a new key.",
+					))
+					hasFailure = true
+				} else {
+					io.Println(ui.Success("Valid"))
 				}
 			}
+			io.Println("")
 
-			key, err := tui.PromptHidden("API Key")
-			if err != nil {
-				return nil
+			// GitHub section
+			io.Println(ui.Bold("GitHub"))
+			if os.Getenv("GITHUB_TOKEN") != "" {
+				io.Println("  Set (via GITHUB_TOKEN)")
+			} else {
+				io.Println("  Not set")
 			}
+			io.Println("")
 
-			key = strings.TrimSpace(key)
-			if key == "" {
-				io.ErrPrintln(ui.FormatError("API key cannot be empty.", "", "Get an API key from https://console.anthropic.com/"))
-				os.Exit(2)
+			if hasFailure {
+				return ErrSilent
 			}
-
-			if !strings.HasPrefix(key, "sk-ant-") {
-				io.ErrPrintln(ui.FormatError("Invalid API key format.", "Keys should start with \"sk-ant-\".", "Get a valid API key from https://console.anthropic.com/"))
-				os.Exit(2)
-			}
-
-			io.ErrPrintln(ui.Dim("Validating API key..."))
-			if err := validateAPIKey(cmd.Context(), key); err != nil {
-				io.ErrPrintln(ui.FormatError("API key validation failed.", "", "Check that your key is correct and has not been revoked."))
-				os.Exit(2)
-			}
-
-			cfg, _ := config.Load()
-			cfg.APIKey = key
-			if err := config.Save(cfg); err != nil {
-				return fmt.Errorf("save API key: %w", err)
-			}
-
-			cfgPath, err := config.Path()
-			if err != nil {
-				return err
-			}
-			io.Printf("\n%s\n", ui.Success(fmt.Sprintf("API key validated and saved to %s", cfgPath)))
-			io.Println(ui.Dim("You can now run code reviews with: chunk build-prompt"))
 			return nil
 		},
 	}
+}
+
+func newAuthRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:       "remove <provider>",
+		Short:     "Remove stored credentials",
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: []string{"circleci", "anthropic"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := args[0]
+			io := iostream.FromCmd(cmd)
+			switch provider {
+			case providerCircleCI:
+				return authRemoveCircleCI(io)
+			case providerAnthropic:
+				return authRemoveAnthropic(io)
+			default:
+				return fmt.Errorf("unknown provider %q: valid providers are circleci, anthropic", provider)
+			}
+		},
+	}
+}
+
+func authRemoveCircleCI(io iostream.Streams) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	if cfg.CircleCIToken == "" {
+		io.Println(ui.Warning("No CircleCI token stored in config file."))
+		if os.Getenv("CIRCLE_TOKEN") != "" || os.Getenv("CIRCLECI_TOKEN") != "" {
+			io.Println("Note: A CircleCI token is set in environment variables.")
+			io.Println("To remove it, unset the environment variable.")
+			io.Println("")
+		}
+		return nil
+	}
+
+	io.Println("")
+	cfgPath, err := config.Path()
+	if err != nil {
+		return err
+	}
+	io.Printf("This will remove your stored CircleCI token from %s\n", cfgPath)
+	confirmed, err := tui.Confirm("Are you sure?", false)
+	if err != nil || !confirmed {
+		io.Println("")
+		io.Println("Cancelled.")
+		io.Println("")
+		return nil
+	}
+
+	if err := config.ClearCircleCIToken(); err != nil {
+		hint := "Check file permissions on the chunk config file"
+		if errPath, pathErr := config.Path(); pathErr == nil {
+			hint = fmt.Sprintf("Check file permissions on %s", errPath)
+		}
+		io.ErrPrintln(ui.FormatError("Failed to remove CircleCI token.", "An error occurred while trying to remove the token from the config file.", hint))
+		return ErrSilent
+	}
+
+	io.Println(ui.Success("CircleCI token removed successfully."))
+	if os.Getenv("CIRCLE_TOKEN") != "" || os.Getenv("CIRCLECI_TOKEN") != "" {
+		io.Println(ui.Warning("Note: CIRCLE_TOKEN/CIRCLECI_TOKEN is still set in your environment variables."))
+	}
+	return nil
+}
+
+func authRemoveAnthropic(io iostream.Streams) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	if cfg.APIKey == "" {
+		io.Println(ui.Warning("No API key stored in config file."))
+		if os.Getenv("ANTHROPIC_API_KEY") != "" {
+			io.Println("Note: ANTHROPIC_API_KEY is set in your environment variables.")
+			io.Println("To remove it, unset the environment variable.")
+			io.Println("")
+		}
+		return nil
+	}
+
+	io.Println("")
+	cfgPath, err := config.Path()
+	if err != nil {
+		return err
+	}
+	io.Printf("This will remove your stored API key from %s\n", cfgPath)
+	confirmed, err := tui.Confirm("Are you sure?", false)
+	if err != nil || !confirmed {
+		io.Println("")
+		io.Println("Cancelled.")
+		io.Println("")
+		return nil
+	}
+
+	if err := config.ClearAPIKey(); err != nil {
+		hint := "Check file permissions on the chunk config file"
+		if errPath, pathErr := config.Path(); pathErr == nil {
+			hint = fmt.Sprintf("Check file permissions on %s", errPath)
+		}
+		io.ErrPrintln(ui.FormatError(
+			"Failed to remove API key.",
+			"An error occurred while trying to remove the API key from the config file.",
+			hint,
+		))
+		return ErrSilent
+	}
+
+	io.Println(ui.Success("API key removed successfully."))
+	return nil
 }
 
 func validateAPIKey(ctx context.Context, apiKey string) error {
@@ -233,7 +418,6 @@ func validateAPIKey(ctx context.Context, apiKey string) error {
 		httpcl.Header("anthropic-version", "2023-06-01"),
 	))
 	if err != nil {
-		// Rate limit means the key is valid
 		if httpcl.HasStatusCode(err, http.StatusTooManyRequests) {
 			return nil
 		}
@@ -242,125 +426,9 @@ func validateAPIKey(ctx context.Context, apiKey string) error {
 	return nil
 }
 
-func newAuthStatusCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "status",
-		Short: "Check authentication status",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			io := iostream.FromCmd(cmd)
-
-			io.Println("")
-			io.Println(ui.Bold("Chunk CLI - Authentication Status"))
-			io.Println("")
-
-			rc := config.Resolve("", "")
-
-			if rc.APIKey == "" {
-				io.Println(ui.Warning("Not authenticated"))
-				io.Println(ui.Dim("No API key found in config file or environment."))
-				io.Println("")
-				io.Println("To authenticate, run: chunk auth login")
-				io.Println("Or set the ANTHROPIC_API_KEY environment variable.")
-				io.Println("")
-				return nil
-			}
-
-			w := 15 // align to "API key source:"
-			switch rc.APIKeySource {
-			case "Config file (user config)":
-				cfgPath, err := config.Path()
-				if err != nil {
-					return err
-				}
-				io.Printf("%s Config file (%s)\n", ui.Label("API key source:", w), cfgPath)
-			case apiKeySourceEnvVar:
-				io.Printf("%s Environment variable (ANTHROPIC_API_KEY)\n", ui.Label("API key source:", w))
-			default:
-				io.Printf("%s %s\n", ui.Label("API key source:", w), rc.APIKeySource)
-			}
-			io.Printf("%s %s\n", ui.Label("API key:", w), config.MaskAPIKey(rc.APIKey))
-
-			io.ErrPrintln(ui.Yellow("Validating API key..."))
-
-			if err := validateAPIKey(cmd.Context(), rc.APIKey); err != nil {
-				io.ErrPrintln("")
-				io.ErrPrintln(ui.FormatError(
-					"API key validation failed.",
-					"The API key could not be validated with the Anthropic API.",
-					"Run `chunk auth login` to set a new key.",
-				))
-				os.Exit(1)
-			}
-
-			io.Println("")
-			io.Println(ui.Success("API key is valid"))
-			return nil
-		},
-	}
-}
-
-func newAuthLogoutCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "logout",
-		Short: "Remove stored credentials",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			io := iostream.FromCmd(cmd)
-			cfg, err := config.Load()
-			if err != nil {
-				return err
-			}
-			if cfg.APIKey == "" {
-				io.Println(ui.Warning("No API key stored in config file."))
-				if os.Getenv("ANTHROPIC_API_KEY") != "" {
-					io.Println("Note: ANTHROPIC_API_KEY is set in your environment variables.")
-					io.Println("To remove it, unset the environment variable.")
-					io.Println("")
-				}
-				return nil
-			}
-
-			io.Println("")
-			cfgPath, err := config.Path()
-			if err != nil {
-				return err
-			}
-			io.Printf("This will remove your stored API key from %s\n", cfgPath)
-			confirmed, err := tui.Confirm("Are you sure you want to logout?", false)
-			if err != nil {
-				io.Println("")
-				io.Println("Logout cancelled.")
-				io.Println("")
-				return nil
-			}
-			if !confirmed {
-				io.Println("")
-				io.Println("Logout cancelled.")
-				io.Println("")
-				return nil
-			}
-
-			if err := config.ClearAPIKey(); err != nil {
-				hint := "Check file permissions on the chunk config file"
-				if errPath, pathErr := config.Path(); pathErr == nil {
-					hint = fmt.Sprintf("Check file permissions on %s", errPath)
-				}
-				io.ErrPrintln(ui.FormatError(
-					"Failed to remove API key.",
-					"An error occurred while trying to remove the API key from the config file.",
-					hint,
-				))
-				os.Exit(2)
-			}
-
-			io.Println(ui.Success("API key removed successfully."))
-			return nil
-		},
-	}
-}
-
 func sourceLabel(source string) string {
 	switch source {
-	case "Config file (user config)":
+	case config.SourceConfigFile:
 		return "Config file"
 	case apiKeySourceEnvVar:
 		return apiKeySourceEnvVar

--- a/internal/cmd/circleci_client.go
+++ b/internal/cmd/circleci_client.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+)
+
+// newCircleCIClient resolves a CircleCI token (env vars then config file) and
+// returns a ready-to-use client. Token resolution and base URL reading belong
+// in the cmd layer, not in the circleci leaf package.
+func newCircleCIClient() (*circleci.Client, error) {
+	token := os.Getenv("CIRCLE_TOKEN")
+	if token == "" {
+		token = os.Getenv("CIRCLECI_TOKEN")
+	}
+	if token == "" {
+		cfg, _ := config.Load()
+		token = cfg.CircleCIToken
+	}
+	if token == "" {
+		return nil, fmt.Errorf("circleci token not found: set CIRCLE_TOKEN or run 'chunk auth set'")
+	}
+	return circleci.NewClientWithToken(token, os.Getenv("CIRCLECI_BASE_URL"))
+}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -47,6 +47,7 @@ func newConfigSetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "set <key> <value>",
 		Short: "Set a config value",
+		Long:  "Set a config value (model, apiKey). Use 'chunk auth set' to store credentials with validation.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -3,15 +3,16 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/anthropic"
-	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
@@ -23,7 +24,7 @@ import (
 // pickCircleCIOrg prompts the user to select a CircleCI organization.
 // Returns the selected org ID and name, or empty strings if selection is skipped.
 func pickCircleCIOrg(ctx context.Context, streams iostream.Streams) (orgID, orgName string) {
-	client, err := circleci.NewClient()
+	client, err := newCircleCIClient()
 	if err != nil {
 		streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Skipping CircleCI setup: %v", err)))
 		return "", ""
@@ -205,8 +206,27 @@ commands, and generates hook config files.`,
 				streams.ErrPrintf("Detected repository: %s\n", ui.Bold(fmt.Sprintf("%s/%s", org, repo)))
 			}
 
-			// Step 2: CircleCI org picker
+			// Step 2: CircleCI token prompt + org picker
 			if !skipCircleCI {
+				rc := config.Resolve("", "")
+				if rc.CircleCIToken == "" {
+					streams.ErrPrintln("A CircleCI token is needed for task runs and sandboxes.")
+					streams.ErrPrintln(ui.Dim("Create one at https://app.circleci.com/settings/user/tokens"))
+					token, err := tui.PromptHidden("CircleCI Token (press Enter to skip)")
+					if errors.Is(err, tui.ErrNoTTY) {
+						streams.ErrPrintf("%s\n", ui.Warning("No CircleCI token configured. Set CIRCLE_TOKEN or run 'chunk auth set'."))
+					} else if err == nil {
+						token = strings.TrimSpace(token)
+						if token != "" {
+							if saveErr := saveCircleCIToken(ctx, token, streams); saveErr != nil {
+								streams.ErrPrintf("%s\n", ui.Warning("Skipping CircleCI setup due to token error."))
+							}
+						} else {
+							streams.ErrPrintln(ui.Dim("Skipping CircleCI token setup."))
+						}
+					}
+				}
+
 				if orgID, orgName := pickCircleCIOrg(ctx, streams); orgID != "" {
 					cfg.CircleCI = &config.CircleCIConfig{OrgID: orgID}
 					streams.ErrPrintf("Selected organization: %s\n", ui.Bold(orgName))

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -21,7 +21,7 @@ func NewRootCmd(version string) *cobra.Command {
 	rootCmd.SetHelpTemplate(rootCmd.HelpTemplate() + `
 Getting started:
   chunk init                    Initialize project configuration
-  chunk auth login              Save your Anthropic API key
+  chunk auth set                Store credentials (CircleCI token, Anthropic API key)
   chunk build-prompt            Generate a review prompt from GitHub PR comments
   chunk task config             Set up CircleCI task configuration
   chunk task run --definition <name> --prompt "<task>"

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/chunk-cli/envbuilder"
-	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/sandbox"
@@ -86,7 +85,7 @@ func newSandboxListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}
@@ -131,7 +130,7 @@ environment variable (e.g. CHUNK_SANDBOX_PROVIDER=unikraft).`,
 			if err != nil {
 				return err
 			}
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}
@@ -174,7 +173,7 @@ func newSandboxExecCmd() *cobra.Command {
 			if err := resolveSandboxID(&sandboxID); err != nil {
 				return err
 			}
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}
@@ -215,7 +214,7 @@ func newSandboxAddSSHKeyCmd() *cobra.Command {
 			if err := resolveSandboxID(&sandboxID); err != nil {
 				return err
 			}
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}
@@ -248,7 +247,7 @@ func newSandboxSSHCmd() *cobra.Command {
 				return err
 			}
 			authSock := os.Getenv("SSH_AUTH_SOCK")
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}
@@ -305,7 +304,7 @@ func newSandboxSyncCmd() *cobra.Command {
 				return err
 			}
 			authSock := os.Getenv("SSH_AUTH_SOCK")
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/task.go
+++ b/internal/cmd/task.go
@@ -38,7 +38,7 @@ func newTaskRunCmd() *cobra.Command {
 		Use:   "run",
 		Short: "Trigger a task run",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}
@@ -99,7 +99,7 @@ func newTaskConfigCmd() *cobra.Command {
 			io := iostream.FromCmd(cmd)
 			ctx := cmd.Context()
 
-			client, err := circleci.NewClient()
+			client, err := newCircleCIClient()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/sandbox"
@@ -92,7 +91,7 @@ func newValidateCmd() *cobra.Command {
 			}
 
 			if sandboxID != "" {
-				client, err := circleci.NewClient()
+				client, err := newCircleCIClient()
 				if err != nil {
 					return err
 				}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,22 +16,28 @@ const (
 	ValidationModel = "claude-haiku-4-5-20251001"
 	dirPermission   = 0o700
 	filePermission  = 0o600
+
+	// SourceConfigFile is the source label used when a value comes from the user config file.
+	SourceConfigFile = "Config file (user config)"
 )
 
 // UserConfig is the on-disk JSON config.
 type UserConfig struct {
-	APIKey string `json:"apiKey,omitempty"`
-	Model  string `json:"model,omitempty"`
+	APIKey        string `json:"apiKey,omitempty"`
+	CircleCIToken string `json:"circleCIToken,omitempty"`
+	Model         string `json:"model,omitempty"`
 }
 
 // ResolvedConfig holds the final resolved values with their sources.
 type ResolvedConfig struct {
-	APIKey       string
-	APIKeySource string
-	Model        string
-	ModelSource  string
-	AnalyzeModel string
-	PromptModel  string
+	APIKey              string
+	APIKeySource        string
+	CircleCIToken       string
+	CircleCITokenSource string
+	Model               string
+	ModelSource         string
+	AnalyzeModel        string
+	PromptModel         string
 }
 
 // Load reads the config file. Returns empty config if not found.
@@ -84,6 +90,16 @@ func ClearAPIKey() error {
 	return Save(cfg)
 }
 
+// ClearCircleCIToken removes the stored CircleCI token from config.
+func ClearCircleCIToken() error {
+	cfg, err := Load()
+	if err != nil {
+		return err
+	}
+	cfg.CircleCIToken = ""
+	return Save(cfg)
+}
+
 // Resolve computes the final config from flags, env, and file.
 // Priority for API key: flag > env > config file > (none).
 // Priority for model: flag > CODE_REVIEW_CLI_MODEL env > config file > default.
@@ -93,6 +109,19 @@ func Resolve(flagAPIKey, flagModel string) ResolvedConfig {
 	rc := ResolvedConfig{
 		AnalyzeModel: AnalyzeModel,
 		PromptModel:  PromptModel,
+	}
+
+	// CircleCI token resolution: CIRCLE_TOKEN env > CIRCLECI_TOKEN env > config file
+	switch {
+	case os.Getenv("CIRCLE_TOKEN") != "":
+		rc.CircleCIToken = os.Getenv("CIRCLE_TOKEN")
+		rc.CircleCITokenSource = "Environment variable (CIRCLE_TOKEN)"
+	case os.Getenv("CIRCLECI_TOKEN") != "":
+		rc.CircleCIToken = os.Getenv("CIRCLECI_TOKEN")
+		rc.CircleCITokenSource = "Environment variable (CIRCLECI_TOKEN)"
+	case cfg.CircleCIToken != "":
+		rc.CircleCIToken = cfg.CircleCIToken
+		rc.CircleCITokenSource = SourceConfigFile
 	}
 
 	// API key resolution: flag > env > config file
@@ -105,7 +134,7 @@ func Resolve(flagAPIKey, flagModel string) ResolvedConfig {
 		rc.APIKeySource = "Environment variable"
 	case cfg.APIKey != "":
 		rc.APIKey = cfg.APIKey
-		rc.APIKeySource = "Config file (user config)"
+		rc.APIKeySource = SourceConfigFile
 	}
 
 	// Model resolution: flag > env > config file > default
@@ -118,7 +147,7 @@ func Resolve(flagAPIKey, flagModel string) ResolvedConfig {
 		rc.ModelSource = "Environment variable"
 	case cfg.Model != "":
 		rc.Model = cfg.Model
-		rc.ModelSource = "Config file (user config)"
+		rc.ModelSource = SourceConfigFile
 	default:
 		rc.Model = DefaultModel
 		rc.ModelSource = "Default"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -244,7 +244,7 @@ func TestResolve_ModelFromConfig(t *testing.T) {
 
 	rc := Resolve("", "")
 	assert.Equal(t, rc.Model, "config-model")
-	assert.Equal(t, rc.ModelSource, "Config file (user config)")
+	assert.Equal(t, rc.ModelSource, SourceConfigFile)
 }
 
 // --- ValidConfigKeys ---

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -74,6 +74,7 @@ func NewFakeCircleCI() *FakeCircleCI {
 	}
 
 	// Existing endpoints
+	r.GET("/api/v2/me", f.handleGetCurrentUser)
 	r.GET("/api/v2/me/collaborations", f.handleCollaborations)
 	r.GET("/api/v1.1/projects", f.handleProjects)
 
@@ -87,6 +88,13 @@ func NewFakeCircleCI() *FakeCircleCI {
 	r.POST("/api/v2/agents/org/:org_id/project/:project_id/runs", f.handleTriggerRun)
 
 	return f
+}
+
+func (f *FakeCircleCI) handleGetCurrentUser(c *gin.Context) {
+	if !f.requireToken(c) {
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"id": "user-123", "login": "testuser"})
 }
 
 func (f *FakeCircleCI) requireToken(c *gin.Context) bool {

--- a/main.go
+++ b/main.go
@@ -17,14 +17,16 @@ func main() {
 
 	rootCmd := cmd.NewRootCmd(version)
 	if err := rootCmd.Execute(); err != nil {
-		var ue *usererr.Error
-		if errors.As(err, &ue) {
-			fmt.Fprintln(os.Stderr, ue.UserMessage())
-		} else {
-			fmt.Fprintln(os.Stderr, err)
-		}
-		if suggestion := errorSuggestion(err); suggestion != "" {
-			fmt.Fprintln(os.Stderr, suggestion)
+		if !errors.Is(err, cmd.ErrSilent) {
+			var ue *usererr.Error
+			if errors.As(err, &ue) {
+				fmt.Fprintln(os.Stderr, ue.UserMessage())
+			} else {
+				fmt.Fprintln(os.Stderr, err)
+			}
+			if suggestion := errorSuggestion(err); suggestion != "" {
+				fmt.Fprintln(os.Stderr, suggestion)
+			}
 		}
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func errorSuggestion(err error) string {
 	case strings.Contains(lower, "authentication") ||
 		strings.Contains(lower, "invalid api key") ||
 		strings.Contains(lower, "401"):
-		return "Hint: Run `chunk auth login` to set up your API key."
+		return "Hint: Run `chunk auth set` to set up your API key."
 	case strings.Contains(lower, "no such host") ||
 		strings.Contains(lower, "connection refused") ||
 		strings.Contains(lower, "network is unreachable") ||


### PR DESCRIPTION
## Summary

- Adds CircleCI token as a first-class config option alongside existing Anthropic/GitHub credentials
- Redesigns `auth` commands for multi-provider support: `auth set [provider]`, `auth remove <provider>`, multi-section `auth status`
- Introduces `newCircleCIClient()` helper to centralize client construction from config
- Adds `ErrSilent` handling in main for clean exits without error spew

Supersedes #210 and #212 — those PRs were a broken stack with divergent implementations. This PR cherry-picks #212's commits onto current `main`, resolving conflicts with the sandbox tracking and e2b provider changes that landed since.

## Test plan

- [x] `task build` — passes
- [x] `task test` — 755 tests pass
- [x] `task lint` — 0 issues
- [x] `task acceptance-test` — passes (included in test run above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)