### PR TITLE
Show config file path in auth token prompts

### DIFF
--- a/internal/authprompt/authprompt.go
+++ b/internal/authprompt/authprompt.go
@@ -82,6 +82,20 @@ func ValidateAPIKey(ctx context.Context, apiKey, baseURL string) error {
 	return nil
 }
 
+func PrintSaveHint(streams iostream.Streams, label string) {
+	if cfgPath, err := config.Path(); err == nil {
+		streams.ErrPrintln(ui.Dim(fmt.Sprintf("%s will be saved to user config (%s, mode 0600)", label, cfgPath)))
+	}
+}
+
+func PrintSaved(streams iostream.Streams, label string) {
+	msg := label + " saved"
+	if cfgPath, err := config.Path(); err == nil {
+		msg = fmt.Sprintf("%s saved to user config (%s)", label, cfgPath)
+	}
+	streams.ErrPrintln(ui.Success(msg))
+}
+
 // EnsureCircleCIClient returns a ready-to-use CircleCI client. If a token is
 // already available (env var or config file), it uses it directly. Otherwise
 // it prompts inline once, validates, saves to config, and returns the client.
@@ -97,6 +111,7 @@ func EnsureCircleCIClient(ctx context.Context, streams iostream.Streams, prompte
 	streams.ErrPrintln("")
 	streams.ErrPrintln(ui.Bold("CircleCI token required"))
 	streams.ErrPrintln("Create a token at https://app.circleci.com/settings/user/tokens")
+	PrintSaveHint(streams, "Token")
 	streams.ErrPrintln("")
 
 	token, err := prompter("CircleCI Token")
@@ -124,7 +139,7 @@ func EnsureCircleCIClient(ctx context.Context, streams iostream.Streams, prompte
 	if err := config.Save(cfg); err != nil {
 		return nil, fmt.Errorf("save token: %w", err)
 	}
-	streams.ErrPrintln(ui.Success("CircleCI token saved"))
+	PrintSaved(streams, "CircleCI token")
 	return circleci.NewClient()
 }
 
@@ -143,6 +158,7 @@ func EnsureAnthropicClient(ctx context.Context, streams iostream.Streams, prompt
 	streams.ErrPrintln("")
 	streams.ErrPrintln(ui.Bold("Anthropic API key required"))
 	streams.ErrPrintln("Get a key at https://console.anthropic.com/")
+	PrintSaveHint(streams, "Key")
 	streams.ErrPrintln("")
 
 	key, err := prompter("API Key")
@@ -173,7 +189,7 @@ func EnsureAnthropicClient(ctx context.Context, streams iostream.Streams, prompt
 	if err := config.Save(cfg); err != nil {
 		return nil, fmt.Errorf("save API key: %w", err)
 	}
-	streams.ErrPrintln(ui.Success("Anthropic API key saved"))
+	PrintSaved(streams, "Anthropic API key")
 	return anthropic.New()
 }
 
@@ -193,6 +209,7 @@ func EnsureGitHubClient(ctx context.Context, streams iostream.Streams, prompter 
 	streams.ErrPrintln("")
 	streams.ErrPrintln(ui.Bold("GitHub token required"))
 	streams.ErrPrintln("Create a token at https://github.com/settings/tokens")
+	PrintSaveHint(streams, "Token")
 	streams.ErrPrintln("")
 
 	token, err := prompter("GitHub Token")
@@ -220,7 +237,7 @@ func EnsureGitHubClient(ctx context.Context, streams iostream.Streams, prompter 
 	if err := config.Save(cfg); err != nil {
 		return nil, fmt.Errorf("save token: %w", err)
 	}
-	streams.ErrPrintln(ui.Success("GitHub token saved"))
+	PrintSaved(streams, "GitHub token")
 	return github.New()
 }
 

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -75,6 +75,7 @@ func authSetCircleCI(ctx context.Context, io iostream.Streams, circleCIBaseURL, 
 	io.Println(ui.Bold("Chunk CLI - CircleCI Token Setup"))
 	io.Println("")
 	io.Println("Create a CircleCI token at https://app.circleci.com/settings/user/tokens")
+	authprompt.PrintSaveHint(io, "Token")
 	io.Println("")
 
 	if circleTokenEnv != "" {
@@ -121,7 +122,7 @@ func authSetAnthropic(ctx context.Context, io iostream.Streams, anthropicBaseURL
 	io.Println(ui.Bold("Chunk CLI - Anthropic API Key Setup"))
 	io.Println("")
 	io.Println("Enter your Anthropic API key (starts with sk-ant-).")
-	io.Println(ui.Dim("The key will be stored securely and never displayed."))
+	authprompt.PrintSaveHint(io, "Key")
 	io.Println("")
 	if anthropicKeyEnv != "" {
 		io.Println(ui.Warning("An Anthropic API key is set in environment variables (ANTHROPIC_API_KEY)."))
@@ -182,11 +183,8 @@ func authSetAnthropic(ctx context.Context, io iostream.Streams, anthropicBaseURL
 		return usererr.New("Could not save credentials. "+configFilePermHint, err)
 	}
 
-	cfgPath, err := config.Path()
-	if err != nil {
-		return usererr.New("Could not access configuration.", err)
-	}
-	io.Printf("\n%s\n", ui.Success(fmt.Sprintf("API key validated and saved to %s", cfgPath)))
+	io.Println("")
+	authprompt.PrintSaved(io, "Anthropic API key")
 	io.Println(ui.Dim("You can now run code reviews with: chunk build-prompt"))
 	return nil
 }
@@ -212,11 +210,8 @@ func saveCircleCIToken(ctx context.Context, token string, streams iostream.Strea
 		)
 	}
 
-	cfgPath, err := config.Path()
-	if err != nil {
-		return usererr.New("Could not access configuration.", err)
-	}
-	streams.ErrPrintf("\n%s\n", ui.Success(fmt.Sprintf("CircleCI token validated and saved to %s", cfgPath)))
+	streams.ErrPrintln("")
+	authprompt.PrintSaved(streams, "CircleCI token")
 	return nil
 }
 
@@ -444,6 +439,7 @@ func authSetGitHub(ctx context.Context, io iostream.Streams, githubBaseURL, gith
 	io.Println(ui.Bold("Chunk CLI - GitHub Token Setup"))
 	io.Println("")
 	io.Println("Create a token at https://github.com/settings/tokens")
+	authprompt.PrintSaveHint(io, "Token")
 	io.Println("")
 
 	if githubTokenEnv != "" {
@@ -499,11 +495,8 @@ func authSetGitHub(ctx context.Context, io iostream.Streams, githubBaseURL, gith
 		return usererr.New("Could not save credentials. "+configFilePermHint, err)
 	}
 
-	cfgPath, err := config.Path()
-	if err != nil {
-		return usererr.New("Could not access configuration.", err)
-	}
-	io.Printf("\n%s\n", ui.Success(fmt.Sprintf("GitHub token validated and saved to %s", cfgPath)))
+	io.Println("")
+	authprompt.PrintSaved(io, "GitHub token")
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Show where tokens will be saved before prompting (path + mode 0600)
- Show where tokens were saved in the success message
- Extract `printSaveHint`/`printSaved` helpers to keep the format in one place