### PR TITLE
Add script to sync E2B templates from cimg Docker images

### DIFF
--- a/scripts/sync-e2b-templates.sh
+++ b/scripts/sync-e2b-templates.sh
@@ -47,6 +47,8 @@ sanitize_version() {
 
 created=0
 failed=0
+cleanup_dirs=()
+trap 'rm -rf "${cleanup_dirs[@]+"${cleanup_dirs[@]}"}"' EXIT
 
 for lang in "${LANGUAGES[@]}"; do
   echo "--- cimg/${lang} ---"
@@ -68,17 +70,17 @@ for lang in "${LANGUAGES[@]}"; do
     echo "  Building template '${template_name}' from cimg/${lang}:${tag} ..."
 
     tmpdir=$(mktemp -d)
+    cleanup_dirs+=("$tmpdir")
     echo "FROM cimg/${lang}:${tag}" > "${tmpdir}/Dockerfile"
 
     if e2b template build --name "$template_name" --dockerfile "${tmpdir}/Dockerfile" --cmd "sleep infinity"; then
       echo "  Created ${template_name}"
-      ((created++))
+      created=$((created + 1))
     else
       echo "  Failed to create ${template_name}" >&2
-      ((failed++))
+      failed=$((failed + 1))
     fi
 
-    rm -rf "$tmpdir"
   done <<< "$tags"
 done
 

--- a/scripts/sync-e2b-templates.sh
+++ b/scripts/sync-e2b-templates.sh
@@ -81,6 +81,7 @@ for lang in "${LANGUAGES[@]}"; do
       failed=$((failed + 1))
     fi
 
+    rm -rf "$tmpdir"
   done <<< "$tags"
 done
 

--- a/scripts/sync-e2b-templates.sh
+++ b/scripts/sync-e2b-templates.sh
@@ -8,19 +8,26 @@ set -euo pipefail
 #   - jq, curl
 #
 # Usage:
-#   ./scripts/sync-e2b-templates.sh [--dry-run]
+#   ./scripts/sync-e2b-templates.sh --team <team-id> [--dry-run]
 
 LANGUAGES=(go python node rust)
 TAGS_PER_LANG=3
 SEMVER_REGEX='^[0-9]+\.[0-9]+\.[0-9]+$'
 DRY_RUN=false
+TEAM=""
 
-for arg in "$@"; do
-  case "$arg" in
-    --dry-run) DRY_RUN=true ;;
-    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true; shift ;;
+    --team) TEAM="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
+
+if [[ -z "$TEAM" ]]; then
+  echo "Error: --team <team-id> is required." >&2
+  exit 1
+fi
 
 # Check prerequisites
 for cmd in e2b jq curl; do
@@ -73,7 +80,7 @@ for lang in "${LANGUAGES[@]}"; do
     cleanup_dirs+=("$tmpdir")
     echo "FROM cimg/${lang}:${tag}" > "${tmpdir}/Dockerfile"
 
-    if e2b template build --name "$template_name" --dockerfile "${tmpdir}/Dockerfile" --cmd "sleep infinity"; then
+    if e2b template build --name "$template_name" --dockerfile "${tmpdir}/Dockerfile" --cmd "sleep infinity" --team "$TEAM"; then
       echo "  Created ${template_name}"
       created=$((created + 1))
     else

--- a/scripts/sync-e2b-templates.sh
+++ b/scripts/sync-e2b-templates.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch recent cimg Docker images from Docker Hub and create E2B templates from them.
+#
+# Prerequisites:
+#   - e2b CLI installed and authenticated (e2b auth login or E2B_ACCESS_TOKEN set)
+#   - jq, curl
+#
+# Usage:
+#   ./scripts/sync-e2b-templates.sh [--dry-run]
+
+LANGUAGES=(go python node rust)
+TAGS_PER_LANG=3
+SEMVER_REGEX='^[0-9]+\.[0-9]+\.[0-9]+$'
+DRY_RUN=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+# Check prerequisites
+for cmd in e2b jq curl; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "Error: '$cmd' is required but not found in PATH." >&2
+    exit 1
+  fi
+done
+
+# Fetch the N most recent full-semver tags for a cimg repository.
+# Args: $1 = repository name (e.g. "go")
+fetch_tags() {
+  local repo="$1"
+  curl -s "https://hub.docker.com/v2/repositories/cimg/${repo}/tags?page_size=100&ordering=last_updated" \
+    | jq -r --arg regex "$SEMVER_REGEX" \
+        '.results[] | select(.name | test($regex)) | .name' \
+    | head -n "$TAGS_PER_LANG"
+}
+
+# Sanitize a version string for use as an E2B template name (dots → dashes).
+sanitize_version() {
+  echo "$1" | tr '.' '-'
+}
+
+created=0
+failed=0
+
+for lang in "${LANGUAGES[@]}"; do
+  echo "--- cimg/${lang} ---"
+
+  tags=$(fetch_tags "$lang")
+  if [[ -z "$tags" ]]; then
+    echo "  No semver tags found, skipping."
+    continue
+  fi
+
+  while IFS= read -r tag; do
+    template_name="cimg-${lang}-$(sanitize_version "$tag")"
+
+    if "$DRY_RUN"; then
+      echo "  [dry-run] Would build template '${template_name}' from cimg/${lang}:${tag}"
+      continue
+    fi
+
+    echo "  Building template '${template_name}' from cimg/${lang}:${tag} ..."
+
+    tmpdir=$(mktemp -d)
+    echo "FROM cimg/${lang}:${tag}" > "${tmpdir}/Dockerfile"
+
+    if e2b template build --name "$template_name" --dockerfile "${tmpdir}/Dockerfile" --cmd "sleep infinity"; then
+      echo "  Created ${template_name}"
+      ((created++))
+    else
+      echo "  Failed to create ${template_name}" >&2
+      ((failed++))
+    fi
+
+    rm -rf "$tmpdir"
+  done <<< "$tags"
+done
+
+echo ""
+echo "Done. Created: ${created}, Failed: ${failed}"


### PR DESCRIPTION
## Summary

- Adds `scripts/sync-e2b-templates.sh` which fetches the 3 most recent full-semver tags for `cimg/go`, `cimg/python`, `cimg/node`, and `cimg/rust` from Docker Hub and creates E2B sandbox templates from each
- Supports `--dry-run` flag to preview what would be built without actually creating templates
- Checks for required tools (`e2b`, `jq`, `curl`) at startup and reports a summary of created/failed templates at the end

## Test plan

- [ ] Run `./scripts/sync-e2b-templates.sh --dry-run` to verify Docker Hub API calls return valid semver tags
- [ ] Run `./scripts/sync-e2b-templates.sh` with E2B credentials to confirm templates are created
- [ ] Verify templates appear in `e2b template list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)