### PR TITLE
Add workspace setting to sandbox.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,8 @@ PLANS.md
 .chunk/sandbox*.patch
 
 # active sandbox tracking
-.chunk/sandbox
+.chunk/sandbox.json
+.chunk/sandbox.*.json
 
 # unikraft
 .unikraft/

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -158,6 +158,57 @@ func writeSettingsExample(dir string, data []byte, streams iostream.Streams) err
 	return nil
 }
 
+var sandboxGitignoreEntries = []string{
+	".chunk/sandbox.json",
+	".chunk/sandbox.*.json",
+}
+
+// ensureGitignoreEntries appends sandbox tracking patterns to .gitignore if
+// they are not already present.
+func ensureGitignoreEntries(workDir string, streams iostream.Streams) error {
+	path := filepath.Join(workDir, ".gitignore")
+
+	existing, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("read .gitignore: %w", err)
+	}
+
+	content := string(existing)
+	var toAdd []string
+	for _, entry := range sandboxGitignoreEntries {
+		if !strings.Contains(content, entry) {
+			toAdd = append(toAdd, entry)
+		}
+	}
+	if len(toAdd) == 0 {
+		return nil
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open .gitignore: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if len(existing) > 0 && existing[len(existing)-1] != '\n' {
+		if _, err := f.WriteString("\n"); err != nil {
+			return err
+		}
+	}
+
+	if _, err := f.WriteString("\n# chunk active sandbox tracking\n"); err != nil {
+		return err
+	}
+	for _, entry := range toAdd {
+		if _, err := f.WriteString(entry + "\n"); err != nil {
+			return err
+		}
+	}
+
+	streams.ErrPrintln(ui.Success("Updated .gitignore with sandbox tracking patterns"))
+	return nil
+}
+
 func newInitCmd() *cobra.Command {
 	var force, skipHooks, skipValidate, skipCircleCI, skipCompletions bool
 	var projectDir string
@@ -250,6 +301,10 @@ commands, and generates hook config files.`,
 				return fmt.Errorf("write config: %w", err)
 			}
 			streams.ErrPrintln(ui.Success("Wrote .chunk/config.json"))
+
+			if err := ensureGitignoreEntries(workDir, streams); err != nil {
+				streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not update .gitignore: %v", err)))
+			}
 
 			// Step 4: Write .claude/settings.json
 			if !skipHooks {

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -237,6 +237,53 @@ func TestInstallCompletionSkipsWhenAlreadyInstalled(t *testing.T) {
 	assert.Assert(t, bytes.Contains(errOut.Bytes(), []byte("already installed")))
 }
 
+func TestEnsureGitignoreEntriesCreatesNew(t *testing.T) {
+	dir := t.TempDir()
+	streams, _, _ := testStreams()
+
+	err := ensureGitignoreEntries(dir, streams)
+	assert.NilError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	assert.NilError(t, err)
+	for _, entry := range sandboxGitignoreEntries {
+		assert.Assert(t, strings.Contains(string(data), entry), "missing %s", entry)
+	}
+}
+
+func TestEnsureGitignoreEntriesAppendsToExisting(t *testing.T) {
+	dir := t.TempDir()
+	existing := "node_modules/\n.env\n"
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(existing), 0o644))
+
+	streams, _, _ := testStreams()
+	err := ensureGitignoreEntries(dir, streams)
+	assert.NilError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	assert.NilError(t, err)
+	content := string(data)
+	assert.Assert(t, strings.HasPrefix(content, existing))
+	for _, entry := range sandboxGitignoreEntries {
+		assert.Assert(t, strings.Contains(content, entry), "missing %s", entry)
+	}
+}
+
+func TestEnsureGitignoreEntriesIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	streams, _, _ := testStreams()
+
+	assert.NilError(t, ensureGitignoreEntries(dir, streams))
+	first, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	assert.NilError(t, err)
+
+	assert.NilError(t, ensureGitignoreEntries(dir, streams))
+	second, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	assert.NilError(t, err)
+
+	assert.Equal(t, string(first), string(second))
+}
+
 func TestInstallCompletionBashWritesRCFile(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -310,7 +310,7 @@ func newSandboxSyncCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID (defaults to active sandbox)")
 	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file")
-	cmd.Flags().StringVar(&workdir, "workdir", "", "Destination path on sandbox (auto-detected as /workspace/<repo> when omitted)")
+	cmd.Flags().StringVar(&workdir, "workdir", "", "Destination path on sandbox (reads from sandbox.json, or defaults to /workspace/<repo>)")
 
 	return cmd
 }

--- a/internal/sandbox/active.go
+++ b/internal/sandbox/active.go
@@ -18,12 +18,12 @@ type ActiveSandbox struct {
 // Claude sessions in the same repo each maintain their own active sandbox.
 func sandboxFileName() string {
 	if id := os.Getenv("CLAUDE_SESSION_ID"); id != "" {
-		return "sandbox." + id
+		return "sandbox." + id + ".json"
 	}
-	return "sandbox"
+	return "sandbox.json"
 }
 
-// LoadActive walks up from cwd looking for .chunk/sandbox. Returns nil if not found.
+// LoadActive walks up from cwd looking for .chunk/sandbox.json. Returns nil if not found.
 func LoadActive() (*ActiveSandbox, error) {
 	path, err := findSandboxFile()
 	if err != nil {
@@ -43,7 +43,7 @@ func LoadActive() (*ActiveSandbox, error) {
 	return &a, nil
 }
 
-// SaveActive writes .chunk/sandbox. If a .chunk/sandbox already exists in a
+// SaveActive writes .chunk/sandbox.json. If the file already exists in a
 // parent directory it is updated in place; otherwise the file is created in
 // cwd's .chunk/ directory.
 func SaveActive(a ActiveSandbox) error {
@@ -62,8 +62,8 @@ func SaveActive(a ActiveSandbox) error {
 }
 
 // saveDir returns the .chunk directory to write into. It prefers an existing
-// .chunk/sandbox found by walking upward; otherwise walks up to find the git
-// root and uses that; falls back to cwd/.chunk when not in a git repo.
+// .chunk/sandbox.json found by walking upward; otherwise walks up to find the
+// git root and uses that; falls back to cwd/.chunk when not in a git repo.
 func saveDir() (string, error) {
 	existing, err := findSandboxFile()
 	if err != nil {
@@ -101,7 +101,7 @@ func findGitRoot() (string, error) {
 	}
 }
 
-// ClearActive removes the .chunk/sandbox file found by walking up from cwd.
+// ClearActive removes the .chunk/sandbox.json file found by walking up from cwd.
 func ClearActive() error {
 	path, err := findSandboxFile()
 	if err != nil {
@@ -113,7 +113,7 @@ func ClearActive() error {
 	return os.Remove(path)
 }
 
-// findSandboxFile walks up from cwd looking for .chunk/sandbox, returning the path or "".
+// findSandboxFile walks up from cwd looking for .chunk/sandbox.json, returning the path or "".
 // When inside a git repository the walk is bounded by the repository root (the directory
 // containing .git); files above that root are never considered. When not inside any git
 // repository only the current directory is checked.

--- a/internal/sandbox/active.go
+++ b/internal/sandbox/active.go
@@ -11,6 +11,7 @@ import (
 type ActiveSandbox struct {
 	SandboxID string `json:"sandbox_id"`
 	Name      string `json:"name,omitempty"`
+	Workspace string `json:"workspace,omitempty"`
 }
 
 // sandboxFileName returns the name of the sandbox state file. When

--- a/internal/sandbox/active_test.go
+++ b/internal/sandbox/active_test.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -177,4 +178,57 @@ func TestSaveActiveUpdatesParentFile(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 	assert.Equal(t, got.SandboxID, "sb-new")
+}
+
+func TestWorkspaceFieldRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	want := ActiveSandbox{SandboxID: "sb-1", Name: "test", Workspace: "/workspace/myrepo"}
+	assert.NilError(t, SaveActive(want))
+
+	got, err := LoadActive()
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+	assert.Equal(t, got.Workspace, want.Workspace)
+	assert.Equal(t, got.SandboxID, want.SandboxID)
+}
+
+func TestWorkspaceOmittedWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	assert.NilError(t, SaveActive(ActiveSandbox{SandboxID: "sb-1"}))
+
+	data, err := os.ReadFile(filepath.Join(dir, ".chunk", "sandbox.json"))
+	assert.NilError(t, err)
+	assert.Assert(t, !strings.Contains(string(data), "workspace"), "empty workspace should be omitted from JSON")
+}
+
+func TestResolveWorkspaceCLIFlagWins(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	assert.NilError(t, SaveActive(ActiveSandbox{SandboxID: "sb-1", Workspace: "/workspace/saved"}))
+
+	got := resolveWorkspace("/workspace/override", "myrepo")
+	assert.Equal(t, got, "/workspace/override")
+}
+
+func TestResolveWorkspaceSandboxJsonFallback(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	assert.NilError(t, SaveActive(ActiveSandbox{SandboxID: "sb-1", Workspace: "/workspace/saved"}))
+
+	got := resolveWorkspace("", "myrepo")
+	assert.Equal(t, got, "/workspace/saved")
+}
+
+func TestResolveWorkspaceDefaultFallback(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	got := resolveWorkspace("", "myrepo")
+	assert.Equal(t, got, "/workspace/myrepo")
 }

--- a/internal/sandbox/active_test.go
+++ b/internal/sandbox/active_test.go
@@ -43,7 +43,7 @@ func TestLoadActiveWalksUpToParent(t *testing.T) {
 	// Write .chunk/sandbox in parent
 	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".chunk"), 0o755))
 	data := []byte(`{"sandbox_id":"sb-parent","name":"parent-box"}`)
-	assert.NilError(t, os.WriteFile(filepath.Join(parent, ".chunk", "sandbox"), data, 0o644))
+	assert.NilError(t, os.WriteFile(filepath.Join(parent, ".chunk", "sandbox.json"), data, 0o644))
 
 	// cd into child — should still find the parent's file
 	t.Chdir(child)
@@ -68,7 +68,7 @@ func TestLoadActiveStopsAtGitRoot(t *testing.T) {
 	// .chunk/sandbox lives in grandparent (above the repo root)
 	assert.NilError(t, os.MkdirAll(filepath.Join(grandparent, ".chunk"), 0o755))
 	data := []byte(`{"sandbox_id":"sb-grandparent"}`)
-	assert.NilError(t, os.WriteFile(filepath.Join(grandparent, ".chunk", "sandbox"), data, 0o644))
+	assert.NilError(t, os.WriteFile(filepath.Join(grandparent, ".chunk", "sandbox.json"), data, 0o644))
 
 	t.Chdir(child)
 
@@ -86,7 +86,7 @@ func TestLoadActiveNoGitRepo(t *testing.T) {
 	// .chunk/sandbox in parent but no .git anywhere
 	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".chunk"), 0o755))
 	data := []byte(`{"sandbox_id":"sb-parent"}`)
-	assert.NilError(t, os.WriteFile(filepath.Join(parent, ".chunk", "sandbox"), data, 0o644))
+	assert.NilError(t, os.WriteFile(filepath.Join(parent, ".chunk", "sandbox.json"), data, 0o644))
 
 	t.Chdir(child)
 
@@ -162,7 +162,7 @@ func TestSaveActiveUpdatesParentFile(t *testing.T) {
 	// Write an existing .chunk/sandbox in parent
 	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".chunk"), 0o755))
 	initial := []byte(`{"sandbox_id":"sb-old"}`)
-	assert.NilError(t, os.WriteFile(filepath.Join(parent, ".chunk", "sandbox"), initial, 0o644))
+	assert.NilError(t, os.WriteFile(filepath.Join(parent, ".chunk", "sandbox.json"), initial, 0o644))
 
 	// Save from child — should update parent's file, not create child's
 	t.Chdir(child)

--- a/internal/sandbox/sync.go
+++ b/internal/sandbox/sync.go
@@ -16,6 +16,32 @@ import (
 
 const workspaceDir = "/workspace"
 
+// resolveWorkspace determines the workspace path. Priority:
+// 1. CLI --workdir flag  2. sandbox.json workspace  3. default.
+func resolveWorkspace(cliWorkdir, repo string) string {
+	if cliWorkdir != "" {
+		return cliWorkdir
+	}
+	if active, err := LoadActive(); err == nil && active != nil && active.Workspace != "" {
+		return active.Workspace
+	}
+	return workspaceDir + "/" + repo
+}
+
+// persistWorkspace saves the resolved workspace back to sandbox.json if it
+// differs from the current value.
+func persistWorkspace(workspace string) error {
+	active, err := LoadActive()
+	if err != nil {
+		return err
+	}
+	if active == nil || active.Workspace == workspace {
+		return nil
+	}
+	active.Workspace = workspace
+	return SaveActive(*active)
+}
+
 // Sync synchronises local changes to a sandbox over SSH.
 // It ensures the workspace base exists, clones the repo into workdir if absent,
 // then resets to the remote base and applies a patch of local changes.
@@ -36,9 +62,10 @@ func Sync(ctx context.Context, client *circleci.Client, sandboxID, identityFile,
 		return fmt.Errorf("sync: %w", err)
 	}
 
-	repoPath := workdir
-	if repoPath == "" {
-		repoPath = workspaceDir + "/" + repo
+	repoPath := resolveWorkspace(workdir, repo)
+
+	if err := persistWorkspace(repoPath); err != nil {
+		io.ErrPrintf("%s\n", ui.Dim(fmt.Sprintf("Could not save workspace: %v", err)))
 	}
 
 	// Ensure the parent directory exists on the sandbox.


### PR DESCRIPTION
## Summary
- Add `workspace` field to `ActiveSandbox` struct in sandbox.json
- `chunk sync` reads workspace from sandbox.json when `--workdir` is not specified
- Priority: CLI `--workdir` > sandbox.json workspace > default `/workspace/<repo>`
- Resolved workspace is persisted back to sandbox.json for subsequent syncs

Stacked on #235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)