### PR TITLE
fix: disable commit signing in validate test git repos

### DIFF
--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -507,6 +507,7 @@ func initGitRepo(t *testing.T, dir string) {
 		{"git", "init"},
 		{"git", "config", "user.email", "test@test.com"},
 		{"git", "config", "user.name", "Test"},
+		{"git", "config", "commit.gpgsign", "false"},
 	} {
 		cmd := exec.Command(args[0], args[1:]...)
 		cmd.Dir = dir


### PR DESCRIPTION
## Summary

- Adds `commit.gpgsign=false` to the `initGitRepo` test helper in `internal/validate/validate_test.go`
- Fixes 8 test failures when the user has global `commit.gpgsign=true` with SSH signing — `git commit` in temp repos would fail non-interactively due to passphrase prompts

## Test plan

- [ ] `task test` — the 8 previously failing cache tests in `internal/validate` now pass
- [ ] No other tests affected (single line change in test helper)