### PR TITLE
Decouple authprompt from tui and ui

### DIFF
--- a/internal/authprompt/authprompt.go
+++ b/internal/authprompt/authprompt.go
@@ -6,25 +6,18 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/anthropic"
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/github"
 	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
-	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
-	"github.com/CircleCI-Public/chunk-cli/internal/tui"
-	"github.com/CircleCI-Public/chunk-cli/internal/ui"
-	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
 )
 
-// ErrCancelled is returned when the user cancels an inline prompt.
-var ErrCancelled = tui.ErrCancelled
-
-// Prompter is a function that prompts the user for hidden input.
-// tui.PromptHidden is the standard implementation; inject a stub in tests.
-type Prompter func(label string) (string, error)
+// ErrNeedsAuth is returned by Resolve* functions when no credentials are
+// available in env vars or config, indicating that the caller should prompt
+// the user interactively.
+var ErrNeedsAuth = errors.New("authentication required")
 
 // ValidateCircleCIToken calls GET /api/v2/me to confirm the token is accepted.
 // A 429 response is treated as valid (rate-limited but authenticated).
@@ -82,24 +75,9 @@ func ValidateAPIKey(ctx context.Context, apiKey, baseURL string) error {
 	return nil
 }
 
-func PrintSaveHint(streams iostream.Streams, label string) {
-	if cfgPath, err := config.Path(); err == nil {
-		streams.ErrPrintln(ui.Dim(fmt.Sprintf("%s will be saved to user config (%s, mode 0600)", label, cfgPath)))
-	}
-}
-
-func PrintSaved(streams iostream.Streams, label string) {
-	msg := label + " saved"
-	if cfgPath, err := config.Path(); err == nil {
-		msg = fmt.Sprintf("%s saved to user config (%s)", label, cfgPath)
-	}
-	streams.ErrPrintln(ui.Success(msg))
-}
-
-// EnsureCircleCIClient returns a ready-to-use CircleCI client. If a token is
-// already available (env var or config file), it uses it directly. Otherwise
-// it prompts inline once, validates, saves to config, and returns the client.
-func EnsureCircleCIClient(ctx context.Context, streams iostream.Streams, prompter Prompter) (*circleci.Client, error) {
+// ResolveCircleCIClient returns a CircleCI client if credentials are available
+// in env vars or config. Returns ErrNeedsAuth when the caller must prompt.
+func ResolveCircleCIClient() (*circleci.Client, error) {
 	rc, err := config.Resolve("", "")
 	if rc.CircleCIToken != "" {
 		return circleci.NewClient()
@@ -107,46 +85,13 @@ func EnsureCircleCIClient(ctx context.Context, streams iostream.Streams, prompte
 	if err != nil {
 		return nil, fmt.Errorf("resolve config: %w", err)
 	}
-
-	streams.ErrPrintln("")
-	streams.ErrPrintln(ui.Bold("CircleCI token required"))
-	streams.ErrPrintln("Create a token at https://app.circleci.com/settings/user/tokens")
-	PrintSaveHint(streams, "Token")
-	streams.ErrPrintln("")
-
-	token, err := prompter("CircleCI Token")
-	if err != nil {
-		if errors.Is(err, tui.ErrNoTTY) {
-			return nil, usererr.New("CircleCI token required: set CIRCLE_TOKEN or run 'chunk auth set circleci'", err)
-		}
-		return nil, err
-	}
-	token = strings.TrimSpace(token)
-	if token == "" {
-		return nil, usererr.New("CircleCI token required: set CIRCLE_TOKEN or run 'chunk auth set circleci'", fmt.Errorf("empty token entered"))
-	}
-
-	streams.ErrPrintln(ui.Dim("Validating CircleCI token..."))
-	if err := ValidateCircleCIToken(ctx, token, os.Getenv("CIRCLECI_BASE_URL")); err != nil {
-		return nil, fmt.Errorf("invalid CircleCI token: %w", err)
-	}
-
-	cfg, err := config.Load()
-	if err != nil {
-		return nil, fmt.Errorf("load config: %w", err)
-	}
-	cfg.CircleCIToken = token
-	if err := config.Save(cfg); err != nil {
-		return nil, fmt.Errorf("save token: %w", err)
-	}
-	PrintSaved(streams, "CircleCI token")
-	return circleci.NewClient()
+	return nil, ErrNeedsAuth
 }
 
-// EnsureAnthropicClient returns a ready-to-use Anthropic client. If a key is
-// already available (env var or config file), it uses it directly. Otherwise
-// it prompts inline once, validates, saves to config, and returns the client.
-func EnsureAnthropicClient(ctx context.Context, streams iostream.Streams, prompter Prompter) (*anthropic.Client, error) {
+// ResolveAnthropicClient returns an Anthropic client if credentials are
+// available in env vars or config. Returns ErrNeedsAuth when the caller must
+// prompt.
+func ResolveAnthropicClient() (*anthropic.Client, error) {
 	rc, err := config.Resolve("", "")
 	if rc.AnthropicAPIKey != "" {
 		return anthropic.New()
@@ -154,101 +99,59 @@ func EnsureAnthropicClient(ctx context.Context, streams iostream.Streams, prompt
 	if err != nil {
 		return nil, fmt.Errorf("resolve config: %w", err)
 	}
-
-	streams.ErrPrintln("")
-	streams.ErrPrintln(ui.Bold("Anthropic API key required"))
-	streams.ErrPrintln("Get a key at https://console.anthropic.com/")
-	PrintSaveHint(streams, "Key")
-	streams.ErrPrintln("")
-
-	key, err := prompter("API Key")
-	if err != nil {
-		if errors.Is(err, tui.ErrNoTTY) {
-			return nil, usererr.New("Anthropic API key required: set ANTHROPIC_API_KEY or run 'chunk auth set anthropic'", err)
-		}
-		return nil, err
-	}
-	key = strings.TrimSpace(key)
-	if key == "" {
-		return nil, usererr.New("Anthropic API key required: set ANTHROPIC_API_KEY or run 'chunk auth set anthropic'", fmt.Errorf("empty key entered"))
-	}
-	if !strings.HasPrefix(key, "sk-ant-") {
-		return nil, usererr.New("Invalid API key format — keys should start with \"sk-ant-\". Get a valid key from https://console.anthropic.com/", fmt.Errorf("invalid key prefix"))
-	}
-
-	streams.ErrPrintln(ui.Dim("Validating API key..."))
-	if err := ValidateAPIKey(ctx, key, os.Getenv("ANTHROPIC_BASE_URL")); err != nil {
-		return nil, fmt.Errorf("invalid Anthropic API key: %w", err)
-	}
-
-	cfg, err := config.Load()
-	if err != nil {
-		return nil, fmt.Errorf("load config: %w", err)
-	}
-	cfg.AnthropicAPIKey = key
-	if err := config.Save(cfg); err != nil {
-		return nil, fmt.Errorf("save API key: %w", err)
-	}
-	PrintSaved(streams, "Anthropic API key")
-	return anthropic.New()
+	return nil, ErrNeedsAuth
 }
 
-// EnsureGitHubClient returns a ready-to-use GitHub client. If a token is
-// already available (env var or config file), it uses it directly. Otherwise
-// it prompts inline once, validates the token against GET /user, saves to
-// config, and returns the client.
-func EnsureGitHubClient(ctx context.Context, streams iostream.Streams, prompter Prompter) (*github.Client, error) {
+// ResolveGitHubClient returns a GitHub client if credentials are available in
+// env vars or config. Returns ErrNeedsAuth when the caller must prompt.
+func ResolveGitHubClient() (*github.Client, error) {
 	rc, err := config.Resolve("", "")
 	if rc.GitHubToken != "" {
-		c, cerr := github.New()
-		if cerr != nil {
-			return nil, cerr
-		}
-		c.SetLogStatus(func(msg string) { streams.ErrPrintln("  " + msg) })
-		return c, nil
+		return github.New()
 	}
 	if err != nil {
 		return nil, fmt.Errorf("resolve config: %w", err)
 	}
+	return nil, ErrNeedsAuth
+}
 
-	streams.ErrPrintln("")
-	streams.ErrPrintln(ui.Bold("GitHub token required"))
-	streams.ErrPrintln("Create a token at https://github.com/settings/tokens")
-	PrintSaveHint(streams, "Token")
-	streams.ErrPrintln("")
-
-	token, err := prompter("GitHub Token")
-	if err != nil {
-		if errors.Is(err, tui.ErrNoTTY) {
-			return nil, usererr.New("GitHub token required: set GITHUB_TOKEN or run 'chunk auth set github'", err)
-		}
-		return nil, err
-	}
-	token = strings.TrimSpace(token)
-	if token == "" {
-		return nil, usererr.New("GitHub token required: set GITHUB_TOKEN or run 'chunk auth set github'", fmt.Errorf("empty token entered"))
-	}
-
-	streams.ErrPrintln(ui.Dim("Validating GitHub token..."))
-	if err := ValidateGitHubToken(ctx, token, os.Getenv("GITHUB_API_URL")); err != nil {
-		return nil, fmt.Errorf("invalid GitHub token: %w", err)
-	}
-
+// SaveCircleCIToken persists a CircleCI token to the config file.
+func SaveCircleCIToken(token string) error {
 	cfg, err := config.Load()
 	if err != nil {
-		return nil, fmt.Errorf("load config: %w", err)
+		return fmt.Errorf("load config: %w", err)
+	}
+	cfg.CircleCIToken = token
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("save token: %w", err)
+	}
+	return nil
+}
+
+// SaveAnthropicKey persists an Anthropic API key to the config file.
+func SaveAnthropicKey(key string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	cfg.AnthropicAPIKey = key
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("save API key: %w", err)
+	}
+	return nil
+}
+
+// SaveGitHubToken persists a GitHub token to the config file.
+func SaveGitHubToken(token string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
 	}
 	cfg.GitHubToken = token
 	if err := config.Save(cfg); err != nil {
-		return nil, fmt.Errorf("save token: %w", err)
+		return fmt.Errorf("save token: %w", err)
 	}
-	PrintSaved(streams, "GitHub token")
-	c, cerr := github.New()
-	if cerr != nil {
-		return nil, cerr
-	}
-	c.SetLogStatus(func(msg string) { streams.ErrPrintln("  " + msg) })
-	return c, nil
+	return nil
 }
 
 // ValidateGitHubToken calls GET /user to confirm the token is accepted.
@@ -271,4 +174,19 @@ func ValidateGitHubToken(ctx context.Context, token, baseURL string) error {
 		return err
 	}
 	return nil
+}
+
+// CircleCIBaseURL returns the configured CircleCI base URL from the environment.
+func CircleCIBaseURL() string {
+	return os.Getenv("CIRCLECI_BASE_URL")
+}
+
+// AnthropicBaseURL returns the configured Anthropic base URL from the environment.
+func AnthropicBaseURL() string {
+	return os.Getenv("ANTHROPIC_BASE_URL")
+}
+
+// GitHubBaseURL returns the configured GitHub API URL from the environment.
+func GitHubBaseURL() string {
+	return os.Getenv("GITHUB_API_URL")
 }

--- a/internal/authprompt/authprompt_test.go
+++ b/internal/authprompt/authprompt_test.go
@@ -5,21 +5,15 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
-	"io"
-	"net/http"
 	"net/http/httptest"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/authprompt"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
-	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
-	"github.com/CircleCI-Public/chunk-cli/internal/tui"
-	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
 )
 
 // isolateConfig sets up a temp HOME so config.Load/Save use an isolated file.
@@ -63,7 +57,7 @@ func TestValidateGitHubToken_OK(t *testing.T) {
 	assert.NilError(t, err)
 }
 
-func TestEnsureCircleCIClient_TokenInEnv(t *testing.T) {
+func TestResolveCircleCIClient_TokenInEnv(t *testing.T) {
 	isolateConfig(t)
 
 	cci := fakes.NewFakeCircleCI()
@@ -73,13 +67,12 @@ func TestEnsureCircleCIClient_TokenInEnv(t *testing.T) {
 	t.Setenv("CIRCLE_TOKEN", randToken("cci-"))
 	t.Setenv("CIRCLECI_BASE_URL", srv.URL)
 
-	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	client, err := authprompt.EnsureCircleCIClient(context.Background(), streams, tui.PromptHidden)
+	client, err := authprompt.ResolveCircleCIClient()
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
 }
 
-func TestEnsureCircleCIClient_TokenInConfig(t *testing.T) {
+func TestResolveCircleCIClient_TokenInConfig(t *testing.T) {
 	isolateConfig(t)
 
 	cci := fakes.NewFakeCircleCI()
@@ -87,7 +80,6 @@ func TestEnsureCircleCIClient_TokenInConfig(t *testing.T) {
 	defer srv.Close()
 
 	t.Setenv("CIRCLECI_BASE_URL", srv.URL)
-	// Ensure env vars are clear so config file wins
 	t.Setenv("CIRCLE_TOKEN", "")
 	t.Setenv("CIRCLECI_TOKEN", "")
 
@@ -96,13 +88,21 @@ func TestEnsureCircleCIClient_TokenInConfig(t *testing.T) {
 	cfg.CircleCIToken = randToken("cci-")
 	assert.NilError(t, config.Save(cfg))
 
-	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	client, err := authprompt.EnsureCircleCIClient(context.Background(), streams, tui.PromptHidden)
+	client, err := authprompt.ResolveCircleCIClient()
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
 }
 
-func TestEnsureAnthropicClient_KeyInEnv(t *testing.T) {
+func TestResolveCircleCIClient_NeedsAuth(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv("CIRCLE_TOKEN", "")
+	t.Setenv("CIRCLECI_TOKEN", "")
+
+	_, err := authprompt.ResolveCircleCIClient()
+	assert.Assert(t, errors.Is(err, authprompt.ErrNeedsAuth))
+}
+
+func TestResolveAnthropicClient_KeyInEnv(t *testing.T) {
 	isolateConfig(t)
 
 	ant := fakes.NewFakeAnthropic("ok")
@@ -112,13 +112,12 @@ func TestEnsureAnthropicClient_KeyInEnv(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", randToken("sk-ant-"))
 	t.Setenv("ANTHROPIC_BASE_URL", srv.URL)
 
-	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	client, err := authprompt.EnsureAnthropicClient(context.Background(), streams, tui.PromptHidden)
+	client, err := authprompt.ResolveAnthropicClient()
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
 }
 
-func TestEnsureAnthropicClient_KeyInConfig(t *testing.T) {
+func TestResolveAnthropicClient_KeyInConfig(t *testing.T) {
 	isolateConfig(t)
 
 	ant := fakes.NewFakeAnthropic("ok")
@@ -133,13 +132,20 @@ func TestEnsureAnthropicClient_KeyInConfig(t *testing.T) {
 	cfg.AnthropicAPIKey = randToken("sk-ant-")
 	assert.NilError(t, config.Save(cfg))
 
-	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	client, err := authprompt.EnsureAnthropicClient(context.Background(), streams, tui.PromptHidden)
+	client, err := authprompt.ResolveAnthropicClient()
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
 }
 
-func TestEnsureGitHubClient_TokenInEnv(t *testing.T) {
+func TestResolveAnthropicClient_NeedsAuth(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	_, err := authprompt.ResolveAnthropicClient()
+	assert.Assert(t, errors.Is(err, authprompt.ErrNeedsAuth))
+}
+
+func TestResolveGitHubClient_TokenInEnv(t *testing.T) {
 	isolateConfig(t)
 
 	gh := fakes.NewFakeGitHub()
@@ -149,13 +155,12 @@ func TestEnsureGitHubClient_TokenInEnv(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", randToken("ghp_"))
 	t.Setenv("GITHUB_API_URL", srv.URL)
 
-	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	client, err := authprompt.EnsureGitHubClient(context.Background(), streams, tui.PromptHidden)
+	client, err := authprompt.ResolveGitHubClient()
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
 }
 
-func TestEnsureGitHubClient_TokenInConfig(t *testing.T) {
+func TestResolveGitHubClient_TokenInConfig(t *testing.T) {
 	isolateConfig(t)
 
 	gh := fakes.NewFakeGitHub()
@@ -170,138 +175,51 @@ func TestEnsureGitHubClient_TokenInConfig(t *testing.T) {
 	cfg.GitHubToken = randToken("ghp_")
 	assert.NilError(t, config.Save(cfg))
 
-	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	client, err := authprompt.EnsureGitHubClient(context.Background(), streams, tui.PromptHidden)
+	client, err := authprompt.ResolveGitHubClient()
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
 }
 
-// --- prompt-and-save path tests (via injected prompter) ---
-
-func assertNoTTYError(t *testing.T, err error, wantSubstr string) {
-	t.Helper()
-	assert.Assert(t, err != nil)
-	assert.Assert(t, errors.Is(err, tui.ErrNoTTY), "expected ErrNoTTY in chain, got: %v", err)
-	var ue *usererr.Error
-	assert.Assert(t, errors.As(err, &ue), "expected *usererr.Error, got: %T %v", err, err)
-	assert.Assert(t, strings.Contains(ue.UserMessage(), wantSubstr),
-		"expected %q in user message %q", wantSubstr, ue.UserMessage())
-}
-
-func TestEnsureCircleCIClient_NoTTY(t *testing.T) {
-	isolateConfig(t)
-	t.Setenv("CIRCLE_TOKEN", "")
-	t.Setenv("CIRCLECI_TOKEN", "")
-
-	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	prompter := func(string) (string, error) { return "", tui.ErrNoTTY }
-	_, err := authprompt.EnsureCircleCIClient(context.Background(), streams, prompter)
-	assertNoTTYError(t, err, "CIRCLE_TOKEN")
-}
-
-func TestEnsureAnthropicClient_NoTTY(t *testing.T) {
-	isolateConfig(t)
-	t.Setenv("ANTHROPIC_API_KEY", "")
-
-	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	prompter := func(string) (string, error) { return "", tui.ErrNoTTY }
-	_, err := authprompt.EnsureAnthropicClient(context.Background(), streams, prompter)
-	assertNoTTYError(t, err, "ANTHROPIC_API_KEY")
-}
-
-func TestEnsureGitHubClient_NoTTY(t *testing.T) {
+func TestResolveGitHubClient_NeedsAuth(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv("GITHUB_TOKEN", "")
 
-	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	prompter := func(string) (string, error) { return "", tui.ErrNoTTY }
-	_, err := authprompt.EnsureGitHubClient(context.Background(), streams, prompter)
-	assertNoTTYError(t, err, "GITHUB_TOKEN")
+	_, err := authprompt.ResolveGitHubClient()
+	assert.Assert(t, errors.Is(err, authprompt.ErrNeedsAuth))
 }
 
-func TestEnsureGitHubClient_PromptAndSave(t *testing.T) {
+func TestSaveCircleCIToken(t *testing.T) {
 	isolateConfig(t)
-
-	gh := fakes.NewFakeGitHub()
-	srv := httptest.NewServer(gh)
-	defer srv.Close()
-
-	t.Setenv("GITHUB_API_URL", srv.URL)
-	t.Setenv("GITHUB_TOKEN", "")
-
-	token := randToken("ghp_")
-	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	prompter := func(string) (string, error) { return token, nil }
-	client, err := authprompt.EnsureGitHubClient(context.Background(), streams, prompter)
-	assert.NilError(t, err)
-	assert.Assert(t, client != nil)
-
-	// Token should have been persisted
-	cfg, err := config.Load()
-	assert.NilError(t, err)
-	assert.Equal(t, cfg.GitHubToken, token)
-}
-
-func TestEnsureAnthropicClient_PromptAndSave(t *testing.T) {
-	isolateConfig(t)
-
-	ant := fakes.NewFakeAnthropic("ok")
-	srv := httptest.NewServer(ant)
-	defer srv.Close()
-
-	t.Setenv("ANTHROPIC_BASE_URL", srv.URL)
-	t.Setenv("ANTHROPIC_API_KEY", "")
-
-	key := randToken("sk-ant-")
-	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	prompter := func(string) (string, error) { return key, nil }
-	client, err := authprompt.EnsureAnthropicClient(context.Background(), streams, prompter)
-	assert.NilError(t, err)
-	assert.Assert(t, client != nil)
-
-	cfg, err := config.Load()
-	assert.NilError(t, err)
-	assert.Equal(t, cfg.AnthropicAPIKey, key)
-}
-
-func TestEnsureCircleCIClient_PromptAndSave(t *testing.T) {
-	isolateConfig(t)
-
-	cci := fakes.NewFakeCircleCI()
-	srv := httptest.NewServer(cci)
-	defer srv.Close()
-
-	t.Setenv("CIRCLECI_BASE_URL", srv.URL)
-	t.Setenv("CIRCLE_TOKEN", "")
-	t.Setenv("CIRCLECI_TOKEN", "")
 
 	token := randToken("cci-")
-	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	prompter := func(string) (string, error) { return token, nil }
-	client, err := authprompt.EnsureCircleCIClient(context.Background(), streams, prompter)
+	err := authprompt.SaveCircleCIToken(token)
 	assert.NilError(t, err)
-	assert.Assert(t, client != nil)
 
 	cfg, err := config.Load()
 	assert.NilError(t, err)
 	assert.Equal(t, cfg.CircleCIToken, token)
 }
 
-func TestEnsureGitHubClient_InvalidToken(t *testing.T) {
+func TestSaveAnthropicKey(t *testing.T) {
 	isolateConfig(t)
-	t.Setenv("GITHUB_TOKEN", "")
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
-	}))
-	defer srv.Close()
+	key := randToken("sk-ant-")
+	err := authprompt.SaveAnthropicKey(key)
+	assert.NilError(t, err)
 
-	t.Setenv("GITHUB_API_URL", srv.URL)
+	cfg, err := config.Load()
+	assert.NilError(t, err)
+	assert.Equal(t, cfg.AnthropicAPIKey, key)
+}
 
-	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	prompter := func(string) (string, error) { return randToken("ghp_"), nil }
-	_, err := authprompt.EnsureGitHubClient(context.Background(), streams, prompter)
-	assert.Assert(t, err != nil)
+func TestSaveGitHubToken(t *testing.T) {
+	isolateConfig(t)
+
+	token := randToken("ghp_")
+	err := authprompt.SaveGitHubToken(token)
+	assert.NilError(t, err)
+
+	cfg, err := config.Load()
+	assert.NilError(t, err)
+	assert.Equal(t, cfg.GitHubToken, token)
 }

--- a/internal/buildprompt/buildprompt_test.go
+++ b/internal/buildprompt/buildprompt_test.go
@@ -14,7 +14,8 @@ import (
 
 	"gotest.tools/v3/assert"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/github"
+	"github.com/CircleCI-Public/chunk-cli/internal/anthropic"
+	ghpkg "github.com/CircleCI-Public/chunk-cli/internal/github"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fixtures"
@@ -28,14 +29,14 @@ func TestRunHappyPath(t *testing.T) {
 	gh.SetOrgRepos(fixtures.OrgReposResponse("test-repo"))
 	gh.SetReviewActivity("test-repo", fixtures.ReviewActivityResponse())
 
-	anthropic := fakes.NewFakeAnthropic(
+	fakeAnthropic := fakes.NewFakeAnthropic(
 		fixtures.AnalysisResponse,
 		fixtures.PromptResponse,
 	)
 
 	ghSrv := httptest.NewServer(gh)
 	defer ghSrv.Close()
-	anthropicSrv := httptest.NewServer(anthropic)
+	anthropicSrv := httptest.NewServer(fakeAnthropic)
 	defer anthropicSrv.Close()
 
 	t.Setenv("GITHUB_TOKEN", "fake-token")
@@ -43,13 +44,18 @@ func TestRunHappyPath(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
 	t.Setenv("ANTHROPIC_BASE_URL", anthropicSrv.URL)
 
+	ghClient, err := ghpkg.New()
+	assert.NilError(t, err)
+	anthropicClient, err := anthropic.New()
+	assert.NilError(t, err)
+
 	outDir := t.TempDir()
 	outputPath := filepath.Join(outDir, "prompt.md")
 
 	var stderr bytes.Buffer
 	streams := iostream.Streams{Out: &bytes.Buffer{}, Err: &stderr}
 
-	err := Run(context.Background(), Options{
+	err = Run(context.Background(), Options{
 		Org:          "test-org",
 		Repos:        []string{"test-repo"},
 		Top:          5,
@@ -57,7 +63,7 @@ func TestRunHappyPath(t *testing.T) {
 		OutputPath:   outputPath,
 		AnalyzeModel: "claude-sonnet-4-6",
 		PromptModel:  "claude-sonnet-4-6",
-	}, streams)
+	}, ghClient, anthropicClient, streams)
 	assert.NilError(t, err)
 
 	// All output files created
@@ -104,16 +110,21 @@ func TestRunNoReposFound(t *testing.T) {
 	t.Setenv("GITHUB_API_URL", ghSrv.URL)
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
 
+	ghClient, err := ghpkg.New()
+	assert.NilError(t, err)
+	anthropicClient, err := anthropic.New()
+	assert.NilError(t, err)
+
 	var stderr bytes.Buffer
 	streams := iostream.Streams{Out: &bytes.Buffer{}, Err: &stderr}
 
 	// Pass empty repos so FetchOrgRepos queries the API (which returns empty)
-	err := Run(context.Background(), Options{
+	err = Run(context.Background(), Options{
 		Org:        "test-org",
 		Repos:      nil,
 		Top:        5,
 		OutputPath: filepath.Join(t.TempDir(), "prompt.md"),
-	}, streams)
+	}, ghClient, anthropicClient, streams)
 	assert.NilError(t, err)
 	assert.Assert(t, strings.Contains(stderr.String(), "No repositories found"))
 }
@@ -124,14 +135,14 @@ func TestRunSkipsRepoResolutionErrors(t *testing.T) {
 	gh.SetReviewActivity("good-repo", fixtures.ReviewActivityResponse())
 	gh.SetRepoError("bad-repo", fixtures.RepoNotFoundError("test-org", "bad-repo"))
 
-	anthropic := fakes.NewFakeAnthropic(
+	fakeAnthropic := fakes.NewFakeAnthropic(
 		fixtures.AnalysisResponse,
 		fixtures.PromptResponse,
 	)
 
 	ghSrv := httptest.NewServer(gh)
 	defer ghSrv.Close()
-	anthropicSrv := httptest.NewServer(anthropic)
+	anthropicSrv := httptest.NewServer(fakeAnthropic)
 	defer anthropicSrv.Close()
 
 	t.Setenv("GITHUB_TOKEN", "fake-token")
@@ -139,20 +150,25 @@ func TestRunSkipsRepoResolutionErrors(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
 	t.Setenv("ANTHROPIC_BASE_URL", anthropicSrv.URL)
 
+	ghClient, err := ghpkg.New()
+	assert.NilError(t, err)
+	anthropicClient, err := anthropic.New()
+	assert.NilError(t, err)
+
 	outDir := t.TempDir()
 	outputPath := filepath.Join(outDir, "prompt.md")
 
 	var stderr bytes.Buffer
 	streams := iostream.Streams{Out: &bytes.Buffer{}, Err: &stderr}
 
-	err := Run(context.Background(), Options{
+	err = Run(context.Background(), Options{
 		Org:          "test-org",
 		Repos:        []string{"good-repo", "bad-repo"},
 		Top:          5,
 		OutputPath:   outputPath,
 		AnalyzeModel: "claude-sonnet-4-6",
 		PromptModel:  "claude-sonnet-4-6",
-	}, streams)
+	}, ghClient, anthropicClient, streams)
 	assert.NilError(t, err)
 	assert.Assert(t, strings.Contains(stderr.String(), "Skipping bad-repo"))
 }
@@ -162,14 +178,14 @@ func TestRunWithMaxComments(t *testing.T) {
 	gh.SetOrgRepos(fixtures.OrgReposResponse("test-repo"))
 	gh.SetReviewActivity("test-repo", fixtures.MultiReviewerResponse())
 
-	anthropic := fakes.NewFakeAnthropic(
+	fakeAnthropic := fakes.NewFakeAnthropic(
 		fixtures.AnalysisResponse,
 		fixtures.PromptResponse,
 	)
 
 	ghSrv := httptest.NewServer(gh)
 	defer ghSrv.Close()
-	anthropicSrv := httptest.NewServer(anthropic)
+	anthropicSrv := httptest.NewServer(fakeAnthropic)
 	defer anthropicSrv.Close()
 
 	t.Setenv("GITHUB_TOKEN", "fake-token")
@@ -177,12 +193,17 @@ func TestRunWithMaxComments(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
 	t.Setenv("ANTHROPIC_BASE_URL", anthropicSrv.URL)
 
+	ghClient, err := ghpkg.New()
+	assert.NilError(t, err)
+	anthropicClient, err := anthropic.New()
+	assert.NilError(t, err)
+
 	outDir := t.TempDir()
 	outputPath := filepath.Join(outDir, "prompt.md")
 
 	streams := iostream.Streams{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
 
-	err := Run(context.Background(), Options{
+	err = Run(context.Background(), Options{
 		Org:          "test-org",
 		Repos:        []string{"test-repo"},
 		Top:          5,
@@ -190,11 +211,11 @@ func TestRunWithMaxComments(t *testing.T) {
 		OutputPath:   outputPath,
 		AnalyzeModel: "claude-sonnet-4-6",
 		PromptModel:  "claude-sonnet-4-6",
-	}, streams)
+	}, ghClient, anthropicClient, streams)
 	assert.NilError(t, err)
 
 	// Verify the anthropic request was made (analysis prompt built with limited comments)
-	reqs := anthropic.Recorder.AllRequests()
+	reqs := fakeAnthropic.Recorder.AllRequests()
 	assert.Assert(t, len(reqs) >= 2, "expected at least 2 anthropic requests")
 }
 
@@ -203,16 +224,16 @@ func TestRunRetryOnTokenLimit(t *testing.T) {
 	gh.SetOrgRepos(fixtures.OrgReposResponse("test-repo"))
 	gh.SetReviewActivity("test-repo", fixtures.MultiReviewerResponse())
 
-	anthropic := fakes.NewFakeAnthropic(
+	fakeAnthropic := fakes.NewFakeAnthropic(
 		fixtures.AnalysisResponse,
 		fixtures.PromptResponse,
 	)
 	// First 2 analysis attempts return token limit errors, third succeeds.
-	anthropic.SetTokenLimitErrors(2)
+	fakeAnthropic.SetTokenLimitErrors(2)
 
 	ghSrv := httptest.NewServer(gh)
 	defer ghSrv.Close()
-	anthropicSrv := httptest.NewServer(anthropic)
+	anthropicSrv := httptest.NewServer(fakeAnthropic)
 	defer anthropicSrv.Close()
 
 	t.Setenv("GITHUB_TOKEN", "fake-token")
@@ -220,13 +241,18 @@ func TestRunRetryOnTokenLimit(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
 	t.Setenv("ANTHROPIC_BASE_URL", anthropicSrv.URL)
 
+	ghClient, err := ghpkg.New()
+	assert.NilError(t, err)
+	anthropicClient, err := anthropic.New()
+	assert.NilError(t, err)
+
 	outDir := t.TempDir()
 	outputPath := filepath.Join(outDir, "prompt.md")
 
 	var stderr bytes.Buffer
 	streams := iostream.Streams{Out: &bytes.Buffer{}, Err: &stderr}
 
-	err := Run(context.Background(), Options{
+	err = Run(context.Background(), Options{
 		Org:          "test-org",
 		Repos:        []string{"test-repo"},
 		Top:          5,
@@ -234,7 +260,7 @@ func TestRunRetryOnTokenLimit(t *testing.T) {
 		OutputPath:   outputPath,
 		AnalyzeModel: "claude-sonnet-4-6",
 		PromptModel:  "claude-sonnet-4-6",
-	}, streams)
+	}, ghClient, anthropicClient, streams)
 	assert.NilError(t, err)
 
 	// Verify retry messages appeared in stderr
@@ -253,40 +279,17 @@ func TestRunMissingGithubToken(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "")
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-	streams := iostream.Streams{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
-	err := Run(context.Background(), Options{
-		Org:        "test-org",
-		Repos:      []string{"test-repo"},
-		Top:        5,
-		OutputPath: filepath.Join(t.TempDir(), "prompt.md"),
-	}, streams)
-	// When no token is set and there is no TTY, EnsureGitHubClient returns a
-	// no-TTY error rather than "GITHUB_TOKEN not set".
+	// With the decoupled auth, client construction fails before Run is called.
+	_, err := ghpkg.New()
 	assert.Assert(t, err != nil, "expected error when GITHUB_TOKEN is missing")
 }
 
 func TestRunMissingAnthropicKey(t *testing.T) {
-	gh := fakes.NewFakeGitHub()
-	gh.SetOrgRepos(fixtures.OrgReposResponse("test-repo"))
-	gh.SetReviewActivity("test-repo", fixtures.ReviewActivityResponse())
-
-	ghSrv := httptest.NewServer(gh)
-	defer ghSrv.Close()
-
-	t.Setenv("GITHUB_TOKEN", "fake-token")
-	t.Setenv("GITHUB_API_URL", ghSrv.URL)
 	t.Setenv("ANTHROPIC_API_KEY", "")
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-	streams := iostream.Streams{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
-	err := Run(context.Background(), Options{
-		Org:        "test-org",
-		Repos:      []string{"test-repo"},
-		Top:        5,
-		OutputPath: filepath.Join(t.TempDir(), "prompt.md"),
-	}, streams)
-	// When no key is set and there is no TTY, EnsureAnthropicClient returns a
-	// no-TTY error rather than "ANTHROPIC_API_KEY not set".
+	// With the decoupled auth, client construction fails before Run is called.
+	_, err := anthropic.New()
 	assert.Assert(t, err != nil, "expected error when Anthropic key is missing")
 }
 
@@ -345,15 +348,15 @@ func TestDeriveOutputPathsNoExtension(t *testing.T) {
 
 func TestAggregateActivity(t *testing.T) {
 	t.Run("merges across repos", func(t *testing.T) {
-		repo1 := map[string]*github.UserActivity{
+		repo1 := map[string]*ghpkg.UserActivity{
 			"alice": {Login: "alice", TotalActivity: 3, ReviewsGiven: 2, Approvals: 1, ReposActiveIn: map[string]bool{"repo1": true}},
 			"bob":   {Login: "bob", TotalActivity: 1, ReviewsGiven: 1, ReposActiveIn: map[string]bool{"repo1": true}},
 		}
-		repo2 := map[string]*github.UserActivity{
+		repo2 := map[string]*ghpkg.UserActivity{
 			"alice": {Login: "alice", TotalActivity: 2, ReviewsGiven: 1, ChangesRequested: 1, ReposActiveIn: map[string]bool{"repo2": true}},
 		}
 
-		result := AggregateActivity([]map[string]*github.UserActivity{repo1, repo2})
+		result := AggregateActivity([]map[string]*ghpkg.UserActivity{repo1, repo2})
 
 		// Sorted by TotalActivity descending
 		assert.Equal(t, len(result), 2)
@@ -376,7 +379,7 @@ func TestAggregateActivity(t *testing.T) {
 // --- TopN ---
 
 func TestTopN(t *testing.T) {
-	activities := []*github.UserActivity{
+	activities := []*ghpkg.UserActivity{
 		{Login: "alice", TotalActivity: 10},
 		{Login: "bob", TotalActivity: 5},
 		{Login: "charlie", TotalActivity: 1},
@@ -417,15 +420,15 @@ func TestTopN(t *testing.T) {
 // --- AggregateDetails ---
 
 func TestAggregateDetails(t *testing.T) {
-	batch1 := []github.ReviewCommentDetail{
+	batch1 := []ghpkg.ReviewCommentDetail{
 		{Reviewer: "alice", Body: "comment1"},
 	}
-	batch2 := []github.ReviewCommentDetail{
+	batch2 := []ghpkg.ReviewCommentDetail{
 		{Reviewer: "bob", Body: "comment2"},
 		{Reviewer: "alice", Body: "comment3"},
 	}
 
-	result := AggregateDetails([][]github.ReviewCommentDetail{batch1, batch2})
+	result := AggregateDetails([][]ghpkg.ReviewCommentDetail{batch1, batch2})
 	assert.Equal(t, len(result), 3)
 }
 
@@ -437,13 +440,13 @@ func TestAggregateDetailsEmpty(t *testing.T) {
 // --- FilterDetailsByReviewers ---
 
 func TestFilterDetailsByReviewers(t *testing.T) {
-	details := []github.ReviewCommentDetail{
+	details := []ghpkg.ReviewCommentDetail{
 		{Reviewer: "alice", Body: "a1"},
 		{Reviewer: "bob", Body: "b1"},
 		{Reviewer: "charlie", Body: "c1"},
 		{Reviewer: "alice", Body: "a2"},
 	}
-	reviewers := []*github.UserActivity{
+	reviewers := []*ghpkg.UserActivity{
 		{Login: "alice"},
 		{Login: "bob"},
 	}
@@ -466,8 +469,8 @@ func TestWriteDetailsJSON(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sub", "details.json")
 
-	details := []github.ReviewCommentDetail{
-		{Reviewer: "alice", Body: "good stuff", PR: github.ReviewCommentDetailPR{Repo: "repo1", Number: 1}},
+	details := []ghpkg.ReviewCommentDetail{
+		{Reviewer: "alice", Body: "good stuff", PR: ghpkg.ReviewCommentDetailPR{Repo: "repo1", Number: 1}},
 	}
 	since := time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC)
 
@@ -490,11 +493,11 @@ func TestWriteDetailsJSON(t *testing.T) {
 // --- AggregatePRRankings ---
 
 func TestAggregatePRRankings(t *testing.T) {
-	details := []github.ReviewCommentDetail{
-		{Reviewer: "alice", PR: github.ReviewCommentDetailPR{Repo: "r1", Number: 10, Title: "PR10", Author: "dan", URL: "http://10", State: "MERGED"}},
-		{Reviewer: "bob", PR: github.ReviewCommentDetailPR{Repo: "r1", Number: 10, Title: "PR10", Author: "dan", URL: "http://10", State: "MERGED"}},
-		{Reviewer: "alice", PR: github.ReviewCommentDetailPR{Repo: "r1", Number: 10, Title: "PR10", Author: "dan", URL: "http://10", State: "MERGED"}},
-		{Reviewer: "alice", PR: github.ReviewCommentDetailPR{Repo: "r1", Number: 20, Title: "PR20", Author: "dan", URL: "http://20", State: "OPEN"}},
+	details := []ghpkg.ReviewCommentDetail{
+		{Reviewer: "alice", PR: ghpkg.ReviewCommentDetailPR{Repo: "r1", Number: 10, Title: "PR10", Author: "dan", URL: "http://10", State: "MERGED"}},
+		{Reviewer: "bob", PR: ghpkg.ReviewCommentDetailPR{Repo: "r1", Number: 10, Title: "PR10", Author: "dan", URL: "http://10", State: "MERGED"}},
+		{Reviewer: "alice", PR: ghpkg.ReviewCommentDetailPR{Repo: "r1", Number: 10, Title: "PR10", Author: "dan", URL: "http://10", State: "MERGED"}},
+		{Reviewer: "alice", PR: ghpkg.ReviewCommentDetailPR{Repo: "r1", Number: 20, Title: "PR20", Author: "dan", URL: "http://20", State: "OPEN"}},
 	}
 
 	rankings := AggregatePRRankings(details)
@@ -568,10 +571,10 @@ func TestWritePRRankingsCSVEmpty(t *testing.T) {
 // --- GroupByReviewer ---
 
 func TestGroupByReviewer(t *testing.T) {
-	comments := []github.ReviewCommentDetail{
-		{Reviewer: "alice", Body: "a1", PR: github.ReviewCommentDetailPR{Repo: "r1", Number: 1}},
-		{Reviewer: "bob", Body: "b1", PR: github.ReviewCommentDetailPR{Repo: "r1", Number: 1}},
-		{Reviewer: "alice", Body: "a2", PR: github.ReviewCommentDetailPR{Repo: "r2", Number: 2}},
+	comments := []ghpkg.ReviewCommentDetail{
+		{Reviewer: "alice", Body: "a1", PR: ghpkg.ReviewCommentDetailPR{Repo: "r1", Number: 1}},
+		{Reviewer: "bob", Body: "b1", PR: ghpkg.ReviewCommentDetailPR{Repo: "r1", Number: 1}},
+		{Reviewer: "alice", Body: "a2", PR: ghpkg.ReviewCommentDetailPR{Repo: "r2", Number: 2}},
 	}
 
 	groups := GroupByReviewer(comments)

--- a/internal/buildprompt/orchestrator.go
+++ b/internal/buildprompt/orchestrator.go
@@ -8,10 +8,8 @@ import (
 	"time"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/anthropic"
-	"github.com/CircleCI-Public/chunk-cli/internal/authprompt"
 	"github.com/CircleCI-Public/chunk-cli/internal/github"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
-	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
 
@@ -72,16 +70,12 @@ func analyzeWithRetry(ctx context.Context, client *anthropic.Client, groups []Re
 }
 
 // Run executes the full build-prompt pipeline: discover, analyze, generate.
-func Run(ctx context.Context, opts Options, streams iostream.Streams) error {
+// The caller must provide authenticated GitHub and Anthropic clients.
+func Run(ctx context.Context, opts Options, ghClient *github.Client, anthropicClient *anthropic.Client, streams iostream.Streams) error {
 	paths := DeriveOutputPaths(opts.OutputPath)
 
 	// --- Step 1: Discover top reviewers ---
 	streams.ErrPrintln(ui.Step(1, 3, "Discovering Top Reviewers"))
-
-	ghClient, err := authprompt.EnsureGitHubClient(ctx, streams, tui.PromptHidden)
-	if err != nil {
-		return err
-	}
 
 	if err := ghClient.ValidateOrg(ctx, opts.Org); err != nil {
 		return err
@@ -145,11 +139,6 @@ func Run(ctx context.Context, opts Options, streams iostream.Streams) error {
 
 	// --- Step 2: Analyze review patterns ---
 	streams.ErrPrintln(ui.Step(2, 3, "Analyzing Review Patterns"))
-
-	anthropicClient, err := authprompt.EnsureAnthropicClient(ctx, streams, tui.PromptHidden)
-	if err != nil {
-		return err
-	}
 
 	reviewerGroups := GroupByReviewer(filteredDetails)
 	if opts.MaxComments > 0 {

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -75,7 +75,7 @@ func authSetCircleCI(ctx context.Context, io iostream.Streams, circleCIBaseURL, 
 	io.Println(ui.Bold("Chunk CLI - CircleCI Token Setup"))
 	io.Println("")
 	io.Println("Create a CircleCI token at https://app.circleci.com/settings/user/tokens")
-	authprompt.PrintSaveHint(io, "Token")
+	printSaveHint(io, "Token")
 	io.Println("")
 
 	if circleTokenEnv != "" {
@@ -122,7 +122,7 @@ func authSetAnthropic(ctx context.Context, io iostream.Streams, anthropicBaseURL
 	io.Println(ui.Bold("Chunk CLI - Anthropic API Key Setup"))
 	io.Println("")
 	io.Println("Enter your Anthropic API key (starts with sk-ant-).")
-	authprompt.PrintSaveHint(io, "Key")
+	printSaveHint(io, "Key")
 	io.Println("")
 	if anthropicKeyEnv != "" {
 		io.Println(ui.Warning("An Anthropic API key is set in environment variables (ANTHROPIC_API_KEY)."))
@@ -184,7 +184,7 @@ func authSetAnthropic(ctx context.Context, io iostream.Streams, anthropicBaseURL
 	}
 
 	io.Println("")
-	authprompt.PrintSaved(io, "Anthropic API key")
+	printSaved(io, "Anthropic API key")
 	io.Println(ui.Dim("You can now run code reviews with: chunk build-prompt"))
 	return nil
 }
@@ -211,7 +211,7 @@ func saveCircleCIToken(ctx context.Context, token string, streams iostream.Strea
 	}
 
 	streams.ErrPrintln("")
-	authprompt.PrintSaved(streams, "CircleCI token")
+	printSaved(streams, "CircleCI token")
 	return nil
 }
 
@@ -439,7 +439,7 @@ func authSetGitHub(ctx context.Context, io iostream.Streams, githubBaseURL, gith
 	io.Println(ui.Bold("Chunk CLI - GitHub Token Setup"))
 	io.Println("")
 	io.Println("Create a token at https://github.com/settings/tokens")
-	authprompt.PrintSaveHint(io, "Token")
+	printSaveHint(io, "Token")
 	io.Println("")
 
 	if githubTokenEnv != "" {
@@ -496,7 +496,7 @@ func authSetGitHub(ctx context.Context, io iostream.Streams, githubBaseURL, gith
 	}
 
 	io.Println("")
-	authprompt.PrintSaved(io, "GitHub token")
+	printSaved(io, "GitHub token")
 	return nil
 }
 

--- a/internal/cmd/authhelper.go
+++ b/internal/cmd/authhelper.go
@@ -33,7 +33,7 @@ func printSaved(streams iostream.Streams, label string) {
 
 // ensureCircleCIClient resolves or interactively prompts for a CircleCI token,
 // validates it, saves it to config, and returns a ready client.
-func ensureCircleCIClient(ctx context.Context, streams iostream.Streams) (*circleci.Client, error) {
+func ensureCircleCIClient(ctx context.Context, streams iostream.Streams, prompter func(string) (string, error)) (*circleci.Client, error) {
 	client, err := authprompt.ResolveCircleCIClient()
 	if err == nil {
 		return client, nil
@@ -47,7 +47,7 @@ func ensureCircleCIClient(ctx context.Context, streams iostream.Streams) (*circl
 	streams.ErrPrintln("Create a token at https://app.circleci.com/settings/user/tokens")
 	streams.ErrPrintln("")
 
-	token, err := tui.PromptHidden("CircleCI Token")
+	token, err := prompter("CircleCI Token")
 	if err != nil {
 		if errors.Is(err, tui.ErrNoTTY) {
 			return nil, usererr.New("CircleCI token required: set CIRCLE_TOKEN or run 'chunk auth set circleci'", err)
@@ -73,7 +73,7 @@ func ensureCircleCIClient(ctx context.Context, streams iostream.Streams) (*circl
 
 // ensureAnthropicClient resolves or interactively prompts for an Anthropic API
 // key, validates it, saves it to config, and returns a ready client.
-func ensureAnthropicClient(ctx context.Context, streams iostream.Streams) (*anthropic.Client, error) {
+func ensureAnthropicClient(ctx context.Context, streams iostream.Streams, prompter func(string) (string, error)) (*anthropic.Client, error) {
 	client, err := authprompt.ResolveAnthropicClient()
 	if err == nil {
 		return client, nil
@@ -87,7 +87,7 @@ func ensureAnthropicClient(ctx context.Context, streams iostream.Streams) (*anth
 	streams.ErrPrintln("Get a key at https://console.anthropic.com/")
 	streams.ErrPrintln("")
 
-	key, err := tui.PromptHidden("API Key")
+	key, err := prompter("API Key")
 	if err != nil {
 		if errors.Is(err, tui.ErrNoTTY) {
 			return nil, usererr.New("Anthropic API key required: set ANTHROPIC_API_KEY or run 'chunk auth set anthropic'", err)
@@ -116,7 +116,7 @@ func ensureAnthropicClient(ctx context.Context, streams iostream.Streams) (*anth
 
 // ensureGitHubClient resolves or interactively prompts for a GitHub token,
 // validates it, saves it to config, and returns a ready client.
-func ensureGitHubClient(ctx context.Context, streams iostream.Streams) (*github.Client, error) {
+func ensureGitHubClient(ctx context.Context, streams iostream.Streams, prompter func(string) (string, error)) (*github.Client, error) {
 	client, err := authprompt.ResolveGitHubClient()
 	if err == nil {
 		return client, nil
@@ -130,7 +130,7 @@ func ensureGitHubClient(ctx context.Context, streams iostream.Streams) (*github.
 	streams.ErrPrintln("Create a token at https://github.com/settings/tokens")
 	streams.ErrPrintln("")
 
-	token, err := tui.PromptHidden("GitHub Token")
+	token, err := prompter("GitHub Token")
 	if err != nil {
 		if errors.Is(err, tui.ErrNoTTY) {
 			return nil, usererr.New("GitHub token required: set GITHUB_TOKEN or run 'chunk auth set github'", err)

--- a/internal/cmd/authhelper.go
+++ b/internal/cmd/authhelper.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/anthropic"
+	"github.com/CircleCI-Public/chunk-cli/internal/authprompt"
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/github"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/tui"
+	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
+)
+
+func printSaveHint(streams iostream.Streams, label string) {
+	if cfgPath, err := config.Path(); err == nil {
+		streams.ErrPrintln(ui.Dim(fmt.Sprintf("%s will be saved to user config (%s, mode 0600)", label, cfgPath)))
+	}
+}
+
+func printSaved(streams iostream.Streams, label string) {
+	msg := label + " saved"
+	if cfgPath, err := config.Path(); err == nil {
+		msg = fmt.Sprintf("%s saved to user config (%s)", label, cfgPath)
+	}
+	streams.ErrPrintln(ui.Success(msg))
+}
+
+// ensureCircleCIClient resolves or interactively prompts for a CircleCI token,
+// validates it, saves it to config, and returns a ready client.
+func ensureCircleCIClient(ctx context.Context, streams iostream.Streams) (*circleci.Client, error) {
+	client, err := authprompt.ResolveCircleCIClient()
+	if err == nil {
+		return client, nil
+	}
+	if !errors.Is(err, authprompt.ErrNeedsAuth) {
+		return nil, err
+	}
+
+	streams.ErrPrintln("")
+	streams.ErrPrintln(ui.Bold("CircleCI token required"))
+	streams.ErrPrintln("Create a token at https://app.circleci.com/settings/user/tokens")
+	streams.ErrPrintln("")
+
+	token, err := tui.PromptHidden("CircleCI Token")
+	if err != nil {
+		if errors.Is(err, tui.ErrNoTTY) {
+			return nil, usererr.New("CircleCI token required: set CIRCLE_TOKEN or run 'chunk auth set circleci'", err)
+		}
+		return nil, err
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil, usererr.New("CircleCI token required: set CIRCLE_TOKEN or run 'chunk auth set circleci'", fmt.Errorf("empty token entered"))
+	}
+
+	streams.ErrPrintln(ui.Dim("Validating CircleCI token..."))
+	if err := authprompt.ValidateCircleCIToken(ctx, token, authprompt.CircleCIBaseURL()); err != nil {
+		return nil, fmt.Errorf("invalid CircleCI token: %w", err)
+	}
+
+	if err := authprompt.SaveCircleCIToken(token); err != nil {
+		return nil, err
+	}
+	streams.ErrPrintln(ui.Success("CircleCI token saved"))
+	return circleci.NewClient()
+}
+
+// ensureAnthropicClient resolves or interactively prompts for an Anthropic API
+// key, validates it, saves it to config, and returns a ready client.
+func ensureAnthropicClient(ctx context.Context, streams iostream.Streams) (*anthropic.Client, error) {
+	client, err := authprompt.ResolveAnthropicClient()
+	if err == nil {
+		return client, nil
+	}
+	if !errors.Is(err, authprompt.ErrNeedsAuth) {
+		return nil, err
+	}
+
+	streams.ErrPrintln("")
+	streams.ErrPrintln(ui.Bold("Anthropic API key required"))
+	streams.ErrPrintln("Get a key at https://console.anthropic.com/")
+	streams.ErrPrintln("")
+
+	key, err := tui.PromptHidden("API Key")
+	if err != nil {
+		if errors.Is(err, tui.ErrNoTTY) {
+			return nil, usererr.New("Anthropic API key required: set ANTHROPIC_API_KEY or run 'chunk auth set anthropic'", err)
+		}
+		return nil, err
+	}
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil, usererr.New("Anthropic API key required: set ANTHROPIC_API_KEY or run 'chunk auth set anthropic'", fmt.Errorf("empty key entered"))
+	}
+	if !strings.HasPrefix(key, "sk-ant-") {
+		return nil, usererr.New("Invalid API key format — keys should start with \"sk-ant-\". Get a valid key from https://console.anthropic.com/", fmt.Errorf("invalid key prefix"))
+	}
+
+	streams.ErrPrintln(ui.Dim("Validating API key..."))
+	if err := authprompt.ValidateAPIKey(ctx, key, authprompt.AnthropicBaseURL()); err != nil {
+		return nil, fmt.Errorf("invalid Anthropic API key: %w", err)
+	}
+
+	if err := authprompt.SaveAnthropicKey(key); err != nil {
+		return nil, err
+	}
+	streams.ErrPrintln(ui.Success("Anthropic API key saved"))
+	return anthropic.New()
+}
+
+// ensureGitHubClient resolves or interactively prompts for a GitHub token,
+// validates it, saves it to config, and returns a ready client.
+func ensureGitHubClient(ctx context.Context, streams iostream.Streams) (*github.Client, error) {
+	client, err := authprompt.ResolveGitHubClient()
+	if err == nil {
+		return client, nil
+	}
+	if !errors.Is(err, authprompt.ErrNeedsAuth) {
+		return nil, err
+	}
+
+	streams.ErrPrintln("")
+	streams.ErrPrintln(ui.Bold("GitHub token required"))
+	streams.ErrPrintln("Create a token at https://github.com/settings/tokens")
+	streams.ErrPrintln("")
+
+	token, err := tui.PromptHidden("GitHub Token")
+	if err != nil {
+		if errors.Is(err, tui.ErrNoTTY) {
+			return nil, usererr.New("GitHub token required: set GITHUB_TOKEN or run 'chunk auth set github'", err)
+		}
+		return nil, err
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil, usererr.New("GitHub token required: set GITHUB_TOKEN or run 'chunk auth set github'", fmt.Errorf("empty token entered"))
+	}
+
+	streams.ErrPrintln(ui.Dim("Validating GitHub token..."))
+	if err := authprompt.ValidateGitHubToken(ctx, token, authprompt.GitHubBaseURL()); err != nil {
+		return nil, fmt.Errorf("invalid GitHub token: %w", err)
+	}
+
+	if err := authprompt.SaveGitHubToken(token); err != nil {
+		return nil, err
+	}
+	streams.ErrPrintln(ui.Success("GitHub token saved"))
+	return github.New()
+}

--- a/internal/cmd/authhelper_test.go
+++ b/internal/cmd/authhelper_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+	"github.com/CircleCI-Public/chunk-cli/internal/tui"
+	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
+)
+
+func isolateConfig(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+}
+
+func randToken(prefix string) string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return prefix + hex.EncodeToString(b)
+}
+
+func discardStreams() iostream.Streams {
+	return iostream.Streams{Out: io.Discard, Err: io.Discard}
+}
+
+func noTTYPrompter(_ string) (string, error) {
+	return "", tui.ErrNoTTY
+}
+
+func TestEnsureCircleCIClient_NoTTY(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv("CIRCLE_TOKEN", "")
+	t.Setenv("CIRCLECI_TOKEN", "")
+
+	_, err := ensureCircleCIClient(context.Background(), discardStreams(), noTTYPrompter)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, errors.Is(err, tui.ErrNoTTY))
+
+	var ue *usererr.Error
+	assert.Assert(t, errors.As(err, &ue))
+	assert.Assert(t, strings.Contains(ue.UserMessage(), "CIRCLE_TOKEN"))
+}
+
+func TestEnsureAnthropicClient_NoTTY(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	_, err := ensureAnthropicClient(context.Background(), discardStreams(), noTTYPrompter)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, errors.Is(err, tui.ErrNoTTY))
+
+	var ue *usererr.Error
+	assert.Assert(t, errors.As(err, &ue))
+	assert.Assert(t, strings.Contains(ue.UserMessage(), "ANTHROPIC_API_KEY"))
+}
+
+func TestEnsureGitHubClient_NoTTY(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv("GITHUB_TOKEN", "")
+
+	_, err := ensureGitHubClient(context.Background(), discardStreams(), noTTYPrompter)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, errors.Is(err, tui.ErrNoTTY))
+
+	var ue *usererr.Error
+	assert.Assert(t, errors.As(err, &ue))
+	assert.Assert(t, strings.Contains(ue.UserMessage(), "GITHUB_TOKEN"))
+}
+
+func TestEnsureGitHubClient_PromptAndSave(t *testing.T) {
+	isolateConfig(t)
+
+	gh := fakes.NewFakeGitHub()
+	srv := httptest.NewServer(gh)
+	defer srv.Close()
+
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GITHUB_API_URL", srv.URL)
+
+	token := randToken("ghp_")
+	prompter := func(_ string) (string, error) { return token, nil }
+
+	client, err := ensureGitHubClient(context.Background(), discardStreams(), prompter)
+	assert.NilError(t, err)
+	assert.Assert(t, client != nil)
+
+	cfg, err := config.Load()
+	assert.NilError(t, err)
+	assert.Equal(t, cfg.GitHubToken, token)
+}
+
+func TestEnsureAnthropicClient_PromptAndSave(t *testing.T) {
+	isolateConfig(t)
+
+	ant := fakes.NewFakeAnthropic("ok")
+	srv := httptest.NewServer(ant)
+	defer srv.Close()
+
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_BASE_URL", srv.URL)
+
+	key := randToken("sk-ant-")
+	prompter := func(_ string) (string, error) { return key, nil }
+
+	client, err := ensureAnthropicClient(context.Background(), discardStreams(), prompter)
+	assert.NilError(t, err)
+	assert.Assert(t, client != nil)
+
+	cfg, err := config.Load()
+	assert.NilError(t, err)
+	assert.Equal(t, cfg.AnthropicAPIKey, key)
+}
+
+func TestEnsureAnthropicClient_InvalidPrefix(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	prompter := func(_ string) (string, error) { return "bad-key", nil }
+
+	_, err := ensureAnthropicClient(context.Background(), discardStreams(), prompter)
+	assert.Assert(t, err != nil)
+
+	var ue *usererr.Error
+	assert.Assert(t, errors.As(err, &ue))
+	assert.Assert(t, strings.Contains(ue.UserMessage(), "sk-ant-"), "expected message about invalid key format, got: %s", ue.UserMessage())
+}
+
+func TestEnsureCircleCIClient_EmptyToken(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv("CIRCLE_TOKEN", "")
+	t.Setenv("CIRCLECI_TOKEN", "")
+
+	prompter := func(_ string) (string, error) { return "", nil }
+
+	_, err := ensureCircleCIClient(context.Background(), discardStreams(), prompter)
+	assert.Assert(t, err != nil)
+
+	var ue *usererr.Error
+	assert.Assert(t, errors.As(err, &ue))
+	assert.Assert(t, strings.Contains(ue.UserMessage(), "CIRCLE_TOKEN"), "expected message about CIRCLE_TOKEN, got: %s", ue.UserMessage())
+}

--- a/internal/cmd/buildprompt.go
+++ b/internal/cmd/buildprompt.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -10,8 +9,6 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/buildprompt"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
-	"github.com/CircleCI-Public/chunk-cli/internal/github"
-	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
@@ -67,6 +64,16 @@ func newBuildPromptCmd() *cobra.Command {
 				}
 			}
 
+			ghClient, err := ensureGitHubClient(cmd.Context(), streams)
+			if err != nil {
+				return err
+			}
+
+			anthropicClient, err := ensureAnthropicClient(cmd.Context(), streams)
+			if err != nil {
+				return err
+			}
+
 			opts := buildprompt.Options{
 				Org:                resolvedOrg,
 				Repos:              resolvedRepos,
@@ -79,20 +86,7 @@ func newBuildPromptCmd() *cobra.Command {
 				IncludeAttribution: includeAttribution,
 			}
 
-			if err := buildprompt.Run(cmd.Context(), opts, iostream.FromCmd(cmd)); err != nil {
-				if httpcl.HasStatusCode(err, 401, 403) {
-					return usererr.New("Authentication failed. Run 'chunk auth set' to update your credentials.", err)
-				}
-				if github.IsResolutionError(err) {
-					return usererr.New("Repository not found. Check the --org and --repos flags.", err)
-				}
-				var ue *usererr.Error
-				if errors.As(err, &ue) {
-					return err
-				}
-				return usererr.New("Build prompt generation failed.", err)
-			}
-			return nil
+			return buildprompt.Run(cmd.Context(), opts, ghClient, anthropicClient, streams)
 		},
 	}
 

--- a/internal/cmd/buildprompt.go
+++ b/internal/cmd/buildprompt.go
@@ -10,6 +10,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/buildprompt"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
 )
@@ -64,12 +65,12 @@ func newBuildPromptCmd() *cobra.Command {
 				}
 			}
 
-			ghClient, err := ensureGitHubClient(cmd.Context(), streams)
+			ghClient, err := ensureGitHubClient(cmd.Context(), streams, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
 
-			anthropicClient, err := ensureAnthropicClient(cmd.Context(), streams)
+			anthropicClient, err := ensureAnthropicClient(cmd.Context(), streams, tui.PromptHidden)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -110,7 +110,7 @@ func newSandboxListCmd() *cobra.Command {
 		Short: "List sandboxes",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			client, err := ensureCircleCIClient(cmd.Context(), io)
+			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -158,7 +158,7 @@ The sandbox backend defaults to e2b. Override with the CHUNK_SANDBOX_PROVIDER
 environment variable (e.g. CHUNK_SANDBOX_PROVIDER=unikraft).`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			client, err := ensureCircleCIClient(cmd.Context(), io)
+			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -208,7 +208,7 @@ func newSandboxExecCmd() *cobra.Command {
 			if err := resolveSandboxID(&sandboxID); err != nil {
 				return err
 			}
-			client, err := ensureCircleCIClient(cmd.Context(), io)
+			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -252,7 +252,7 @@ func newSandboxAddSSHKeyCmd() *cobra.Command {
 			if err := resolveSandboxID(&sandboxID); err != nil {
 				return err
 			}
-			client, err := ensureCircleCIClient(cmd.Context(), io)
+			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -289,7 +289,7 @@ func newSandboxSSHCmd() *cobra.Command {
 				return err
 			}
 			authSock := os.Getenv("SSH_AUTH_SOCK")
-			client, err := ensureCircleCIClient(cmd.Context(), io)
+			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -352,7 +352,7 @@ func newSandboxSyncCmd() *cobra.Command {
 				return err
 			}
 			authSock := os.Getenv("SSH_AUTH_SOCK")
-			client, err := ensureCircleCIClient(cmd.Context(), io)
+			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/chunk-cli/envbuilder"
-	"github.com/CircleCI-Public/chunk-cli/internal/authprompt"
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
@@ -111,7 +110,7 @@ func newSandboxListCmd() *cobra.Command {
 		Short: "List sandboxes",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			client, err := authprompt.EnsureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), io)
 			if err != nil {
 				return err
 			}
@@ -159,7 +158,7 @@ The sandbox backend defaults to e2b. Override with the CHUNK_SANDBOX_PROVIDER
 environment variable (e.g. CHUNK_SANDBOX_PROVIDER=unikraft).`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			client, err := authprompt.EnsureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), io)
 			if err != nil {
 				return err
 			}
@@ -209,7 +208,7 @@ func newSandboxExecCmd() *cobra.Command {
 			if err := resolveSandboxID(&sandboxID); err != nil {
 				return err
 			}
-			client, err := authprompt.EnsureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), io)
 			if err != nil {
 				return err
 			}
@@ -253,7 +252,7 @@ func newSandboxAddSSHKeyCmd() *cobra.Command {
 			if err := resolveSandboxID(&sandboxID); err != nil {
 				return err
 			}
-			client, err := authprompt.EnsureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), io)
 			if err != nil {
 				return err
 			}
@@ -290,7 +289,7 @@ func newSandboxSSHCmd() *cobra.Command {
 				return err
 			}
 			authSock := os.Getenv("SSH_AUTH_SOCK")
-			client, err := authprompt.EnsureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), io)
 			if err != nil {
 				return err
 			}
@@ -353,7 +352,7 @@ func newSandboxSyncCmd() *cobra.Command {
 				return err
 			}
 			authSock := os.Getenv("SSH_AUTH_SOCK")
-			client, err := authprompt.EnsureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), io)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/task.go
+++ b/internal/cmd/task.go
@@ -53,7 +53,7 @@ func newTaskRunCmd() *cobra.Command {
 			}
 
 			io := iostream.FromCmd(cmd)
-			client, err := ensureCircleCIClient(cmd.Context(), io)
+			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -125,7 +125,7 @@ func newTaskConfigCmd() *cobra.Command {
 			io.Println(ui.Bold("Chunk Run Setup"))
 			io.Println("")
 
-			client, err := ensureCircleCIClient(ctx, io)
+			client, err := ensureCircleCIClient(ctx, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/task.go
+++ b/internal/cmd/task.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/authprompt"
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
@@ -54,7 +53,7 @@ func newTaskRunCmd() *cobra.Command {
 			}
 
 			io := iostream.FromCmd(cmd)
-			client, err := authprompt.EnsureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), io)
 			if err != nil {
 				return err
 			}
@@ -126,7 +125,7 @@ func newTaskConfigCmd() *cobra.Command {
 			io.Println(ui.Bold("Chunk Run Setup"))
 			io.Println("")
 
-			client, err := authprompt.EnsureCircleCIClient(ctx, io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(ctx, io)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/sandbox"
+	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
 	"github.com/CircleCI-Public/chunk-cli/internal/validate"
@@ -95,7 +96,7 @@ func newValidateCmd() *cobra.Command {
 			}
 
 			if sandboxID != "" {
-				client, err := ensureCircleCIClient(cmd.Context(), streams)
+				client, err := ensureCircleCIClient(cmd.Context(), streams, tui.PromptHidden)
 				if err != nil {
 					return err
 				}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -10,11 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/authprompt"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/sandbox"
-	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
 	"github.com/CircleCI-Public/chunk-cli/internal/validate"
@@ -97,7 +95,7 @@ func newValidateCmd() *cobra.Command {
 			}
 
 			if sandboxID != "" {
-				client, err := authprompt.EnsureCircleCIClient(cmd.Context(), streams, tui.PromptHidden)
+				client, err := ensureCircleCIClient(cmd.Context(), streams)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
## Summary
- Replace `Ensure*` functions in `authprompt` with `Resolve*` (returns `ErrNeedsAuth`) + `Save*` helpers
- Move all interactive prompting (tui/ui) to cmd layer via `ensureCircleCIClient`/`ensureAnthropicClient`/`ensureGitHubClient` in `authhelper.go`
- `buildprompt.Run` now receives pre-authenticated clients as parameters
- `authprompt` no longer imports `tui`, `ui`, `iostream`, or `usererr`
- `buildprompt` no longer imports `authprompt` or `tui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)