### PR TITLE
Move ANSI styling out of usererr into display layer

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -108,8 +108,9 @@ func authSetCircleCI(ctx context.Context, io iostream.Streams, circleCIBaseURL, 
 
 	token = strings.TrimSpace(token)
 	if token == "" {
-		return usererr.New(
-			ui.FormatError("Token cannot be empty.", "", "Create a token at https://app.circleci.com/settings/user/tokens"),
+		return usererr.NewDetailed(
+			"Token cannot be empty.", "",
+			"Create a token at https://app.circleci.com/settings/user/tokens",
 			fmt.Errorf("empty circleci token"),
 		)
 	}
@@ -153,23 +154,27 @@ func authSetAnthropic(ctx context.Context, io iostream.Streams, anthropicBaseURL
 
 	key = strings.TrimSpace(key)
 	if key == "" {
-		return usererr.New(
-			ui.FormatError("API key cannot be empty.", "", "Get an API key from https://console.anthropic.com/"),
+		return usererr.NewDetailed(
+			"API key cannot be empty.", "",
+			"Get an API key from https://console.anthropic.com/",
 			fmt.Errorf("empty anthropic key"),
 		)
 	}
 
 	if !strings.HasPrefix(key, "sk-ant-") {
-		return usererr.New(
-			ui.FormatError("Invalid API key format.", "Keys should start with \"sk-ant-\".", "Get a valid API key from https://console.anthropic.com/"),
+		return usererr.NewDetailed(
+			"Invalid API key format.",
+			"Keys should start with \"sk-ant-\".",
+			"Get a valid API key from https://console.anthropic.com/",
 			fmt.Errorf("invalid anthropic key format"),
 		)
 	}
 
 	io.ErrPrintln(ui.Dim("Validating API key..."))
 	if err := authprompt.ValidateAPIKey(ctx, key, anthropicBaseURL); err != nil {
-		return usererr.New(
-			ui.FormatError("API key validation failed.", "", "Check that your key is correct and has not been revoked."),
+		return usererr.NewDetailed(
+			"API key validation failed.", "",
+			"Check that your key is correct and has not been revoked.",
 			err,
 		)
 	}
@@ -192,8 +197,9 @@ func authSetAnthropic(ctx context.Context, io iostream.Streams, anthropicBaseURL
 func saveCircleCIToken(ctx context.Context, token string, streams iostream.Streams, circleCIBaseURL string) error {
 	streams.ErrPrintln(ui.Dim("Validating CircleCI token..."))
 	if err := authprompt.ValidateCircleCIToken(ctx, token, circleCIBaseURL); err != nil {
-		return usererr.New(
-			ui.FormatError("CircleCI token validation failed.", "", "Check that your token is correct."),
+		return usererr.NewDetailed(
+			"CircleCI token validation failed.", "",
+			"Check that your token is correct.",
 			fmt.Errorf("validate token: %w", err),
 		)
 	}
@@ -204,8 +210,9 @@ func saveCircleCIToken(ctx context.Context, token string, streams iostream.Strea
 	}
 	cfg.CircleCIToken = token
 	if err := config.Save(cfg); err != nil {
-		return usererr.New(
-			ui.FormatError("Failed to save CircleCI token.", "", "Check that your config file is writable."),
+		return usererr.NewDetailed(
+			"Failed to save CircleCI token.", "",
+			"Check that your config file is writable.",
 			fmt.Errorf("save token: %w", err),
 		)
 	}
@@ -374,8 +381,10 @@ func authRemoveCircleCI(io iostream.Streams, circleTokenEnv string) error {
 		if errPath, pathErr := config.Path(); pathErr == nil {
 			hint = fmt.Sprintf("Check file permissions on %s.", errPath)
 		}
-		return usererr.New(
-			ui.FormatError("Failed to remove CircleCI token.", "An error occurred while trying to remove the token from the config file.", hint),
+		return usererr.NewDetailed(
+			"Failed to remove CircleCI token.",
+			"An error occurred while trying to remove the token from the config file.",
+			hint,
 			err,
 		)
 	}
@@ -421,8 +430,10 @@ func authRemoveAnthropic(io iostream.Streams, anthropicKeyEnv string) error {
 		if errPath, pathErr := config.Path(); pathErr == nil {
 			hint = fmt.Sprintf("Check file permissions on %s.", errPath)
 		}
-		return usererr.New(
-			ui.FormatError("Failed to remove API key.", "An error occurred while trying to remove the API key from the config file.", hint),
+		return usererr.NewDetailed(
+			"Failed to remove API key.",
+			"An error occurred while trying to remove the API key from the config file.",
+			hint,
 			err,
 		)
 	}
@@ -472,16 +483,18 @@ func authSetGitHub(ctx context.Context, io iostream.Streams, githubBaseURL, gith
 
 	token = strings.TrimSpace(token)
 	if token == "" {
-		return usererr.New(
-			ui.FormatError("Token cannot be empty.", "", "Create a token at https://github.com/settings/tokens"),
+		return usererr.NewDetailed(
+			"Token cannot be empty.", "",
+			"Create a token at https://github.com/settings/tokens",
 			fmt.Errorf("empty github token"),
 		)
 	}
 
 	io.ErrPrintln(ui.Dim("Validating GitHub token..."))
 	if err := authprompt.ValidateGitHubToken(ctx, token, githubBaseURL); err != nil {
-		return usererr.New(
-			ui.FormatError("GitHub token validation failed.", "", "Check that your token is correct and has not been revoked."),
+		return usererr.NewDetailed(
+			"GitHub token validation failed.", "",
+			"Check that your token is correct and has not been revoked.",
 			err,
 		)
 	}
@@ -534,8 +547,10 @@ func authRemoveGitHub(io iostream.Streams, githubTokenEnv string) error {
 		if errPath, pathErr := config.Path(); pathErr == nil {
 			hint = fmt.Sprintf("Check file permissions on %s.", errPath)
 		}
-		return usererr.New(
-			ui.FormatError("Failed to remove GitHub token.", "An error occurred while trying to remove the token from the config file.", hint),
+		return usererr.NewDetailed(
+			"Failed to remove GitHub token.",
+			"An error occurred while trying to remove the token from the config file.",
+			hint,
 			err,
 		)
 	}

--- a/internal/usererr/usererr.go
+++ b/internal/usererr/usererr.go
@@ -6,13 +6,21 @@ import "fmt"
 // Error() delegates to the wrapped error. UserMessage() returns
 // human-friendly text (may be capitalized, punctuated).
 type Error struct {
-	userMsg string // user-facing message
-	err     error  // underlying Go error
+	userMsg    string // user-facing message
+	detail     string // optional detail line
+	suggestion string // optional suggestion line
+	err        error  // underlying Go error
 }
 
 // New wraps err with a user-facing message.
 func New(userMsg string, err error) *Error {
 	return &Error{userMsg: userMsg, err: err}
+}
+
+// NewDetailed wraps err with structured user-facing fields (brief, detail, suggestion)
+// that are kept as plain text. Formatting is applied at the display boundary.
+func NewDetailed(brief, detail, suggestion string, err error) *Error {
+	return &Error{userMsg: brief, detail: detail, suggestion: suggestion, err: err}
 }
 
 // Newf wraps a formatted error with a user-facing message.
@@ -28,6 +36,12 @@ func (e *Error) Error() string {
 func (e *Error) UserMessage() string {
 	return e.userMsg
 }
+
+// Detail returns the optional detail line.
+func (e *Error) Detail() string { return e.detail }
+
+// Suggestion returns the optional suggestion line.
+func (e *Error) Suggestion() string { return e.suggestion }
 
 // Unwrap returns the underlying error.
 func (e *Error) Unwrap() error {

--- a/internal/usererr/usererr_test.go
+++ b/internal/usererr/usererr_test.go
@@ -53,6 +53,23 @@ func TestError(t *testing.T) {
 	})
 }
 
+func TestNewDetailed(t *testing.T) {
+	cause := fmt.Errorf("root")
+	ue := usererr.NewDetailed("Brief msg.", "Some detail.", "Try this.", cause)
+	if ue.UserMessage() != "Brief msg." {
+		t.Errorf("UserMessage() = %q", ue.UserMessage())
+	}
+	if ue.Detail() != "Some detail." {
+		t.Errorf("Detail() = %q", ue.Detail())
+	}
+	if ue.Suggestion() != "Try this." {
+		t.Errorf("Suggestion() = %q", ue.Suggestion())
+	}
+	if !errors.Is(ue, cause) {
+		t.Error("Unwrap chain broken")
+	}
+}
+
 func TestNewf(t *testing.T) {
 	sentinel := fmt.Errorf("root cause")
 	ue := usererr.Newf("Could not save file.", "save %s: %w", "config.json", sentinel)

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 		var ue *usererr.Error
 		if errors.As(err, &ue) {
 			if ue.Detail() != "" || ue.Suggestion() != "" {
-				fmt.Fprintln(os.Stderr, ui.FormatError(ue.UserMessage(), ue.Detail(), ue.Suggestion()))
+				fmt.Fprint(os.Stderr, ui.FormatError(ue.UserMessage(), ue.Detail(), ue.Suggestion()))
 			} else {
 				fmt.Fprintln(os.Stderr, ue.UserMessage())
 			}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/cmd"
+	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 	"github.com/CircleCI-Public/chunk-cli/internal/usererr"
 )
 
@@ -19,7 +20,11 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		var ue *usererr.Error
 		if errors.As(err, &ue) {
-			fmt.Fprintln(os.Stderr, ue.UserMessage())
+			if ue.Detail() != "" || ue.Suggestion() != "" {
+				fmt.Fprintln(os.Stderr, ui.FormatError(ue.UserMessage(), ue.Detail(), ue.Suggestion()))
+			} else {
+				fmt.Fprintln(os.Stderr, ue.UserMessage())
+			}
 		} else {
 			fmt.Fprintln(os.Stderr, err)
 			if suggestion := errorSuggestion(err); suggestion != "" {


### PR DESCRIPTION
## Summary
- Add `usererr.NewDetailed(brief, detail, suggestion, err)` to carry structured error fields as plain text
- Replace 11 `usererr.New(ui.FormatError(...))` calls in auth.go with `usererr.NewDetailed(...)`
- Format structured errors with `ui.FormatError` at the display boundary in `main.go`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>