### PR TITLE
Eliminate ErrSilent, use usererr consistently

### DIFF
--- a/acceptance/auth_test.go
+++ b/acceptance/auth_test.go
@@ -239,7 +239,7 @@ func TestAuthSetInvalidProvider(t *testing.T) {
 
 	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for invalid provider")
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "unknown provider"),
+	assert.Assert(t, strings.Contains(combined, "Unknown provider"),
 		"expected error about unknown provider, got: %s", combined)
 }
 

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
 )
 
 const (
@@ -22,11 +22,7 @@ const (
 	providerGitHub    = "github"
 )
 
-// ErrSilent is returned when a command has already reported its error to the user
-// and wants to exit non-zero without printing anything further.
-var ErrSilent = errors.New("silent")
-
-const configFilePermHint = "Check file permissions on the chunk config file"
+const configFilePermHint = "Check file permissions on the chunk config file."
 
 func newAuthCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -65,7 +61,10 @@ func newAuthSetCmd() *cobra.Command {
 				githubTokenEnv := os.Getenv("GITHUB_TOKEN")
 				return authSetGitHub(cmd.Context(), io, githubBaseURL, githubTokenEnv)
 			default:
-				return fmt.Errorf("unknown provider %q: valid providers are circleci, anthropic, github", provider)
+				return usererr.Newf(
+					fmt.Sprintf("Unknown provider %q. Valid providers: circleci, anthropic, github.", provider),
+					"unknown provider %q", provider,
+				)
 			}
 		},
 	}
@@ -86,8 +85,7 @@ func authSetCircleCI(ctx context.Context, io iostream.Streams, circleCIBaseURL, 
 
 	cfg, err := config.Load()
 	if err != nil {
-		io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", err)))
-		return fmt.Errorf("load config: %w", err)
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	if cfg.CircleCIToken != "" {
 		io.Printf("A CircleCI token is already stored in config.\n")
@@ -109,14 +107,13 @@ func authSetCircleCI(ctx context.Context, io iostream.Streams, circleCIBaseURL, 
 
 	token = strings.TrimSpace(token)
 	if token == "" {
-		io.ErrPrintln(ui.FormatError("Token cannot be empty.", "", "Create a token at https://app.circleci.com/settings/user/tokens"))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("Token cannot be empty.", "", "Create a token at https://app.circleci.com/settings/user/tokens"),
+			fmt.Errorf("empty circleci token"),
+		)
 	}
 
-	if err := saveCircleCIToken(ctx, token, io, circleCIBaseURL); err != nil {
-		return ErrSilent
-	}
-	return nil
+	return saveCircleCIToken(ctx, token, io, circleCIBaseURL)
 }
 
 func authSetAnthropic(ctx context.Context, io iostream.Streams, anthropicBaseURL, anthropicKeyEnv string) error {
@@ -134,8 +131,7 @@ func authSetAnthropic(ctx context.Context, io iostream.Streams, anthropicBaseURL
 
 	cfg, err := config.Load()
 	if err != nil {
-		io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", err)))
-		return fmt.Errorf("load config: %w", err)
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	if cfg.AnthropicAPIKey != "" {
 		io.Printf("An Anthropic API key is already stored in config.\n")
@@ -156,62 +152,69 @@ func authSetAnthropic(ctx context.Context, io iostream.Streams, anthropicBaseURL
 
 	key = strings.TrimSpace(key)
 	if key == "" {
-		io.ErrPrintln(ui.FormatError("API key cannot be empty.", "", "Get an API key from https://console.anthropic.com/"))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("API key cannot be empty.", "", "Get an API key from https://console.anthropic.com/"),
+			fmt.Errorf("empty anthropic key"),
+		)
 	}
 
 	if !strings.HasPrefix(key, "sk-ant-") {
-		io.ErrPrintln(ui.FormatError("Invalid API key format.", "Keys should start with \"sk-ant-\".", "Get a valid API key from https://console.anthropic.com/"))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("Invalid API key format.", "Keys should start with \"sk-ant-\".", "Get a valid API key from https://console.anthropic.com/"),
+			fmt.Errorf("invalid anthropic key format"),
+		)
 	}
 
 	io.ErrPrintln(ui.Dim("Validating API key..."))
 	if err := authprompt.ValidateAPIKey(ctx, key, anthropicBaseURL); err != nil {
-		io.ErrPrintln(ui.FormatError("API key validation failed.", "", "Check that your key is correct and has not been revoked."))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("API key validation failed.", "", "Check that your key is correct and has not been revoked."),
+			err,
+		)
 	}
 
 	cfg, err = config.Load()
 	if err != nil {
-		return fmt.Errorf("load config before save: %w", err)
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	cfg.AnthropicAPIKey = key
 	if err := config.Save(cfg); err != nil {
-		return fmt.Errorf("save API key: %w", err)
+		return usererr.New("Could not save credentials. "+configFilePermHint, err)
 	}
 
 	cfgPath, err := config.Path()
 	if err != nil {
-		return err
+		return usererr.New("Could not access configuration.", err)
 	}
 	io.Printf("\n%s\n", ui.Success(fmt.Sprintf("API key validated and saved to %s", cfgPath)))
 	io.Println(ui.Dim("You can now run code reviews with: chunk build-prompt"))
 	return nil
 }
 
-// saveCircleCIToken validates and saves a CircleCI token to user config.
-// It prints status messages to streams and returns an error if anything fails.
 func saveCircleCIToken(ctx context.Context, token string, streams iostream.Streams, circleCIBaseURL string) error {
 	streams.ErrPrintln(ui.Dim("Validating CircleCI token..."))
 	if err := authprompt.ValidateCircleCIToken(ctx, token, circleCIBaseURL); err != nil {
-		streams.ErrPrintln(ui.FormatError("CircleCI token validation failed.", "", "Check that your token is correct."))
-		return fmt.Errorf("validate token: %w", err)
+		return usererr.New(
+			ui.FormatError("CircleCI token validation failed.", "", "Check that your token is correct."),
+			fmt.Errorf("validate token: %w", err),
+		)
 	}
 
 	cfg, err := config.Load()
 	if err != nil {
-		streams.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", err)))
-		return fmt.Errorf("load config: %w", err)
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	cfg.CircleCIToken = token
 	if err := config.Save(cfg); err != nil {
-		streams.ErrPrintln(ui.FormatError("Failed to save CircleCI token.", "", "Check that your config file is writable."))
-		return fmt.Errorf("save token: %w", err)
+		return usererr.New(
+			ui.FormatError("Failed to save CircleCI token.", "", "Check that your config file is writable."),
+			fmt.Errorf("save token: %w", err),
+		)
 	}
 
 	cfgPath, err := config.Path()
 	if err != nil {
-		return err
+		return usererr.New("Could not access configuration.", err)
 	}
 	streams.ErrPrintf("\n%s\n", ui.Success(fmt.Sprintf("CircleCI token validated and saved to %s", cfgPath)))
 	return nil
@@ -303,7 +306,7 @@ func newAuthStatusCmd() *cobra.Command {
 			io.Println("")
 
 			if hasFailure {
-				return ErrSilent
+				return usererr.Newf("One or more credential checks failed.", "auth status: validation failures")
 			}
 			return nil
 		},
@@ -333,7 +336,10 @@ func newAuthRemoveCmd() *cobra.Command {
 				githubTokenEnv := os.Getenv("GITHUB_TOKEN")
 				return authRemoveGitHub(io, githubTokenEnv)
 			default:
-				return fmt.Errorf("unknown provider %q: valid providers are circleci, anthropic, github", provider)
+				return usererr.Newf(
+					fmt.Sprintf("Unknown provider %q. Valid providers: circleci, anthropic, github.", provider),
+					"unknown provider %q", provider,
+				)
 			}
 		},
 	}
@@ -342,7 +348,7 @@ func newAuthRemoveCmd() *cobra.Command {
 func authRemoveCircleCI(io iostream.Streams, circleTokenEnv string) error {
 	cfg, err := config.Load()
 	if err != nil {
-		return err
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	if cfg.CircleCIToken == "" {
 		io.Println(ui.Warning("No CircleCI token stored in config file."))
@@ -357,7 +363,7 @@ func authRemoveCircleCI(io iostream.Streams, circleTokenEnv string) error {
 	io.Println("")
 	cfgPath, err := config.Path()
 	if err != nil {
-		return err
+		return usererr.New("Could not access configuration.", err)
 	}
 	io.Printf("This will remove your stored CircleCI token from %s\n", cfgPath)
 	confirmed, err := tui.Confirm("Are you sure?", false)
@@ -371,10 +377,12 @@ func authRemoveCircleCI(io iostream.Streams, circleTokenEnv string) error {
 	if err := config.Clear("circleCIToken"); err != nil {
 		hint := configFilePermHint
 		if errPath, pathErr := config.Path(); pathErr == nil {
-			hint = fmt.Sprintf("Check file permissions on %s", errPath)
+			hint = fmt.Sprintf("Check file permissions on %s.", errPath)
 		}
-		io.ErrPrintln(ui.FormatError("Failed to remove CircleCI token.", "An error occurred while trying to remove the token from the config file.", hint))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("Failed to remove CircleCI token.", "An error occurred while trying to remove the token from the config file.", hint),
+			err,
+		)
 	}
 
 	io.Println(ui.Success("CircleCI token removed successfully."))
@@ -387,7 +395,7 @@ func authRemoveCircleCI(io iostream.Streams, circleTokenEnv string) error {
 func authRemoveAnthropic(io iostream.Streams, anthropicKeyEnv string) error {
 	cfg, err := config.Load()
 	if err != nil {
-		return err
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	if cfg.AnthropicAPIKey == "" {
 		io.Println(ui.Warning("No API key stored in config file."))
@@ -402,7 +410,7 @@ func authRemoveAnthropic(io iostream.Streams, anthropicKeyEnv string) error {
 	io.Println("")
 	cfgPath, err := config.Path()
 	if err != nil {
-		return err
+		return usererr.New("Could not access configuration.", err)
 	}
 	io.Printf("This will remove your stored API key from %s\n", cfgPath)
 	confirmed, err := tui.Confirm("Are you sure?", false)
@@ -416,14 +424,12 @@ func authRemoveAnthropic(io iostream.Streams, anthropicKeyEnv string) error {
 	if err := config.Clear("anthropicAPIKey"); err != nil {
 		hint := configFilePermHint
 		if errPath, pathErr := config.Path(); pathErr == nil {
-			hint = fmt.Sprintf("Check file permissions on %s", errPath)
+			hint = fmt.Sprintf("Check file permissions on %s.", errPath)
 		}
-		io.ErrPrintln(ui.FormatError(
-			"Failed to remove API key.",
-			"An error occurred while trying to remove the API key from the config file.",
-			hint,
-		))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("Failed to remove API key.", "An error occurred while trying to remove the API key from the config file.", hint),
+			err,
+		)
 	}
 
 	io.Println(ui.Success("API key removed successfully."))
@@ -448,8 +454,7 @@ func authSetGitHub(ctx context.Context, io iostream.Streams, githubBaseURL, gith
 
 	cfg, err := config.Load()
 	if err != nil {
-		io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", err)))
-		return fmt.Errorf("load config: %w", err)
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	if cfg.GitHubToken != "" {
 		io.Printf("A GitHub token is already stored in config.\n")
@@ -471,28 +476,32 @@ func authSetGitHub(ctx context.Context, io iostream.Streams, githubBaseURL, gith
 
 	token = strings.TrimSpace(token)
 	if token == "" {
-		io.ErrPrintln(ui.FormatError("Token cannot be empty.", "", "Create a token at https://github.com/settings/tokens"))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("Token cannot be empty.", "", "Create a token at https://github.com/settings/tokens"),
+			fmt.Errorf("empty github token"),
+		)
 	}
 
 	io.ErrPrintln(ui.Dim("Validating GitHub token..."))
 	if err := authprompt.ValidateGitHubToken(ctx, token, githubBaseURL); err != nil {
-		io.ErrPrintln(ui.FormatError("GitHub token validation failed.", "", "Check that your token is correct and has not been revoked."))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("GitHub token validation failed.", "", "Check that your token is correct and has not been revoked."),
+			err,
+		)
 	}
 
 	cfg, err = config.Load()
 	if err != nil {
-		return fmt.Errorf("load config before save: %w", err)
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	cfg.GitHubToken = token
 	if err := config.Save(cfg); err != nil {
-		return fmt.Errorf("save token: %w", err)
+		return usererr.New("Could not save credentials. "+configFilePermHint, err)
 	}
 
 	cfgPath, err := config.Path()
 	if err != nil {
-		return err
+		return usererr.New("Could not access configuration.", err)
 	}
 	io.Printf("\n%s\n", ui.Success(fmt.Sprintf("GitHub token validated and saved to %s", cfgPath)))
 	return nil
@@ -501,7 +510,7 @@ func authSetGitHub(ctx context.Context, io iostream.Streams, githubBaseURL, gith
 func authRemoveGitHub(io iostream.Streams, githubTokenEnv string) error {
 	cfg, err := config.Load()
 	if err != nil {
-		return err
+		return usererr.New("Could not load configuration. "+configFilePermHint, err)
 	}
 	if cfg.GitHubToken == "" {
 		io.Println(ui.Warning("No GitHub token stored in config file."))
@@ -516,7 +525,7 @@ func authRemoveGitHub(io iostream.Streams, githubTokenEnv string) error {
 	io.Println("")
 	cfgPath, err := config.Path()
 	if err != nil {
-		return err
+		return usererr.New("Could not access configuration.", err)
 	}
 	io.Printf("This will remove your stored GitHub token from %s\n", cfgPath)
 	confirmed, err := tui.Confirm("Are you sure?", false)
@@ -530,10 +539,12 @@ func authRemoveGitHub(io iostream.Streams, githubTokenEnv string) error {
 	if err := config.Clear("gitHubToken"); err != nil {
 		hint := configFilePermHint
 		if errPath, pathErr := config.Path(); pathErr == nil {
-			hint = fmt.Sprintf("Check file permissions on %s", errPath)
+			hint = fmt.Sprintf("Check file permissions on %s.", errPath)
 		}
-		io.ErrPrintln(ui.FormatError("Failed to remove GitHub token.", "An error occurred while trying to remove the token from the config file.", hint))
-		return ErrSilent
+		return usererr.New(
+			ui.FormatError("Failed to remove GitHub token.", "An error occurred while trying to remove the token from the config file.", hint),
+			err,
+		)
 	}
 
 	io.Println(ui.Success("GitHub token removed successfully."))

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
 )
 
 func newConfigCmd() *cobra.Command {
@@ -68,13 +69,15 @@ func newConfigSetCmd() *cobra.Command {
 			key, value := args[0], args[1]
 
 			if !config.ValidConfigKeys[key] {
-				io.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Unknown config key: %q", key)))
-				return ErrSilent
+				return usererr.Newf(
+					fmt.Sprintf("Unknown config key: %q. Supported keys: model.", key),
+					"unknown config key %q", key,
+				)
 			}
 
 			cfg, err := config.Load()
 			if err != nil {
-				return err
+				return usererr.New("Could not load configuration. "+configFilePermHint, err)
 			}
 
 			if key == "model" {
@@ -82,7 +85,7 @@ func newConfigSetCmd() *cobra.Command {
 			}
 
 			if err := config.Save(cfg); err != nil {
-				return err
+				return usererr.New("Could not save configuration. "+configFilePermHint, err)
 			}
 
 			io.Printf("%s\n", ui.Success(fmt.Sprintf("Set %s to %s", key, value)))

--- a/internal/usererr/usererr.go
+++ b/internal/usererr/usererr.go
@@ -1,5 +1,7 @@
 package usererr
 
+import "fmt"
+
 // Error wraps a Go error with a user-facing message.
 // Error() delegates to the wrapped error. UserMessage() returns
 // human-friendly text (may be capitalized, punctuated).
@@ -11,6 +13,11 @@ type Error struct {
 // New wraps err with a user-facing message.
 func New(userMsg string, err error) *Error {
 	return &Error{userMsg: userMsg, err: err}
+}
+
+// Newf wraps a formatted error with a user-facing message.
+func Newf(userMsg string, format string, args ...any) *Error {
+	return &Error{userMsg: userMsg, err: fmt.Errorf(format, args...)}
 }
 
 func (e *Error) Error() string {

--- a/internal/usererr/usererr_test.go
+++ b/internal/usererr/usererr_test.go
@@ -52,3 +52,18 @@ func TestError(t *testing.T) {
 		}
 	})
 }
+
+func TestNewf(t *testing.T) {
+	sentinel := fmt.Errorf("root cause")
+	ue := usererr.Newf("Could not save file.", "save %s: %w", "config.json", sentinel)
+
+	if got := ue.UserMessage(); got != "Could not save file." {
+		t.Errorf("UserMessage() = %q", got)
+	}
+	if got := ue.Error(); got != "save config.json: root cause" {
+		t.Errorf("Error() = %q", got)
+	}
+	if !errors.Is(ue, sentinel) {
+		t.Error("errors.Is failed to match wrapped sentinel")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -17,13 +17,11 @@ func main() {
 
 	rootCmd := cmd.NewRootCmd(version)
 	if err := rootCmd.Execute(); err != nil {
-		if !errors.Is(err, cmd.ErrSilent) {
-			var ue *usererr.Error
-			if errors.As(err, &ue) {
-				fmt.Fprintln(os.Stderr, ue.UserMessage())
-			} else {
-				fmt.Fprintln(os.Stderr, err)
-			}
+		var ue *usererr.Error
+		if errors.As(err, &ue) {
+			fmt.Fprintln(os.Stderr, ue.UserMessage())
+		} else {
+			fmt.Fprintln(os.Stderr, err)
 			if suggestion := errorSuggestion(err); suggestion != "" {
 				fmt.Fprintln(os.Stderr, suggestion)
 			}


### PR DESCRIPTION
## Summary

- Remove `ErrSilent` sentinel — all auth.go and config.go error paths now return `usererr.Error`
- Add `usererr.Newf` convenience constructor
- Fix double-suggestion in `main.go` — `errorSuggestion` now skipped for usererr errors
- Wrap ~16 raw `fmt.Errorf` returns in auth.go and config.go with actionable user messages
- Refactor `saveCircleCIToken` to return `usererr.Error` instead of printing then returning `ErrSilent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)