### PR TITLE
Rename sandbox organization_id to org_id

### DIFF
--- a/acceptance/sandbox_gaps_test.go
+++ b/acceptance/sandbox_gaps_test.go
@@ -222,7 +222,7 @@ func TestSandboxCreateOrgIDFromConfig(t *testing.T) {
 	var body map[string]interface{}
 	err := json.Unmarshal(createReqs[0].Body, &body)
 	assert.NilError(t, err)
-	assert.Equal(t, body["organization_id"], "org-from-config")
+	assert.Equal(t, body["org_id"], "org-from-config")
 }
 
 func TestSandboxCreateNoOrgIDNoConfig(t *testing.T) {

--- a/acceptance/sandbox_test.go
+++ b/acceptance/sandbox_test.go
@@ -20,8 +20,8 @@ import (
 func TestSandboxesListHappyPath(t *testing.T) {
 	cci := fakes.NewFakeCircleCI()
 	cci.Sandboxes = []fakes.Sandbox{
-		{ID: "sb-111", Name: "dev-sandbox", OrganizationID: "org-aaa"},
-		{ID: "sb-222", Name: "staging-sandbox", OrganizationID: "org-aaa"},
+		{ID: "sb-111", Name: "dev-sandbox", OrgID: "org-aaa"},
+		{ID: "sb-222", Name: "staging-sandbox", OrgID: "org-aaa"},
 	}
 	srv := httptest.NewServer(cci)
 	defer srv.Close()
@@ -69,8 +69,8 @@ func TestSandboxesListEmpty(t *testing.T) {
 func TestSandboxesListFiltersByOrg(t *testing.T) {
 	cci := fakes.NewFakeCircleCI()
 	cci.Sandboxes = []fakes.Sandbox{
-		{ID: "sb-111", Name: "org-a-box", OrganizationID: "org-a"},
-		{ID: "sb-222", Name: "org-b-box", OrganizationID: "org-b"},
+		{ID: "sb-111", Name: "org-a-box", OrgID: "org-a"},
+		{ID: "sb-222", Name: "org-b-box", OrgID: "org-b"},
 	}
 	srv := httptest.NewServer(cci)
 	defer srv.Close()
@@ -140,7 +140,7 @@ func TestSandboxesCreateHappyPath(t *testing.T) {
 	var body map[string]interface{}
 	err := json.Unmarshal(createReqs[0].Body, &body)
 	assert.NilError(t, err)
-	assert.Equal(t, body["organization_id"], "org-aaa")
+	assert.Equal(t, body["org_id"], "org-aaa")
 	assert.Equal(t, body["name"], "my-new-sandbox")
 }
 
@@ -425,7 +425,7 @@ func TestSandboxesCreateMissingName(t *testing.T) {
 func TestSandboxesListFromConfig(t *testing.T) {
 	cci := fakes.NewFakeCircleCI()
 	cci.Sandboxes = []fakes.Sandbox{
-		{ID: "sb-999", Name: "config-sandbox", OrganizationID: "org-from-config"},
+		{ID: "sb-999", Name: "config-sandbox", OrgID: "org-from-config"},
 	}
 	srv := httptest.NewServer(cci)
 	defer srv.Close()

--- a/internal/circleci/circleci_test.go
+++ b/internal/circleci/circleci_test.go
@@ -76,9 +76,9 @@ func TestNewClient(t *testing.T) {
 func TestListSandboxes(t *testing.T) {
 	fake := fakes.NewFakeCircleCI()
 	fake.Sandboxes = []fakes.Sandbox{
-		{ID: "sb-1", Name: "dev", OrganizationID: "org-1"},
-		{ID: "sb-2", Name: "staging", OrganizationID: "org-1"},
-		{ID: "sb-3", Name: "other", OrganizationID: "org-2"},
+		{ID: "sb-1", Name: "dev", OrgID: "org-1"},
+		{ID: "sb-2", Name: "staging", OrgID: "org-1"},
+		{ID: "sb-3", Name: "other", OrgID: "org-2"},
 	}
 	srv := httptest.NewServer(fake)
 	defer srv.Close()
@@ -144,8 +144,8 @@ func TestCreateSandbox(t *testing.T) {
 	if sb.Name != "my-sandbox" {
 		t.Errorf("expected name my-sandbox, got %s", sb.Name)
 	}
-	if sb.OrganizationID != "org-1" {
-		t.Errorf("expected org org-1, got %s", sb.OrganizationID)
+	if sb.OrgID != "org-1" {
+		t.Errorf("expected org org-1, got %s", sb.OrgID)
 	}
 	if sb.Image != "ubuntu:22.04" {
 		t.Errorf("expected image ubuntu:22.04, got %s", sb.Image)

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -50,10 +50,10 @@ func (c *Client) ListSandboxes(ctx context.Context, orgID string) ([]Sandbox, er
 
 func (c *Client) CreateSandbox(ctx context.Context, orgID, name, provider, image string) (*Sandbox, error) {
 	body := CreateSandboxRequest{
-		OrganizationID: orgID,
-		Name:           name,
-		Provider:       provider,
-		Image:          image,
+		OrgID:    orgID,
+		Name:     name,
+		Provider: provider,
+		Image:    image,
 	}
 	var resp Sandbox
 	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodPost, "/api/v2/sandbox/instances",

--- a/internal/circleci/types.go
+++ b/internal/circleci/types.go
@@ -1,10 +1,10 @@
 package circleci
 
 type Sandbox struct {
-	ID             string `json:"id"`
-	Name           string `json:"name"`
-	OrganizationID string `json:"organization_id"`
-	Image          string `json:"image,omitempty"`
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	OrgID string `json:"org_id"`
+	Image string `json:"image,omitempty"`
 }
 
 type listSandboxesResponse struct {
@@ -53,8 +53,8 @@ type RunResponse struct {
 }
 
 type CreateSandboxRequest struct {
-	OrganizationID string `json:"organization_id"`
-	Name           string `json:"name"`
-	Provider       string `json:"provider,omitempty"`
-	Image          string `json:"image,omitempty"`
+	OrgID    string `json:"org_id"`
+	Name     string `json:"name"`
+	Provider string `json:"provider,omitempty"`
+	Image    string `json:"image,omitempty"`
 }

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -47,9 +47,9 @@ func TestOpenSessionDefaultKeyFallback(t *testing.T) {
 func TestList(t *testing.T) {
 	cci := fakes.NewFakeCircleCI()
 	cci.Sandboxes = []fakes.Sandbox{
-		{ID: "sb-1", Name: "alpha", OrganizationID: "org-1"},
-		{ID: "sb-2", Name: "beta", OrganizationID: "org-1"},
-		{ID: "sb-3", Name: "gamma", OrganizationID: "org-2"},
+		{ID: "sb-1", Name: "alpha", OrgID: "org-1"},
+		{ID: "sb-2", Name: "beta", OrgID: "org-1"},
+		{ID: "sb-3", Name: "gamma", OrgID: "org-2"},
 	}
 	srv := httptest.NewServer(cci)
 	defer srv.Close()
@@ -84,7 +84,7 @@ func TestCreate(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, sb.ID, "sandbox-new-123")
 	assert.Equal(t, sb.Name, "my-sandbox")
-	assert.Equal(t, sb.OrganizationID, "org-1")
+	assert.Equal(t, sb.OrgID, "org-1")
 }
 
 func TestExec(t *testing.T) {

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -24,11 +24,11 @@ type Project struct {
 }
 
 type Sandbox struct {
-	ID             string `json:"id"`
-	Name           string `json:"name"`
-	OrganizationID string `json:"organization_id"`
-	Provider       string `json:"provider,omitempty"`
-	Image          string `json:"image,omitempty"`
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	OrgID    string `json:"org_id"`
+	Provider string `json:"provider,omitempty"`
+	Image    string `json:"image,omitempty"`
 }
 
 type RunResponse struct {
@@ -131,7 +131,7 @@ func (f *FakeCircleCI) handleListSandboxes(c *gin.Context) {
 	orgID := c.Query("org_id")
 	var filtered []Sandbox
 	for _, s := range f.Sandboxes {
-		if s.OrganizationID == orgID {
+		if s.OrgID == orgID {
 			filtered = append(filtered, s)
 		}
 	}
@@ -155,10 +155,10 @@ func (f *FakeCircleCI) handleCreateSandbox(c *gin.Context) {
 	}
 
 	var body struct {
-		OrganizationID string `json:"organization_id"`
-		Name           string `json:"name"`
-		Provider       string `json:"provider,omitempty"`
-		Image          string `json:"image,omitempty"`
+		OrgID    string `json:"org_id"`
+		Name     string `json:"name"`
+		Provider string `json:"provider,omitempty"`
+		Image    string `json:"image,omitempty"`
 	}
 	if err := json.NewDecoder(c.Request.Body).Decode(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"message": "Bad request"})
@@ -166,10 +166,10 @@ func (f *FakeCircleCI) handleCreateSandbox(c *gin.Context) {
 	}
 
 	sandbox := Sandbox{
-		ID:             "sandbox-new-123",
-		Name:           body.Name,
-		OrganizationID: body.OrganizationID,
-		Image:          body.Image,
+		ID:    "sandbox-new-123",
+		Name:  body.Name,
+		OrgID: body.OrgID,
+		Image: body.Image,
 	}
 
 	f.mu.Lock()


### PR DESCRIPTION
## Summary
- Align client types with provisioner API field rename from `organization_id` to `org_id`
- Update `Sandbox` and `CreateSandboxRequest` structs, fakes, and all tests