### PR TITLE
Redesign auth commands for multi-provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Create and work in cloud sandbox environments:
 
 ```bash
 # Authenticate
-chunk auth login
+chunk auth set circleci
 
 # Create a sandbox
 chunk sandbox create --name my-sandbox --image ubuntu:22.04
@@ -98,7 +98,7 @@ chunk sandbox create --name my-sandbox --template-id <template-id>
 ## Commands
 
 ```
-chunk auth login|status|logout       Authentication
+chunk auth set|status|remove         Authentication
 chunk sandbox list|create|exec|ssh   Manage cloud sandbox environments
 chunk sandbox sync|env|build         Sync files, detect env, build images
 chunk sandbox env setup              Create sandbox and run setup steps

--- a/acceptance/auth_test.go
+++ b/acceptance/auth_test.go
@@ -3,15 +3,19 @@ package acceptance
 import (
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/chunk-cli/internal/testing/env"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 )
+
+// --- auth status ---
 
 func TestAuthStatusWithEnvKey(t *testing.T) {
 	anthropic := fakes.NewFakeAnthropic()
@@ -20,6 +24,7 @@ func TestAuthStatusWithEnvKey(t *testing.T) {
 
 	env := testenv.NewTestEnv(t)
 	env.AnthropicURL = srv.URL
+	env.CircleToken = "" // Anthropic-only test
 
 	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
 
@@ -28,22 +33,28 @@ func TestAuthStatusWithEnvKey(t *testing.T) {
 	assert.Assert(t,
 		strings.Contains(combined, "Environment variable") || strings.Contains(combined, "environment variable"),
 		"expected output to mention environment variable, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "API key is valid"),
+	assert.Assert(t, strings.Contains(combined, "Valid"),
 		"expected validation success message, got: %s", combined)
 }
 
 func TestAuthStatusNoKey(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.AnthropicKey = ""
+	env.CircleToken = ""
 
 	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "Not authenticated") || strings.Contains(combined, "not authenticated"),
-		"expected output to indicate no auth, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "chunk auth login"),
-		"expected help text about login command, got: %s", combined)
+	// All three sections are always shown, each reporting "Not set" when unconfigured
+	assert.Assert(t, strings.Contains(combined, "CircleCI"),
+		"expected CircleCI section, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "Anthropic"),
+		"expected Anthropic section, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "GitHub"),
+		"expected GitHub section, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "Not set"),
+		"expected Not set in output, got: %s", combined)
 }
 
 func TestAuthStatusInvalidKey(t *testing.T) {
@@ -58,6 +69,7 @@ func TestAuthStatusInvalidKey(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.AnthropicURL = srv.URL
 	env.AnthropicKey = "sk-ant-invalid-key-0000"
+	env.CircleToken = "" // Anthropic-only test
 
 	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
 
@@ -74,6 +86,7 @@ func TestAuthStatusShowsHeader(t *testing.T) {
 
 	env := testenv.NewTestEnv(t)
 	env.AnthropicURL = srv.URL
+	env.CircleToken = "" // Anthropic-only test
 
 	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
 
@@ -92,10 +105,11 @@ func TestAuthStatusEnvOverridesConfig(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.AnthropicURL = srv.URL
 	env.AnthropicKey = "sk-ant-env-key-EEEE"
+	env.CircleToken = "" // Anthropic-only test
 
 	// Store a different key in config file
-	setResult := binary.RunCLI(t, []string{"config", "set", "apiKey", "sk-ant-config-key-CCCC"}, env, env.HomeDir)
-	assert.Equal(t, setResult.ExitCode, 0, "config set failed\nstdout: %s\nstderr: %s", setResult.Stdout, setResult.Stderr)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(env.HomeDir, ".config"))
+	assert.NilError(t, config.Save(config.UserConfig{AnthropicAPIKey: "sk-ant-config-key-CCCC"}))
 
 	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
@@ -115,8 +129,8 @@ func TestAuthStatusMaskExactlyFourChars(t *testing.T) {
 
 	env := testenv.NewTestEnv(t)
 	env.AnthropicURL = srv.URL
-	// Key where last-4 and chars-5-to-8-from-end are distinct
 	env.AnthropicKey = "sk-ant-AAAA-BBBB-CCCC-DDDD"
+	env.CircleToken = "" // Anthropic-only test
 
 	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
@@ -128,33 +142,6 @@ func TestAuthStatusMaskExactlyFourChars(t *testing.T) {
 		"expected chars 5-8 from end to be masked, got: %s", combined)
 }
 
-func TestAuthLogoutNoStoredKey(t *testing.T) {
-	env := testenv.NewTestEnv(t)
-	env.AnthropicKey = ""
-
-	result := binary.RunCLI(t, []string{"auth", "logout"}, env, env.HomeDir)
-
-	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
-	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "No API key"),
-		"expected output to indicate no stored key, got: %s", combined)
-}
-
-func TestAuthLogoutNoStoredKeyWithEnvVar(t *testing.T) {
-	env := testenv.NewTestEnv(t)
-	env.AnthropicKey = "sk-ant-env-only-key"
-
-	// No config file key, but env var is set
-	result := binary.RunCLI(t, []string{"auth", "logout"}, env, env.HomeDir)
-
-	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
-	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "No API key"),
-		"expected no stored key message, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "ANTHROPIC_API_KEY"),
-		"expected env var note, got: %s", combined)
-}
-
 // auth status reads key from config file when no env var is set
 func TestAuthStatusFromConfigFile(t *testing.T) {
 	anthropic := fakes.NewFakeAnthropic()
@@ -164,10 +151,11 @@ func TestAuthStatusFromConfigFile(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.AnthropicURL = srv.URL
 	env.AnthropicKey = "" // no env var
+	env.CircleToken = ""  // Anthropic-only test
 
 	// Store key in config file
-	setResult := binary.RunCLI(t, []string{"config", "set", "apiKey", "sk-ant-config-only-XYZW"}, env, env.HomeDir)
-	assert.Equal(t, setResult.ExitCode, 0, "config set failed: %s", setResult.Stderr)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(env.HomeDir, ".config"))
+	assert.NilError(t, config.Save(config.UserConfig{AnthropicAPIKey: "sk-ant-config-only-XYZW"}))
 
 	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
 
@@ -175,7 +163,7 @@ func TestAuthStatusFromConfigFile(t *testing.T) {
 	combined := result.Stdout + result.Stderr
 	assert.Assert(t, strings.Contains(combined, "Config file"),
 		"expected config file source, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "API key is valid"),
+	assert.Assert(t, strings.Contains(combined, "Valid"),
 		"expected key valid message, got: %s", combined)
 	// Last 4 chars visible
 	assert.Assert(t, strings.Contains(combined, "XYZW"),
@@ -190,6 +178,7 @@ func TestAuthStatusUsesCountTokensEndpoint(t *testing.T) {
 
 	env := testenv.NewTestEnv(t)
 	env.AnthropicURL = srv.URL
+	env.CircleToken = "" // Anthropic-only test
 
 	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
@@ -204,71 +193,182 @@ func TestAuthStatusUsesCountTokensEndpoint(t *testing.T) {
 	}
 }
 
-// auth logout with a stored config key prompts for confirmation.
-// Without a TTY the confirmation prompt fails and logout is cancelled,
-// but the output shows the config file path, proving the key was detected.
-func TestAuthLogoutWithStoredKey(t *testing.T) {
+// auth status with all three providers configured shows all sections
+func TestAuthStatusAllProviders(t *testing.T) {
+	anthropic := fakes.NewFakeAnthropic()
+	anthropicSrv := httptest.NewServer(anthropic)
+	defer anthropicSrv.Close()
+
+	circleci := fakes.NewFakeCircleCI()
+	circleCISrv := httptest.NewServer(circleci)
+	defer circleCISrv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.AnthropicURL = anthropicSrv.URL
+	env.CircleCIURL = circleCISrv.URL
+
+	result := binary.RunCLI(t, []string{"auth", "status"}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "CircleCI"),
+		"expected CircleCI section, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "Anthropic"),
+		"expected Anthropic section, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "GitHub"),
+		"expected GitHub section, got: %s", combined)
+}
+
+// auth set with an unrecognised provider prints an error and exits non-zero
+func TestAuthSetInvalidProvider(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+
+	result := binary.RunCLI(t, []string{"auth", "set", "invalid-provider"}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for invalid provider")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "unknown provider"),
+		"expected error about unknown provider, got: %s", combined)
+}
+
+// --- auth remove ---
+
+func TestAuthRemoveNoStoredKey(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{"auth", "remove", "anthropic"}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "No API key"),
+		"expected output to indicate no stored key, got: %s", combined)
+}
+
+func TestAuthRemoveNoStoredKeyWithEnvVar(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = "sk-ant-env-only-key"
+
+	// No config file key, but env var is set
+	result := binary.RunCLI(t, []string{"auth", "remove", "anthropic"}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "No API key"),
+		"expected no stored key message, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "ANTHROPIC_API_KEY"),
+		"expected env var note, got: %s", combined)
+}
+
+// auth remove anthropic with a stored config key prompts for confirmation.
+// Without a TTY the confirmation prompt fails and remove is cancelled.
+func TestAuthRemoveWithStoredKey(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.AnthropicKey = "" // no env var
 
 	// Store a key in config
-	setResult := binary.RunCLI(t, []string{"config", "set", "apiKey", "sk-ant-stored-key-1234"}, env, env.HomeDir)
-	assert.Equal(t, setResult.ExitCode, 0, "config set failed: %s", setResult.Stderr)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(env.HomeDir, ".config"))
+	assert.NilError(t, config.Save(config.UserConfig{AnthropicAPIKey: "sk-ant-stored-key-1234"}))
 
-	result := binary.RunCLI(t, []string{"auth", "logout"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"auth", "remove", "anthropic"}, env, env.HomeDir)
 
-	// Without a TTY, confirm prompt returns error and logout is cancelled
+	// Without a TTY, confirm prompt returns error and remove is cancelled
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 	combined := result.Stdout + result.Stderr
 	// The command should detect the stored key and mention the config path
 	assert.Assert(t,
-		strings.Contains(combined, "remove") || strings.Contains(combined, "cancelled"),
+		strings.Contains(combined, "remove") || strings.Contains(combined, "Cancelled"),
 		"expected removal prompt or cancellation, got: %s", combined)
 	assert.Assert(t, strings.Contains(combined, env.HomeDir), "expected config path in output, got: %s", combined)
 
-	// Key should not have been removed — cancelled logout leaves config intact.
+	// Key should not have been removed — cancelled remove leaves config intact.
 	showResult := binary.RunCLI(t, []string{"config", "show"}, env, env.HomeDir)
-	assert.Equal(t, showResult.ExitCode, 0, "config show failed after cancelled logout: %s", showResult.Stderr)
+	assert.Equal(t, showResult.ExitCode, 0, "config show failed after cancelled remove: %s", showResult.Stderr)
 	assert.Assert(t, strings.Contains(showResult.Stdout, "1234"), "expected stored key (masked) in config output, got: %s", showResult.Stdout)
 }
 
-// auth logout with both env var and config key: running logout shows
-// the stored key and (if confirmed) removes config key but env var remains.
-// Without a TTY the confirmation fails, but the output proves both were detected.
-func TestAuthLogoutWithEnvAndConfigKey(t *testing.T) {
+// auth remove with both env var and config key.
+// Without a TTY the confirmation fails, but the output proves the stored key was detected.
+func TestAuthRemoveWithEnvAndConfigKey(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.AnthropicKey = "sk-ant-env-key-EEEE"
 
 	// Store a different key in config
-	setResult := binary.RunCLI(t, []string{"config", "set", "apiKey", "sk-ant-config-key-CCCC"}, env, env.HomeDir)
-	assert.Equal(t, setResult.ExitCode, 0, "config set failed: %s", setResult.Stderr)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(env.HomeDir, ".config"))
+	assert.NilError(t, config.Save(config.UserConfig{AnthropicAPIKey: "sk-ant-config-key-CCCC"}))
 
-	result := binary.RunCLI(t, []string{"auth", "logout"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"auth", "remove", "anthropic"}, env, env.HomeDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 	combined := result.Stdout + result.Stderr
-	// Should detect the stored config key and show removal prompt
 	assert.Assert(t,
-		strings.Contains(combined, "remove") || strings.Contains(combined, "cancelled"),
+		strings.Contains(combined, "remove") || strings.Contains(combined, "Cancelled"),
 		"expected removal prompt or cancellation, got: %s", combined)
 	assert.Assert(t, strings.Contains(combined, env.HomeDir), "expected config path in output, got: %s", combined)
 
-	// Key should not have been removed — cancelled logout leaves config intact.
+	// Key should not have been removed — cancelled remove leaves config intact.
 	showResult := binary.RunCLI(t, []string{"config", "show"}, env, env.HomeDir)
-	assert.Equal(t, showResult.ExitCode, 0, "config show failed after cancelled logout: %s", showResult.Stderr)
+	assert.Equal(t, showResult.ExitCode, 0, "config show failed after cancelled remove: %s", showResult.Stderr)
 	assert.Assert(t, strings.Contains(showResult.Stdout, "EEEE"), "expected env key (masked) in config output, got: %s", showResult.Stdout)
 }
 
-// auth login without TTY: prompts for key but bubbletea fails without terminal,
-// so command exits cleanly without storing anything.
-func TestAuthLoginNoTTYExitsCleanly(t *testing.T) {
+// auth remove requires a provider argument
+func TestAuthRemoveRequiresProvider(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+
+	result := binary.RunCLI(t, []string{"auth", "remove"}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit when provider omitted")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "remove") || strings.Contains(combined, "accepts"),
+		"expected usage error, got: %s", combined)
+}
+
+// auth remove circleci removes a stored CircleCI token (cancelled without TTY)
+func TestAuthRemoveCircleCI(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	env.CircleToken = "" // no env var
+
+	// Store a CircleCI token via the config package instead of raw JSON
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(env.HomeDir, ".config"))
+	assert.NilError(t, config.Save(config.UserConfig{CircleCIToken: "circle-tok-1234"}))
+
+	result := binary.RunCLI(t, []string{"auth", "remove", "circleci"}, env, env.HomeDir)
+
+	// Without a TTY, confirm prompt cancels
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t,
+		strings.Contains(combined, "remove") || strings.Contains(combined, "Cancelled"),
+		"expected removal prompt or cancellation, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, env.HomeDir), "expected config path in output, got: %s", combined)
+}
+
+// --- auth set ---
+
+// auth set anthropic without TTY exits cleanly
+func TestAuthSetAnthropicNoTTYExitsCleanly(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.AnthropicKey = ""
 
-	result := binary.RunCLI(t, []string{"auth", "login"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"auth", "set", "anthropic"}, env, env.HomeDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 	combined := result.Stdout + result.Stderr
 	assert.Assert(t, strings.Contains(combined, "API Key Setup"),
-		"expected login header, got: %s", combined)
+		"expected Anthropic login header, got: %s", combined)
+}
+
+// auth set circleci without TTY exits cleanly
+func TestAuthSetCircleCI(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	env.CircleToken = ""
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{"auth", "set", "circleci"}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "CircleCI Token Setup"),
+		"expected CircleCI setup header, got: %s", combined)
 }

--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -1,7 +1,6 @@
 package acceptance
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +9,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/chunk-cli/internal/testing/env"
 )
@@ -41,7 +41,7 @@ func TestConfigShowDefaults(t *testing.T) {
 		"expected '(Default)' source annotation, got: %s", combined)
 }
 
-// apiKey.slice(-4) not .slice(0,4) — verify last 4 chars shown, not first 4
+// anthropicAPIKey last 4 chars shown, not first 4
 func TestConfigShowMasksLastFourChars(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	// Use a key where the first 4 and last 4 chars are distinct
@@ -65,9 +65,9 @@ func TestConfigShowFromConfigFile(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.AnthropicKey = "" // no env var
 
-	// Store key via config set
-	setResult := binary.RunCLI(t, []string{"config", "set", "apiKey", "sk-ant-stored-key-ZZZZ"}, env, env.HomeDir)
-	assert.Equal(t, setResult.ExitCode, 0, "config set failed\nstdout: %s\nstderr: %s", setResult.Stdout, setResult.Stderr)
+	// Store key directly in config file
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(env.HomeDir, ".config"))
+	assert.NilError(t, config.Save(config.UserConfig{AnthropicAPIKey: "sk-ant-stored-key-ZZZZ"}))
 
 	result := binary.RunCLI(t, []string{"config", "show"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
@@ -98,7 +98,7 @@ func TestConfigSetInvalidKey(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 
 	result := binary.RunCLI(t, []string{"config", "set", "badkey", "somevalue"}, env, env.HomeDir)
-	assert.Equal(t, result.ExitCode, 2, "expected exit code 2 for invalid key\nstdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	assert.Equal(t, result.ExitCode, 1, "expected exit code 1 for invalid key\nstdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 
 	combined := result.Stdout + result.Stderr
 	assert.Assert(t,
@@ -148,13 +148,12 @@ func TestConfigShowModelFromEnvVar(t *testing.T) {
 
 func TestConfigShowAPIKeyEnvPrecedenceOverFile(t *testing.T) {
 	env := testenv.NewTestEnv(t)
-	env.AnthropicKey = "" // clear initially to set via file first
 
-	// Store key via config set
-	setResult := binary.RunCLI(t, []string{"config", "set", "apiKey", "sk-ant-file-key-FILE"}, env, env.HomeDir)
-	assert.Equal(t, setResult.ExitCode, 0, "config set failed")
+	// Store key directly in config file
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(env.HomeDir, ".config"))
+	assert.NilError(t, config.Save(config.UserConfig{AnthropicAPIKey: "sk-ant-file-key-FILE"}))
 
-	// Now set env var — it should win
+	// Set env var — it should win
 	env.AnthropicKey = "sk-ant-env-key-ENVK"
 	result := binary.RunCLI(t, []string{"config", "show"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
@@ -187,24 +186,6 @@ func TestConfigShowModelEnvPrecedenceOverFile(t *testing.T) {
 		"file model should not appear when env var is set, got: %s", combined)
 	assert.Assert(t, strings.Contains(combined, "Environment variable"),
 		"expected env var source, got: %s", combined)
-}
-
-func TestConfigSetAPIKeyStoredInFile(t *testing.T) {
-	env := testenv.NewTestEnv(t)
-
-	result := binary.RunCLI(t, []string{"config", "set", "apiKey", "sk-ant-stored-1234"}, env, env.HomeDir)
-	assert.Equal(t, result.ExitCode, 0, "config set failed")
-
-	// Read the config file directly
-	configFile := filepath.Join(env.HomeDir, ".config", "chunk", "config.json")
-	data, err := os.ReadFile(configFile)
-	assert.NilError(t, err, "config file should exist")
-
-	var cfg map[string]string
-	err = json.Unmarshal(data, &cfg)
-	assert.NilError(t, err, "config should be valid JSON")
-	assert.Equal(t, cfg["apiKey"], "sk-ant-stored-1234",
-		"expected stored apiKey value in config.json")
 }
 
 func TestConfigSetMissingValue(t *testing.T) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,7 @@ chunk-cli/
 └── internal/
     ├── cmd/                   # Cobra command definitions (thin wrappers)
     │   ├── root.go            # Root command, registers all subcommands
-    │   ├── auth.go            # auth status, auth logout
+    │   ├── auth.go            # auth set, auth status, auth remove
     │   ├── buildprompt.go     # build-prompt
     │   ├── completion.go      # completion install/uninstall/zsh
     │   ├── config.go          # config show/set

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -7,8 +7,9 @@ Complete command reference for the `chunk` CLI.
 ```
 chunk
 ├── auth
-│   ├── status                      # Check authentication status
-│   └── logout                      # Clear stored API key
+│   ├── set <provider>               # Store credential (circleci | anthropic)
+│   ├── status                      # Check authentication status (CircleCI, Anthropic, GitHub)
+│   └── remove <provider>           # Remove stored credential (circleci | anthropic)
 │
 ├── build-prompt                    # Mine PR comments → analyze → generate prompt
 │   --org <org>                     # GitHub org (auto-detected from git remote)

--- a/internal/anthropic/client.go
+++ b/internal/anthropic/client.go
@@ -21,8 +21,11 @@ type Client struct {
 // It resolves the API key via config (env > config file) and reads
 // ANTHROPIC_BASE_URL from the environment.
 func New() (*Client, error) {
-	rc := config.Resolve("", "")
-	key := rc.APIKey
+	rc, err := config.Resolve("", "")
+	if err != nil {
+		return nil, fmt.Errorf("resolve config: %w", err)
+	}
+	key := rc.AnthropicAPIKey
 	if key == "" {
 		return nil, fmt.Errorf("ANTHROPIC_API_KEY environment variable or config file is required")
 	}

--- a/internal/circleci/circleci_test.go
+++ b/internal/circleci/circleci_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 )
@@ -21,55 +23,34 @@ func newTestClient(t *testing.T, url string) *Client {
 }
 
 func TestNewClient(t *testing.T) {
-	t.Run("missing token", func(t *testing.T) {
+	t.Run("creates client with token from env", func(t *testing.T) {
+		t.Setenv("CIRCLE_TOKEN", "explicit-token")
+		t.Setenv("CIRCLECI_BASE_URL", "")
+		c, err := NewClient()
+		assert.NilError(t, err)
+		assert.Assert(t, c != nil)
+	})
+
+	t.Run("uses base URL from env", func(t *testing.T) {
+		fake := fakes.NewFakeCircleCI()
+		srv := httptest.NewServer(fake)
+		defer srv.Close()
+
+		t.Setenv("CIRCLE_TOKEN", "test-token")
+		t.Setenv("CIRCLECI_BASE_URL", srv.URL)
+		c, err := NewClient()
+		assert.NilError(t, err)
+
+		ctx := context.Background()
+		assert.NilError(t, c.GetCurrentUser(ctx))
+	})
+
+	t.Run("returns error when no token", func(t *testing.T) {
 		t.Setenv("CIRCLE_TOKEN", "")
 		t.Setenv("CIRCLECI_TOKEN", "")
-
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 		_, err := NewClient()
-		if err == nil {
-			t.Fatal("expected error when no token set")
-		}
-	})
-
-	t.Run("CIRCLE_TOKEN", func(t *testing.T) {
-		t.Setenv("CIRCLE_TOKEN", "tok1")
-		t.Setenv("CIRCLECI_TOKEN", "")
-		t.Setenv("CIRCLECI_BASE_URL", "")
-
-		c, err := NewClient()
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if c == nil {
-			t.Fatal("expected non-nil client")
-		}
-	})
-
-	t.Run("CIRCLECI_TOKEN fallback", func(t *testing.T) {
-		t.Setenv("CIRCLE_TOKEN", "")
-		t.Setenv("CIRCLECI_TOKEN", "tok2")
-		t.Setenv("CIRCLECI_BASE_URL", "")
-
-		c, err := NewClient()
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if c == nil {
-			t.Fatal("expected non-nil client")
-		}
-	})
-
-	t.Run("custom base URL", func(t *testing.T) {
-		t.Setenv("CIRCLE_TOKEN", "tok")
-		t.Setenv("CIRCLECI_BASE_URL", "https://custom.example.com")
-
-		c, err := NewClient()
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if c == nil {
-			t.Fatal("expected non-nil client")
-		}
+		assert.Assert(t, err != nil)
 	})
 }
 

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 )
 
@@ -13,13 +14,15 @@ type Client struct {
 	cl *httpcl.Client
 }
 
+// NewClient resolves a CircleCI token via config (env vars then config file)
+// and returns a ready-to-use client.
 func NewClient() (*Client, error) {
-	token := os.Getenv("CIRCLE_TOKEN")
-	if token == "" {
-		token = os.Getenv("CIRCLECI_TOKEN")
+	rc, err := config.Resolve("", "")
+	if err != nil {
+		return nil, fmt.Errorf("resolve config: %w", err)
 	}
-	if token == "" {
-		return nil, fmt.Errorf("CIRCLE_TOKEN or CIRCLECI_TOKEN environment variable is required")
+	if rc.CircleCIToken == "" {
+		return nil, fmt.Errorf("circleci token not found: set CIRCLE_TOKEN or run 'chunk auth set circleci'")
 	}
 
 	baseURL := os.Getenv("CIRCLECI_BASE_URL")
@@ -29,11 +32,17 @@ func NewClient() (*Client, error) {
 
 	cl := httpcl.New(httpcl.Config{
 		BaseURL:    baseURL,
-		AuthToken:  token,
+		AuthToken:  rc.CircleCIToken,
 		AuthHeader: "Circle-Token",
 	})
 
 	return &Client{cl: cl}, nil
+}
+
+// GetCurrentUser calls GET /api/v2/me to validate the token.
+func (c *Client) GetCurrentUser(ctx context.Context) error {
+	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v2/me"))
+	return err
 }
 
 func (c *Client) ListSandboxes(ctx context.Context, orgID string) ([]Sandbox, error) {

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -16,89 +17,422 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
 
-const apiKeySourceEnvVar = "Environment variable"
+const (
+	providerCircleCI  = "circleci"
+	providerAnthropic = "anthropic"
+)
+
+// ErrSilent is returned when a command has already reported its error to the user
+// and wants to exit non-zero without printing anything further.
+var ErrSilent = errors.New("silent")
 
 func newAuthCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "Manage authentication",
 	}
-	cmd.AddCommand(newAuthLoginCmd())
+	cmd.AddCommand(newAuthSetCmd())
 	cmd.AddCommand(newAuthStatusCmd())
-	cmd.AddCommand(newAuthLogoutCmd())
+	cmd.AddCommand(newAuthRemoveCmd())
 	return cmd
 }
 
-func newAuthLoginCmd() *cobra.Command {
+func newAuthSetCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "login",
-		Short: "Store API key for authentication",
+		Use:       "set <provider>",
+		Short:     "Store credentials for a provider",
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: []string{"circleci", "anthropic"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := args[0]
+			io := iostream.FromCmd(cmd)
+			switch provider {
+			case providerCircleCI:
+				circleCIBaseURL := os.Getenv("CIRCLECI_BASE_URL")
+				circleTokenEnv := os.Getenv("CIRCLE_TOKEN")
+				if circleTokenEnv == "" {
+					circleTokenEnv = os.Getenv("CIRCLECI_TOKEN")
+				}
+				return authSetCircleCI(cmd.Context(), io, circleCIBaseURL, circleTokenEnv)
+			case providerAnthropic:
+				anthropicBaseURL := os.Getenv("ANTHROPIC_BASE_URL")
+				anthropicKeyEnv := os.Getenv("ANTHROPIC_API_KEY")
+				return authSetAnthropic(cmd.Context(), io, anthropicBaseURL, anthropicKeyEnv)
+			default:
+				return fmt.Errorf("unknown provider %q: valid providers are circleci, anthropic", provider)
+			}
+		},
+	}
+}
+
+func authSetCircleCI(ctx context.Context, io iostream.Streams, circleCIBaseURL, circleTokenEnv string) error {
+	io.Println("")
+	io.Println(ui.Bold("Chunk CLI - CircleCI Token Setup"))
+	io.Println("")
+	io.Println("Create a CircleCI token at https://app.circleci.com/settings/user/tokens")
+	io.Println("")
+
+	if circleTokenEnv != "" {
+		io.Println(ui.Warning("A CircleCI token is set in environment variables (CIRCLE_TOKEN/CIRCLECI_TOKEN)."))
+		io.Println(ui.Dim("Environment variables take precedence over stored config."))
+		io.Println("")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", err)))
+		return fmt.Errorf("load config: %w", err)
+	}
+	if cfg.CircleCIToken != "" {
+		io.Printf("A CircleCI token is already stored in config.\n")
+		replace, err := tui.Confirm("Do you want to replace it?", false)
+		if err != nil {
+			io.Println("Cancelled.")
+			return nil
+		}
+		if !replace {
+			io.Println("Keeping existing token.")
+			return nil
+		}
+	}
+
+	token, err := tui.PromptHidden("CircleCI Token")
+	if err != nil {
+		return nil
+	}
+
+	token = strings.TrimSpace(token)
+	if token == "" {
+		io.ErrPrintln(ui.FormatError("Token cannot be empty.", "", "Create a token at https://app.circleci.com/settings/user/tokens"))
+		return ErrSilent
+	}
+
+	if err := saveCircleCIToken(ctx, token, io, circleCIBaseURL); err != nil {
+		return ErrSilent
+	}
+	return nil
+}
+
+func authSetAnthropic(ctx context.Context, io iostream.Streams, anthropicBaseURL, anthropicKeyEnv string) error {
+	io.Println("")
+	io.Println(ui.Bold("Chunk CLI - Anthropic API Key Setup"))
+	io.Println("")
+	io.Println("Enter your Anthropic API key (starts with sk-ant-).")
+	io.Println(ui.Dim("The key will be stored securely and never displayed."))
+	io.Println("")
+	if anthropicKeyEnv != "" {
+		io.Println(ui.Warning("An Anthropic API key is set in environment variables (ANTHROPIC_API_KEY)."))
+		io.Println(ui.Dim("Environment variables take precedence over stored config."))
+		io.Println("")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", err)))
+		return fmt.Errorf("load config: %w", err)
+	}
+	if cfg.AnthropicAPIKey != "" {
+		io.Printf("An Anthropic API key is already stored in config.\n")
+		replace, err := tui.Confirm("Do you want to replace it?", false)
+		if err != nil {
+			return nil
+		}
+		if !replace {
+			io.Println("Keeping existing API key.")
+			return nil
+		}
+	}
+
+	key, err := tui.PromptHidden("API Key")
+	if err != nil {
+		return nil
+	}
+
+	key = strings.TrimSpace(key)
+	if key == "" {
+		io.ErrPrintln(ui.FormatError("API key cannot be empty.", "", "Get an API key from https://console.anthropic.com/"))
+		return ErrSilent
+	}
+
+	if !strings.HasPrefix(key, "sk-ant-") {
+		io.ErrPrintln(ui.FormatError("Invalid API key format.", "Keys should start with \"sk-ant-\".", "Get a valid API key from https://console.anthropic.com/"))
+		return ErrSilent
+	}
+
+	io.ErrPrintln(ui.Dim("Validating API key..."))
+	if err := validateAPIKey(ctx, key, anthropicBaseURL); err != nil {
+		io.ErrPrintln(ui.FormatError("API key validation failed.", "", "Check that your key is correct and has not been revoked."))
+		return ErrSilent
+	}
+
+	cfg, err = config.Load()
+	if err != nil {
+		return fmt.Errorf("load config before save: %w", err)
+	}
+	cfg.AnthropicAPIKey = key
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("save API key: %w", err)
+	}
+
+	cfgPath, err := config.Path()
+	if err != nil {
+		return err
+	}
+	io.Printf("\n%s\n", ui.Success(fmt.Sprintf("API key validated and saved to %s", cfgPath)))
+	io.Println(ui.Dim("You can now run code reviews with: chunk build-prompt"))
+	return nil
+}
+
+// saveCircleCIToken validates and saves a CircleCI token to user config.
+// It prints status messages to streams and returns an error if anything fails.
+func saveCircleCIToken(ctx context.Context, token string, streams iostream.Streams, circleCIBaseURL string) error {
+	streams.ErrPrintln(ui.Dim("Validating CircleCI token..."))
+	if err := validateCircleCIToken(ctx, token, circleCIBaseURL); err != nil {
+		streams.ErrPrintln(ui.FormatError("CircleCI token validation failed.", "", "Check that your token is correct."))
+		return fmt.Errorf("validate token: %w", err)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		streams.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", err)))
+		return fmt.Errorf("load config: %w", err)
+	}
+	cfg.CircleCIToken = token
+	if err := config.Save(cfg); err != nil {
+		streams.ErrPrintln(ui.FormatError("Failed to save CircleCI token.", "", "Check that your config file is writable."))
+		return fmt.Errorf("save token: %w", err)
+	}
+
+	cfgPath, err := config.Path()
+	if err != nil {
+		return err
+	}
+	streams.ErrPrintf("\n%s\n", ui.Success(fmt.Sprintf("CircleCI token validated and saved to %s", cfgPath)))
+	return nil
+}
+
+func validateCircleCIToken(ctx context.Context, token, baseURL string) error {
+	if baseURL == "" {
+		baseURL = "https://circleci.com"
+	}
+
+	cl := httpcl.New(httpcl.Config{
+		BaseURL:    baseURL,
+		AuthToken:  token,
+		AuthHeader: "Circle-Token",
+	})
+
+	_, err := cl.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v2/me"))
+	if err != nil {
+		if httpcl.HasStatusCode(err, http.StatusTooManyRequests) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func newAuthStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Check authentication status",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
+			circleCIBaseURL := os.Getenv("CIRCLECI_BASE_URL")
+			anthropicBaseURL := os.Getenv("ANTHROPIC_BASE_URL")
 
 			io.Println("")
-			io.Println(ui.Bold("Chunk CLI - API Key Setup"))
-			io.Println("")
-			io.Println("Enter your Anthropic API key (starts with sk-ant-).")
-			io.Println(ui.Dim("The key will be stored securely and never displayed."))
+			io.Println(ui.Bold("Chunk CLI - Authentication Status"))
 			io.Println("")
 
-			// Check for existing key
-			rc := config.Resolve("", "")
-			if rc.APIKey != "" {
-				io.Printf("An API key is already configured (source: %s)\n",
-					sourceLabel(rc.APIKeySource))
-				replace, err := tui.Confirm("Do you want to replace it?", false)
-				if err != nil {
-					return nil
+			rc, resolveErr := config.Resolve("", "")
+			if resolveErr != nil {
+				io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", resolveErr)))
+			}
+
+			hasFailure := false
+
+			// CircleCI section
+			io.Println(ui.Bold("CircleCI"))
+			if rc.CircleCIToken == "" {
+				io.Println("  Not set")
+			} else {
+				io.Printf("  Source: %s\n", rc.CircleCITokenSource)
+				io.Printf("  Token:  %s\n", config.MaskKey(rc.CircleCIToken))
+				io.ErrPrintln(ui.Dim("Validating CircleCI token..."))
+				if err := validateCircleCIToken(cmd.Context(), rc.CircleCIToken, circleCIBaseURL); err != nil {
+					io.ErrPrintln(ui.FormatError(
+						"CircleCI token validation failed.",
+						"",
+						"Run `chunk auth set circleci` to set a new token.",
+					))
+					hasFailure = true
+				} else {
+					io.Println(ui.Success("Valid"))
 				}
-				if !replace {
-					io.Println("Keeping existing API key.")
-					return nil
+			}
+			io.Println("")
+
+			// Anthropic section
+			io.Println(ui.Bold("Anthropic"))
+			if rc.AnthropicAPIKey == "" {
+				io.Println("  Not set")
+			} else {
+				io.Printf("  Source: %s\n", rc.AnthropicAPIKeySource)
+				io.Printf("  Key:    %s\n", config.MaskKey(rc.AnthropicAPIKey))
+				io.ErrPrintln(ui.Dim("Validating API key..."))
+				if err := validateAPIKey(cmd.Context(), rc.AnthropicAPIKey, anthropicBaseURL); err != nil {
+					io.ErrPrintln(ui.FormatError(
+						"API key validation failed.",
+						"The API key could not be validated with the Anthropic API.",
+						"Run `chunk auth set anthropic` to set a new key.",
+					))
+					hasFailure = true
+				} else {
+					io.Println(ui.Success("Valid"))
 				}
 			}
+			io.Println("")
 
-			key, err := tui.PromptHidden("API Key")
-			if err != nil {
-				return nil
+			// GitHub section (env-var only, no auth set/remove support)
+			io.Println(ui.Bold("GitHub"))
+			if rc.GitHubToken != "" {
+				io.Println("  Set (via GITHUB_TOKEN)")
+			} else {
+				io.Println("  Not set")
+				io.Println(ui.Dim("  Set the GITHUB_TOKEN environment variable to configure."))
 			}
+			io.Println("")
 
-			key = strings.TrimSpace(key)
-			if key == "" {
-				io.ErrPrintln(ui.FormatError("API key cannot be empty.", "", "Get an API key from https://console.anthropic.com/"))
-				os.Exit(2)
+			if hasFailure {
+				return ErrSilent
 			}
-
-			if !strings.HasPrefix(key, "sk-ant-") {
-				io.ErrPrintln(ui.FormatError("Invalid API key format.", "Keys should start with \"sk-ant-\".", "Get a valid API key from https://console.anthropic.com/"))
-				os.Exit(2)
-			}
-
-			io.ErrPrintln(ui.Dim("Validating API key..."))
-			if err := validateAPIKey(cmd.Context(), key); err != nil {
-				io.ErrPrintln(ui.FormatError("API key validation failed.", "", "Check that your key is correct and has not been revoked."))
-				os.Exit(2)
-			}
-
-			cfg, _ := config.Load()
-			cfg.APIKey = key
-			if err := config.Save(cfg); err != nil {
-				return fmt.Errorf("save API key: %w", err)
-			}
-
-			cfgPath, err := config.Path()
-			if err != nil {
-				return err
-			}
-			io.Printf("\n%s\n", ui.Success(fmt.Sprintf("API key validated and saved to %s", cfgPath)))
-			io.Println(ui.Dim("You can now run code reviews with: chunk build-prompt"))
 			return nil
 		},
 	}
 }
 
-func validateAPIKey(ctx context.Context, apiKey string) error {
-	baseURL := os.Getenv("ANTHROPIC_BASE_URL")
+func newAuthRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:       "remove <provider>",
+		Short:     "Remove stored credentials",
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: []string{"circleci", "anthropic"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := args[0]
+			io := iostream.FromCmd(cmd)
+			switch provider {
+			case providerCircleCI:
+				circleTokenEnv := os.Getenv("CIRCLE_TOKEN")
+				if circleTokenEnv == "" {
+					circleTokenEnv = os.Getenv("CIRCLECI_TOKEN")
+				}
+				return authRemoveCircleCI(io, circleTokenEnv)
+			case providerAnthropic:
+				anthropicKeyEnv := os.Getenv("ANTHROPIC_API_KEY")
+				return authRemoveAnthropic(io, anthropicKeyEnv)
+			default:
+				return fmt.Errorf("unknown provider %q: valid providers are circleci, anthropic", provider)
+			}
+		},
+	}
+}
+
+func authRemoveCircleCI(io iostream.Streams, circleTokenEnv string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	if cfg.CircleCIToken == "" {
+		io.Println(ui.Warning("No CircleCI token stored in config file."))
+		if circleTokenEnv != "" {
+			io.Println("Note: A CircleCI token is set in environment variables.")
+			io.Println("To remove it, unset the environment variable.")
+			io.Println("")
+		}
+		return nil
+	}
+
+	io.Println("")
+	cfgPath, err := config.Path()
+	if err != nil {
+		return err
+	}
+	io.Printf("This will remove your stored CircleCI token from %s\n", cfgPath)
+	confirmed, err := tui.Confirm("Are you sure?", false)
+	if err != nil || !confirmed {
+		io.Println("")
+		io.Println("Cancelled.")
+		io.Println("")
+		return nil
+	}
+
+	if err := config.Clear("circleCIToken"); err != nil {
+		hint := "Check file permissions on the chunk config file"
+		if errPath, pathErr := config.Path(); pathErr == nil {
+			hint = fmt.Sprintf("Check file permissions on %s", errPath)
+		}
+		io.ErrPrintln(ui.FormatError("Failed to remove CircleCI token.", "An error occurred while trying to remove the token from the config file.", hint))
+		return ErrSilent
+	}
+
+	io.Println(ui.Success("CircleCI token removed successfully."))
+	if circleTokenEnv != "" {
+		io.Println(ui.Warning("Note: CIRCLE_TOKEN/CIRCLECI_TOKEN is still set in your environment variables."))
+	}
+	return nil
+}
+
+func authRemoveAnthropic(io iostream.Streams, anthropicKeyEnv string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	if cfg.AnthropicAPIKey == "" {
+		io.Println(ui.Warning("No API key stored in config file."))
+		if anthropicKeyEnv != "" {
+			io.Println("Note: ANTHROPIC_API_KEY is set in your environment variables.")
+			io.Println("To remove it, unset the environment variable.")
+			io.Println("")
+		}
+		return nil
+	}
+
+	io.Println("")
+	cfgPath, err := config.Path()
+	if err != nil {
+		return err
+	}
+	io.Printf("This will remove your stored API key from %s\n", cfgPath)
+	confirmed, err := tui.Confirm("Are you sure?", false)
+	if err != nil || !confirmed {
+		io.Println("")
+		io.Println("Cancelled.")
+		io.Println("")
+		return nil
+	}
+
+	if err := config.Clear("anthropicAPIKey"); err != nil {
+		hint := "Check file permissions on the chunk config file"
+		if errPath, pathErr := config.Path(); pathErr == nil {
+			hint = fmt.Sprintf("Check file permissions on %s", errPath)
+		}
+		io.ErrPrintln(ui.FormatError(
+			"Failed to remove API key.",
+			"An error occurred while trying to remove the API key from the config file.",
+			hint,
+		))
+		return ErrSilent
+	}
+
+	io.Println(ui.Success("API key removed successfully."))
+	if anthropicKeyEnv != "" {
+		io.Println(ui.Warning("Note: ANTHROPIC_API_KEY is still set in your environment variables."))
+	}
+	return nil
+}
+
+func validateAPIKey(ctx context.Context, apiKey, baseURL string) error {
 	if baseURL == "" {
 		baseURL = "https://api.anthropic.com"
 	}
@@ -126,138 +460,10 @@ func validateAPIKey(ctx context.Context, apiKey string) error {
 		httpcl.Header("anthropic-version", "2023-06-01"),
 	))
 	if err != nil {
-		// Rate limit means the key is valid
 		if httpcl.HasStatusCode(err, http.StatusTooManyRequests) {
 			return nil
 		}
 		return err
 	}
 	return nil
-}
-
-func newAuthStatusCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "status",
-		Short: "Check authentication status",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			io := iostream.FromCmd(cmd)
-
-			io.Println("")
-			io.Println(ui.Bold("Chunk CLI - Authentication Status"))
-			io.Println("")
-
-			rc := config.Resolve("", "")
-
-			if rc.APIKey == "" {
-				io.Println(ui.Warning("Not authenticated"))
-				io.Println(ui.Dim("No API key found in config file or environment."))
-				io.Println("")
-				io.Println("To authenticate, run: chunk auth login")
-				io.Println("Or set the ANTHROPIC_API_KEY environment variable.")
-				io.Println("")
-				return nil
-			}
-
-			w := 15 // align to "API key source:"
-			switch rc.APIKeySource {
-			case "Config file (user config)":
-				cfgPath, err := config.Path()
-				if err != nil {
-					return err
-				}
-				io.Printf("%s Config file (%s)\n", ui.Label("API key source:", w), cfgPath)
-			case apiKeySourceEnvVar:
-				io.Printf("%s Environment variable (ANTHROPIC_API_KEY)\n", ui.Label("API key source:", w))
-			default:
-				io.Printf("%s %s\n", ui.Label("API key source:", w), rc.APIKeySource)
-			}
-			io.Printf("%s %s\n", ui.Label("API key:", w), config.MaskAPIKey(rc.APIKey))
-
-			io.ErrPrintln(ui.Yellow("Validating API key..."))
-
-			if err := validateAPIKey(cmd.Context(), rc.APIKey); err != nil {
-				io.ErrPrintln("")
-				io.ErrPrintln(ui.FormatError(
-					"API key validation failed.",
-					"The API key could not be validated with the Anthropic API.",
-					"Run `chunk auth login` to set a new key.",
-				))
-				os.Exit(1)
-			}
-
-			io.Println("")
-			io.Println(ui.Success("API key is valid"))
-			return nil
-		},
-	}
-}
-
-func newAuthLogoutCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "logout",
-		Short: "Remove stored credentials",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			io := iostream.FromCmd(cmd)
-			cfg, err := config.Load()
-			if err != nil {
-				return err
-			}
-			if cfg.APIKey == "" {
-				io.Println(ui.Warning("No API key stored in config file."))
-				if os.Getenv("ANTHROPIC_API_KEY") != "" {
-					io.Println("Note: ANTHROPIC_API_KEY is set in your environment variables.")
-					io.Println("To remove it, unset the environment variable.")
-					io.Println("")
-				}
-				return nil
-			}
-
-			io.Println("")
-			cfgPath, err := config.Path()
-			if err != nil {
-				return err
-			}
-			io.Printf("This will remove your stored API key from %s\n", cfgPath)
-			confirmed, err := tui.Confirm("Are you sure you want to logout?", false)
-			if err != nil {
-				io.Println("")
-				io.Println("Logout cancelled.")
-				io.Println("")
-				return nil
-			}
-			if !confirmed {
-				io.Println("")
-				io.Println("Logout cancelled.")
-				io.Println("")
-				return nil
-			}
-
-			if err := config.ClearAPIKey(); err != nil {
-				hint := "Check file permissions on the chunk config file"
-				if errPath, pathErr := config.Path(); pathErr == nil {
-					hint = fmt.Sprintf("Check file permissions on %s", errPath)
-				}
-				io.ErrPrintln(ui.FormatError(
-					"Failed to remove API key.",
-					"An error occurred while trying to remove the API key from the config file.",
-					hint,
-				))
-				os.Exit(2)
-			}
-
-			io.Println(ui.Success("API key removed successfully."))
-			return nil
-		},
-	}
-}
-
-func sourceLabel(source string) string {
-	switch source {
-	case "Config file (user config)":
-		return "Config file"
-	case apiKeySourceEnvVar:
-		return apiKeySourceEnvVar
-	default:
-		return source
-	}
 }

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -27,15 +26,24 @@ func newConfigShowCmd() *cobra.Command {
 		Short: "Display resolved configuration",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			rc := config.Resolve("", "")
+			rc, resolveErr := config.Resolve("", "")
+			if resolveErr != nil {
+				io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", resolveErr)))
+			}
 
 			w := 15
 			io.Printf("%s %s %s\n", ui.Label("model:", w), rc.Model, ui.Dim("("+rc.ModelSource+")"))
 
-			if rc.APIKey != "" {
-				io.Printf("%s %s %s\n", ui.Label("apiKey:", w), config.MaskAPIKey(rc.APIKey), ui.Dim("("+rc.APIKeySource+")"))
+			if rc.AnthropicAPIKey != "" {
+				io.Printf("%s %s %s\n", ui.Label("anthropicAPIKey:", w), config.MaskKey(rc.AnthropicAPIKey), ui.Dim("("+rc.AnthropicAPIKeySource+")"))
 			} else {
-				io.Printf("%s %s\n", ui.Label("apiKey:", w), ui.Dim("(not set)"))
+				io.Printf("%s %s\n", ui.Label("anthropicAPIKey:", w), ui.Dim("(not set)"))
+			}
+
+			if rc.CircleCIToken != "" {
+				io.Printf("%s %s %s\n", ui.Label("circleCIToken:", w), config.MaskKey(rc.CircleCIToken), ui.Dim("("+rc.CircleCITokenSource+")"))
+			} else {
+				io.Printf("%s %s\n", ui.Label("circleCIToken:", w), ui.Dim("(not set)"))
 			}
 
 			return nil
@@ -47,6 +55,7 @@ func newConfigSetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "set <key> <value>",
 		Short: "Set a config value",
+		Long:  "Set a config value (model). Use 'chunk auth set <provider>' to store credentials with validation.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
@@ -54,7 +63,7 @@ func newConfigSetCmd() *cobra.Command {
 
 			if !config.ValidConfigKeys[key] {
 				io.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Unknown config key: %q", key)))
-				os.Exit(2)
+				return ErrSilent
 			}
 
 			cfg, err := config.Load()
@@ -62,11 +71,8 @@ func newConfigSetCmd() *cobra.Command {
 				return err
 			}
 
-			switch key {
-			case "model":
+			if key == "model" {
 				cfg.Model = value
-			case "apiKey":
-				cfg.APIKey = value
 			}
 
 			if err := config.Save(cfg); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -21,7 +21,7 @@ func NewRootCmd(version string) *cobra.Command {
 	rootCmd.SetHelpTemplate(rootCmd.HelpTemplate() + `
 Getting started:
   chunk init                    Initialize project configuration
-  chunk auth login              Save your Anthropic API key
+  chunk auth set <provider>     Store credentials (CircleCI token, Anthropic API key)
   chunk build-prompt            Generate a review prompt from GitHub PR comments
   chunk task config             Set up CircleCI task configuration
   chunk task run --definition <name> --prompt "<task>"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,11 @@ type UserConfig struct {
 	AnthropicAPIKey string `json:"anthropicAPIKey,omitempty"`
 	CircleCIToken   string `json:"circleCIToken,omitempty"`
 	Model           string `json:"model,omitempty"`
+
+	// LegacyAPIKey reads the pre-rename "apiKey" field so existing users don't
+	// silently lose their stored Anthropic key on upgrade. Migrated into
+	// AnthropicAPIKey by Load and dropped on the next Save (omitempty).
+	LegacyAPIKey string `json:"apiKey,omitempty"`
 }
 
 // ResolvedConfig holds the final resolved values with their sources.
@@ -60,6 +65,10 @@ func Load() (UserConfig, error) {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return UserConfig{}, err
 	}
+	if cfg.AnthropicAPIKey == "" && cfg.LegacyAPIKey != "" {
+		cfg.AnthropicAPIKey = cfg.LegacyAPIKey
+	}
+	cfg.LegacyAPIKey = ""
 	return cfg, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"strings"
@@ -16,22 +17,30 @@ const (
 	ValidationModel = "claude-haiku-4-5-20251001"
 	dirPermission   = 0o700
 	filePermission  = 0o600
+
+	// SourceConfigFile is the source label used when a value comes from the user config file.
+	SourceConfigFile = "Config file (user config)"
 )
 
 // UserConfig is the on-disk JSON config.
 type UserConfig struct {
-	APIKey string `json:"apiKey,omitempty"`
-	Model  string `json:"model,omitempty"`
+	AnthropicAPIKey string `json:"anthropicAPIKey,omitempty"`
+	CircleCIToken   string `json:"circleCIToken,omitempty"`
+	Model           string `json:"model,omitempty"`
 }
 
 // ResolvedConfig holds the final resolved values with their sources.
 type ResolvedConfig struct {
-	APIKey       string
-	APIKeySource string
-	Model        string
-	ModelSource  string
-	AnalyzeModel string
-	PromptModel  string
+	AnthropicAPIKey       string
+	AnthropicAPIKeySource string
+	CircleCIToken         string
+	CircleCITokenSource   string
+	GitHubToken           string
+	GitHubTokenSource     string
+	Model                 string
+	ModelSource           string
+	AnalyzeModel          string
+	PromptModel           string
 }
 
 // Load reads the config file. Returns empty config if not found.
@@ -74,38 +83,64 @@ func Save(cfg UserConfig) error {
 	return os.WriteFile(p, data, filePermission)
 }
 
-// ClearAPIKey removes the stored API key from config.
-func ClearAPIKey() error {
+// Clear removes a stored config value by key.
+func Clear(key string) error {
 	cfg, err := Load()
 	if err != nil {
 		return err
 	}
-	cfg.APIKey = ""
+	switch key {
+	case "anthropicAPIKey":
+		cfg.AnthropicAPIKey = ""
+	case "circleCIToken":
+		cfg.CircleCIToken = ""
+	default:
+		return fmt.Errorf("unknown config key: %s", key)
+	}
 	return Save(cfg)
 }
 
 // Resolve computes the final config from flags, env, and file.
 // Priority for API key: flag > env > config file > (none).
 // Priority for model: flag > CODE_REVIEW_CLI_MODEL env > config file > default.
-func Resolve(flagAPIKey, flagModel string) ResolvedConfig {
-	cfg, _ := Load()
+func Resolve(flagAPIKey, flagModel string) (ResolvedConfig, error) {
+	cfg, err := Load()
 
 	rc := ResolvedConfig{
 		AnalyzeModel: AnalyzeModel,
 		PromptModel:  PromptModel,
 	}
 
+	// CircleCI token resolution: CIRCLE_TOKEN env > CIRCLECI_TOKEN env > config file
+	switch {
+	case os.Getenv("CIRCLE_TOKEN") != "":
+		rc.CircleCIToken = os.Getenv("CIRCLE_TOKEN")
+		rc.CircleCITokenSource = "Environment variable (CIRCLE_TOKEN)"
+	case os.Getenv("CIRCLECI_TOKEN") != "":
+		rc.CircleCIToken = os.Getenv("CIRCLECI_TOKEN")
+		rc.CircleCITokenSource = "Environment variable (CIRCLECI_TOKEN)"
+	case cfg.CircleCIToken != "":
+		rc.CircleCIToken = cfg.CircleCIToken
+		rc.CircleCITokenSource = SourceConfigFile
+	}
+
 	// API key resolution: flag > env > config file
 	switch {
 	case flagAPIKey != "":
-		rc.APIKey = flagAPIKey
-		rc.APIKeySource = "Flag"
+		rc.AnthropicAPIKey = flagAPIKey
+		rc.AnthropicAPIKeySource = "Flag"
 	case os.Getenv("ANTHROPIC_API_KEY") != "":
-		rc.APIKey = os.Getenv("ANTHROPIC_API_KEY")
-		rc.APIKeySource = "Environment variable"
-	case cfg.APIKey != "":
-		rc.APIKey = cfg.APIKey
-		rc.APIKeySource = "Config file (user config)"
+		rc.AnthropicAPIKey = os.Getenv("ANTHROPIC_API_KEY")
+		rc.AnthropicAPIKeySource = "Environment variable"
+	case cfg.AnthropicAPIKey != "":
+		rc.AnthropicAPIKey = cfg.AnthropicAPIKey
+		rc.AnthropicAPIKeySource = SourceConfigFile
+	}
+
+	// GitHub token resolution: GITHUB_TOKEN env only (no config file support)
+	if v := os.Getenv("GITHUB_TOKEN"); v != "" {
+		rc.GitHubToken = v
+		rc.GitHubTokenSource = "Environment variable (GITHUB_TOKEN)"
 	}
 
 	// Model resolution: flag > env > config file > default
@@ -118,17 +153,17 @@ func Resolve(flagAPIKey, flagModel string) ResolvedConfig {
 		rc.ModelSource = "Environment variable"
 	case cfg.Model != "":
 		rc.Model = cfg.Model
-		rc.ModelSource = "Config file (user config)"
+		rc.ModelSource = SourceConfigFile
 	default:
 		rc.Model = DefaultModel
 		rc.ModelSource = "Default"
 	}
 
-	return rc
+	return rc, err
 }
 
-// MaskAPIKey masks all but the last 4 characters with *.
-func MaskAPIKey(key string) string {
+// MaskKey masks all but the last 4 characters with *.
+func MaskKey(key string) string {
 	if len(key) <= 4 {
 		return "****"
 	}
@@ -136,7 +171,8 @@ func MaskAPIKey(key string) string {
 }
 
 // ValidConfigKeys are the keys accepted by "config set".
+// Credentials (anthropicAPIKey, circleCIToken) are intentionally excluded —
+// users should use "auth set" which validates before storing.
 var ValidConfigKeys = map[string]bool{
-	"model":  true,
-	"apiKey": true,
+	"model": true,
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -47,7 +47,7 @@ func TestLoad_NoFile(t *testing.T) {
 
 	cfg, err := Load()
 	assert.NilError(t, err)
-	assert.Equal(t, cfg.APIKey, "")
+	assert.Equal(t, cfg.AnthropicAPIKey, "")
 	assert.Equal(t, cfg.Model, "")
 }
 
@@ -56,12 +56,12 @@ func TestLoad_ValidFile(t *testing.T) {
 	chunkDir := filepath.Join(dir, "chunk")
 	assert.NilError(t, os.MkdirAll(chunkDir, 0o700))
 
-	data := `{"apiKey":"sk-test-1234","model":"claude-test"}`
+	data := `{"anthropicAPIKey":"sk-test-1234","model":"claude-test"}`
 	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), []byte(data), 0o600))
 
 	cfg, err := Load()
 	assert.NilError(t, err)
-	assert.Equal(t, cfg.APIKey, "sk-test-1234")
+	assert.Equal(t, cfg.AnthropicAPIKey, "sk-test-1234")
 	assert.Equal(t, cfg.Model, "claude-test")
 }
 
@@ -127,52 +127,73 @@ func TestSave_OmitsEmptyFields(t *testing.T) {
 	data, err := os.ReadFile(p)
 	assert.NilError(t, err)
 
-	// apiKey should be omitted from JSON (omitempty)
+	// anthropicAPIKey should be omitted from JSON (omitempty)
 	var raw map[string]interface{}
 	assert.NilError(t, json.Unmarshal(data, &raw))
-	_, hasKey := raw["apiKey"]
-	assert.Assert(t, !hasKey, "expected apiKey to be omitted, got %v", raw)
+	_, hasKey := raw["anthropicAPIKey"]
+	assert.Assert(t, !hasKey, "expected anthropicAPIKey to be omitted, got %v", raw)
 }
 
 func TestSaveAndLoad_Roundtrip(t *testing.T) {
 	setupTempConfig(t)
 
-	original := UserConfig{APIKey: "sk-round", Model: "claude-trip"}
+	original := UserConfig{AnthropicAPIKey: "sk-round", Model: "claude-trip"}
 	assert.NilError(t, Save(original))
 
 	loaded, err := Load()
 	assert.NilError(t, err)
-	assert.Equal(t, loaded.APIKey, original.APIKey)
+	assert.Equal(t, loaded.AnthropicAPIKey, original.AnthropicAPIKey)
 	assert.Equal(t, loaded.Model, original.Model)
 }
 
-// --- ClearAPIKey ---
+// --- Clear ---
 
-func TestClearAPIKey(t *testing.T) {
+func TestClear_AnthropicAPIKey(t *testing.T) {
 	setupTempConfig(t)
 
-	assert.NilError(t, Save(UserConfig{APIKey: "sk-secret", Model: "m1"}))
+	assert.NilError(t, Save(UserConfig{AnthropicAPIKey: "sk-secret", Model: "m1"}))
 
-	err := ClearAPIKey()
+	err := Clear("anthropicAPIKey")
 	assert.NilError(t, err)
 
 	cfg, err := Load()
 	assert.NilError(t, err)
-	assert.Equal(t, cfg.APIKey, "")
+	assert.Equal(t, cfg.AnthropicAPIKey, "")
 	assert.Equal(t, cfg.Model, "m1") // model preserved
 }
 
-func TestClearAPIKey_NoExistingFile(t *testing.T) {
+func TestClear_CircleCIToken(t *testing.T) {
+	setupTempConfig(t)
+
+	assert.NilError(t, Save(UserConfig{CircleCIToken: "tok-secret", Model: "m1"}))
+
+	err := Clear("circleCIToken")
+	assert.NilError(t, err)
+
+	cfg, err := Load()
+	assert.NilError(t, err)
+	assert.Equal(t, cfg.CircleCIToken, "")
+	assert.Equal(t, cfg.Model, "m1") // model preserved
+}
+
+func TestClear_UnknownKey(t *testing.T) {
+	setupTempConfig(t)
+
+	err := Clear("badkey")
+	assert.Assert(t, err != nil, "expected error for unknown key")
+}
+
+func TestClear_NoExistingFile(t *testing.T) {
 	setupTempConfig(t)
 
 	// Should succeed even if no config file exists
-	err := ClearAPIKey()
+	err := Clear("anthropicAPIKey")
 	assert.NilError(t, err)
 }
 
-// --- MaskAPIKey ---
+// --- MaskKey ---
 
-func TestMaskAPIKey(t *testing.T) {
+func TestMaskKey(t *testing.T) {
 	tests := []struct {
 		name string
 		key  string
@@ -186,7 +207,7 @@ func TestMaskAPIKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, MaskAPIKey(tt.key), tt.want)
+			assert.Equal(t, MaskKey(tt.key), tt.want)
 		})
 	}
 }
@@ -197,9 +218,9 @@ func TestResolve_Defaults(t *testing.T) {
 	setupTempConfig(t)
 	t.Setenv("ANTHROPIC_API_KEY", "")
 
-	rc := Resolve("", "")
+	rc, _ := Resolve("", "")
 
-	assert.Equal(t, rc.APIKey, "")
+	assert.Equal(t, rc.AnthropicAPIKey, "")
 	assert.Equal(t, rc.Model, DefaultModel)
 	assert.Equal(t, rc.ModelSource, "Default")
 	assert.Equal(t, rc.AnalyzeModel, AnalyzeModel)
@@ -210,30 +231,30 @@ func TestResolve_EnvKey(t *testing.T) {
 	setupTempConfig(t)
 	t.Setenv("ANTHROPIC_API_KEY", "sk-from-env")
 
-	rc := Resolve("", "")
-	assert.Equal(t, rc.APIKey, "sk-from-env")
-	assert.Equal(t, rc.APIKeySource, "Environment variable")
+	rc, _ := Resolve("", "")
+	assert.Equal(t, rc.AnthropicAPIKey, "sk-from-env")
+	assert.Equal(t, rc.AnthropicAPIKeySource, "Environment variable")
 }
 
 func TestResolve_EnvOverridesConfigFile(t *testing.T) {
 	setupTempConfig(t)
 	t.Setenv("ANTHROPIC_API_KEY", "sk-from-env")
 
-	assert.NilError(t, Save(UserConfig{APIKey: "sk-from-file"}))
+	assert.NilError(t, Save(UserConfig{AnthropicAPIKey: "sk-from-file"}))
 
-	rc := Resolve("", "")
-	assert.Equal(t, rc.APIKey, "sk-from-env")
-	assert.Equal(t, rc.APIKeySource, "Environment variable")
+	rc, _ := Resolve("", "")
+	assert.Equal(t, rc.AnthropicAPIKey, "sk-from-env")
+	assert.Equal(t, rc.AnthropicAPIKeySource, "Environment variable")
 }
 
 func TestResolve_FlagOverridesAll(t *testing.T) {
 	setupTempConfig(t)
 	t.Setenv("ANTHROPIC_API_KEY", "sk-from-env")
-	assert.NilError(t, Save(UserConfig{APIKey: "sk-from-file", Model: "file-model"}))
+	assert.NilError(t, Save(UserConfig{AnthropicAPIKey: "sk-from-file", Model: "file-model"}))
 
-	rc := Resolve("sk-from-flag", "flag-model")
-	assert.Equal(t, rc.APIKey, "sk-from-flag")
-	assert.Equal(t, rc.APIKeySource, "Flag")
+	rc, _ := Resolve("sk-from-flag", "flag-model")
+	assert.Equal(t, rc.AnthropicAPIKey, "sk-from-flag")
+	assert.Equal(t, rc.AnthropicAPIKeySource, "Flag")
 	assert.Equal(t, rc.Model, "flag-model")
 	assert.Equal(t, rc.ModelSource, "Flag")
 }
@@ -242,15 +263,15 @@ func TestResolve_ModelFromConfig(t *testing.T) {
 	setupTempConfig(t)
 	assert.NilError(t, Save(UserConfig{Model: "config-model"}))
 
-	rc := Resolve("", "")
+	rc, _ := Resolve("", "")
 	assert.Equal(t, rc.Model, "config-model")
-	assert.Equal(t, rc.ModelSource, "Config file (user config)")
+	assert.Equal(t, rc.ModelSource, SourceConfigFile)
 }
 
 // --- ValidConfigKeys ---
 
 func TestValidConfigKeys(t *testing.T) {
 	assert.Assert(t, ValidConfigKeys["model"])
-	assert.Assert(t, ValidConfigKeys["apiKey"])
+	assert.Assert(t, !ValidConfigKeys["anthropicAPIKey"])
 	assert.Assert(t, !ValidConfigKeys["badkey"])
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,6 +65,46 @@ func TestLoad_ValidFile(t *testing.T) {
 	assert.Equal(t, cfg.Model, "claude-test")
 }
 
+func TestLoad_MigratesLegacyAPIKey(t *testing.T) {
+	dir := setupTempConfig(t)
+	chunkDir := filepath.Join(dir, "chunk")
+	assert.NilError(t, os.MkdirAll(chunkDir, 0o700))
+
+	data := `{"apiKey":"sk-legacy-1234","model":"claude-test"}`
+	p := filepath.Join(chunkDir, "config.json")
+	assert.NilError(t, os.WriteFile(p, []byte(data), 0o600))
+
+	cfg, err := Load()
+	assert.NilError(t, err)
+	assert.Equal(t, cfg.AnthropicAPIKey, "sk-legacy-1234")
+	assert.Equal(t, cfg.LegacyAPIKey, "")
+	assert.Equal(t, cfg.Model, "claude-test")
+
+	// Saving the migrated config drops the old "apiKey" field from disk.
+	assert.NilError(t, Save(cfg))
+	raw, err := os.ReadFile(p)
+	assert.NilError(t, err)
+	var m map[string]interface{}
+	assert.NilError(t, json.Unmarshal(raw, &m))
+	_, hasLegacy := m["apiKey"]
+	assert.Assert(t, !hasLegacy, "expected legacy apiKey to be dropped, got %v", m)
+	assert.Equal(t, m["anthropicAPIKey"], "sk-legacy-1234")
+}
+
+func TestLoad_NewKeyTakesPrecedenceOverLegacy(t *testing.T) {
+	dir := setupTempConfig(t)
+	chunkDir := filepath.Join(dir, "chunk")
+	assert.NilError(t, os.MkdirAll(chunkDir, 0o700))
+
+	data := `{"apiKey":"sk-old","anthropicAPIKey":"sk-new"}`
+	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), []byte(data), 0o600))
+
+	cfg, err := Load()
+	assert.NilError(t, err)
+	assert.Equal(t, cfg.AnthropicAPIKey, "sk-new")
+	assert.Equal(t, cfg.LegacyAPIKey, "")
+}
+
 func TestLoad_InvalidJSON(t *testing.T) {
 	dir := setupTempConfig(t)
 	chunkDir := filepath.Join(dir, "chunk")

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -74,6 +74,7 @@ func NewFakeCircleCI() *FakeCircleCI {
 	}
 
 	// Existing endpoints
+	r.GET("/api/v2/me", f.handleGetCurrentUser)
 	r.GET("/api/v2/me/collaborations", f.handleCollaborations)
 	r.GET("/api/v1.1/projects", f.handleProjects)
 
@@ -87,6 +88,13 @@ func NewFakeCircleCI() *FakeCircleCI {
 	r.POST("/api/v2/agents/org/:org_id/project/:project_id/runs", f.handleTriggerRun)
 
 	return f
+}
+
+func (f *FakeCircleCI) handleGetCurrentUser(c *gin.Context) {
+	if !f.requireToken(c) {
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"id": "user-123", "login": "testuser"})
 }
 
 func (f *FakeCircleCI) requireToken(c *gin.Context) bool {

--- a/main.go
+++ b/main.go
@@ -17,14 +17,16 @@ func main() {
 
 	rootCmd := cmd.NewRootCmd(version)
 	if err := rootCmd.Execute(); err != nil {
-		var ue *usererr.Error
-		if errors.As(err, &ue) {
-			fmt.Fprintln(os.Stderr, ue.UserMessage())
-		} else {
-			fmt.Fprintln(os.Stderr, err)
-		}
-		if suggestion := errorSuggestion(err); suggestion != "" {
-			fmt.Fprintln(os.Stderr, suggestion)
+		if !errors.Is(err, cmd.ErrSilent) {
+			var ue *usererr.Error
+			if errors.As(err, &ue) {
+				fmt.Fprintln(os.Stderr, ue.UserMessage())
+			} else {
+				fmt.Fprintln(os.Stderr, err)
+			}
+			if suggestion := errorSuggestion(err); suggestion != "" {
+				fmt.Fprintln(os.Stderr, suggestion)
+			}
 		}
 		os.Exit(1)
 	}
@@ -39,7 +41,7 @@ func errorSuggestion(err error) string {
 	case strings.Contains(lower, "authentication") ||
 		strings.Contains(lower, "invalid api key") ||
 		strings.Contains(lower, "401"):
-		return "Hint: Run `chunk auth login` to set up your API key."
+		return "Hint: Run `chunk auth set anthropic` to set up your API key."
 	case strings.Contains(lower, "no such host") ||
 		strings.Contains(lower, "connection refused") ||
 		strings.Contains(lower, "network is unreachable") ||


### PR DESCRIPTION
## Summary

https://linear.app/circleci/issue/FACT-73/simplify-tokenauth-management

- Redesign `auth` commands (`set`, `status`, `remove`) to accept a provider argument (`anthropic`, `circleci`) instead of the previous `login`/`logout` flow
- Add interactive credential input with hidden prompts, validation against live APIs, and confirmation before overwriting existing credentials
- Show all provider statuses in `auth status` (Anthropic, CircleCI, GitHub) with source indicators (env var vs config file) and masked key display
- `auth remove` warns when env vars will still take precedence after removing stored config
- Extend the user config schema: rename `apiKey` → `anthropicAPIKey` and add `circleCIToken`. `Load()` migrates the legacy `apiKey` field forward so existing users don't silently lose their stored key on upgrade; the legacy field is dropped from disk on the next `Save()`.
- `circleci.NewClient` now resolves its token via `config.Resolve` (env vars then config file) so a token stored by `chunk auth set circleci` is actually used. Adds `GetCurrentUser` for token validation during `auth set`.
- Replace `os.Exit(2)` in `config set` with proper cobra error handling (`ErrSilent`)
- Update help text, hints, and docs to reflect the new command signatures

chunk auth set circleci:

<img width="713" height="182" alt="Screenshot 2026-04-14 at 4 09 38 PM" src="https://github.com/user-attachments/assets/12838590-4278-4ed6-8eb2-5870e55f6859" />

chunk auth status:

<img width="713" height="274" alt="Screenshot 2026-04-14 at 4 07 49 PM" src="https://github.com/user-attachments/assets/0b73f20a-b954-4b51-992c-d49dfded3e59" />

chunk auth set anthropic:

<img width="713" height="192" alt="Screenshot 2026-04-14 at 4 08 11 PM" src="https://github.com/user-attachments/assets/816871fa-7191-4a94-8a15-7b745faddf24" />

chunk auth status:

<img width="713" height="373" alt="Screenshot 2026-04-14 at 4 08 26 PM" src="https://github.com/user-attachments/assets/2042d0b3-b38a-4780-8ac9-2797d7af3c9e" />

## Test plan

- [x] \`task build\` succeeds
- [x] \`task test\` — all tests pass (includes new coverage for legacy \`apiKey\` migration and \`circleCIToken\` resolution)
- [x] \`task lint\` — 0 issues
- [x] \`chunk --help\` shows \`chunk auth set <provider>\`
- [x] \`chunk config set badkey badvalue\` exits cleanly with code 1
- [x] Acceptance tests cover status with env vars, config file keys, masking, and env-overrides-config behavior
- [x] Existing config containing \`{"apiKey": "..."}\` still authenticates after upgrade and is rewritten as \`anthropicAPIKey\` on next save

🤖 Generated with [Claude Code](https://claude.com/claude-code)