### PR TITLE
Add StatusFunc to decouple ui from logic

### DIFF
--- a/internal/buildprompt/buildprompt_test.go
+++ b/internal/buildprompt/buildprompt_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -21,6 +22,12 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fixtures"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/gitrepo"
 )
+
+func testStatus(buf *bytes.Buffer) iostream.StatusFunc {
+	return func(_ iostream.Level, msg string) {
+		fmt.Fprintln(buf, msg)
+	}
+}
 
 // --- Run (orchestrator) integration tests ---
 
@@ -53,7 +60,6 @@ func TestRunHappyPath(t *testing.T) {
 	outputPath := filepath.Join(outDir, "prompt.md")
 
 	var stderr bytes.Buffer
-	streams := iostream.Streams{Out: &bytes.Buffer{}, Err: &stderr}
 
 	err = Run(context.Background(), Options{
 		Org:          "test-org",
@@ -63,7 +69,8 @@ func TestRunHappyPath(t *testing.T) {
 		OutputPath:   outputPath,
 		AnalyzeModel: "claude-sonnet-4-6",
 		PromptModel:  "claude-sonnet-4-6",
-	}, ghClient, anthropicClient, streams)
+		Status:       testStatus(&stderr),
+	}, ghClient, anthropicClient)
 	assert.NilError(t, err)
 
 	// All output files created
@@ -93,7 +100,7 @@ func TestRunHappyPath(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, strings.Contains(string(analysisBytes), "Review Pattern Analysis"))
 
-	// Stderr has step progress
+	// Status callback has step progress
 	assert.Assert(t, strings.Contains(stderr.String(), "Step 1/3"))
 	assert.Assert(t, strings.Contains(stderr.String(), "Step 2/3"))
 	assert.Assert(t, strings.Contains(stderr.String(), "Step 3/3"))
@@ -116,7 +123,6 @@ func TestRunNoReposFound(t *testing.T) {
 	assert.NilError(t, err)
 
 	var stderr bytes.Buffer
-	streams := iostream.Streams{Out: &bytes.Buffer{}, Err: &stderr}
 
 	// Pass empty repos so FetchOrgRepos queries the API (which returns empty)
 	err = Run(context.Background(), Options{
@@ -124,7 +130,8 @@ func TestRunNoReposFound(t *testing.T) {
 		Repos:      nil,
 		Top:        5,
 		OutputPath: filepath.Join(t.TempDir(), "prompt.md"),
-	}, ghClient, anthropicClient, streams)
+		Status:     testStatus(&stderr),
+	}, ghClient, anthropicClient)
 	assert.NilError(t, err)
 	assert.Assert(t, strings.Contains(stderr.String(), "No repositories found"))
 }
@@ -159,7 +166,6 @@ func TestRunSkipsRepoResolutionErrors(t *testing.T) {
 	outputPath := filepath.Join(outDir, "prompt.md")
 
 	var stderr bytes.Buffer
-	streams := iostream.Streams{Out: &bytes.Buffer{}, Err: &stderr}
 
 	err = Run(context.Background(), Options{
 		Org:          "test-org",
@@ -168,7 +174,8 @@ func TestRunSkipsRepoResolutionErrors(t *testing.T) {
 		OutputPath:   outputPath,
 		AnalyzeModel: "claude-sonnet-4-6",
 		PromptModel:  "claude-sonnet-4-6",
-	}, ghClient, anthropicClient, streams)
+		Status:       testStatus(&stderr),
+	}, ghClient, anthropicClient)
 	assert.NilError(t, err)
 	assert.Assert(t, strings.Contains(stderr.String(), "Skipping bad-repo"))
 }
@@ -201,7 +208,7 @@ func TestRunWithMaxComments(t *testing.T) {
 	outDir := t.TempDir()
 	outputPath := filepath.Join(outDir, "prompt.md")
 
-	streams := iostream.Streams{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	var statusBuf bytes.Buffer
 
 	err = Run(context.Background(), Options{
 		Org:          "test-org",
@@ -211,7 +218,8 @@ func TestRunWithMaxComments(t *testing.T) {
 		OutputPath:   outputPath,
 		AnalyzeModel: "claude-sonnet-4-6",
 		PromptModel:  "claude-sonnet-4-6",
-	}, ghClient, anthropicClient, streams)
+		Status:       testStatus(&statusBuf),
+	}, ghClient, anthropicClient)
 	assert.NilError(t, err)
 
 	// Verify the anthropic request was made (analysis prompt built with limited comments)
@@ -250,7 +258,6 @@ func TestRunRetryOnTokenLimit(t *testing.T) {
 	outputPath := filepath.Join(outDir, "prompt.md")
 
 	var stderr bytes.Buffer
-	streams := iostream.Streams{Out: &bytes.Buffer{}, Err: &stderr}
 
 	err = Run(context.Background(), Options{
 		Org:          "test-org",
@@ -260,10 +267,11 @@ func TestRunRetryOnTokenLimit(t *testing.T) {
 		OutputPath:   outputPath,
 		AnalyzeModel: "claude-sonnet-4-6",
 		PromptModel:  "claude-sonnet-4-6",
-	}, ghClient, anthropicClient, streams)
+		Status:       testStatus(&stderr),
+	}, ghClient, anthropicClient)
 	assert.NilError(t, err)
 
-	// Verify retry messages appeared in stderr
+	// Verify retry messages appeared via status callback
 	assert.Assert(t, strings.Contains(stderr.String(), "Token limit exceeded"))
 
 	// Verify output files were created

--- a/internal/buildprompt/orchestrator.go
+++ b/internal/buildprompt/orchestrator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/anthropic"
 	"github.com/CircleCI-Public/chunk-cli/internal/github"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
-	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
 
 // maxCommentsPerReviewer returns the maximum comment count across all groups.
@@ -26,7 +25,7 @@ func maxCommentsPerReviewer(groups []ReviewerGroup) int {
 
 // analyzeWithRetry attempts analysis, binary-searching for a viable comment
 // limit when the prompt exceeds the model's context window.
-func analyzeWithRetry(ctx context.Context, client *anthropic.Client, groups []ReviewerGroup, opts Options, streams iostream.Streams) (string, error) {
+func analyzeWithRetry(ctx context.Context, client *anthropic.Client, groups []ReviewerGroup, opts Options) (string, error) {
 	minComments := 1
 	currentMax := opts.MaxComments
 	if currentMax <= 0 {
@@ -47,7 +46,7 @@ func analyzeWithRetry(ctx context.Context, client *anthropic.Client, groups []Re
 			totalComments += g.TotalComments
 		}
 
-		streams.ErrPrintf("  %s\n", ui.Dim(fmt.Sprintf("Sending %d comments (~%d tokens)", totalComments, estimatedTokens)))
+		opts.Status(iostream.LevelInfo, fmt.Sprintf("Sending %d comments (~%d tokens)", totalComments, estimatedTokens))
 
 		analysis, err := client.AnalyzeReviews(ctx, prompt, opts.AnalyzeModel)
 		if err == nil {
@@ -65,17 +64,17 @@ func analyzeWithRetry(ctx context.Context, client *anthropic.Client, groups []Re
 			return "", err
 		}
 
-		streams.ErrPrintf("  %s\n", ui.Warning(fmt.Sprintf("Token limit exceeded, reducing to %d comments per reviewer...", currentLimit)))
+		opts.Status(iostream.LevelWarn, fmt.Sprintf("Token limit exceeded, reducing to %d comments per reviewer...", currentLimit))
 	}
 }
 
 // Run executes the full build-prompt pipeline: discover, analyze, generate.
 // The caller must provide authenticated GitHub and Anthropic clients.
-func Run(ctx context.Context, opts Options, ghClient *github.Client, anthropicClient *anthropic.Client, streams iostream.Streams) error {
+func Run(ctx context.Context, opts Options, ghClient *github.Client, anthropicClient *anthropic.Client) error {
 	paths := DeriveOutputPaths(opts.OutputPath)
 
 	// --- Step 1: Discover top reviewers ---
-	streams.ErrPrintln(ui.Step(1, 3, "Discovering Top Reviewers"))
+	opts.Status(iostream.LevelStep, "Step 1/3: Discovering Top Reviewers")
 
 	if err := ghClient.ValidateOrg(ctx, opts.Org); err != nil {
 		return err
@@ -91,7 +90,7 @@ func Run(ctx context.Context, opts Options, ghClient *github.Client, anthropicCl
 	}
 
 	if len(repos) == 0 {
-		streams.ErrPrintln(ui.Warning("No repositories found."))
+		opts.Status(iostream.LevelWarn, "No repositories found.")
 		return nil
 	}
 
@@ -99,11 +98,11 @@ func Run(ctx context.Context, opts Options, ghClient *github.Client, anthropicCl
 	var allDetails [][]github.ReviewCommentDetail
 
 	for i, repo := range repos {
-		streams.ErrPrintf("  %s %s\n", ui.Dim(fmt.Sprintf("[%d/%d]", i+1, len(repos))), ui.Bold(repo))
+		opts.Status(iostream.LevelInfo, fmt.Sprintf("[%d/%d] %s", i+1, len(repos), repo))
 		result, err := ghClient.FetchReviewActivity(ctx, opts.Org, repo, opts.Since)
 		if err != nil {
 			if github.IsResolutionError(err) {
-				streams.ErrPrintf("  %s\n", ui.Warning(fmt.Sprintf("Skipping %s: %v", repo, err)))
+				opts.Status(iostream.LevelWarn, fmt.Sprintf("Skipping %s: %v", repo, err))
 				continue
 			}
 			return err
@@ -134,18 +133,18 @@ func Run(ctx context.Context, opts Options, ghClient *github.Client, anthropicCl
 		return fmt.Errorf("write PR rankings CSV: %w", err)
 	}
 
-	streams.ErrPrintf("  %s\n", ui.Success(fmt.Sprintf("Details written to %s", paths.DetailsPath)))
-	streams.ErrPrintf("  %s\n", ui.Success(fmt.Sprintf("PR rankings written to %s", paths.CSVPath)))
+	opts.Status(iostream.LevelDone, fmt.Sprintf("Details written to %s", paths.DetailsPath))
+	opts.Status(iostream.LevelDone, fmt.Sprintf("PR rankings written to %s", paths.CSVPath))
 
 	// --- Step 2: Analyze review patterns ---
-	streams.ErrPrintln(ui.Step(2, 3, "Analyzing Review Patterns"))
+	opts.Status(iostream.LevelStep, "Step 2/3: Analyzing Review Patterns")
 
 	reviewerGroups := GroupByReviewer(filteredDetails)
 	if opts.MaxComments > 0 {
 		reviewerGroups = LimitCommentsPerReviewer(reviewerGroups, opts.MaxComments)
 	}
 
-	analysis, err := analyzeWithRetry(ctx, anthropicClient, reviewerGroups, opts, streams)
+	analysis, err := analyzeWithRetry(ctx, anthropicClient, reviewerGroups, opts)
 	if err != nil {
 		return fmt.Errorf("analyze reviews: %w", err)
 	}
@@ -163,10 +162,10 @@ func Run(ctx context.Context, opts Options, ghClient *github.Client, anthropicCl
 	if err := os.WriteFile(paths.AnalysisPath, []byte(report), 0o644); err != nil {
 		return fmt.Errorf("write analysis: %w", err)
 	}
-	streams.ErrPrintf("  %s\n", ui.Success(fmt.Sprintf("Analysis written to %s", paths.AnalysisPath)))
+	opts.Status(iostream.LevelDone, fmt.Sprintf("Analysis written to %s", paths.AnalysisPath))
 
 	// --- Step 3: Generate review prompt ---
-	streams.ErrPrintln(ui.Step(3, 3, "Generating PR Review Prompt"))
+	opts.Status(iostream.LevelStep, "Step 3/3: Generating PR Review Prompt")
 
 	analysisContent, err := os.ReadFile(paths.AnalysisPath)
 	if err != nil {
@@ -186,7 +185,7 @@ func Run(ctx context.Context, opts Options, ghClient *github.Client, anthropicCl
 	if err := os.WriteFile(paths.PromptPath, []byte(generatedPrompt+footer), 0o644); err != nil {
 		return fmt.Errorf("write prompt: %w", err)
 	}
-	streams.ErrPrintf("  %s\n", ui.Success(fmt.Sprintf("Prompt written to %s", paths.PromptPath)))
+	opts.Status(iostream.LevelDone, fmt.Sprintf("Prompt written to %s", paths.PromptPath))
 
 	return nil
 }

--- a/internal/buildprompt/types.go
+++ b/internal/buildprompt/types.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/github"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 )
 
 // Options holds the configuration for a build-prompt run.
@@ -17,6 +18,7 @@ type Options struct {
 	AnalyzeModel       string
 	PromptModel        string
 	IncludeAttribution bool
+	Status             iostream.StatusFunc
 }
 
 // OutputPaths holds the derived file paths for build-prompt outputs.

--- a/internal/cmd/buildprompt.go
+++ b/internal/cmd/buildprompt.go
@@ -85,9 +85,10 @@ func newBuildPromptCmd() *cobra.Command {
 				AnalyzeModel:       analyzeModel,
 				PromptModel:        promptModel,
 				IncludeAttribution: includeAttribution,
+				Status:             newStatusFunc(streams),
 			}
 
-			return buildprompt.Run(cmd.Context(), opts, ghClient, anthropicClient, streams)
+			return buildprompt.Run(cmd.Context(), opts, ghClient, anthropicClient)
 		},
 	}
 

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -356,7 +356,7 @@ func newSandboxSyncCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = sandbox.Sync(cmd.Context(), client, sandboxID, identityFile, authSock, workdir, io)
+			err = sandbox.Sync(cmd.Context(), client, sandboxID, identityFile, authSock, workdir, newStatusFunc(io))
 			if err != nil {
 				if httpcl.HasStatusCode(err, 401, 403) {
 					return usererr.New("Not authorized to sync files. Check your CircleCI token and try again.", err)

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -19,6 +19,21 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/validate"
 )
 
+func newStatusFunc(streams iostream.Streams) iostream.StatusFunc {
+	return func(level iostream.Level, msg string) {
+		switch level {
+		case iostream.LevelStep:
+			streams.ErrPrintln(ui.Bold(msg))
+		case iostream.LevelInfo:
+			streams.ErrPrintf("  %s\n", ui.Dim(msg))
+		case iostream.LevelWarn:
+			streams.ErrPrintf("  %s\n", ui.Warning(msg))
+		case iostream.LevelDone:
+			streams.ErrPrintf("  %s\n", ui.Success(msg))
+		}
+	}
+}
+
 func newValidateCmd() *cobra.Command {
 	var sandboxID, identityFile, workdir string
 	var dryRun, list, save, forceRun, status bool
@@ -31,6 +46,7 @@ func newValidateCmd() *cobra.Command {
 		Args:         cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			streams := iostream.FromCmd(cmd)
+			statusFn := newStatusFunc(streams)
 
 			workDir := projectDir
 			if workDir == "" {
@@ -52,7 +68,7 @@ func newValidateCmd() *cobra.Command {
 				if err != nil {
 					cfg = &config.ProjectConfig{}
 				}
-				return validate.List(cfg, streams)
+				return validate.List(cfg, statusFn)
 			}
 
 			// --status: check cache only
@@ -61,7 +77,7 @@ func newValidateCmd() *cobra.Command {
 				if err != nil {
 					cfg = &config.ProjectConfig{}
 				}
-				return validate.Status(workDir, name, cfg, streams)
+				return validate.Status(workDir, name, cfg, statusFn)
 			}
 
 			// --cmd: run inline command
@@ -80,7 +96,7 @@ func newValidateCmd() *cobra.Command {
 					}
 					streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", cmdName)))
 				}
-				return validate.RunInline(cmd.Context(), workDir, cmdName, inlineCmd, forceRun, streams)
+				return validate.RunInline(cmd.Context(), workDir, cmdName, inlineCmd, forceRun, statusFn, streams)
 			}
 
 			cfg, err := config.LoadProjectConfig(workDir)
@@ -92,7 +108,7 @@ func newValidateCmd() *cobra.Command {
 			}
 
 			if dryRun {
-				return validate.RunDryRun(cfg, name, streams)
+				return validate.RunDryRun(cfg, name, statusFn)
 			}
 
 			if sandboxID != "" {
@@ -150,11 +166,11 @@ func newValidateCmd() *cobra.Command {
 						return err
 					}
 				}
-				return validate.RunNamed(cmd.Context(), workDir, name, forceRun, cfg, streams)
+				return validate.RunNamed(cmd.Context(), workDir, name, forceRun, cfg, statusFn, streams)
 			}
 
 			// Run all
-			return validate.RunAll(cmd.Context(), workDir, forceRun, cfg, streams)
+			return validate.RunAll(cmd.Context(), workDir, forceRun, cfg, statusFn, streams)
 		},
 	}
 

--- a/internal/iostream/status.go
+++ b/internal/iostream/status.go
@@ -1,0 +1,16 @@
+package iostream
+
+// Level indicates the kind of status message.
+type Level int
+
+// Status levels for progress reporting.
+const (
+	LevelStep Level = iota // numbered step heading (e.g. "Step 1/3: Discovering...")
+	LevelInfo              // dim informational detail
+	LevelWarn              // yellow warning
+	LevelDone              // green success/completion
+)
+
+// StatusFunc is a callback for reporting progress from business logic.
+// Business logic calls this instead of importing ui directly.
+type StatusFunc func(level Level, msg string)

--- a/internal/sandbox/sync.go
+++ b/internal/sandbox/sync.go
@@ -11,7 +11,6 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
-	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
 
 const workspaceDir = "/workspace"
@@ -20,7 +19,7 @@ const workspaceDir = "/workspace"
 // It ensures the workspace base exists, clones the repo into workdir if absent,
 // then resets to the remote base and applies a patch of local changes.
 // workdir overrides the destination path; defaults to /workspace/<repo>.
-func Sync(ctx context.Context, client *circleci.Client, sandboxID, identityFile, authSock, workdir string, io iostream.Streams) error {
+func Sync(ctx context.Context, client *circleci.Client, sandboxID, identityFile, authSock, workdir string, status iostream.StatusFunc) error {
 	session, err := OpenSession(ctx, client, sandboxID, identityFile, authSock)
 	if err != nil {
 		return err
@@ -66,13 +65,13 @@ func Sync(ctx context.Context, client *circleci.Client, sandboxID, identityFile,
 				ShellEscape(branch), ShellEscape(repoURL), ShellEscape(repoPath),
 			)
 		} else {
-			io.ErrPrintf("%s\n", ui.Dim("Branch not pushed to remote; cloning default branch instead."))
+			status(iostream.LevelInfo, "Branch not pushed to remote; cloning default branch instead.")
 			cloneCmd = fmt.Sprintf("git clone %s %s",
 				ShellEscape(repoURL), ShellEscape(repoPath),
 			)
 		}
 
-		io.ErrPrintf("%s\n", ui.Dim(fmt.Sprintf("Cloning %s/%s into %s...", org, repo, repoPath)))
+		status(iostream.LevelInfo, fmt.Sprintf("Cloning %s/%s into %s...", org, repo, repoPath))
 		cloneResult, err := ExecOverSSH(ctx, session, cloneCmd, nil, nil)
 		if err != nil {
 			return fmt.Errorf("sync: clone: %w", err)
@@ -96,7 +95,7 @@ func Sync(ctx context.Context, client *circleci.Client, sandboxID, identityFile,
 		return err
 	}
 	if patch == "" {
-		io.ErrPrintln(ui.Dim("No local changes relative to remote base."))
+		status(iostream.LevelInfo, "No local changes relative to remote base.")
 		return nil
 	}
 
@@ -129,6 +128,6 @@ func Sync(ctx context.Context, client *circleci.Client, sandboxID, identityFile,
 		return fmt.Errorf("sync failed: %s", detail)
 	}
 
-	io.ErrPrintln(ui.Success("Synced."))
+	status(iostream.LevelDone, "Synced.")
 	return nil
 }

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
-	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
 
 // shellEscape wraps arg in single quotes for safe use in a POSIX sh -c command.
@@ -24,20 +23,20 @@ func shellEscape(arg string) string {
 const DefaultTimeout = 300
 
 // List prints all configured command names and their run strings.
-func List(cfg *config.ProjectConfig, streams iostream.Streams) error {
+func List(cfg *config.ProjectConfig, status iostream.StatusFunc) error {
 	if !cfg.HasCommands() {
-		streams.Println(ui.Dim("No commands configured."))
-		streams.Println(ui.Dim("Add commands with: chunk validate <name> --cmd \"your command\" --save"))
+		status(iostream.LevelInfo, "No commands configured.")
+		status(iostream.LevelInfo, "Add commands with: chunk validate <name> --cmd \"your command\" --save")
 		return nil
 	}
 	for _, c := range cfg.Commands {
-		streams.Printf("  %s: %s\n", ui.Bold(c.Name), ui.Gray(c.Run))
+		status(iostream.LevelInfo, fmt.Sprintf("%s: %s", c.Name, c.Run))
 	}
 	return nil
 }
 
 // Status checks the cache for each command (or a single named command) and prints its status.
-func Status(workDir, name string, cfg *config.ProjectConfig, streams iostream.Streams) error {
+func Status(workDir, name string, cfg *config.ProjectConfig, status iostream.StatusFunc) error {
 	commands := cfg.Commands
 	if name != "" {
 		c := cfg.FindCommand(name)
@@ -50,19 +49,27 @@ func Status(workDir, name string, cfg *config.ProjectConfig, streams iostream.St
 	for _, c := range commands {
 		cached := CheckCache(workDir, c.Name, c.FileExt)
 		if cached != nil {
-			streams.Printf("  %s: cached (%s)\n", ui.Bold(c.Name), colorStatus(cached.Status))
+			level := iostream.LevelDone
+			if cached.Status != statusPass {
+				level = iostream.LevelWarn
+			}
+			status(level, fmt.Sprintf("%s: cached (%s)", c.Name, strings.ToUpper(cached.Status)))
 		} else {
-			streams.Printf("  %s: %s\n", ui.Bold(c.Name), ui.Dim("no cached result"))
+			status(iostream.LevelInfo, fmt.Sprintf("%s: no cached result", c.Name))
 		}
 	}
 	return nil
 }
 
 // RunInline runs an inline command string, caching the result under the given name.
-func RunInline(ctx context.Context, workDir, name, command string, force bool, streams iostream.Streams) error {
+func RunInline(ctx context.Context, workDir, name, command string, force bool, status iostream.StatusFunc, streams iostream.Streams) error {
 	if !force {
 		if cached := CheckCache(workDir, name, ""); cached != nil {
-			streams.Printf("%s: cached (%s)\n", ui.Bold(name), colorStatus(cached.Status))
+			level := iostream.LevelDone
+			if cached.Status != statusPass {
+				level = iostream.LevelWarn
+			}
+			status(level, fmt.Sprintf("%s: cached (%s)", name, strings.ToUpper(cached.Status)))
 			if cached.ExitCode != 0 {
 				return fmt.Errorf("%s: cached failure", name)
 			}
@@ -70,11 +77,11 @@ func RunInline(ctx context.Context, workDir, name, command string, force bool, s
 		}
 	}
 
-	return runAndCache(ctx, workDir, name, command, "", 0, streams)
+	return runAndCache(ctx, workDir, name, command, "", 0, status, streams)
 }
 
 // RunNamed runs a single named command from config with caching.
-func RunNamed(ctx context.Context, workDir, name string, force bool, cfg *config.ProjectConfig, streams iostream.Streams) error {
+func RunNamed(ctx context.Context, workDir, name string, force bool, cfg *config.ProjectConfig, status iostream.StatusFunc, streams iostream.Streams) error {
 	c := cfg.FindCommand(name)
 	if c == nil {
 		return fmt.Errorf("command %q not configured", name)
@@ -82,7 +89,11 @@ func RunNamed(ctx context.Context, workDir, name string, force bool, cfg *config
 
 	if !force {
 		if cached := CheckCache(workDir, c.Name, c.FileExt); cached != nil {
-			streams.Printf("%s: cached (%s)\n", ui.Bold(c.Name), colorStatus(cached.Status))
+			level := iostream.LevelDone
+			if cached.Status != statusPass {
+				level = iostream.LevelWarn
+			}
+			status(level, fmt.Sprintf("%s: cached (%s)", c.Name, strings.ToUpper(cached.Status)))
 			if cached.ExitCode != 0 {
 				return fmt.Errorf("%s: cached failure", c.Name)
 			}
@@ -90,11 +101,11 @@ func RunNamed(ctx context.Context, workDir, name string, force bool, cfg *config
 		}
 	}
 
-	return runAndCache(ctx, workDir, c.Name, c.Run, c.FileExt, c.Timeout, streams)
+	return runAndCache(ctx, workDir, c.Name, c.Run, c.FileExt, c.Timeout, status, streams)
 }
 
 // RunAll runs all configured commands with optional cache bypass.
-func RunAll(ctx context.Context, workDir string, force bool, cfg *config.ProjectConfig, streams iostream.Streams) error {
+func RunAll(ctx context.Context, workDir string, force bool, cfg *config.ProjectConfig, status iostream.StatusFunc, streams iostream.Streams) error {
 	if !cfg.HasCommands() {
 		return fmt.Errorf("no validate commands configured, run 'chunk init' first")
 	}
@@ -102,7 +113,11 @@ func RunAll(ctx context.Context, workDir string, force bool, cfg *config.Project
 	for i, c := range cfg.Commands {
 		if !force {
 			if cached := CheckCache(workDir, c.Name, c.FileExt); cached != nil {
-				streams.ErrPrintf("%s: cached (%s)\n", ui.Bold(c.Name), colorStatus(cached.Status))
+				level := iostream.LevelDone
+				if cached.Status != statusPass {
+					level = iostream.LevelWarn
+				}
+				status(level, fmt.Sprintf("%s: cached (%s)", c.Name, strings.ToUpper(cached.Status)))
 				if cached.ExitCode != 0 {
 					return fmt.Errorf("%s: cached failure", c.Name)
 				}
@@ -110,9 +125,9 @@ func RunAll(ctx context.Context, workDir string, force bool, cfg *config.Project
 			}
 		}
 
-		if err := runAndCache(ctx, workDir, c.Name, c.Run, c.FileExt, c.Timeout, streams); err != nil {
+		if err := runAndCache(ctx, workDir, c.Name, c.Run, c.FileExt, c.Timeout, status, streams); err != nil {
 			for j := i + 1; j < len(cfg.Commands); j++ {
-				streams.ErrPrintf("%s: %s\n", ui.Bold(cfg.Commands[j].Name), ui.Yellow(fmt.Sprintf("skipped (%s failed)", c.Name)))
+				status(iostream.LevelWarn, fmt.Sprintf("%s: skipped (%s failed)", cfg.Commands[j].Name, c.Name))
 			}
 			return err
 		}
@@ -121,7 +136,7 @@ func RunAll(ctx context.Context, workDir string, force bool, cfg *config.Project
 }
 
 // RunDryRun prints commands without executing them.
-func RunDryRun(cfg *config.ProjectConfig, name string, streams iostream.Streams) error {
+func RunDryRun(cfg *config.ProjectConfig, name string, status iostream.StatusFunc) error {
 	if !cfg.HasCommands() {
 		return fmt.Errorf("no validate commands configured, run 'chunk init' first")
 	}
@@ -136,7 +151,7 @@ func RunDryRun(cfg *config.ProjectConfig, name string, streams iostream.Streams)
 	}
 
 	for _, c := range commands {
-		streams.Printf("%s: %s\n", ui.Bold(c.Name), ui.Gray(c.Run))
+		status(iostream.LevelInfo, fmt.Sprintf("%s: %s", c.Name, c.Run))
 	}
 	return nil
 }
@@ -162,19 +177,8 @@ func RunRemote(ctx context.Context, exec func(ctx context.Context, script string
 	return nil
 }
 
-func colorStatus(status string) string {
-	switch status {
-	case statusPass:
-		return ui.Green("PASS")
-	case statusFail:
-		return ui.Red("FAIL")
-	default:
-		return status
-	}
-}
-
-func runAndCache(ctx context.Context, workDir, name, command, fileExt string, timeoutSec int, streams iostream.Streams) error {
-	streams.ErrPrintf("%s %s\n", ui.Dim("Running "+name+":"), ui.Gray(command))
+func runAndCache(ctx context.Context, workDir, name, command, fileExt string, timeoutSec int, status iostream.StatusFunc, streams iostream.Streams) error {
+	status(iostream.LevelInfo, fmt.Sprintf("Running %s: %s", name, command))
 
 	if timeoutSec <= 0 {
 		timeoutSec = DefaultTimeout

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"os"
 	"os/exec"
@@ -60,6 +61,12 @@ func writeConfig(t *testing.T, dir string, commands []config.Command) string {
 func newStreams() (iostream.Streams, *bytes.Buffer, *bytes.Buffer) {
 	var out, errBuf bytes.Buffer
 	return iostream.Streams{Out: &out, Err: &errBuf}, &out, &errBuf
+}
+
+func testStatus(buf *bytes.Buffer) iostream.StatusFunc {
+	return func(_ iostream.Level, msg string) {
+		fmt.Fprintln(buf, msg)
+	}
 }
 
 // --- LoadProjectConfig tests ---
@@ -137,9 +144,9 @@ func TestRunDryRun(t *testing.T) {
 			{Name: "install", Run: "npm install"},
 			{Name: "test", Run: "npm test"},
 		}}
-		streams, out, _ := newStreams()
+		var out bytes.Buffer
 
-		assert.NilError(t, RunDryRun(cfg, "", streams))
+		assert.NilError(t, RunDryRun(cfg, "", testStatus(&out)))
 
 		assert.Assert(t, strings.Contains(out.String(), "install: npm install"), "got: %s", out.String())
 		assert.Assert(t, strings.Contains(out.String(), "test: npm test"), "got: %s", out.String())
@@ -147,9 +154,9 @@ func TestRunDryRun(t *testing.T) {
 
 	t.Run("no commands", func(t *testing.T) {
 		cfg := &config.ProjectConfig{}
-		streams, _, _ := newStreams()
+		var out bytes.Buffer
 
-		err := RunDryRun(cfg, "", streams)
+		err := RunDryRun(cfg, "", testStatus(&out))
 		assert.ErrorContains(t, err, "no validate commands")
 	})
 }
@@ -162,19 +169,21 @@ func TestRunAll(t *testing.T) {
 			{Name: "install", Run: "echo installed"},
 			{Name: "test", Run: "echo tested"},
 		}}
-		streams, out, errBuf := newStreams()
+		streams, out, _ := newStreams()
+		var statusBuf bytes.Buffer
 
-		assert.NilError(t, RunAll(context.Background(), ".", true, cfg, streams))
+		assert.NilError(t, RunAll(context.Background(), ".", true, cfg, testStatus(&statusBuf), streams))
 		assert.Assert(t, strings.Contains(out.String(), "installed"), "got: %s", out.String())
 		assert.Assert(t, strings.Contains(out.String(), "tested"), "got: %s", out.String())
-		assert.Assert(t, strings.Contains(errBuf.String(), "Running install"), "got: %s", errBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "Running install"), "got: %s", statusBuf.String())
 	})
 
 	t.Run("no commands", func(t *testing.T) {
 		cfg := &config.ProjectConfig{}
 		streams, _, _ := newStreams()
+		var statusBuf bytes.Buffer
 
-		err := RunAll(context.Background(), ".", true, cfg, streams)
+		err := RunAll(context.Background(), ".", true, cfg, testStatus(&statusBuf), streams)
 		assert.ErrorContains(t, err, "no validate commands")
 	})
 
@@ -183,8 +192,9 @@ func TestRunAll(t *testing.T) {
 			{Name: "test", Run: "false"},
 		}}
 		streams, _, _ := newStreams()
+		var statusBuf bytes.Buffer
 
-		err := RunAll(context.Background(), ".", true, cfg, streams)
+		err := RunAll(context.Background(), ".", true, cfg, testStatus(&statusBuf), streams)
 		assert.ErrorContains(t, err, "test command failed")
 	})
 
@@ -194,13 +204,14 @@ func TestRunAll(t *testing.T) {
 			{Name: "test", Run: "echo should-not-run"},
 			{Name: "lint", Run: "echo should-not-run-either"},
 		}}
-		streams, out, errBuf := newStreams()
+		streams, out, _ := newStreams()
+		var statusBuf bytes.Buffer
 
-		err := RunAll(context.Background(), ".", true, cfg, streams)
+		err := RunAll(context.Background(), ".", true, cfg, testStatus(&statusBuf), streams)
 		assert.Assert(t, err != nil, "expected error")
 		assert.Assert(t, !strings.Contains(out.String(), "should-not-run"), "skipped command should not produce output, got: %s", out.String())
-		assert.Assert(t, strings.Contains(errBuf.String(), "test: skipped"), "got: %s", errBuf.String())
-		assert.Assert(t, strings.Contains(errBuf.String(), "lint: skipped"), "got: %s", errBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "test: skipped"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "lint: skipped"), "got: %s", statusBuf.String())
 	})
 
 	t.Run("single command success", func(t *testing.T) {
@@ -208,8 +219,9 @@ func TestRunAll(t *testing.T) {
 			{Name: "test", Run: "echo ok"},
 		}}
 		streams, out, _ := newStreams()
+		var statusBuf bytes.Buffer
 
-		assert.NilError(t, RunAll(context.Background(), ".", true, cfg, streams))
+		assert.NilError(t, RunAll(context.Background(), ".", true, cfg, testStatus(&statusBuf), streams))
 		assert.Assert(t, strings.Contains(out.String(), "ok"), "got: %s", out.String())
 	})
 }


### PR DESCRIPTION
## Summary
- Introduce `iostream.StatusFunc` callback type with `Level` constants (Step, Info, Warn, Done)
- Replace direct `ui.*` calls in `buildprompt`, `validate`, and `sandbox/sync` with StatusFunc
- Add `newStatusFunc` helper in cmd/ that wraps `ui.*` formatting
- Remove `internal/ui` imports from all three business logic packages

## Test plan
- [x] All 798 tests pass (race detector enabled)
- [x] Go linter passes (0 issues)
- [x] Acceptance tests pass including cached status output checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)