### PR TITLE
feat: offer shell completion install during chunk init

### DIFF
--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -95,11 +95,10 @@ func installCompletion(streams iostream.Streams) (err error) {
 	line := completionTag + "\n" + sh.source + "\n"
 
 	// Check if already installed.
-	if data, err := os.ReadFile(sh.rcFile); err == nil {
-		if strings.Contains(string(data), completionTag) {
-			streams.ErrPrintln(ui.Warning("Completion already installed."))
-			return nil
-		}
+	data, readErr := os.ReadFile(sh.rcFile)
+	if readErr == nil && strings.Contains(string(data), completionTag) {
+		streams.ErrPrintln(ui.Warning("Completion already installed."))
+		return nil
 	}
 
 	f, err := os.OpenFile(sh.rcFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -60,44 +60,68 @@ func detectShell(home string) (shellConfig, error) {
 	}
 }
 
+// completionInstalled reports whether the completion tag is already in the
+// user's shell rc file. Returns error if shell is unsupported or HOME unset.
+func completionInstalled() (bool, error) {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return false, fmt.Errorf("HOME not set")
+	}
+
+	sh, err := detectShell(home)
+	if err != nil {
+		return false, err
+	}
+
+	data, err := os.ReadFile(sh.rcFile)
+	if err != nil {
+		return false, nil // rc file doesn't exist — not installed
+	}
+	return strings.Contains(string(data), completionTag), nil
+}
+
+// installCompletion appends the completion source line to the user's shell rc file.
+func installCompletion(streams iostream.Streams) (err error) {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return fmt.Errorf("HOME not set")
+	}
+
+	sh, err := detectShell(home)
+	if err != nil {
+		return err
+	}
+
+	line := completionTag + "\n" + sh.source + "\n"
+
+	// Check if already installed.
+	if data, err := os.ReadFile(sh.rcFile); err == nil {
+		if strings.Contains(string(data), completionTag) {
+			streams.ErrPrintln(ui.Warning("Completion already installed."))
+			return nil
+		}
+	}
+
+	f, err := os.OpenFile(sh.rcFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", sh.rcFile, err)
+	}
+	defer closer.ErrorHandler(f, &err)
+
+	if _, err := f.WriteString("\n" + line); err != nil {
+		return fmt.Errorf("write %s: %w", sh.rcFile, err)
+	}
+
+	streams.ErrPrintln(ui.Success("Completion installed."))
+	return nil
+}
+
 func newCompletionInstallCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "install",
 		Short: "Install shell completion",
-		RunE: func(cmd *cobra.Command, _ []string) (err error) {
-			io := iostream.FromCmd(cmd)
-			home := os.Getenv("HOME")
-			if home == "" {
-				return fmt.Errorf("HOME not set")
-			}
-
-			sh, err := detectShell(home)
-			if err != nil {
-				return err
-			}
-
-			line := completionTag + "\n" + sh.source + "\n"
-
-			// Check if already installed
-			if data, err := os.ReadFile(sh.rcFile); err == nil {
-				if strings.Contains(string(data), completionTag) {
-					io.ErrPrintln(ui.Warning("Completion already installed."))
-					return nil
-				}
-			}
-
-			f, err := os.OpenFile(sh.rcFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-			if err != nil {
-				return fmt.Errorf("open %s: %w", sh.rcFile, err)
-			}
-			defer closer.ErrorHandler(f, &err)
-
-			if _, err := f.WriteString("\n" + line); err != nil {
-				return fmt.Errorf("write %s: %w", sh.rcFile, err)
-			}
-
-			io.ErrPrintln(ui.Success("Completion installed."))
-			return nil
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return installCompletion(iostream.FromCmd(cmd))
 		},
 	}
 }

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -263,7 +263,9 @@ commands, and generates hook config files.`,
 					streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Skipping shell completions: %v", err)))
 				} else if !installed {
 					yes, confirmErr := tui.Confirm("Install shell completions?", true)
-					if confirmErr == nil && yes {
+					if confirmErr != nil {
+						streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not confirm: %v", confirmErr)))
+					} else if yes {
 						if installErr := installCompletion(streams); installErr != nil {
 							streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not install completions: %v", installErr)))
 						}

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -159,7 +159,7 @@ func writeSettingsExample(dir string, data []byte, streams iostream.Streams) err
 }
 
 func newInitCmd() *cobra.Command {
-	var force, skipHooks, skipValidate, skipCircleCI bool
+	var force, skipHooks, skipValidate, skipCircleCI, skipCompletions bool
 	var projectDir string
 
 	cmd := &cobra.Command{
@@ -256,6 +256,21 @@ commands, and generates hook config files.`,
 				}
 			}
 
+			// Step 5: Shell completions
+			if !skipCompletions {
+				installed, err := completionInstalled()
+				if err != nil {
+					streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Skipping shell completions: %v", err)))
+				} else if !installed {
+					yes, confirmErr := tui.Confirm("Install shell completions?", true)
+					if confirmErr == nil && yes {
+						if installErr := installCompletion(streams); installErr != nil {
+							streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not install completions: %v", installErr)))
+						}
+					}
+				}
+			}
+
 			streams.ErrPrintln(ui.Success("Project initialized"))
 			return nil
 		},
@@ -265,6 +280,7 @@ commands, and generates hook config files.`,
 	cmd.Flags().BoolVar(&skipHooks, "skip-hooks", false, "Skip hook file generation")
 	cmd.Flags().BoolVar(&skipValidate, "skip-validate", false, "Skip validate command detection")
 	cmd.Flags().BoolVar(&skipCircleCI, "skip-circleci", false, "Skip CircleCI org picker")
+	cmd.Flags().BoolVar(&skipCompletions, "skip-completions", false, "Skip shell completion installation")
 	cmd.Flags().StringVar(&projectDir, "project-dir", "", "Project directory (defaults to current directory)")
 
 	return cmd

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -236,3 +236,23 @@ func TestInstallCompletionSkipsWhenAlreadyInstalled(t *testing.T) {
 	assert.Equal(t, string(data), existing)
 	assert.Assert(t, bytes.Contains(errOut.Bytes(), []byte("already installed")))
 }
+
+func TestInstallCompletionBashWritesRCFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SHELL", "/bin/bash")
+
+	// Create .bashrc so detectShell prefers it over .bash_profile.
+	rcFile := filepath.Join(home, ".bashrc")
+	assert.NilError(t, os.WriteFile(rcFile, []byte("# existing config\n"), 0o644))
+
+	streams, _, errOut := testStreams()
+	err := installCompletion(streams)
+	assert.NilError(t, err)
+
+	data, err := os.ReadFile(rcFile)
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(string(data), completionTag))
+	assert.Assert(t, strings.Contains(string(data), "source <(chunk completion bash)"))
+	assert.Assert(t, bytes.Contains(errOut.Bytes(), []byte(ui.Success("Completion installed."))))
+}

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -7,12 +7,14 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
 
 func fakeConfirmYes(_ string, _ bool) (bool, error) { return true, nil }
@@ -167,4 +169,70 @@ func TestWriteSettingsAlreadyUpToDate(t *testing.T) {
 	streams2, _, errOut := testStreams()
 	assert.NilError(t, writeSettings(dir, commands, streams2, fakeConfirmYes))
 	assert.Assert(t, bytes.Contains(errOut.Bytes(), []byte("already up to date")))
+}
+
+func setupShellEnv(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SHELL", "/bin/zsh")
+	return home
+}
+
+func TestCompletionInstalledFalseWhenNoRCFile(t *testing.T) {
+	setupShellEnv(t)
+
+	installed, err := completionInstalled()
+	assert.NilError(t, err)
+	assert.Assert(t, !installed)
+}
+
+func TestCompletionInstalledTrueWhenTagPresent(t *testing.T) {
+	home := setupShellEnv(t)
+	rcFile := filepath.Join(home, ".zshrc")
+	assert.NilError(t, os.WriteFile(rcFile, []byte(completionTag+"\nsource <(chunk completion zsh)\n"), 0o644))
+
+	installed, err := completionInstalled()
+	assert.NilError(t, err)
+	assert.Assert(t, installed)
+}
+
+func TestCompletionInstalledUnsupportedShell(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SHELL", "/bin/fish")
+
+	_, err := completionInstalled()
+	assert.Assert(t, err != nil)
+}
+
+func TestInstallCompletionWritesRCFile(t *testing.T) {
+	home := setupShellEnv(t)
+	rcFile := filepath.Join(home, ".zshrc")
+	streams, _, errOut := testStreams()
+
+	err := installCompletion(streams)
+	assert.NilError(t, err)
+
+	data, err := os.ReadFile(rcFile)
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(string(data), completionTag))
+	assert.Assert(t, strings.Contains(string(data), "source <(chunk completion zsh)"))
+	assert.Assert(t, bytes.Contains(errOut.Bytes(), []byte(ui.Success("Completion installed."))))
+}
+
+func TestInstallCompletionSkipsWhenAlreadyInstalled(t *testing.T) {
+	home := setupShellEnv(t)
+	rcFile := filepath.Join(home, ".zshrc")
+	existing := completionTag + "\nsource <(chunk completion zsh)\n"
+	assert.NilError(t, os.WriteFile(rcFile, []byte(existing), 0o644))
+
+	streams, _, errOut := testStreams()
+	err := installCompletion(streams)
+	assert.NilError(t, err)
+
+	// File unchanged.
+	data, err := os.ReadFile(rcFile)
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), existing)
+	assert.Assert(t, bytes.Contains(errOut.Bytes(), []byte("already installed")))
 }


### PR DESCRIPTION
## Summary

- Extracts `completionInstalled()` and `installCompletion()` helpers from the `completion install` command so both `chunk completion install` and `chunk init` can reuse the logic
- Adds Step 5 to `chunk init`: detects shell compatibility, checks if already installed, prompts with `tui.Confirm`, installs on acceptance
- New `--skip-completions` flag for non-interactive / CI use
- Follows the same graceful-failure pattern as other init steps (warn and continue, never fatal)

## Test plan

- [x] `task build` compiles cleanly
- [x] `task test` — new tests in `init_test.go` pass (completionInstalled, installCompletion)
- [x] `task lint` — no issues
- [x] Manual: `chunk init` in a test repo shows completion prompt after settings step
- [x] Manual: `chunk init --skip-completions` skips the prompt
- [x] Manual: `chunk completion install` still works independently