### PR TITLE
Restore workspace persistence in sandbox file

### DIFF
--- a/internal/cmd/authhelper.go
+++ b/internal/cmd/authhelper.go
@@ -45,6 +45,7 @@ func ensureCircleCIClient(ctx context.Context, streams iostream.Streams, prompte
 	streams.ErrPrintln("")
 	streams.ErrPrintln(ui.Bold("CircleCI token required"))
 	streams.ErrPrintln("Create a token at https://app.circleci.com/settings/user/tokens")
+	printSaveHint(streams, "Token")
 	streams.ErrPrintln("")
 
 	token, err := prompter("CircleCI Token")
@@ -67,7 +68,7 @@ func ensureCircleCIClient(ctx context.Context, streams iostream.Streams, prompte
 	if err := authprompt.SaveCircleCIToken(token); err != nil {
 		return nil, err
 	}
-	streams.ErrPrintln(ui.Success("CircleCI token saved"))
+	printSaved(streams, "CircleCI token")
 	return circleci.NewClient()
 }
 
@@ -85,6 +86,7 @@ func ensureAnthropicClient(ctx context.Context, streams iostream.Streams, prompt
 	streams.ErrPrintln("")
 	streams.ErrPrintln(ui.Bold("Anthropic API key required"))
 	streams.ErrPrintln("Get a key at https://console.anthropic.com/")
+	printSaveHint(streams, "Key")
 	streams.ErrPrintln("")
 
 	key, err := prompter("API Key")
@@ -110,7 +112,7 @@ func ensureAnthropicClient(ctx context.Context, streams iostream.Streams, prompt
 	if err := authprompt.SaveAnthropicKey(key); err != nil {
 		return nil, err
 	}
-	streams.ErrPrintln(ui.Success("Anthropic API key saved"))
+	printSaved(streams, "Anthropic API key")
 	return anthropic.New()
 }
 
@@ -128,6 +130,7 @@ func ensureGitHubClient(ctx context.Context, streams iostream.Streams, prompter 
 	streams.ErrPrintln("")
 	streams.ErrPrintln(ui.Bold("GitHub token required"))
 	streams.ErrPrintln("Create a token at https://github.com/settings/tokens")
+	printSaveHint(streams, "Token")
 	streams.ErrPrintln("")
 
 	token, err := prompter("GitHub Token")
@@ -150,6 +153,6 @@ func ensureGitHubClient(ctx context.Context, streams iostream.Streams, prompter 
 	if err := authprompt.SaveGitHubToken(token); err != nil {
 		return nil, err
 	}
-	streams.ErrPrintln(ui.Success("GitHub token saved"))
+	printSaved(streams, "GitHub token")
 	return github.New()
 }

--- a/internal/sandbox/active.go
+++ b/internal/sandbox/active.go
@@ -11,6 +11,7 @@ import (
 type ActiveSandbox struct {
 	SandboxID string `json:"sandbox_id"`
 	Name      string `json:"name,omitempty"`
+	Workspace string `json:"workspace,omitempty"`
 }
 
 // sandboxFileName returns the name of the sandbox state file. When

--- a/internal/sandbox/active_test.go
+++ b/internal/sandbox/active_test.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -177,4 +178,57 @@ func TestSaveActiveUpdatesParentFile(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 	assert.Equal(t, got.SandboxID, "sb-new")
+}
+
+func TestWorkspaceFieldRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	want := ActiveSandbox{SandboxID: "sb-1", Name: "test", Workspace: "/workspace/myrepo"}
+	assert.NilError(t, SaveActive(want))
+
+	got, err := LoadActive()
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+	assert.Equal(t, got.Workspace, want.Workspace)
+	assert.Equal(t, got.SandboxID, want.SandboxID)
+}
+
+func TestWorkspaceOmittedWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	assert.NilError(t, SaveActive(ActiveSandbox{SandboxID: "sb-1"}))
+
+	data, err := os.ReadFile(filepath.Join(dir, ".chunk", sandboxFileName()))
+	assert.NilError(t, err)
+	assert.Assert(t, !strings.Contains(string(data), "workspace"), "empty workspace should be omitted from JSON")
+}
+
+func TestResolveWorkspaceCLIFlagWins(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	assert.NilError(t, SaveActive(ActiveSandbox{SandboxID: "sb-1", Workspace: "/workspace/saved"}))
+
+	got := resolveWorkspace("/workspace/override", "myrepo")
+	assert.Equal(t, got, "/workspace/override")
+}
+
+func TestResolveWorkspaceSandboxFallback(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	assert.NilError(t, SaveActive(ActiveSandbox{SandboxID: "sb-1", Workspace: "/workspace/saved"}))
+
+	got := resolveWorkspace("", "myrepo")
+	assert.Equal(t, got, "/workspace/saved")
+}
+
+func TestResolveWorkspaceDefaultFallback(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	got := resolveWorkspace("", "myrepo")
+	assert.Equal(t, got, "./workspace/myrepo")
 }

--- a/internal/sandbox/sync.go
+++ b/internal/sandbox/sync.go
@@ -15,6 +15,32 @@ import (
 
 const workspaceDir = "./workspace"
 
+// resolveWorkspace determines the workspace path. Priority:
+// 1. CLI --workdir flag  2. sandbox.json workspace  3. default.
+func resolveWorkspace(cliWorkdir, repo string) string {
+	if cliWorkdir != "" {
+		return cliWorkdir
+	}
+	if active, err := LoadActive(); err == nil && active != nil && active.Workspace != "" {
+		return active.Workspace
+	}
+	return workspaceDir + "/" + repo
+}
+
+// persistWorkspace saves the resolved workspace back to the sandbox file if it
+// differs from the current value.
+func persistWorkspace(workspace string) error {
+	active, err := LoadActive()
+	if err != nil {
+		return err
+	}
+	if active == nil || active.Workspace == workspace {
+		return nil
+	}
+	active.Workspace = workspace
+	return SaveActive(*active)
+}
+
 // Sync synchronises local changes to a sandbox over SSH.
 // It ensures the workspace base exists, clones the repo into workdir if absent,
 // then resets to the remote base and applies a patch of local changes.
@@ -35,9 +61,10 @@ func Sync(ctx context.Context, client *circleci.Client, sandboxID, identityFile,
 		return fmt.Errorf("sync: %w", err)
 	}
 
-	repoPath := workdir
-	if repoPath == "" {
-		repoPath = workspaceDir + "/" + repo
+	repoPath := resolveWorkspace(workdir, repo)
+
+	if err := persistWorkspace(repoPath); err != nil {
+		status(iostream.LevelWarn, fmt.Sprintf("Could not save workspace: %v", err))
 	}
 
 	// Ensure the parent directory exists on the sandbox.


### PR DESCRIPTION
## Summary
- Re-adds the `Workspace` field to `ActiveSandbox` and the `resolveWorkspace`/`persistWorkspace` helpers
- Originally added in #236, accidentally removed in #240 as part of the auth refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)