### PR TITLE
Extract task config form into testable function

### DIFF
--- a/internal/cmd/task.go
+++ b/internal/cmd/task.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
-	"sort"
-	"strings"
 	"sync"
 
 	"github.com/spf13/cobra"
@@ -91,7 +91,6 @@ func newTaskRunCmd() *cobra.Command {
 	return cmd
 }
 
-//nolint:gocyclo // cobra command wiring with many flags
 func newTaskConfigCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "config",
@@ -134,188 +133,29 @@ func newTaskConfigCmd() *cobra.Command {
 
 			io.ErrPrintln(ui.Dim("Fetching your CircleCI projects..."))
 
-			// Fetch projects and collaborations in parallel
-			var projects []circleci.FollowedProject
-			var collabs []circleci.Collaboration
-			var projErr, collabErr error
-
-			var wg sync.WaitGroup
-			wg.Add(2)
-			go func() {
-				defer wg.Done()
-				projects, projErr = client.ListFollowedProjects(ctx)
-			}()
-			go func() {
-				defer wg.Done()
-				collabs, collabErr = client.ListCollaborations(ctx)
-			}()
-			wg.Wait()
-
-			if projErr != nil {
-				return usererr.New("Could not fetch CircleCI projects. Check your token and network connection.", fmt.Errorf("fetch projects: %w", projErr))
-			}
-			if collabErr != nil {
-				return usererr.New("Could not fetch CircleCI projects. Check your token and network connection.", fmt.Errorf("fetch collaborations: %w", collabErr))
-			}
-
-			var orgID, projectID, orgType string
-
-			// Sort projects alphabetically
-			sort.Slice(projects, func(i, j int) bool {
-				a := fmt.Sprintf("%s/%s", projects[i].Username, projects[i].Reponame)
-				b := fmt.Sprintf("%s/%s", projects[j].Username, projects[j].Reponame)
-				return a < b
-			})
-
-			// Build project selection list
-			items := make([]string, 0, len(projects)+1)
-			for _, p := range projects {
-				items = append(items, fmt.Sprintf("%s/%s", p.Username, p.Reponame))
-			}
-			items = append(items, "Enter manually")
-
-			idx, err := tui.SelectFromList("Select a project:", items)
+			projects, collabs, err := fetchProjectsAndCollabs(ctx, client)
 			if err != nil {
+				return err
+			}
+
+			prompts := task.Prompts{
+				Confirm:    tui.Confirm,
+				SelectFrom: tui.SelectFromList,
+				PromptText: tui.PromptText,
+				Warn:       func(msg string) { io.ErrPrintln(ui.Yellow(msg)) },
+			}
+
+			fetchDetail := func(ctx context.Context, slug string) (*circleci.ProjectDetail, error) {
+				io.ErrPrintf("%s\n", ui.Dim(fmt.Sprintf("Fetching project details for %s...", slug)))
+				return client.GetProjectBySlug(ctx, slug)
+			}
+
+			runCfg, err := task.CollectRunConfig(ctx, prompts, projects, collabs, fetchDetail)
+			if errors.Is(err, tui.ErrCancelled) {
 				return nil
 			}
-
-			if idx < len(projects) {
-				// Selected a project from the list
-				p := projects[idx]
-				vcsPrefix := "gh"
-				if strings.EqualFold(p.VcsType, "bitbucket") {
-					vcsPrefix = "bb"
-				}
-				slug := fmt.Sprintf("%s/%s/%s", vcsPrefix, p.Username, p.Reponame)
-
-				io.ErrPrintf("%s\n", ui.Dim(fmt.Sprintf("Fetching project details for %s...", slug)))
-				detail, err := client.GetProjectBySlug(ctx, slug)
-				if err != nil {
-					return usererr.New("Could not fetch project details. Check your token and network connection.", fmt.Errorf("fetch project details: %w", err))
-				}
-
-				projectID = detail.ID
-				orgID = detail.OrgID
-				orgType = task.MapVcsTypeToOrgType(p.VcsType)
-			} else {
-				// Manual entry
-				if len(collabs) == 0 {
-					return usererr.New(
-						"No organizations found. Check your CircleCI token has access to at least one organization.",
-						fmt.Errorf("no organizations found"),
-					)
-				}
-
-				orgItems := make([]string, len(collabs))
-				for i, c := range collabs {
-					orgItems[i] = c.Name
-				}
-
-				orgIdx, err := tui.SelectFromList("Select your organization:", orgItems)
-				if err != nil {
-					return nil
-				}
-
-				orgID = collabs[orgIdx].ID
-				orgType = task.MapVcsTypeToOrgType(collabs[orgIdx].VcsType)
-
-				projectID, err = tui.PromptText("Project ID (UUID)", "")
-				if err != nil {
-					return nil
-				}
-				if projectID == "" {
-					return usererr.New("Project ID is required.", fmt.Errorf("project ID is required"))
-				}
-			}
-
-			// Warn if selected org differs from CIRCLECI_ORG_ID
-			if envOrgID := os.Getenv("CIRCLECI_ORG_ID"); envOrgID != "" && envOrgID != orgID {
-				_, _ = fmt.Fprintln(io.Err, ui.Warning(fmt.Sprintf(
-					"Warning: selected project org (%s) differs from CIRCLECI_ORG_ID (%s)",
-					orgID, envOrgID,
-				)))
-			}
-
-			// Collect definitions
-			definitions := make(map[string]task.RunDefinition)
-
-			for {
-				name, err := tui.PromptText("Definition name (e.g. dev, prod)", "")
-				if err != nil {
-					return nil
-				}
-				if name == "" {
-					return usererr.New("Definition name is required.", fmt.Errorf("definition name is required"))
-				}
-
-				// Prompt for definition ID with UUID validation
-				var defID string
-				for {
-					defID, err = tui.PromptText("Definition ID (UUID)", "")
-					if err != nil {
-						return nil
-					}
-					if defID == "" {
-						io.Println(ui.Yellow("  This field is required."))
-						continue
-					}
-					if !task.IsValidUUID(defID) {
-						io.Println(ui.Yellow("  Must be a valid UUID (e.g. 550e8400-e29b-41d4-a716-446655440000)."))
-						continue
-					}
-					break
-				}
-
-				// Prompt for optional description
-				description, err := tui.PromptText("Description (optional)", "")
-				if err != nil {
-					return nil
-				}
-
-				defaultBranch, err := tui.PromptText("Default branch", "main")
-				if err != nil {
-					return nil
-				}
-
-				// Prompt for environment ID with optional UUID validation
-				var envID string
-				for {
-					envID, err = tui.PromptText("Environment ID (optional UUID)", "")
-					if err != nil {
-						return nil
-					}
-					if envID == "" {
-						break
-					}
-					if !task.IsValidUUID(envID) {
-						io.Println(ui.Yellow("  Must be a valid UUID (e.g. 550e8400-e29b-41d4-a716-446655440000)."))
-						continue
-					}
-					break
-				}
-
-				def := task.RunDefinition{
-					DefinitionID:  defID,
-					Description:   description,
-					DefaultBranch: defaultBranch,
-				}
-				if envID != "" {
-					def.ChunkEnvironmentID = &envID
-				}
-
-				definitions[name] = def
-
-				more, err := tui.Confirm("Add another definition?", false)
-				if err != nil || !more {
-					break
-				}
-			}
-
-			runCfg := &task.RunConfig{
-				OrgID:       orgID,
-				ProjectID:   projectID,
-				OrgType:     orgType,
-				Definitions: definitions,
+			if err != nil {
+				return err
 			}
 
 			if err := task.SaveRunConfig(repoRoot, runCfg); err != nil {
@@ -329,4 +169,30 @@ func newTaskConfigCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func fetchProjectsAndCollabs(ctx context.Context, client *circleci.Client) ([]circleci.FollowedProject, []circleci.Collaboration, error) {
+	var projects []circleci.FollowedProject
+	var collabs []circleci.Collaboration
+	var projErr, collabErr error
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		projects, projErr = client.ListFollowedProjects(ctx)
+	}()
+	go func() {
+		defer wg.Done()
+		collabs, collabErr = client.ListCollaborations(ctx)
+	}()
+	wg.Wait()
+
+	if projErr != nil {
+		return nil, nil, usererr.New("Could not fetch CircleCI projects. Check your token and network connection.", fmt.Errorf("fetch projects: %w", projErr))
+	}
+	if collabErr != nil {
+		return nil, nil, usererr.New("Could not fetch CircleCI projects. Check your token and network connection.", fmt.Errorf("fetch collaborations: %w", collabErr))
+	}
+	return projects, collabs, nil
 }

--- a/internal/task/collect.go
+++ b/internal/task/collect.go
@@ -1,0 +1,226 @@
+package task
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+)
+
+// Prompts provides the interactive UI operations needed to collect run config.
+type Prompts struct {
+	Confirm    func(label string, defaultVal bool) (bool, error)
+	SelectFrom func(label string, items []string) (int, error)
+	PromptText func(label string, defaultVal string) (string, error)
+	Warn       func(msg string)
+}
+
+// ProjectDetailFunc fetches project detail by slug (e.g. "gh/org/repo").
+type ProjectDetailFunc func(ctx context.Context, slug string) (*circleci.ProjectDetail, error)
+
+// CollectRunConfig drives the interactive form to build a RunConfig.
+// It takes already-fetched projects and collaborations plus injected UI
+// and data-fetch dependencies so the logic is testable without a TTY.
+func CollectRunConfig(
+	ctx context.Context,
+	prompts Prompts,
+	projects []circleci.FollowedProject,
+	collabs []circleci.Collaboration,
+	fetchDetail ProjectDetailFunc,
+) (*RunConfig, error) {
+	orgID, projectID, orgType, err := collectProject(ctx, prompts, projects, collabs, fetchDetail)
+	if err != nil {
+		return nil, err
+	}
+
+	// Warn if selected org differs from CIRCLECI_ORG_ID
+	if envOrgID := os.Getenv("CIRCLECI_ORG_ID"); envOrgID != "" && envOrgID != orgID {
+		prompts.Warn(fmt.Sprintf(
+			"Warning: selected project org (%s) differs from CIRCLECI_ORG_ID (%s)",
+			orgID, envOrgID,
+		))
+	}
+
+	definitions, err := collectDefinitions(prompts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RunConfig{
+		OrgID:       orgID,
+		ProjectID:   projectID,
+		OrgType:     orgType,
+		Definitions: definitions,
+	}, nil
+}
+
+func collectProject(
+	ctx context.Context,
+	prompts Prompts,
+	projects []circleci.FollowedProject,
+	collabs []circleci.Collaboration,
+	fetchDetail ProjectDetailFunc,
+) (orgID, projectID, orgType string, err error) {
+	// Sort projects alphabetically
+	sort.Slice(projects, func(i, j int) bool {
+		a := fmt.Sprintf("%s/%s", projects[i].Username, projects[i].Reponame)
+		b := fmt.Sprintf("%s/%s", projects[j].Username, projects[j].Reponame)
+		return a < b
+	})
+
+	// Build project selection list
+	items := make([]string, 0, len(projects)+1)
+	for _, p := range projects {
+		items = append(items, fmt.Sprintf("%s/%s", p.Username, p.Reponame))
+	}
+	items = append(items, "Enter manually")
+
+	idx, err := prompts.SelectFrom("Select a project:", items)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	if idx < len(projects) {
+		return resolveProjectFromList(ctx, projects[idx], fetchDetail)
+	}
+	return collectManualProject(prompts, collabs)
+}
+
+func resolveProjectFromList(
+	ctx context.Context,
+	p circleci.FollowedProject,
+	fetchDetail ProjectDetailFunc,
+) (orgID, projectID, orgType string, err error) {
+	vcsPrefix := "gh"
+	if strings.EqualFold(p.VcsType, "bitbucket") {
+		vcsPrefix = "bb"
+	}
+	slug := fmt.Sprintf("%s/%s/%s", vcsPrefix, p.Username, p.Reponame)
+
+	detail, err := fetchDetail(ctx, slug)
+	if err != nil {
+		return "", "", "", fmt.Errorf("fetch project details: %w", err)
+	}
+	return detail.OrgID, detail.ID, MapVcsTypeToOrgType(p.VcsType), nil
+}
+
+func collectManualProject(
+	prompts Prompts,
+	collabs []circleci.Collaboration,
+) (orgID, projectID, orgType string, err error) {
+	if len(collabs) == 0 {
+		return "", "", "", fmt.Errorf("no organizations found")
+	}
+
+	orgItems := make([]string, len(collabs))
+	for i, c := range collabs {
+		orgItems[i] = c.Name
+	}
+
+	orgIdx, err := prompts.SelectFrom("Select your organization:", orgItems)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	orgID = collabs[orgIdx].ID
+	orgType = MapVcsTypeToOrgType(collabs[orgIdx].VcsType)
+
+	projectID, err = prompts.PromptText("Project ID (UUID)", "")
+	if err != nil {
+		return "", "", "", err
+	}
+	if projectID == "" {
+		return "", "", "", fmt.Errorf("project ID is required")
+	}
+	return orgID, projectID, orgType, nil
+}
+
+func collectDefinitions(prompts Prompts) (map[string]RunDefinition, error) {
+	definitions := make(map[string]RunDefinition)
+
+	for {
+		name, err := prompts.PromptText("Definition name (e.g. dev, prod)", "")
+		if err != nil {
+			return nil, err
+		}
+		if name == "" {
+			return nil, fmt.Errorf("definition name is required")
+		}
+
+		defID, err := collectRequiredUUID(prompts, "Definition ID (UUID)")
+		if err != nil {
+			return nil, err
+		}
+
+		description, err := prompts.PromptText("Description (optional)", "")
+		if err != nil {
+			return nil, err
+		}
+
+		defaultBranch, err := prompts.PromptText("Default branch", "main")
+		if err != nil {
+			return nil, err
+		}
+
+		envID, err := collectOptionalUUID(prompts, "Environment ID (optional UUID)")
+		if err != nil {
+			return nil, err
+		}
+
+		def := RunDefinition{
+			DefinitionID:  defID,
+			Description:   description,
+			DefaultBranch: defaultBranch,
+		}
+		if envID != "" {
+			def.ChunkEnvironmentID = &envID
+		}
+
+		definitions[name] = def
+
+		more, err := prompts.Confirm("Add another definition?", false)
+		if err != nil || !more {
+			break
+		}
+	}
+
+	return definitions, nil
+}
+
+func collectRequiredUUID(prompts Prompts, label string) (string, error) {
+	for {
+		val, err := prompts.PromptText(label, "")
+		if err != nil {
+			return "", err
+		}
+		if val == "" {
+			prompts.Warn("  This field is required.")
+			continue
+		}
+		if !IsValidUUID(val) {
+			prompts.Warn("  Must be a valid UUID (e.g. 550e8400-e29b-41d4-a716-446655440000).")
+			continue
+		}
+		return val, nil
+	}
+}
+
+func collectOptionalUUID(prompts Prompts, label string) (string, error) {
+	for {
+		val, err := prompts.PromptText(label, "")
+		if err != nil {
+			return "", err
+		}
+		if val == "" {
+			return "", nil
+		}
+		if !IsValidUUID(val) {
+			prompts.Warn("  Must be a valid UUID (e.g. 550e8400-e29b-41d4-a716-446655440000).")
+			continue
+		}
+		return val, nil
+	}
+}

--- a/internal/task/collect_test.go
+++ b/internal/task/collect_test.go
@@ -1,0 +1,422 @@
+package task
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+)
+
+// fakePrompts returns a Prompts struct that replays canned responses.
+// selectResponses is consumed in order by SelectFrom calls.
+// textResponses is consumed in order by PromptText calls.
+// confirmResponses is consumed in order by Confirm calls.
+func fakePrompts(
+	selectResponses []int,
+	textResponses []string,
+	confirmResponses []bool,
+	warnings *[]string,
+) Prompts {
+	si, ti, ci := 0, 0, 0
+	return Prompts{
+		SelectFrom: func(label string, items []string) (int, error) {
+			if si >= len(selectResponses) {
+				return -1, errors.New("unexpected SelectFrom call")
+			}
+			idx := selectResponses[si]
+			si++
+			return idx, nil
+		},
+		PromptText: func(label, defaultVal string) (string, error) {
+			if ti >= len(textResponses) {
+				return "", errors.New("unexpected PromptText call")
+			}
+			val := textResponses[ti]
+			ti++
+			if val == "" {
+				return defaultVal, nil
+			}
+			return val, nil
+		},
+		Confirm: func(label string, defaultVal bool) (bool, error) {
+			if ci >= len(confirmResponses) {
+				return false, nil
+			}
+			val := confirmResponses[ci]
+			ci++
+			return val, nil
+		},
+		Warn: func(msg string) {
+			if warnings != nil {
+				*warnings = append(*warnings, msg)
+			}
+		},
+	}
+}
+
+func fakeFetchDetail(orgID, projectID string) ProjectDetailFunc {
+	return func(_ context.Context, slug string) (*circleci.ProjectDetail, error) {
+		return &circleci.ProjectDetail{
+			ID:    projectID,
+			OrgID: orgID,
+			Slug:  slug,
+		}, nil
+	}
+}
+
+func TestCollectRunConfig_SelectFromList(t *testing.T) {
+	projects := []circleci.FollowedProject{
+		{Username: "acme", Reponame: "api", VcsType: "github"},
+	}
+	// Select first project (index 0), then fill one definition, then decline more.
+	prompts := fakePrompts(
+		[]int{0},
+		[]string{
+			"dev",                                  // definition name
+			"550e8400-e29b-41d4-a716-446655440000", // definition ID
+			"",                                     // description (empty -> default)
+			"",                                     // default branch (empty -> "main")
+			"",                                     // environment ID (empty -> skip)
+		},
+		[]bool{false}, // don't add another
+		nil,
+	)
+
+	cfg, err := CollectRunConfig(
+		context.Background(),
+		prompts,
+		projects,
+		nil,
+		fakeFetchDetail("org-1", "proj-1"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.OrgID != "org-1" {
+		t.Fatalf("OrgID = %q, want %q", cfg.OrgID, "org-1")
+	}
+	if cfg.ProjectID != "proj-1" {
+		t.Fatalf("ProjectID = %q, want %q", cfg.ProjectID, "proj-1")
+	}
+	if cfg.OrgType != "github" {
+		t.Fatalf("OrgType = %q, want %q", cfg.OrgType, "github")
+	}
+	if len(cfg.Definitions) != 1 {
+		t.Fatalf("got %d definitions, want 1", len(cfg.Definitions))
+	}
+	dev := cfg.Definitions["dev"]
+	if dev.DefinitionID != "550e8400-e29b-41d4-a716-446655440000" {
+		t.Fatalf("DefinitionID = %q", dev.DefinitionID)
+	}
+	if dev.DefaultBranch != "main" {
+		t.Fatalf("DefaultBranch = %q, want %q", dev.DefaultBranch, "main")
+	}
+	if dev.ChunkEnvironmentID != nil {
+		t.Fatalf("ChunkEnvironmentID = %v, want nil", dev.ChunkEnvironmentID)
+	}
+}
+
+func TestCollectRunConfig_ManualEntry(t *testing.T) {
+	collabs := []circleci.Collaboration{
+		{ID: "org-99", Name: "my-org", VcsType: "github"},
+	}
+	// Select "Enter manually" (index 0, but 0 projects so index 0 is manual).
+	// Actually, with 0 projects, items = ["Enter manually"], index 0 triggers manual.
+	prompts := fakePrompts(
+		[]int{
+			0, // "Enter manually" (only item since no projects)
+			0, // select org index 0
+		},
+		[]string{
+			"proj-manual",                          // project ID
+			"prod",                                 // definition name
+			"660e8400-e29b-41d4-a716-446655440000", // definition ID
+			"production env",                       // description
+			"release",                              // default branch
+			"770e8400-e29b-41d4-a716-446655440000", // environment ID
+		},
+		[]bool{false}, // don't add another
+		nil,
+	)
+
+	cfg, err := CollectRunConfig(
+		context.Background(),
+		prompts,
+		nil, // no followed projects
+		collabs,
+		nil, // fetchDetail not needed for manual
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.OrgID != "org-99" {
+		t.Fatalf("OrgID = %q, want %q", cfg.OrgID, "org-99")
+	}
+	if cfg.ProjectID != "proj-manual" {
+		t.Fatalf("ProjectID = %q, want %q", cfg.ProjectID, "proj-manual")
+	}
+	if cfg.OrgType != "github" {
+		t.Fatalf("OrgType = %q, want %q", cfg.OrgType, "github")
+	}
+
+	prod := cfg.Definitions["prod"]
+	if prod.DefinitionID != "660e8400-e29b-41d4-a716-446655440000" {
+		t.Fatalf("DefinitionID = %q", prod.DefinitionID)
+	}
+	if prod.Description != "production env" {
+		t.Fatalf("Description = %q", prod.Description)
+	}
+	if prod.DefaultBranch != "release" {
+		t.Fatalf("DefaultBranch = %q, want %q", prod.DefaultBranch, "release")
+	}
+	if prod.ChunkEnvironmentID == nil || *prod.ChunkEnvironmentID != "770e8400-e29b-41d4-a716-446655440000" {
+		t.Fatalf("ChunkEnvironmentID = %v", prod.ChunkEnvironmentID)
+	}
+}
+
+func TestCollectRunConfig_MultipleDefinitions(t *testing.T) {
+	projects := []circleci.FollowedProject{
+		{Username: "acme", Reponame: "web", VcsType: "github"},
+	}
+	prompts := fakePrompts(
+		[]int{0}, // select project
+		[]string{
+			// first definition
+			"dev",
+			"aaaa1111-bbbb-cccc-dddd-eeeeeeee0001",
+			"", // description
+			"", // branch
+			"", // env
+			// second definition
+			"prod",
+			"aaaa1111-bbbb-cccc-dddd-eeeeeeee0002",
+			"production",
+			"release",
+			"",
+		},
+		[]bool{true, false}, // add another, then stop
+		nil,
+	)
+
+	cfg, err := CollectRunConfig(
+		context.Background(),
+		prompts,
+		projects,
+		nil,
+		fakeFetchDetail("org-1", "proj-1"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Definitions) != 2 {
+		t.Fatalf("got %d definitions, want 2", len(cfg.Definitions))
+	}
+	if _, ok := cfg.Definitions["dev"]; !ok {
+		t.Fatal("missing dev definition")
+	}
+	if _, ok := cfg.Definitions["prod"]; !ok {
+		t.Fatal("missing prod definition")
+	}
+}
+
+func TestCollectRunConfig_InvalidUUIDRetries(t *testing.T) {
+	projects := []circleci.FollowedProject{
+		{Username: "acme", Reponame: "api", VcsType: "github"},
+	}
+	var warnings []string
+	prompts := fakePrompts(
+		[]int{0},
+		[]string{
+			"dev",                                  // definition name
+			"not-valid",                            // invalid UUID (triggers warning, retries)
+			"550e8400-e29b-41d4-a716-446655440000", // valid UUID
+			"",                                     // description
+			"",                                     // branch
+			"not-valid",                            // invalid env UUID (triggers warning, retries)
+			"660e8400-e29b-41d4-a716-446655440000", // valid env UUID
+		},
+		[]bool{false},
+		&warnings,
+	)
+
+	cfg, err := CollectRunConfig(
+		context.Background(),
+		prompts,
+		projects,
+		nil,
+		fakeFetchDetail("org-1", "proj-1"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 2 {
+		t.Fatalf("got %d warnings, want 2", len(warnings))
+	}
+	dev := cfg.Definitions["dev"]
+	if dev.DefinitionID != "550e8400-e29b-41d4-a716-446655440000" {
+		t.Fatalf("DefinitionID = %q", dev.DefinitionID)
+	}
+	if dev.ChunkEnvironmentID == nil || *dev.ChunkEnvironmentID != "660e8400-e29b-41d4-a716-446655440000" {
+		t.Fatalf("ChunkEnvironmentID = %v", dev.ChunkEnvironmentID)
+	}
+}
+
+func TestCollectRunConfig_RequiredDefIDRetries(t *testing.T) {
+	projects := []circleci.FollowedProject{
+		{Username: "acme", Reponame: "api", VcsType: "github"},
+	}
+	var warnings []string
+
+	si, ti, ci := 0, 0, 0
+	selectResps := []int{0}
+	// PromptText returns "" for empty, but the fakePrompts helper returns defaultVal on "".
+	// We need a custom prompts to simulate truly empty input for the required UUID retry.
+	textResps := []struct {
+		val     string
+		isEmpty bool
+	}{
+		{val: "dev"},    // definition name
+		{isEmpty: true}, // empty definition ID -> required
+		{val: "550e8400-e29b-41d4-a716-446655440000"}, // valid definition ID
+		{val: ""}, // description (use default)
+		{val: ""}, // branch (use default)
+		{val: ""}, // env ID (skip)
+	}
+	confirmResps := []bool{false}
+
+	prompts := Prompts{
+		SelectFrom: func(label string, items []string) (int, error) {
+			idx := selectResps[si]
+			si++
+			return idx, nil
+		},
+		PromptText: func(label, defaultVal string) (string, error) {
+			r := textResps[ti]
+			ti++
+			if r.isEmpty {
+				return "", nil
+			}
+			if r.val == "" {
+				return defaultVal, nil
+			}
+			return r.val, nil
+		},
+		Confirm: func(label string, defaultVal bool) (bool, error) {
+			val := confirmResps[ci]
+			ci++
+			return val, nil
+		},
+		Warn: func(msg string) {
+			warnings = append(warnings, msg)
+		},
+	}
+
+	cfg, err := CollectRunConfig(
+		context.Background(),
+		prompts,
+		projects,
+		nil,
+		fakeFetchDetail("org-1", "proj-1"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("got %d warnings, want 1: %v", len(warnings), warnings)
+	}
+	if warnings[0] != "  This field is required." {
+		t.Fatalf("unexpected warning: %q", warnings[0])
+	}
+	dev := cfg.Definitions["dev"]
+	if dev.DefinitionID != "550e8400-e29b-41d4-a716-446655440000" {
+		t.Fatalf("DefinitionID = %q", dev.DefinitionID)
+	}
+	_ = cfg
+}
+
+func TestCollectRunConfig_NoCollabsError(t *testing.T) {
+	// Select "Enter manually" with no collabs -> error
+	prompts := fakePrompts(
+		[]int{0},
+		nil,
+		nil,
+		nil,
+	)
+
+	_, err := CollectRunConfig(
+		context.Background(),
+		prompts,
+		nil, // no projects, so "Enter manually" is index 0
+		nil, // no collabs
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected error for no organizations")
+	}
+}
+
+func TestCollectRunConfig_OrgMismatchWarning(t *testing.T) {
+	projects := []circleci.FollowedProject{
+		{Username: "acme", Reponame: "api", VcsType: "github"},
+	}
+	var warnings []string
+	prompts := fakePrompts(
+		[]int{0},
+		[]string{
+			"dev",
+			"550e8400-e29b-41d4-a716-446655440000",
+			"", "", "",
+		},
+		[]bool{false},
+		&warnings,
+	)
+
+	t.Setenv("CIRCLECI_ORG_ID", "different-org")
+
+	_, err := CollectRunConfig(
+		context.Background(),
+		prompts,
+		projects,
+		nil,
+		fakeFetchDetail("org-1", "proj-1"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, w := range warnings {
+		if w == "Warning: selected project org (org-1) differs from CIRCLECI_ORG_ID (different-org)" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected org mismatch warning, got: %v", warnings)
+	}
+}
+
+func TestCollectRunConfig_BitbucketPrefix(t *testing.T) {
+	projects := []circleci.FollowedProject{
+		{Username: "acme", Reponame: "api", VcsType: "Bitbucket"},
+	}
+	var capturedSlug string
+	fetch := func(_ context.Context, slug string) (*circleci.ProjectDetail, error) {
+		capturedSlug = slug
+		return &circleci.ProjectDetail{ID: "proj-1", OrgID: "org-1", Slug: slug}, nil
+	}
+
+	prompts := fakePrompts(
+		[]int{0},
+		[]string{"dev", "550e8400-e29b-41d4-a716-446655440000", "", "", ""},
+		[]bool{false},
+		nil,
+	)
+
+	_, err := CollectRunConfig(context.Background(), prompts, projects, nil, fetch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedSlug != "bb/acme/api" {
+		t.Fatalf("slug = %q, want %q", capturedSlug, "bb/acme/api")
+	}
+}

--- a/internal/task/config.go
+++ b/internal/task/config.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+const orgTypeGitHub = "github"
+
 var uuidRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
 type RunDefinition struct {
@@ -81,8 +83,8 @@ func SaveRunConfig(workDir string, cfg *RunConfig) error {
 // "github" and "gh" map to "github"; everything else maps to "circleci".
 func MapVcsTypeToOrgType(vcsType string) string {
 	lower := strings.ToLower(vcsType)
-	if lower == "github" || lower == "gh" {
-		return "github"
+	if lower == orgTypeGitHub || lower == "gh" {
+		return orgTypeGitHub
 	}
 	return "circleci"
 }


### PR DESCRIPTION
## Summary
- Move interactive form logic from cobra RunE handler into `task.CollectRunConfig()` with injected `Prompts` struct
- Cobra handler now: fetches data, wires TUI implementations, calls `CollectRunConfig`, saves result
- Eight new tests cover list selection, manual entry, multiple definitions, UUID validation retries, no-collabs error, org mismatch warning, and bitbucket slug prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)