### PR TITLE
Add sandbox snapshot create and get commands

### DIFF
--- a/acceptance/sandbox_snapshot_test.go
+++ b/acceptance/sandbox_snapshot_test.go
@@ -1,0 +1,199 @@
+package acceptance
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/chunk-cli/internal/testing/env"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+)
+
+func TestSandboxSnapshotCreateHappyPath(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, []string{
+		"sandbox", "snapshot", "create",
+		"--sandbox-id", "sb-111",
+		"--name", "my-checkpoint",
+	}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "snap-new-123"),
+		"expected snapshot ID in stderr, got: %s", result.Stderr)
+}
+
+func TestSandboxSnapshotCreateSendsSandboxIDInBody(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, []string{
+		"sandbox", "snapshot", "create",
+		"--sandbox-id", "sb-111",
+		"--name", "my-checkpoint",
+	}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	reqs := cci.Recorder.AllRequests()
+	snapReqs := filterByMethod(reqs, "POST", "/api/v2/sandbox/snapshots")
+	assert.Equal(t, len(snapReqs), 1, "expected 1 create snapshot request")
+
+	var body map[string]interface{}
+	err := json.Unmarshal(snapReqs[0].Body, &body)
+	assert.NilError(t, err)
+	assert.Equal(t, body["sandbox_id"], "sb-111")
+	assert.Equal(t, body["name"], "my-checkpoint")
+}
+
+func TestSandboxSnapshotCreateMissingName(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+
+	result := binary.RunCLI(t, []string{
+		"sandbox", "snapshot", "create",
+		"--sandbox-id", "sb-111",
+	}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for missing --name")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "name"),
+		"expected error about missing --name, got: %s", combined)
+}
+
+func TestSandboxSnapshotCreateUsesActiveSandbox(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	workDir := t.TempDir()
+
+	// create sandbox → sets active sandbox to "sandbox-new-123"
+	result := binary.RunCLI(t, []string{
+		"sandbox", "create",
+		"--org-id", "org-aaa",
+		"--name", "test-box",
+	}, env, workDir)
+	assert.Equal(t, result.ExitCode, 0, "create stderr: %s", result.Stderr)
+
+	// snapshot create without --sandbox-id should use the active sandbox
+	result = binary.RunCLI(t, []string{
+		"sandbox", "snapshot", "create",
+		"--name", "my-checkpoint",
+	}, env, workDir)
+	assert.Equal(t, result.ExitCode, 0, "snapshot create stderr: %s", result.Stderr)
+
+	reqs := cci.Recorder.AllRequests()
+	snapReqs := filterByMethod(reqs, "POST", "/api/v2/sandbox/snapshots")
+	assert.Assert(t, len(snapReqs) >= 1, "expected at least 1 create snapshot request")
+
+	var body map[string]interface{}
+	err := json.Unmarshal(snapReqs[0].Body, &body)
+	assert.NilError(t, err)
+	assert.Equal(t, body["sandbox_id"], "sandbox-new-123",
+		"expected active sandbox ID in request body")
+}
+
+func TestSandboxSnapshotCreateNoActiveSandbox(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	workDir := t.TempDir()
+
+	result := binary.RunCLI(t, []string{
+		"sandbox", "snapshot", "create",
+		"--name", "my-checkpoint",
+	}, env, workDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit with no sandbox ID")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "sandbox-id") || strings.Contains(combined, "active sandbox"),
+		"expected helpful error, got: %s", combined)
+}
+
+func TestSandboxSnapshotCreateAPIError(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.CreateSnapshotStatusCode = 500
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, []string{
+		"sandbox", "snapshot", "create",
+		"--sandbox-id", "sb-111",
+		"--name", "my-checkpoint",
+	}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for 500 response")
+}
+
+func TestSandboxSnapshotGetHappyPath(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.Snapshots = []fakes.Snapshot{
+		{ID: "snap-abc", Name: "my-checkpoint"},
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, []string{
+		"sandbox", "snapshot", "get", "snap-abc",
+	}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stdout, "snap-abc"),
+		"expected snapshot ID in output, got: %s", result.Stdout)
+	assert.Assert(t, strings.Contains(result.Stdout, "my-checkpoint"),
+		"expected snapshot name in output, got: %s", result.Stdout)
+}
+
+func TestSandboxSnapshotGetNotFound(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, []string{
+		"sandbox", "snapshot", "get", "snap-does-not-exist",
+	}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for not found")
+}
+
+func TestSandboxSnapshotMissingToken(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"create", []string{"sandbox", "snapshot", "create", "--sandbox-id", "sb-111", "--name", "snap"}},
+		{"get", []string{"sandbox", "snapshot", "get", "snap-abc"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := testenv.NewTestEnv(t)
+			env.CircleToken = ""
+
+			result := binary.RunCLI(t, tt.args, env, env.HomeDir)
+			assert.Assert(t, result.ExitCode != 0, "expected non-zero exit code without token")
+		})
+	}
+}

--- a/acceptance/sandbox_snapshot_test.go
+++ b/acceptance/sandbox_snapshot_test.go
@@ -13,25 +13,6 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 )
 
-func TestSandboxSnapshotCreateHappyPath(t *testing.T) {
-	cci := fakes.NewFakeCircleCI()
-	srv := httptest.NewServer(cci)
-	defer srv.Close()
-
-	env := testenv.NewTestEnv(t)
-	env.CircleCIURL = srv.URL
-
-	result := binary.RunCLI(t, []string{
-		"sandbox", "snapshot", "create",
-		"--sandbox-id", "sb-111",
-		"--name", "my-checkpoint",
-	}, env, env.HomeDir)
-
-	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Assert(t, strings.Contains(result.Stderr, "snap-new-123"),
-		"expected snapshot ID in stderr, got: %s", result.Stderr)
-}
-
 func TestSandboxSnapshotCreateSendsSandboxIDInBody(t *testing.T) {
 	cci := fakes.NewFakeCircleCI()
 	srv := httptest.NewServer(cci)

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -95,6 +95,30 @@ func (c *Client) Exec(ctx context.Context, sandboxID, command string, args []str
 	return &resp, nil
 }
 
+func (c *Client) CreateSnapshot(ctx context.Context, sandboxID, name string) (*Snapshot, error) {
+	var resp Snapshot
+	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodPost, "/api/v2/sandbox/snapshots",
+		httpcl.Body(CreateSnapshotRequest{SandboxID: sandboxID, Name: name}),
+		httpcl.JSONDecoder(&resp),
+	))
+	if err != nil {
+		return nil, fmt.Errorf("create snapshot: %w", err)
+	}
+	return &resp, nil
+}
+
+func (c *Client) GetSnapshot(ctx context.Context, id string) (*Snapshot, error) {
+	var resp Snapshot
+	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodGet,
+		fmt.Sprintf("/api/v2/sandbox/snapshots/%s", id),
+		httpcl.JSONDecoder(&resp),
+	))
+	if err != nil {
+		return nil, fmt.Errorf("get snapshot: %w", err)
+	}
+	return &resp, nil
+}
+
 func (c *Client) TriggerRun(ctx context.Context, orgID, projectID string, body TriggerRunRequest) (*RunResponse, error) {
 	var resp RunResponse
 	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodPost,

--- a/internal/circleci/types.go
+++ b/internal/circleci/types.go
@@ -58,3 +58,16 @@ type CreateSandboxRequest struct {
 	Provider       string `json:"provider,omitempty"`
 	Image          string `json:"image,omitempty"`
 }
+
+type Snapshot struct {
+	ID             string `json:"id"`
+	OrganizationID string `json:"organization_id"`
+	Name           string `json:"name"`
+	Tag            string `json:"tag,omitempty"`
+}
+
+type CreateSnapshotRequest struct {
+	SandboxID string  `json:"sandbox_id"`
+	Name      string  `json:"name"`
+	Tag       *string `json:"tag,omitempty"`
+}

--- a/internal/circleci/types.go
+++ b/internal/circleci/types.go
@@ -67,7 +67,6 @@ type Snapshot struct {
 }
 
 type CreateSnapshotRequest struct {
-	SandboxID string  `json:"sandbox_id"`
-	Name      string  `json:"name"`
-	Tag       *string `json:"tag,omitempty"`
+	SandboxID string `json:"sandbox_id"`
+	Name      string `json:"name"`
 }

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -38,6 +38,7 @@ func newSandboxCmd() *cobra.Command {
 	cmd.AddCommand(newSandboxUseCmd())
 	cmd.AddCommand(newSandboxCurrentCmd())
 	cmd.AddCommand(newSandboxForgetCmd())
+	cmd.AddCommand(newSandboxSnapshotCmd())
 
 	return cmd
 }
@@ -477,6 +478,74 @@ Example:
 
 	cmd.Flags().StringVar(&dir, "dir", ".", "Directory to write Dockerfile.test and build from")
 	cmd.Flags().StringVar(&tag, "tag", "", "Image tag (e.g. myapp:latest)")
+
+	return cmd
+}
+
+func newSandboxSnapshotCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "snapshot",
+		Short: "Manage sandbox snapshots",
+	}
+	cmd.AddCommand(newSandboxSnapshotCreateCmd())
+	cmd.AddCommand(newSandboxSnapshotGetCmd())
+	return cmd
+}
+
+func newSandboxSnapshotCreateCmd() *cobra.Command {
+	var sandboxID, name string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a snapshot of a sandbox",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			io := iostream.FromCmd(cmd)
+			if err := resolveSandboxID(&sandboxID); err != nil {
+				return err
+			}
+			client, err := circleci.NewClient()
+			if err != nil {
+				return err
+			}
+			snap, err := sandbox.CreateSnapshot(cmd.Context(), client, sandboxID, name)
+			if err != nil {
+				return err
+			}
+			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Created snapshot %s", snap.ID)))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID (defaults to active sandbox)")
+	cmd.Flags().StringVar(&name, "name", "", "Snapshot name")
+	_ = cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+func newSandboxSnapshotGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <snapshot-id>",
+		Short: "Get a snapshot by ID",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			io := iostream.FromCmd(cmd)
+			client, err := circleci.NewClient()
+			if err != nil {
+				return err
+			}
+			snap, err := sandbox.GetSnapshot(cmd.Context(), client, args[0])
+			if err != nil {
+				return err
+			}
+			if snap.Name != "" {
+				io.Printf("%s  %s\n", snap.Name, snap.ID)
+			} else {
+				io.Printf("%s\n", snap.ID)
+			}
+			return nil
+		},
+	}
 
 	return cmd
 }

--- a/internal/sandbox/snapshot.go
+++ b/internal/sandbox/snapshot.go
@@ -1,0 +1,15 @@
+package sandbox
+
+import (
+	"context"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+)
+
+func CreateSnapshot(ctx context.Context, client *circleci.Client, sandboxID, name string) (*circleci.Snapshot, error) {
+	return client.CreateSnapshot(ctx, sandboxID, name)
+}
+
+func GetSnapshot(ctx context.Context, client *circleci.Client, id string) (*circleci.Snapshot, error) {
+	return client.GetSnapshot(ctx, id)
+}

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -72,6 +72,7 @@ type FakeCircleCI struct {
 	ExecStatusCode           int // override for POST /sandbox/instances/:id/exec
 	AddKeyStatusCode         int // override for POST /sandbox/instances/:id/ssh/add-key
 	CreateSnapshotStatusCode int // override for POST /sandbox/snapshots
+	GetSnapshotStatusCode    int // override for GET /sandbox/snapshots/:id
 }
 
 func NewFakeCircleCI() *FakeCircleCI {
@@ -273,6 +274,11 @@ func (f *FakeCircleCI) handleGetSnapshot(c *gin.Context) {
 	}
 	f.mu.RLock()
 	defer f.mu.RUnlock()
+
+	if f.GetSnapshotStatusCode != 0 {
+		c.JSON(f.GetSnapshotStatusCode, gin.H{"message": "API error"})
+		return
+	}
 
 	id := c.Param("id")
 	for _, s := range f.Snapshots {

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -31,6 +31,13 @@ type Sandbox struct {
 	Image          string `json:"image,omitempty"`
 }
 
+type Snapshot struct {
+	ID             string `json:"id"`
+	OrganizationID string `json:"organization_id"`
+	Name           string `json:"name"`
+	Tag            string `json:"tag,omitempty"`
+}
+
 type RunResponse struct {
 	RunID      string `json:"runId,omitempty"`
 	PipelineID string `json:"pipelineId,omitempty"`
@@ -53,16 +60,18 @@ type FakeCircleCI struct {
 	Collaborations []Collaboration
 	Projects       []Project
 	Sandboxes      []Sandbox
+	Snapshots      []Snapshot
 	RunResponse    *RunResponse
 	AddKeyURL      string
 	ExecResponse   *ExecResponse
 	RunStatusCode  int // override status code for trigger run endpoint
 
 	// Per-endpoint status code overrides for testing error responses.
-	ListStatusCode   int // override for GET /sandbox/instances
-	CreateStatusCode int // override for POST /sandbox/instances
-	ExecStatusCode   int // override for POST /sandbox/instances/:id/exec
-	AddKeyStatusCode int // override for POST /sandbox/instances/:id/ssh/add-key
+	ListStatusCode           int // override for GET /sandbox/instances
+	CreateStatusCode         int // override for POST /sandbox/instances
+	ExecStatusCode           int // override for POST /sandbox/instances/:id/exec
+	AddKeyStatusCode         int // override for POST /sandbox/instances/:id/ssh/add-key
+	CreateSnapshotStatusCode int // override for POST /sandbox/snapshots
 }
 
 func NewFakeCircleCI() *FakeCircleCI {
@@ -82,6 +91,10 @@ func NewFakeCircleCI() *FakeCircleCI {
 	r.POST("/api/v2/sandbox/instances", f.handleCreateSandbox)
 	r.POST("/api/v2/sandbox/instances/:id/ssh/add-key", f.handleAddSSHKey)
 	r.POST("/api/v2/sandbox/instances/:id/exec", f.handleExec)
+
+	// Snapshot endpoints
+	r.POST("/api/v2/sandbox/snapshots", f.handleCreateSnapshot)
+	r.GET("/api/v2/sandbox/snapshots/:id", f.handleGetSnapshot)
 
 	// Task run endpoint
 	r.POST("/api/v2/agents/org/:org_id/project/:project_id/runs", f.handleTriggerRun)
@@ -219,6 +232,56 @@ func (f *FakeCircleCI) handleExec(c *gin.Context) {
 		Stderr:    "",
 		ExitCode:  0,
 	})
+}
+
+func (f *FakeCircleCI) handleCreateSnapshot(c *gin.Context) {
+	if !f.requireToken(c) {
+		return
+	}
+	f.mu.RLock()
+	statusCode := f.CreateSnapshotStatusCode
+	f.mu.RUnlock()
+	if statusCode != 0 {
+		c.JSON(statusCode, gin.H{"message": "API error"})
+		return
+	}
+
+	var body struct {
+		SandboxID string `json:"sandbox_id"`
+		Name      string `json:"name"`
+	}
+	if err := json.NewDecoder(c.Request.Body).Decode(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "Bad request"})
+		return
+	}
+
+	snap := Snapshot{
+		ID:   "snap-new-123",
+		Name: body.Name,
+	}
+
+	f.mu.Lock()
+	f.Snapshots = append(f.Snapshots, snap)
+	f.mu.Unlock()
+
+	c.JSON(http.StatusCreated, snap)
+}
+
+func (f *FakeCircleCI) handleGetSnapshot(c *gin.Context) {
+	if !f.requireToken(c) {
+		return
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	id := c.Param("id")
+	for _, s := range f.Snapshots {
+		if s.ID == id {
+			c.JSON(http.StatusOK, s)
+			return
+		}
+	}
+	c.JSON(http.StatusNotFound, gin.H{"message": "snapshot not found"})
 }
 
 func (f *FakeCircleCI) handleTriggerRun(c *gin.Context) {


### PR DESCRIPTION


- **`chunk sandbox snapshot create`**: Creates a snapshot of a sandbox. Accepts   
  `--sandbox-id` (falls back to active sandbox) and `--name` (required). Calls `POST
   /api/v2/sandbox/snapshots` on the server with `sandbox_id` and `name` in the     
  request body.                                                                   
  - **`chunk sandbox snapshot get`**: Fetches a snapshot by ID. Calls `GET
  /api/v2/sandbox/snapshots/:id`.
  - **Fake server handlers**: Added `POST /api/v2/sandbox/snapshots` and `GET
  /api/v2/sandbox/snapshots/:id` to `FakeCircleCI` for use in acceptance tests.     
  - **Acceptance tests**: 9 tests covering happy paths, request body shape, active
  sandbox fallback, missing flags, auth errors, and API errors.                     
                                                                                  
  Note: list and restore are not included here — those require new endpoints on the 
  sandbox-provisioner side first.

  ## Test plan                                                                    

  - [ ] `go test ./...` passes
  - [ ] `chunk sandbox snapshot create --sandbox-id <id> --name <name>` creates a
  snapshot and prints the ID                                                        
  - [ ] `chunk sandbox snapshot create --name <name>` uses the active sandbox when
  `--sandbox-id` is omitted                                                         
  - [ ] `chunk sandbox snapshot get <id>` prints the snapshot name and ID