### PR TITLE
Replace bare fmt.Printf in retry.go with callback

### DIFF
--- a/internal/authprompt/authprompt.go
+++ b/internal/authprompt/authprompt.go
@@ -200,7 +200,12 @@ func EnsureAnthropicClient(ctx context.Context, streams iostream.Streams, prompt
 func EnsureGitHubClient(ctx context.Context, streams iostream.Streams, prompter Prompter) (*github.Client, error) {
 	rc, err := config.Resolve("", "")
 	if rc.GitHubToken != "" {
-		return github.New()
+		c, cerr := github.New()
+		if cerr != nil {
+			return nil, cerr
+		}
+		c.SetLogStatus(func(msg string) { streams.ErrPrintln("  " + msg) })
+		return c, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("resolve config: %w", err)
@@ -238,7 +243,12 @@ func EnsureGitHubClient(ctx context.Context, streams iostream.Streams, prompter 
 		return nil, fmt.Errorf("save token: %w", err)
 	}
 	PrintSaved(streams, "GitHub token")
-	return github.New()
+	c, cerr := github.New()
+	if cerr != nil {
+		return nil, cerr
+	}
+	c.SetLogStatus(func(msg string) { streams.ErrPrintln("  " + msg) })
+	return c, nil
 }
 
 // ValidateGitHubToken calls GET /user to confirm the token is accepted.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -17,6 +17,16 @@ type Client struct {
 	// retryDelayOverride, if non-zero, replaces the exponential backoff
 	// delay in doWithRetry. Intended for tests only.
 	retryDelayOverride time.Duration
+
+	// logStatus, if non-nil, is called with informational progress
+	// messages (e.g. retry/rate-limit waits). Callers typically wire
+	// this to stderr output.
+	logStatus func(string)
+}
+
+// SetLogStatus sets an optional callback for progress/status messages.
+func (c *Client) SetLogStatus(fn func(string)) {
+	c.logStatus = fn
 }
 
 // New creates a GitHub GraphQL client.

--- a/internal/github/retry.go
+++ b/internal/github/retry.go
@@ -86,7 +86,7 @@ func (c *Client) doWithRetry(ctx context.Context, query string, vars map[string]
 
 		lastErr = err
 		delay := c.retryDelay(attempt)
-		fmt.Printf("  GitHub API error on attempt %d/%d, retrying in %s...\n", attempt+1, maxRetries, delay)
+		c.status(fmt.Sprintf("GitHub API error on attempt %d/%d, retrying in %s...", attempt+1, maxRetries, delay))
 
 		select {
 		case <-ctx.Done():
@@ -102,7 +102,7 @@ func (c *Client) doWithRetry(ctx context.Context, query string, vars map[string]
 }
 
 // waitForRateLimit sleeps until the rate limit resets if remaining is below the threshold.
-func waitForRateLimit(ctx context.Context, rl RateLimit) error {
+func (c *Client) waitForRateLimit(ctx context.Context, rl RateLimit) error {
 	if rl.Remaining >= rateLimitThreshold {
 		return nil
 	}
@@ -117,12 +117,19 @@ func waitForRateLimit(ctx context.Context, rl RateLimit) error {
 		return nil
 	}
 
-	fmt.Printf("Rate limit low (%d remaining). Waiting %s until reset...\n", rl.Remaining, wait.Truncate(time.Second))
+	c.status(fmt.Sprintf("Rate limit low (%d remaining). Waiting %s until reset...", rl.Remaining, wait.Truncate(time.Second)))
 
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-time.After(wait):
 		return nil
+	}
+}
+
+// status emits a progress message via the logStatus callback, if set.
+func (c *Client) status(msg string) {
+	if c.logStatus != nil {
+		c.logStatus(msg)
 	}
 }

--- a/internal/github/retry_test.go
+++ b/internal/github/retry_test.go
@@ -147,8 +147,9 @@ func TestDoWithRetry_RespectsContextCancellation(t *testing.T) {
 }
 
 func TestWaitForRateLimit_AboveThreshold(t *testing.T) {
+	c := &Client{}
 	start := time.Now()
-	err := waitForRateLimit(context.Background(), RateLimit{
+	err := c.waitForRateLimit(context.Background(), RateLimit{
 		Remaining: 1000,
 		ResetAt:   time.Now().Add(time.Hour).Format(time.RFC3339),
 	})
@@ -161,8 +162,9 @@ func TestWaitForRateLimit_AboveThreshold(t *testing.T) {
 }
 
 func TestWaitForRateLimit_BelowThresholdPastReset(t *testing.T) {
+	c := &Client{}
 	start := time.Now()
-	err := waitForRateLimit(context.Background(), RateLimit{
+	err := c.waitForRateLimit(context.Background(), RateLimit{
 		Remaining: 100,
 		ResetAt:   time.Now().Add(-time.Hour).Format(time.RFC3339),
 	})
@@ -175,10 +177,11 @@ func TestWaitForRateLimit_BelowThresholdPastReset(t *testing.T) {
 }
 
 func TestWaitForRateLimit_CancelledContext(t *testing.T) {
+	c := &Client{}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := waitForRateLimit(ctx, RateLimit{
+	err := c.waitForRateLimit(ctx, RateLimit{
 		Remaining: 100,
 		ResetAt:   time.Now().Add(time.Hour).Format(time.RFC3339),
 	})

--- a/internal/github/reviews.go
+++ b/internal/github/reviews.go
@@ -107,7 +107,7 @@ func (c *Client) FetchReviewActivity(ctx context.Context, org, repo string, sinc
 		cursor = prData.PageInfo.EndCursor
 
 		// Throttle if rate limit is low
-		if err := waitForRateLimit(ctx, resp.Data.RateLimit); err != nil {
+		if err := c.waitForRateLimit(ctx, resp.Data.RateLimit); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Summary
- Add `logStatus` callback field to `github.Client` with `SetLogStatus` setter
- Replace direct `fmt.Printf` calls in `retry.go` with `c.status()` helper that invokes the callback (no-op when nil)
- Convert `waitForRateLimit` from package-level function to `Client` method so it can access the callback
- Wire callback to `streams.ErrPrintln` in `EnsureGitHubClient` so messages go to stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)