### PR TITLE
Restore SetLogStatus on GitHub client

### DIFF
--- a/internal/authprompt/authprompt.go
+++ b/internal/authprompt/authprompt.go
@@ -104,10 +104,10 @@ func ResolveAnthropicClient() (*anthropic.Client, error) {
 
 // ResolveGitHubClient returns a GitHub client if credentials are available in
 // env vars or config. Returns ErrNeedsAuth when the caller must prompt.
-func ResolveGitHubClient() (*github.Client, error) {
+func ResolveGitHubClient(logStatus func(string)) (*github.Client, error) {
 	rc, err := config.Resolve("", "")
 	if rc.GitHubToken != "" {
-		return github.New()
+		return github.New(logStatus)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("resolve config: %w", err)

--- a/internal/authprompt/authprompt_test.go
+++ b/internal/authprompt/authprompt_test.go
@@ -155,7 +155,7 @@ func TestResolveGitHubClient_TokenInEnv(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", randToken("ghp_"))
 	t.Setenv("GITHUB_API_URL", srv.URL)
 
-	client, err := authprompt.ResolveGitHubClient()
+	client, err := authprompt.ResolveGitHubClient(nil)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
 }
@@ -175,7 +175,7 @@ func TestResolveGitHubClient_TokenInConfig(t *testing.T) {
 	cfg.GitHubToken = randToken("ghp_")
 	assert.NilError(t, config.Save(cfg))
 
-	client, err := authprompt.ResolveGitHubClient()
+	client, err := authprompt.ResolveGitHubClient(nil)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
 }
@@ -184,7 +184,7 @@ func TestResolveGitHubClient_NeedsAuth(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv("GITHUB_TOKEN", "")
 
-	_, err := authprompt.ResolveGitHubClient()
+	_, err := authprompt.ResolveGitHubClient(nil)
 	assert.Assert(t, errors.Is(err, authprompt.ErrNeedsAuth))
 }
 

--- a/internal/buildprompt/buildprompt_test.go
+++ b/internal/buildprompt/buildprompt_test.go
@@ -51,7 +51,7 @@ func TestRunHappyPath(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
 	t.Setenv("ANTHROPIC_BASE_URL", anthropicSrv.URL)
 
-	ghClient, err := ghpkg.New()
+	ghClient, err := ghpkg.New(nil)
 	assert.NilError(t, err)
 	anthropicClient, err := anthropic.New()
 	assert.NilError(t, err)
@@ -117,7 +117,7 @@ func TestRunNoReposFound(t *testing.T) {
 	t.Setenv("GITHUB_API_URL", ghSrv.URL)
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
 
-	ghClient, err := ghpkg.New()
+	ghClient, err := ghpkg.New(nil)
 	assert.NilError(t, err)
 	anthropicClient, err := anthropic.New()
 	assert.NilError(t, err)
@@ -157,7 +157,7 @@ func TestRunSkipsRepoResolutionErrors(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
 	t.Setenv("ANTHROPIC_BASE_URL", anthropicSrv.URL)
 
-	ghClient, err := ghpkg.New()
+	ghClient, err := ghpkg.New(nil)
 	assert.NilError(t, err)
 	anthropicClient, err := anthropic.New()
 	assert.NilError(t, err)
@@ -200,7 +200,7 @@ func TestRunWithMaxComments(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
 	t.Setenv("ANTHROPIC_BASE_URL", anthropicSrv.URL)
 
-	ghClient, err := ghpkg.New()
+	ghClient, err := ghpkg.New(nil)
 	assert.NilError(t, err)
 	anthropicClient, err := anthropic.New()
 	assert.NilError(t, err)
@@ -249,7 +249,7 @@ func TestRunRetryOnTokenLimit(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
 	t.Setenv("ANTHROPIC_BASE_URL", anthropicSrv.URL)
 
-	ghClient, err := ghpkg.New()
+	ghClient, err := ghpkg.New(nil)
 	assert.NilError(t, err)
 	anthropicClient, err := anthropic.New()
 	assert.NilError(t, err)
@@ -288,7 +288,7 @@ func TestRunMissingGithubToken(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	// With the decoupled auth, client construction fails before Run is called.
-	_, err := ghpkg.New()
+	_, err := ghpkg.New(nil)
 	assert.Assert(t, err != nil, "expected error when GITHUB_TOKEN is missing")
 }
 

--- a/internal/cmd/authhelper.go
+++ b/internal/cmd/authhelper.go
@@ -119,7 +119,8 @@ func ensureAnthropicClient(ctx context.Context, streams iostream.Streams, prompt
 // ensureGitHubClient resolves or interactively prompts for a GitHub token,
 // validates it, saves it to config, and returns a ready client.
 func ensureGitHubClient(ctx context.Context, streams iostream.Streams, prompter func(string) (string, error)) (*github.Client, error) {
-	client, err := authprompt.ResolveGitHubClient()
+	logStatus := func(msg string) { streams.ErrPrintln("  " + msg) }
+	client, err := authprompt.ResolveGitHubClient(logStatus)
 	if err == nil {
 		return client, nil
 	}
@@ -154,5 +155,5 @@ func ensureGitHubClient(ctx context.Context, streams iostream.Streams, prompter 
 		return nil, err
 	}
 	printSaved(streams, "GitHub token")
-	return github.New()
+	return github.New(logStatus)
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -24,15 +24,11 @@ type Client struct {
 	logStatus func(string)
 }
 
-// SetLogStatus sets an optional callback for progress/status messages.
-func (c *Client) SetLogStatus(fn func(string)) {
-	c.logStatus = fn
-}
-
 // New creates a GitHub GraphQL client.
 // It resolves the token via config (GITHUB_TOKEN env > config file) and reads
 // GITHUB_API_URL from the environment.
-func New() (*Client, error) {
+// An optional logStatus callback receives progress messages (e.g. retry waits).
+func New(logStatus func(string)) (*Client, error) {
 	rc, err := config.Resolve("", "")
 	if rc.GitHubToken == "" {
 		if err != nil {
@@ -53,7 +49,7 @@ func New() (*Client, error) {
 		UserAgent:  "chunk-cli",
 	})
 
-	return &Client{http: c}, nil
+	return &Client{http: c, logStatus: logStatus}, nil
 }
 
 // graphQLRequest is the JSON body sent to /graphql.

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -16,7 +16,7 @@ func newTestClient(t *testing.T, srv *httptest.Server) *github.Client {
 	t.Helper()
 	t.Setenv("GITHUB_TOKEN", "test-token")
 	t.Setenv("GITHUB_API_URL", srv.URL)
-	c, err := github.New()
+	c, err := github.New(nil)
 	if err != nil {
 		t.Fatalf("github.New: %v", err)
 	}
@@ -27,7 +27,7 @@ func newTestClient(t *testing.T, srv *httptest.Server) *github.Client {
 
 func TestNew_MissingToken(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "")
-	_, err := github.New()
+	_, err := github.New(nil)
 	if err == nil {
 		t.Fatal("expected error when GITHUB_TOKEN is empty")
 	}
@@ -36,7 +36,7 @@ func TestNew_MissingToken(t *testing.T) {
 func TestNew_DefaultURL(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "tok")
 	t.Setenv("GITHUB_API_URL", "")
-	c, err := github.New()
+	c, err := github.New(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/github/retry_test.go
+++ b/internal/github/retry_test.go
@@ -194,7 +194,7 @@ func testClient(t *testing.T, url string) *Client {
 	t.Helper()
 	t.Setenv("GITHUB_TOKEN", "test-token")
 	t.Setenv("GITHUB_API_URL", url)
-	c, err := New()
+	c, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}


### PR DESCRIPTION
## Summary
- The authprompt decoupling (#256) dropped the `SetLogStatus` call that wires GitHub retry/rate-limit messages to stderr
- Restores the callback in both the resolve and post-save paths of `ensureGitHubClient`

🤖 Generated with [Claude Code](https://claude.com/claude-code)