### PR TITLE
Add sandbox reset

### DIFF
--- a/acceptance/sandbox_reset_test.go
+++ b/acceptance/sandbox_reset_test.go
@@ -1,0 +1,122 @@
+package acceptance
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/chunk-cli/internal/testing/env"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+)
+
+func TestSandboxResetHappyPath(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, []string{
+		"sandbox", "reset",
+		"--sandbox-id", "sb-111",
+	}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "sb-111"),
+		"expected sandbox ID in success message, got: %s", result.Stderr)
+}
+
+func TestSandboxResetSendsCorrectSandboxID(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, []string{
+		"sandbox", "reset",
+		"--sandbox-id", "sb-target",
+	}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	reqs := cci.Recorder.AllRequests()
+	resetReqs := filterByMethod(reqs, "POST", "/api/v2/sandbox/instances/sb-target/reset")
+	assert.Equal(t, len(resetReqs), 1, "expected 1 reset request for sb-target")
+}
+
+func TestSandboxResetUsesActiveSandbox(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	workDir := t.TempDir()
+
+	// create sets active sandbox to "sandbox-new-123"
+	result := binary.RunCLI(t, []string{
+		"sandbox", "create",
+		"--org-id", "org-aaa",
+		"--name", "test-box",
+	}, env, workDir)
+	assert.Equal(t, result.ExitCode, 0, "create stderr: %s", result.Stderr)
+
+	// reset without --sandbox-id should use the active sandbox
+	result = binary.RunCLI(t, []string{
+		"sandbox", "reset",
+	}, env, workDir)
+	assert.Equal(t, result.ExitCode, 0, "reset stderr: %s", result.Stderr)
+
+	reqs := cci.Recorder.AllRequests()
+	resetReqs := filterByMethod(reqs, "POST", "/api/v2/sandbox/instances/sandbox-new-123/reset")
+	assert.Equal(t, len(resetReqs), 1, "expected reset request for active sandbox ID")
+}
+
+func TestSandboxResetNoActiveSandbox(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	workDir := t.TempDir()
+
+	result := binary.RunCLI(t, []string{
+		"sandbox", "reset",
+	}, env, workDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit with no sandbox ID")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "sandbox-id") || strings.Contains(combined, "active sandbox"),
+		"expected helpful error, got: %s", combined)
+}
+
+func TestSandboxResetAPIError(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.ResetStatusCode = 500
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, []string{
+		"sandbox", "reset",
+		"--sandbox-id", "sb-111",
+	}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for 500 response")
+}
+
+func TestSandboxResetMissingToken(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	env.CircleToken = ""
+
+	result := binary.RunCLI(t, []string{
+		"sandbox", "reset",
+		"--sandbox-id", "sb-111",
+	}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit without token")
+}

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -95,6 +95,18 @@ func (c *Client) Exec(ctx context.Context, sandboxID, command string, args []str
 	return &resp, nil
 }
 
+func (c *Client) ResetSandbox(ctx context.Context, sandboxID string) (*ResetSandboxResponse, error) {
+	var resp ResetSandboxResponse
+	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodPost,
+		fmt.Sprintf("/api/v2/sandbox/instances/%s/reset", sandboxID),
+		httpcl.JSONDecoder(&resp),
+	))
+	if err != nil {
+		return nil, fmt.Errorf("reset sandbox: %w", err)
+	}
+	return &resp, nil
+}
+
 func (c *Client) TriggerRun(ctx context.Context, orgID, projectID string, body TriggerRunRequest) (*RunResponse, error) {
 	var resp RunResponse
 	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodPost,

--- a/internal/circleci/types.go
+++ b/internal/circleci/types.go
@@ -58,3 +58,7 @@ type CreateSandboxRequest struct {
 	Provider string `json:"provider,omitempty"`
 	Image    string `json:"image,omitempty"`
 }
+
+type ResetSandboxResponse struct {
+	ID string `json:"id"`
+}

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -37,6 +37,7 @@ func newSandboxCmd() *cobra.Command {
 	cmd.AddCommand(newSandboxUseCmd())
 	cmd.AddCommand(newSandboxCurrentCmd())
 	cmd.AddCommand(newSandboxForgetCmd())
+	cmd.AddCommand(newSandboxResetCmd())
 
 	return cmd
 }
@@ -472,6 +473,39 @@ Example:
 
 	cmd.Flags().StringVar(&dir, "dir", ".", "Directory to write Dockerfile.test and build from")
 	cmd.Flags().StringVar(&tag, "tag", "", "Image tag (e.g. myapp:latest)")
+
+	return cmd
+}
+
+func newSandboxResetCmd() *cobra.Command {
+	var sandboxID string
+
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Reset a sandbox to a clean state after snapshotting",
+		Long: `Reset a sandbox to a clean state.
+
+Unsets agent-specific environment variables, terminates the agent process,
+and removes the agent from the sandbox. Run this after taking a snapshot to
+ensure the snapshot base is clean for future use.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			io := iostream.FromCmd(cmd)
+			if err := resolveSandboxID(&sandboxID); err != nil {
+				return err
+			}
+			client, err := circleci.NewClient()
+			if err != nil {
+				return err
+			}
+			if _, err := sandbox.Reset(cmd.Context(), client, sandboxID); err != nil {
+				return err
+			}
+			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Reset sandbox %s", sandboxID)))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID (defaults to active sandbox)")
 
 	return cmd
 }

--- a/internal/sandbox/reset.go
+++ b/internal/sandbox/reset.go
@@ -1,0 +1,11 @@
+package sandbox
+
+import (
+	"context"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+)
+
+func Reset(ctx context.Context, client *circleci.Client, sandboxID string) (*circleci.ResetSandboxResponse, error) {
+	return client.ResetSandbox(ctx, sandboxID)
+}

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -63,6 +63,9 @@ type FakeCircleCI struct {
 	CreateStatusCode int // override for POST /sandbox/instances
 	ExecStatusCode   int // override for POST /sandbox/instances/:id/exec
 	AddKeyStatusCode int // override for POST /sandbox/instances/:id/ssh/add-key
+	ResetStatusCode  int // override for POST /sandbox/instances/:id/reset
+
+	ResetRequests []string // IDs of sandboxes reset via handleResetSandbox
 }
 
 func NewFakeCircleCI() *FakeCircleCI {
@@ -82,6 +85,7 @@ func NewFakeCircleCI() *FakeCircleCI {
 	r.POST("/api/v2/sandbox/instances", f.handleCreateSandbox)
 	r.POST("/api/v2/sandbox/instances/:id/ssh/add-key", f.handleAddSSHKey)
 	r.POST("/api/v2/sandbox/instances/:id/exec", f.handleExec)
+	r.POST("/api/v2/sandbox/instances/:id/reset", f.handleResetSandbox)
 
 	// Task run endpoint
 	r.POST("/api/v2/agents/org/:org_id/project/:project_id/runs", f.handleTriggerRun)
@@ -244,4 +248,27 @@ func (f *FakeCircleCI) handleTriggerRun(c *gin.Context) {
 		RunID:      "run-abc-123",
 		PipelineID: "pipeline-def-456",
 	})
+}
+
+func (f *FakeCircleCI) handleResetSandbox(c *gin.Context) {
+	if !f.requireToken(c) {
+		return
+	}
+
+	f.mu.RLock()
+	statusCode := f.ResetStatusCode
+	f.mu.RUnlock()
+
+	if statusCode != 0 {
+		c.JSON(statusCode, gin.H{"message": "API error"})
+		return
+	}
+
+	id := c.Param("id")
+
+	f.mu.Lock()
+	f.ResetRequests = append(f.ResetRequests, id)
+	f.mu.Unlock()
+
+	c.JSON(http.StatusOK, gin.H{"id": id})
 }


### PR DESCRIPTION
Adds a chunk sandbox reset subcommand that resets a sandbox to a clean satate after snapshotting. It unsets agent-specific environment variables, terminates the agent process, and removes the agent from the sandbox. 

To test:

- [ ] task acceptance test passes
- [ ] task test passes with -race 
- [ ] Manual: chunk sandbox reset --sandbox-id <id> prints success; chunk sandbox reset with no active sandbox prints a helpful error. 