### PR TITLE
Consistent usererr.Error across all commands

### DIFF
--- a/acceptance/auth_test.go
+++ b/acceptance/auth_test.go
@@ -239,7 +239,7 @@ func TestAuthSetInvalidProvider(t *testing.T) {
 
 	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for invalid provider")
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "unknown provider"),
+	assert.Assert(t, strings.Contains(combined, "Unknown provider"),
 		"expected error about unknown provider, got: %s", combined)
 }
 

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
 )
 
 const (
@@ -22,11 +22,7 @@ const (
 	providerGitHub    = "github"
 )
 
-// ErrSilent is returned when a command has already reported its error to the user
-// and wants to exit non-zero without printing anything further.
-var ErrSilent = errors.New("silent")
-
-const configFilePermHint = "Check file permissions on the chunk config file"
+const configFilePermHint = "Check file permissions on the chunk config file."
 
 func newAuthCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -65,7 +61,10 @@ func newAuthSetCmd() *cobra.Command {
 				githubTokenEnv := os.Getenv("GITHUB_TOKEN")
 				return authSetGitHub(cmd.Context(), io, githubBaseURL, githubTokenEnv)
 			default:
-				return fmt.Errorf("unknown provider %q: valid providers are circleci, anthropic, github", provider)
+				return usererr.Newf(
+					fmt.Sprintf("Unknown provider %q. Valid providers: circleci, anthropic, github.", provider),
+					"unknown provider %q", provider,
+				)
 			}
 		},
 	}
@@ -86,8 +85,7 @@ func authSetCircleCI(ctx context.Context, io iostream.Streams, circleCIBaseURL, 
 
 	cfg, err := config.Load()
 	if err != nil {
-		io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", err)))
-		return fmt.Errorf("load config: %w", err)
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	if cfg.CircleCIToken != "" {
 		io.Printf("A CircleCI token is already stored in config.\n")
@@ -109,14 +107,13 @@ func authSetCircleCI(ctx context.Context, io iostream.Streams, circleCIBaseURL, 
 
 	token = strings.TrimSpace(token)
 	if token == "" {
-		io.ErrPrintln(ui.FormatError("Token cannot be empty.", "", "Create a token at https://app.circleci.com/settings/user/tokens"))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("Token cannot be empty.", "", "Create a token at https://app.circleci.com/settings/user/tokens"),
+			fmt.Errorf("empty circleci token"),
+		)
 	}
 
-	if err := saveCircleCIToken(ctx, token, io, circleCIBaseURL); err != nil {
-		return ErrSilent
-	}
-	return nil
+	return saveCircleCIToken(ctx, token, io, circleCIBaseURL)
 }
 
 func authSetAnthropic(ctx context.Context, io iostream.Streams, anthropicBaseURL, anthropicKeyEnv string) error {
@@ -134,8 +131,7 @@ func authSetAnthropic(ctx context.Context, io iostream.Streams, anthropicBaseURL
 
 	cfg, err := config.Load()
 	if err != nil {
-		io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", err)))
-		return fmt.Errorf("load config: %w", err)
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	if cfg.AnthropicAPIKey != "" {
 		io.Printf("An Anthropic API key is already stored in config.\n")
@@ -156,62 +152,69 @@ func authSetAnthropic(ctx context.Context, io iostream.Streams, anthropicBaseURL
 
 	key = strings.TrimSpace(key)
 	if key == "" {
-		io.ErrPrintln(ui.FormatError("API key cannot be empty.", "", "Get an API key from https://console.anthropic.com/"))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("API key cannot be empty.", "", "Get an API key from https://console.anthropic.com/"),
+			fmt.Errorf("empty anthropic key"),
+		)
 	}
 
 	if !strings.HasPrefix(key, "sk-ant-") {
-		io.ErrPrintln(ui.FormatError("Invalid API key format.", "Keys should start with \"sk-ant-\".", "Get a valid API key from https://console.anthropic.com/"))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("Invalid API key format.", "Keys should start with \"sk-ant-\".", "Get a valid API key from https://console.anthropic.com/"),
+			fmt.Errorf("invalid anthropic key format"),
+		)
 	}
 
 	io.ErrPrintln(ui.Dim("Validating API key..."))
 	if err := authprompt.ValidateAPIKey(ctx, key, anthropicBaseURL); err != nil {
-		io.ErrPrintln(ui.FormatError("API key validation failed.", "", "Check that your key is correct and has not been revoked."))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("API key validation failed.", "", "Check that your key is correct and has not been revoked."),
+			err,
+		)
 	}
 
 	cfg, err = config.Load()
 	if err != nil {
-		return fmt.Errorf("load config before save: %w", err)
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	cfg.AnthropicAPIKey = key
 	if err := config.Save(cfg); err != nil {
-		return fmt.Errorf("save API key: %w", err)
+		return usererr.New("Could not save credentials. "+configFilePermHint, err)
 	}
 
 	cfgPath, err := config.Path()
 	if err != nil {
-		return err
+		return usererr.New("Could not access configuration.", err)
 	}
 	io.Printf("\n%s\n", ui.Success(fmt.Sprintf("API key validated and saved to %s", cfgPath)))
 	io.Println(ui.Dim("You can now run code reviews with: chunk build-prompt"))
 	return nil
 }
 
-// saveCircleCIToken validates and saves a CircleCI token to user config.
-// It prints status messages to streams and returns an error if anything fails.
 func saveCircleCIToken(ctx context.Context, token string, streams iostream.Streams, circleCIBaseURL string) error {
 	streams.ErrPrintln(ui.Dim("Validating CircleCI token..."))
 	if err := authprompt.ValidateCircleCIToken(ctx, token, circleCIBaseURL); err != nil {
-		streams.ErrPrintln(ui.FormatError("CircleCI token validation failed.", "", "Check that your token is correct."))
-		return fmt.Errorf("validate token: %w", err)
+		return usererr.New(
+			ui.FormatError("CircleCI token validation failed.", "", "Check that your token is correct."),
+			fmt.Errorf("validate token: %w", err),
+		)
 	}
 
 	cfg, err := config.Load()
 	if err != nil {
-		streams.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", err)))
-		return fmt.Errorf("load config: %w", err)
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	cfg.CircleCIToken = token
 	if err := config.Save(cfg); err != nil {
-		streams.ErrPrintln(ui.FormatError("Failed to save CircleCI token.", "", "Check that your config file is writable."))
-		return fmt.Errorf("save token: %w", err)
+		return usererr.New(
+			ui.FormatError("Failed to save CircleCI token.", "", "Check that your config file is writable."),
+			fmt.Errorf("save token: %w", err),
+		)
 	}
 
 	cfgPath, err := config.Path()
 	if err != nil {
-		return err
+		return usererr.New("Could not access configuration.", err)
 	}
 	streams.ErrPrintf("\n%s\n", ui.Success(fmt.Sprintf("CircleCI token validated and saved to %s", cfgPath)))
 	return nil
@@ -303,7 +306,7 @@ func newAuthStatusCmd() *cobra.Command {
 			io.Println("")
 
 			if hasFailure {
-				return ErrSilent
+				return usererr.Newf("One or more credential checks failed.", "auth status: validation failures")
 			}
 			return nil
 		},
@@ -333,7 +336,10 @@ func newAuthRemoveCmd() *cobra.Command {
 				githubTokenEnv := os.Getenv("GITHUB_TOKEN")
 				return authRemoveGitHub(io, githubTokenEnv)
 			default:
-				return fmt.Errorf("unknown provider %q: valid providers are circleci, anthropic, github", provider)
+				return usererr.Newf(
+					fmt.Sprintf("Unknown provider %q. Valid providers: circleci, anthropic, github.", provider),
+					"unknown provider %q", provider,
+				)
 			}
 		},
 	}
@@ -342,7 +348,7 @@ func newAuthRemoveCmd() *cobra.Command {
 func authRemoveCircleCI(io iostream.Streams, circleTokenEnv string) error {
 	cfg, err := config.Load()
 	if err != nil {
-		return err
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	if cfg.CircleCIToken == "" {
 		io.Println(ui.Warning("No CircleCI token stored in config file."))
@@ -357,7 +363,7 @@ func authRemoveCircleCI(io iostream.Streams, circleTokenEnv string) error {
 	io.Println("")
 	cfgPath, err := config.Path()
 	if err != nil {
-		return err
+		return usererr.New("Could not access configuration.", err)
 	}
 	io.Printf("This will remove your stored CircleCI token from %s\n", cfgPath)
 	confirmed, err := tui.Confirm("Are you sure?", false)
@@ -371,10 +377,12 @@ func authRemoveCircleCI(io iostream.Streams, circleTokenEnv string) error {
 	if err := config.Clear("circleCIToken"); err != nil {
 		hint := configFilePermHint
 		if errPath, pathErr := config.Path(); pathErr == nil {
-			hint = fmt.Sprintf("Check file permissions on %s", errPath)
+			hint = fmt.Sprintf("Check file permissions on %s.", errPath)
 		}
-		io.ErrPrintln(ui.FormatError("Failed to remove CircleCI token.", "An error occurred while trying to remove the token from the config file.", hint))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("Failed to remove CircleCI token.", "An error occurred while trying to remove the token from the config file.", hint),
+			err,
+		)
 	}
 
 	io.Println(ui.Success("CircleCI token removed successfully."))
@@ -387,7 +395,7 @@ func authRemoveCircleCI(io iostream.Streams, circleTokenEnv string) error {
 func authRemoveAnthropic(io iostream.Streams, anthropicKeyEnv string) error {
 	cfg, err := config.Load()
 	if err != nil {
-		return err
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	if cfg.AnthropicAPIKey == "" {
 		io.Println(ui.Warning("No API key stored in config file."))
@@ -402,7 +410,7 @@ func authRemoveAnthropic(io iostream.Streams, anthropicKeyEnv string) error {
 	io.Println("")
 	cfgPath, err := config.Path()
 	if err != nil {
-		return err
+		return usererr.New("Could not access configuration.", err)
 	}
 	io.Printf("This will remove your stored API key from %s\n", cfgPath)
 	confirmed, err := tui.Confirm("Are you sure?", false)
@@ -416,14 +424,12 @@ func authRemoveAnthropic(io iostream.Streams, anthropicKeyEnv string) error {
 	if err := config.Clear("anthropicAPIKey"); err != nil {
 		hint := configFilePermHint
 		if errPath, pathErr := config.Path(); pathErr == nil {
-			hint = fmt.Sprintf("Check file permissions on %s", errPath)
+			hint = fmt.Sprintf("Check file permissions on %s.", errPath)
 		}
-		io.ErrPrintln(ui.FormatError(
-			"Failed to remove API key.",
-			"An error occurred while trying to remove the API key from the config file.",
-			hint,
-		))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("Failed to remove API key.", "An error occurred while trying to remove the API key from the config file.", hint),
+			err,
+		)
 	}
 
 	io.Println(ui.Success("API key removed successfully."))
@@ -448,8 +454,7 @@ func authSetGitHub(ctx context.Context, io iostream.Streams, githubBaseURL, gith
 
 	cfg, err := config.Load()
 	if err != nil {
-		io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", err)))
-		return fmt.Errorf("load config: %w", err)
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	if cfg.GitHubToken != "" {
 		io.Printf("A GitHub token is already stored in config.\n")
@@ -471,28 +476,32 @@ func authSetGitHub(ctx context.Context, io iostream.Streams, githubBaseURL, gith
 
 	token = strings.TrimSpace(token)
 	if token == "" {
-		io.ErrPrintln(ui.FormatError("Token cannot be empty.", "", "Create a token at https://github.com/settings/tokens"))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("Token cannot be empty.", "", "Create a token at https://github.com/settings/tokens"),
+			fmt.Errorf("empty github token"),
+		)
 	}
 
 	io.ErrPrintln(ui.Dim("Validating GitHub token..."))
 	if err := authprompt.ValidateGitHubToken(ctx, token, githubBaseURL); err != nil {
-		io.ErrPrintln(ui.FormatError("GitHub token validation failed.", "", "Check that your token is correct and has not been revoked."))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("GitHub token validation failed.", "", "Check that your token is correct and has not been revoked."),
+			err,
+		)
 	}
 
 	cfg, err = config.Load()
 	if err != nil {
-		return fmt.Errorf("load config before save: %w", err)
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	cfg.GitHubToken = token
 	if err := config.Save(cfg); err != nil {
-		return fmt.Errorf("save token: %w", err)
+		return usererr.New("Could not save credentials. "+configFilePermHint, err)
 	}
 
 	cfgPath, err := config.Path()
 	if err != nil {
-		return err
+		return usererr.New("Could not access configuration.", err)
 	}
 	io.Printf("\n%s\n", ui.Success(fmt.Sprintf("GitHub token validated and saved to %s", cfgPath)))
 	return nil
@@ -501,7 +510,7 @@ func authSetGitHub(ctx context.Context, io iostream.Streams, githubBaseURL, gith
 func authRemoveGitHub(io iostream.Streams, githubTokenEnv string) error {
 	cfg, err := config.Load()
 	if err != nil {
-		return err
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	if cfg.GitHubToken == "" {
 		io.Println(ui.Warning("No GitHub token stored in config file."))
@@ -516,7 +525,7 @@ func authRemoveGitHub(io iostream.Streams, githubTokenEnv string) error {
 	io.Println("")
 	cfgPath, err := config.Path()
 	if err != nil {
-		return err
+		return usererr.New("Could not access configuration.", err)
 	}
 	io.Printf("This will remove your stored GitHub token from %s\n", cfgPath)
 	confirmed, err := tui.Confirm("Are you sure?", false)
@@ -530,10 +539,12 @@ func authRemoveGitHub(io iostream.Streams, githubTokenEnv string) error {
 	if err := config.Clear("gitHubToken"); err != nil {
 		hint := configFilePermHint
 		if errPath, pathErr := config.Path(); pathErr == nil {
-			hint = fmt.Sprintf("Check file permissions on %s", errPath)
+			hint = fmt.Sprintf("Check file permissions on %s.", errPath)
 		}
-		io.ErrPrintln(ui.FormatError("Failed to remove GitHub token.", "An error occurred while trying to remove the token from the config file.", hint))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("Failed to remove GitHub token.", "An error occurred while trying to remove the token from the config file.", hint),
+			err,
+		)
 	}
 
 	io.Println(ui.Success("GitHub token removed successfully."))

--- a/internal/cmd/buildprompt.go
+++ b/internal/cmd/buildprompt.go
@@ -34,12 +34,12 @@ func newBuildPromptCmd() *cobra.Command {
 		Short: "Analyze GitHub PR comments and generate a review prompt for AI coding agents",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if top <= 0 {
-				return fmt.Errorf("--top must be a positive integer, got %d", top)
+				return usererr.Newf("--top must be a positive integer.", "invalid --top value: %d", top)
 			}
 
 			cwd, err := os.Getwd()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return usererr.New("Could not determine working directory.", err)
 			}
 			resolvedOrg, resolvedRepos, err := buildprompt.ResolveOrgAndRepos(org, repos, cwd)
 			if err != nil {

--- a/internal/cmd/buildprompt.go
+++ b/internal/cmd/buildprompt.go
@@ -9,8 +9,11 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/buildprompt"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/github"
+	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
 )
 
 func newBuildPromptCmd() *cobra.Command {
@@ -40,7 +43,7 @@ func newBuildPromptCmd() *cobra.Command {
 			}
 			resolvedOrg, resolvedRepos, err := buildprompt.ResolveOrgAndRepos(org, repos, cwd)
 			if err != nil {
-				return err
+				return usererr.New("Could not determine org and repos. Use --org and --repos flags.", err)
 			}
 
 			sinceTime, err := parseSince(since)
@@ -75,7 +78,16 @@ func newBuildPromptCmd() *cobra.Command {
 				IncludeAttribution: includeAttribution,
 			}
 
-			return buildprompt.Run(cmd.Context(), opts, iostream.FromCmd(cmd))
+			if err := buildprompt.Run(cmd.Context(), opts, iostream.FromCmd(cmd)); err != nil {
+				if httpcl.HasStatusCode(err, 401, 403) {
+					return usererr.New("Authentication failed. Run 'chunk auth set' to update your credentials.", err)
+				}
+				if github.IsResolutionError(err) {
+					return usererr.New("Repository not found. Check the --org and --repos flags.", err)
+				}
+				return usererr.New("Build prompt generation failed.", err)
+			}
+			return nil
 		},
 	}
 

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -65,7 +65,7 @@ func detectShell(home string) (shellConfig, error) {
 func completionInstalled() (bool, error) {
 	home := os.Getenv("HOME")
 	if home == "" {
-		return false, fmt.Errorf("HOME not set")
+		return false, usererr.Newf("HOME environment variable is not set.", "HOME not set")
 	}
 
 	sh, err := detectShell(home)
@@ -84,7 +84,7 @@ func completionInstalled() (bool, error) {
 func installCompletion(streams iostream.Streams) (err error) {
 	home := os.Getenv("HOME")
 	if home == "" {
-		return fmt.Errorf("HOME not set")
+		return usererr.Newf("HOME environment variable is not set.", "HOME not set")
 	}
 
 	sh, err := detectShell(home)
@@ -103,12 +103,12 @@ func installCompletion(streams iostream.Streams) (err error) {
 
 	f, err := os.OpenFile(sh.rcFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
-		return fmt.Errorf("open %s: %w", sh.rcFile, err)
+		return usererr.New(fmt.Sprintf("Could not update %s. Check file permissions.", sh.rcFile), err)
 	}
 	defer closer.ErrorHandler(f, &err)
 
 	if _, err := f.WriteString("\n" + line); err != nil {
-		return fmt.Errorf("write %s: %w", sh.rcFile, err)
+		return usererr.New(fmt.Sprintf("Could not update %s. Check file permissions.", sh.rcFile), err)
 	}
 
 	streams.ErrPrintln(ui.Success("Completion installed."))
@@ -155,7 +155,7 @@ func newCompletionUninstallCmd() *cobra.Command {
 			io := iostream.FromCmd(cmd)
 			home := os.Getenv("HOME")
 			if home == "" {
-				return fmt.Errorf("HOME not set")
+				return usererr.Newf("HOME environment variable is not set.", "HOME not set")
 			}
 
 			sh, err := detectShell(home)
@@ -188,7 +188,7 @@ func newCompletionUninstallCmd() *cobra.Command {
 			}
 
 			if err := os.WriteFile(sh.rcFile, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
-				return fmt.Errorf("write %s: %w", sh.rcFile, err)
+				return usererr.New(fmt.Sprintf("Could not update %s. Check file permissions.", sh.rcFile), err)
 			}
 
 			io.ErrPrintln(ui.Success("Completion uninstalled."))

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
 )
 
 func newConfigCmd() *cobra.Command {
@@ -68,13 +69,15 @@ func newConfigSetCmd() *cobra.Command {
 			key, value := args[0], args[1]
 
 			if !config.ValidConfigKeys[key] {
-				io.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Unknown config key: %q", key)))
-				return ErrSilent
+				return usererr.Newf(
+					fmt.Sprintf("Unknown config key: %q. Supported keys: model.", key),
+					"unknown config key %q", key,
+				)
 			}
 
 			cfg, err := config.Load()
 			if err != nil {
-				return err
+				return usererr.New("Could not load configuration. "+configFilePermHint, err)
 			}
 
 			if key == "model" {
@@ -82,7 +85,7 @@ func newConfigSetCmd() *cobra.Command {
 			}
 
 			if err := config.Save(cfg); err != nil {
-				return err
+				return usererr.New("Could not save configuration. "+configFilePermHint, err)
 			}
 
 			io.Printf("%s\n", ui.Success(fmt.Sprintf("Set %s to %s", key, value)))

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -18,6 +18,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/settings"
 	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
 	"github.com/CircleCI-Public/chunk-cli/internal/validate"
 )
 
@@ -40,23 +41,23 @@ func withTrailingNewline(data []byte) []byte {
 func writeSettings(workDir string, commands []config.Command, streams iostream.Streams, confirm confirmFunc) error {
 	generated, err := settings.Build(commands)
 	if err != nil {
-		return fmt.Errorf("build settings: %w", err)
+		return usererr.New("Could not build .claude/settings.json.", fmt.Errorf("build settings: %w", err))
 	}
 
 	dir := filepath.Join(workDir, ".claude")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("create .claude dir: %w", err)
+		return usererr.New("Could not create .claude directory. Check file permissions.", fmt.Errorf("create .claude dir: %w", err))
 	}
 
 	path := filepath.Join(dir, "settings.json")
 	existing, readErr := os.ReadFile(path)
 	if readErr != nil {
 		if !errors.Is(readErr, fs.ErrNotExist) {
-			return fmt.Errorf("read existing settings.json: %w", readErr)
+			return usererr.New("Could not read .claude/settings.json. Check file permissions.", fmt.Errorf("read existing settings.json: %w", readErr))
 		}
 		// No existing file — write directly.
 		if err := os.WriteFile(path, withTrailingNewline(generated), 0o644); err != nil {
-			return fmt.Errorf("write settings.json: %w", err)
+			return usererr.New("Could not write .claude/settings.json. Check file permissions.", fmt.Errorf("write settings.json: %w", err))
 		}
 		streams.ErrPrintln(ui.Success("Wrote .claude/settings.json"))
 		return nil
@@ -65,7 +66,7 @@ func writeSettings(workDir string, commands []config.Command, streams iostream.S
 	// Existing file found — compute merge.
 	result, err := settings.Merge(existing, generated)
 	if err != nil {
-		return fmt.Errorf("merge settings: %w", err)
+		return usererr.New("Could not merge .claude/settings.json.", fmt.Errorf("merge settings: %w", err))
 	}
 
 	if !result.Changed {
@@ -104,7 +105,7 @@ func writeSettings(workDir string, commands []config.Command, streams iostream.S
 	}
 
 	if err := os.WriteFile(path, withTrailingNewline(result.Merged), 0o644); err != nil {
-		return fmt.Errorf("write settings.json: %w", err)
+		return usererr.New("Could not write .claude/settings.json. Check file permissions.", fmt.Errorf("write settings.json: %w", err))
 	}
 	streams.ErrPrintln(ui.Success("Updated .claude/settings.json"))
 	return nil
@@ -114,7 +115,7 @@ func writeSettings(workDir string, commands []config.Command, streams iostream.S
 func writeSettingsExample(dir string, data []byte, streams iostream.Streams) error {
 	exPath := filepath.Join(dir, "settings.example.json")
 	if err := os.WriteFile(exPath, withTrailingNewline(data), 0o644); err != nil {
-		return fmt.Errorf("write settings.example.json: %w", err)
+		return usererr.New("Could not write .claude/settings.example.json.", fmt.Errorf("write settings.example.json: %w", err))
 	}
 	streams.ErrPrintln(ui.Success("Wrote .claude/settings.example.json (existing settings.json preserved)"))
 	return nil
@@ -140,14 +141,14 @@ hook config files.`,
 				var err error
 				workDir, err = os.Getwd()
 				if err != nil {
-					return err
+					return usererr.New("Could not determine working directory.", err)
 				}
 			}
 
 			gitCmd := exec.Command("git", "rev-parse", "--git-dir")
 			gitCmd.Dir = workDir
 			if err := gitCmd.Run(); err != nil {
-				return fmt.Errorf("not a git repository, run this command from inside a git repo")
+				return usererr.New("Not a git repository. Run this command from inside a git repo.", err)
 			}
 
 			// Guard: exit cleanly if config exists and --force not set
@@ -199,14 +200,14 @@ hook config files.`,
 
 			// Save config
 			if err := config.SaveProjectConfig(workDir, cfg); err != nil {
-				return fmt.Errorf("write config: %w", err)
+				return usererr.New("Could not write .chunk/config.json. Check file permissions.", fmt.Errorf("write config: %w", err))
 			}
 			streams.ErrPrintln(ui.Success("Wrote .chunk/config.json"))
 
 			// Step 3: Write .claude/settings.json
 			if !skipHooks {
 				if err := writeSettings(workDir, cfg.Commands, streams, tui.Confirm); err != nil {
-					return fmt.Errorf("settings: %w", err)
+					return err
 				}
 			}
 

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -15,6 +15,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/envbuilder"
 	"github.com/CircleCI-Public/chunk-cli/internal/authprompt"
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/sandbox"
 	"github.com/CircleCI-Public/chunk-cli/internal/secrets"
@@ -51,10 +52,13 @@ func resolveSandboxID(sandboxID *string) error {
 	}
 	active, err := sandbox.LoadActive()
 	if err != nil {
-		return fmt.Errorf("load active sandbox: %w", err)
+		return usererr.New("Could not load the active sandbox. "+configFilePermHint+".", err)
 	}
 	if active == nil {
-		return fmt.Errorf("--sandbox-id is required (no active sandbox set; run 'chunk sandbox use <id>' or 'chunk sandbox create')")
+		return usererr.New(
+			"No active sandbox is set. Run 'chunk sandbox use <id>' or 'chunk sandbox create' first.",
+			fmt.Errorf("no active sandbox and --sandbox-id not provided"),
+		)
 	}
 	*sandboxID = active.SandboxID
 	return nil
@@ -76,10 +80,16 @@ func orgPicker(ctx context.Context, client *circleci.Client) func() (string, err
 	return func() (string, error) {
 		collabs, err := client.ListCollaborations(ctx)
 		if err != nil {
-			return "", fmt.Errorf("--org-id is required (failed to list collaborations: %w)", err)
+			if httpcl.HasStatusCode(err, 401, 403) {
+				return "", usererr.New("Not authorized. Check your CircleCI token and try again.", err)
+			}
+			return "", usererr.New("Could not list organizations. Pass --org-id or check your network connection.", err)
 		}
 		if len(collabs) == 0 {
-			return "", fmt.Errorf("--org-id is required: no organizations found")
+			return "", usererr.New(
+				"No organizations found. Pass --org-id or join an organization in CircleCI.",
+				fmt.Errorf("no organizations found for current user"),
+			)
 		}
 		labels := make([]string, len(collabs))
 		for i, c := range collabs {
@@ -87,7 +97,7 @@ func orgPicker(ctx context.Context, client *circleci.Client) func() (string, err
 		}
 		idx, err := tui.SelectFromList("Select an organization:", labels)
 		if err != nil {
-			return "", err
+			return "", usererr.New("Could not select an organization. Pass --org-id instead.", err)
 		}
 		return collabs[idx].ID, nil
 	}
@@ -111,7 +121,10 @@ func newSandboxListCmd() *cobra.Command {
 			}
 			sandboxes, err := sandbox.List(cmd.Context(), client, resolvedOrgID)
 			if err != nil {
-				return err
+				if httpcl.HasStatusCode(err, 401, 403) {
+					return usererr.New("Not authorized to list sandboxes. Check your CircleCI token and try again.", err)
+				}
+				return usererr.New("Could not list sandboxes. Check your network connection and try again.", err)
 			}
 			if len(sandboxes) == 0 {
 				io.ErrPrintln(ui.Dim("No sandboxes found"))
@@ -160,7 +173,10 @@ environment variable (e.g. CHUNK_SANDBOX_PROVIDER=unikraft).`,
 			}
 			sb, err := sandbox.Create(cmd.Context(), client, resolvedOrgID, name, provider, image)
 			if err != nil {
-				return err
+				if httpcl.HasStatusCode(err, 401, 403) {
+					return usererr.New("Not authorized to create sandboxes. Check your CircleCI token and try again.", err)
+				}
+				return usererr.New("Could not create the sandbox. Check your network connection and try again.", err)
 			}
 			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Created sandbox %s (%s)", sb.Name, sb.ID)))
 			if err := sandbox.SaveActive(sandbox.ActiveSandbox{SandboxID: sb.ID, Name: sb.Name}); err != nil {
@@ -203,7 +219,10 @@ func newSandboxExecCmd() *cobra.Command {
 			allArgs = append(allArgs, args...)
 			resp, err := sandbox.Exec(cmd.Context(), client, sandboxID, command, allArgs)
 			if err != nil {
-				return err
+				if httpcl.HasStatusCode(err, 401, 403) {
+					return usererr.New("Not authorized to execute commands. Check your CircleCI token and try again.", err)
+				}
+				return usererr.New("Could not execute the command in the sandbox. Check the sandbox is running and try again.", err)
 			}
 			if resp.Stdout != "" {
 				_, _ = fmt.Fprint(io.Out, resp.Stdout)
@@ -240,7 +259,10 @@ func newSandboxAddSSHKeyCmd() *cobra.Command {
 			}
 			resp, err := sandbox.AddSSHKey(cmd.Context(), client, sandboxID, publicKey, publicKeyFile)
 			if err != nil {
-				return err
+				if httpcl.HasStatusCode(err, 401, 403) {
+					return usererr.New("Not authorized to add SSH keys. Check your CircleCI token and try again.", err)
+				}
+				return usererr.New("Could not add the SSH key. Check the sandbox is running and try again.", err)
 			}
 			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("SSH key added. Sandbox URL: %s", resp.URL)))
 			return nil
@@ -282,7 +304,7 @@ func newSandboxSSHCmd() *cobra.Command {
 				if !filepath.IsAbs(path) {
 					cwd, err := os.Getwd()
 					if err != nil {
-						return fmt.Errorf("get working directory: %w", err)
+						return usererr.New("Could not determine the current directory.", err)
 					}
 					path = filepath.Join(cwd, path)
 				}
@@ -299,7 +321,14 @@ func newSandboxSSHCmd() *cobra.Command {
 				return usererr.New(fmt.Sprintf("resolve secrets: %s", err), err)
 			}
 			envVars = resolved
-			return sandbox.SSH(cmd.Context(), client, sandboxID, identityFile, authSock, args, envVars, io)
+			err = sandbox.SSH(cmd.Context(), client, sandboxID, identityFile, authSock, args, envVars, io)
+			if err != nil {
+				if httpcl.HasStatusCode(err, 401, 403) {
+					return usererr.New("Not authorized to connect via SSH. Check your CircleCI token and try again.", err)
+				}
+				return usererr.New("Could not connect to the sandbox via SSH. Check the sandbox is running and try again.", err)
+			}
+			return nil
 		},
 	}
 
@@ -328,7 +357,14 @@ func newSandboxSyncCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return sandbox.Sync(cmd.Context(), client, sandboxID, identityFile, authSock, workdir, io)
+			err = sandbox.Sync(cmd.Context(), client, sandboxID, identityFile, authSock, workdir, io)
+			if err != nil {
+				if httpcl.HasStatusCode(err, 401, 403) {
+					return usererr.New("Not authorized to sync files. Check your CircleCI token and try again.", err)
+				}
+				return usererr.New("Could not sync files to the sandbox. Check the sandbox is running and try again.", err)
+			}
+			return nil
 		},
 	}
 
@@ -347,7 +383,7 @@ func newSandboxUseCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
 			if err := sandbox.SaveActive(sandbox.ActiveSandbox{SandboxID: args[0]}); err != nil {
-				return err
+				return usererr.New("Could not save the active sandbox. "+configFilePermHint+".", err)
 			}
 			io.ErrPrintf("Set %s as active sandbox\n", args[0])
 			return nil
@@ -363,7 +399,7 @@ func newSandboxCurrentCmd() *cobra.Command {
 			io := iostream.FromCmd(cmd)
 			active, err := sandbox.LoadActive()
 			if err != nil {
-				return err
+				return usererr.New("Could not load the active sandbox. "+configFilePermHint+".", err)
 			}
 			if active == nil {
 				io.ErrPrintln("No active sandbox")
@@ -386,7 +422,7 @@ func newSandboxForgetCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 			if err := sandbox.ClearActive(); err != nil {
-				return err
+				return usererr.New("Could not clear the active sandbox. "+configFilePermHint+".", err)
 			}
 			io.ErrPrintln("Active sandbox cleared")
 			return nil
@@ -408,18 +444,18 @@ generate a Dockerfile and build a test image.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 			if _, err := os.Stat(dir); err != nil {
-				return fmt.Errorf("directory %q not found: %w", dir, err)
+				return usererr.New(fmt.Sprintf("Directory %q not found. Check the --dir path and try again.", dir), err)
 			}
 			io.ErrPrintf("Detecting environment in %s...\n", dir)
 
 			env, err := envbuilder.DetectEnvironment(cmd.Context(), dir)
 			if err != nil {
-				return fmt.Errorf("detect environment: %w", err)
+				return usererr.New("Could not detect the environment. Check the directory contains a supported project.", err)
 			}
 
 			out, err := json.MarshalIndent(env, "", "  ")
 			if err != nil {
-				return fmt.Errorf("marshal environment: %w", err)
+				return usererr.New("Could not encode the environment spec.", err)
 			}
 			io.Printf("%s\n", out)
 			return nil
@@ -444,7 +480,10 @@ Example:
   chunk sandbox env --dir . | chunk sandbox build --dir .`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if tag != "" && !validDockerTag.MatchString(tag) {
-				return fmt.Errorf("invalid docker tag %q", tag)
+				return usererr.New(
+					fmt.Sprintf("Invalid image tag %q. Use a tag like 'myapp:latest'.", tag),
+					fmt.Errorf("invalid docker tag %q", tag),
+				)
 			}
 
 			streams := iostream.FromCmd(cmd)
@@ -454,22 +493,25 @@ Example:
 			// Check cmd.InOrStdin() so injected readers (e.g. in tests) are not blocked.
 			if f, ok := cmd.InOrStdin().(*os.File); ok {
 				if fi, err := f.Stat(); err == nil && fi.Mode()&os.ModeCharDevice != 0 {
-					return fmt.Errorf("no input on stdin — pipe a JSON env spec from 'chunk sandbox env'")
+					return usererr.New(
+						"No input on stdin. Pipe a JSON env spec, for example: chunk sandbox env | chunk sandbox build",
+						fmt.Errorf("no input on stdin"),
+					)
 				}
 			}
 
 			raw, err := io.ReadAll(cmd.InOrStdin())
 			if err != nil {
-				return fmt.Errorf("read environment spec: %w", err)
+				return usererr.New("Could not read the environment spec from stdin.", err)
 			}
 			var env envbuilder.Environment
 			if err := json.Unmarshal(raw, &env); err != nil {
-				return fmt.Errorf("parse environment spec: %w", err)
+				return usererr.New("Invalid environment spec. Pipe the output of 'chunk sandbox env' into this command.", err)
 			}
 
 			dockerfilePath, err := envbuilder.WriteDockerfile(dir, &env)
 			if err != nil {
-				return fmt.Errorf("write dockerfile: %w", err)
+				return usererr.New("Could not write the Dockerfile. Check directory permissions and try again.", err)
 			}
 			streams.ErrPrintf("Wrote %s\n", dockerfilePath)
 
@@ -486,7 +528,7 @@ Example:
 			dockerCmd.Stdout = streams.Out
 			dockerCmd.Stderr = streams.Err
 			if err := dockerCmd.Run(); err != nil {
-				return fmt.Errorf("docker build: %w", err)
+				return usererr.New("Docker build failed. Check the build output above for details.", err)
 			}
 
 			streams.ErrPrintf("%s\n", ui.Success("Docker image built successfully"))

--- a/internal/cmd/skills.go
+++ b/internal/cmd/skills.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -9,6 +8,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/skills"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
 )
 
 func newSkillCmd() *cobra.Command {
@@ -29,7 +29,7 @@ func newSkillInstallCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			home := os.Getenv("HOME")
 			if home == "" {
-				return fmt.Errorf("HOME not set")
+				return usererr.Newf("HOME environment variable is not set.", "HOME not set")
 			}
 			io := iostream.FromCmd(cmd)
 			results := skills.Install(home)

--- a/internal/cmd/task.go
+++ b/internal/cmd/task.go
@@ -16,6 +16,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/task"
 	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
 )
 
 func newTaskCmd() *cobra.Command {
@@ -40,11 +41,11 @@ func newTaskRunCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return usererr.New("Could not determine working directory.", fmt.Errorf("get working directory: %w", err))
 			}
 			repoRoot, err := gitutil.RepoRoot(cwd)
 			if err != nil {
-				return fmt.Errorf("not in a git repository: %w", err)
+				return usererr.New("Not in a git repository. Run this command from inside a git repo.", fmt.Errorf("not in a git repository: %w", err))
 			}
 
 			cfg, err := task.LoadRunConfig(repoRoot)
@@ -102,11 +103,11 @@ func newTaskConfigCmd() *cobra.Command {
 			// Find git repo root instead of using cwd
 			cwd, err := os.Getwd()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return usererr.New("Could not determine working directory.", fmt.Errorf("get working directory: %w", err))
 			}
 			repoRoot, err := gitutil.RepoRoot(cwd)
 			if err != nil {
-				return fmt.Errorf("not in a git repository: %w", err)
+				return usererr.New("Not in a git repository. Run this command from inside a git repo.", fmt.Errorf("not in a git repository: %w", err))
 			}
 
 			// Check for existing config and prompt before overwriting
@@ -151,10 +152,10 @@ func newTaskConfigCmd() *cobra.Command {
 			wg.Wait()
 
 			if projErr != nil {
-				return fmt.Errorf("fetch projects: %w", projErr)
+				return usererr.New("Could not fetch CircleCI projects. Check your token and network connection.", fmt.Errorf("fetch projects: %w", projErr))
 			}
 			if collabErr != nil {
-				return fmt.Errorf("fetch collaborations: %w", collabErr)
+				return usererr.New("Could not fetch CircleCI projects. Check your token and network connection.", fmt.Errorf("fetch collaborations: %w", collabErr))
 			}
 
 			var orgID, projectID, orgType string
@@ -190,7 +191,7 @@ func newTaskConfigCmd() *cobra.Command {
 				io.ErrPrintf("%s\n", ui.Dim(fmt.Sprintf("Fetching project details for %s...", slug)))
 				detail, err := client.GetProjectBySlug(ctx, slug)
 				if err != nil {
-					return fmt.Errorf("fetch project details: %w", err)
+					return usererr.New("Could not fetch project details. Check your token and network connection.", fmt.Errorf("fetch project details: %w", err))
 				}
 
 				projectID = detail.ID
@@ -199,7 +200,10 @@ func newTaskConfigCmd() *cobra.Command {
 			} else {
 				// Manual entry
 				if len(collabs) == 0 {
-					return fmt.Errorf("no organizations found")
+					return usererr.New(
+						"No organizations found. Check your CircleCI token has access to at least one organization.",
+						fmt.Errorf("no organizations found"),
+					)
 				}
 
 				orgItems := make([]string, len(collabs))
@@ -220,7 +224,7 @@ func newTaskConfigCmd() *cobra.Command {
 					return nil
 				}
 				if projectID == "" {
-					return fmt.Errorf("project ID is required")
+					return usererr.New("Project ID is required.", fmt.Errorf("project ID is required"))
 				}
 			}
 
@@ -241,7 +245,7 @@ func newTaskConfigCmd() *cobra.Command {
 					return nil
 				}
 				if name == "" {
-					return fmt.Errorf("definition name is required")
+					return usererr.New("Definition name is required.", fmt.Errorf("definition name is required"))
 				}
 
 				// Prompt for definition ID with UUID validation

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -16,6 +16,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/sandbox"
 	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
 	"github.com/CircleCI-Public/chunk-cli/internal/validate"
 )
 
@@ -76,7 +77,7 @@ func newValidateCmd() *cobra.Command {
 				}
 				if save {
 					if err := config.SaveCommand(workDir, cmdName, inlineCmd); err != nil {
-						return fmt.Errorf("save command: %w", err)
+						return usererr.New("Could not save command to .chunk/config.json.", err)
 					}
 					streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", cmdName)))
 				}
@@ -85,7 +86,10 @@ func newValidateCmd() *cobra.Command {
 
 			cfg, err := config.LoadProjectConfig(workDir)
 			if err != nil || !cfg.HasCommands() {
-				return fmt.Errorf("no validate commands configured, run 'chunk init' first")
+				return usererr.New(
+					"No validate commands configured. Run 'chunk init' first.",
+					fmt.Errorf("no validate commands configured"),
+				)
 			}
 
 			if dryRun {
@@ -100,7 +104,7 @@ func newValidateCmd() *cobra.Command {
 				authSock := os.Getenv("SSH_AUTH_SOCK")
 				session, err := sandbox.OpenSession(cmd.Context(), client, sandboxID, identityFile, authSock)
 				if err != nil {
-					return fmt.Errorf("open session: %w", err)
+					return usererr.New("Could not open SSH session to sandbox.", err)
 				}
 				dest := workdir
 				if dest == "" {
@@ -120,22 +124,25 @@ func newValidateCmd() *cobra.Command {
 				if cfg.FindCommand(name) == nil {
 					isTTY := term.IsTerminal(int(os.Stdin.Fd()))
 					if !isTTY {
-						return fmt.Errorf("command %q is not configured\nAdd %q to .chunk/config.json", name, name)
+						return usererr.New(
+							fmt.Sprintf("Command %q is not configured. Add it to .chunk/config.json.", name),
+							fmt.Errorf("command %q is not configured", name),
+						)
 					}
 					// Interactive setup: prompt for command
 					streams.ErrPrintf("Command %s is not configured yet.\n\n", ui.Bold(name))
 					streams.ErrPrintf("What command should %s run? ", ui.Bold(name))
 					scanner := bufio.NewScanner(os.Stdin)
 					if !scanner.Scan() {
-						return fmt.Errorf("no input received")
+						return usererr.New("No command entered.", fmt.Errorf("no input received"))
 					}
 					input := strings.TrimSpace(scanner.Text())
 					if input == "" {
 						streams.ErrPrintln(ui.Dim("No command entered, aborting."))
-						return fmt.Errorf("no command entered")
+						return usererr.New("No command entered.", fmt.Errorf("no command entered"))
 					}
 					if err := config.SaveCommand(workDir, name, input); err != nil {
-						return fmt.Errorf("save command: %w", err)
+						return usererr.New("Could not save command to .chunk/config.json.", err)
 					}
 					streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", name)))
 					// Reload config after save

--- a/internal/usererr/usererr.go
+++ b/internal/usererr/usererr.go
@@ -1,5 +1,7 @@
 package usererr
 
+import "fmt"
+
 // Error wraps a Go error with a user-facing message.
 // Error() delegates to the wrapped error. UserMessage() returns
 // human-friendly text (may be capitalized, punctuated).
@@ -11,6 +13,11 @@ type Error struct {
 // New wraps err with a user-facing message.
 func New(userMsg string, err error) *Error {
 	return &Error{userMsg: userMsg, err: err}
+}
+
+// Newf wraps a formatted error with a user-facing message.
+func Newf(userMsg string, format string, args ...any) *Error {
+	return &Error{userMsg: userMsg, err: fmt.Errorf(format, args...)}
 }
 
 func (e *Error) Error() string {

--- a/internal/usererr/usererr_test.go
+++ b/internal/usererr/usererr_test.go
@@ -52,3 +52,18 @@ func TestError(t *testing.T) {
 		}
 	})
 }
+
+func TestNewf(t *testing.T) {
+	sentinel := fmt.Errorf("root cause")
+	ue := usererr.Newf("Could not save file.", "save %s: %w", "config.json", sentinel)
+
+	if got := ue.UserMessage(); got != "Could not save file." {
+		t.Errorf("UserMessage() = %q", got)
+	}
+	if got := ue.Error(); got != "save config.json: root cause" {
+		t.Errorf("Error() = %q", got)
+	}
+	if !errors.Is(ue, sentinel) {
+		t.Error("errors.Is failed to match wrapped sentinel")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -17,13 +17,11 @@ func main() {
 
 	rootCmd := cmd.NewRootCmd(version)
 	if err := rootCmd.Execute(); err != nil {
-		if !errors.Is(err, cmd.ErrSilent) {
-			var ue *usererr.Error
-			if errors.As(err, &ue) {
-				fmt.Fprintln(os.Stderr, ue.UserMessage())
-			} else {
-				fmt.Fprintln(os.Stderr, err)
-			}
+		var ue *usererr.Error
+		if errors.As(err, &ue) {
+			fmt.Fprintln(os.Stderr, ue.UserMessage())
+		} else {
+			fmt.Fprintln(os.Stderr, err)
 			if suggestion := errorSuggestion(err); suggestion != "" {
 				fmt.Fprintln(os.Stderr, suggestion)
 			}


### PR DESCRIPTION
## Summary

- Eliminate `ErrSilent` sentinel — all error paths now return `usererr.Error` with human-readable `UserMessage()`
- Add `usererr.Newf` convenience constructor
- Fix double-suggestion in `main.go` (`errorSuggestion` now skipped for usererr)
- Wrap ~80 raw `fmt.Errorf` returns across all cmd files with actionable user messages
- Selective HTTP 401/403 wrapping for API call errors (sandbox, buildprompt)

Files: main.go, usererr.go, auth.go, config.go, sandbox.go, task.go, validate.go, init.go, completion.go, skills.go, buildprompt.go

## Test plan
- [x] `task test` — 798 tests pass
- [x] `task lint` — 0 Go issues
- [x] Acceptance tests updated for new message casing

🤖 Generated with [Claude Code](https://claude.com/claude-code)