### PR TITLE
Replace human-facing errors with typed errors

### DIFF
--- a/internal/anthropic/anthropic_test.go
+++ b/internal/anthropic/anthropic_test.go
@@ -3,6 +3,7 @@ package anthropic
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -36,7 +37,7 @@ func TestNew(t *testing.T) {
 			name:        "missing API key",
 			apiKey:      "",
 			wantErr:     true,
-			errContains: "ANTHROPIC_API_KEY",
+			errContains: "api key not found",
 		},
 		{
 			name:   "default base URL",
@@ -339,8 +340,8 @@ func TestFullWorkflow(t *testing.T) {
 	assert.Assert(t, strings.Contains(body1.Messages[0].Content, fixtures.AnalysisResponse))
 }
 
-func TestIsTokenLimitError(t *testing.T) {
-	t.Run("returns true for prompt too long", func(t *testing.T) {
+func TestErrTokenLimit(t *testing.T) {
+	t.Run("wrapped for prompt too long", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
@@ -351,10 +352,10 @@ func TestIsTokenLimitError(t *testing.T) {
 		c := newTestClient(t, srv.URL)
 		_, err := c.Ask(context.Background(), "m", 10, "p")
 		assert.Assert(t, err != nil)
-		assert.Assert(t, IsTokenLimitError(err))
+		assert.Assert(t, errors.Is(err, ErrTokenLimit))
 	})
 
-	t.Run("returns false for other errors", func(t *testing.T) {
+	t.Run("not wrapped for other errors", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusInternalServerError)
@@ -365,11 +366,11 @@ func TestIsTokenLimitError(t *testing.T) {
 		c := newTestClient(t, srv.URL)
 		_, err := c.Ask(context.Background(), "m", 10, "p")
 		assert.Assert(t, err != nil)
-		assert.Assert(t, !IsTokenLimitError(err))
+		assert.Assert(t, !errors.Is(err, ErrTokenLimit))
 	})
 
-	t.Run("returns false for nil error", func(t *testing.T) {
-		assert.Assert(t, !IsTokenLimitError(nil))
+	t.Run("not present for nil error", func(t *testing.T) {
+		assert.Assert(t, !errors.Is(nil, ErrTokenLimit))
 	})
 }
 

--- a/internal/anthropic/client.go
+++ b/internal/anthropic/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -11,6 +12,40 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 )
+
+var (
+	// ErrKeyNotFound indicates no Anthropic API key was found in env or config.
+	ErrKeyNotFound = errors.New("api key not found")
+
+	// ErrTokenLimit indicates the prompt exceeds the model's context window.
+	ErrTokenLimit = errors.New("prompt exceeds context window")
+)
+
+func isTokenLimitErr(err error) bool {
+	var he *httpcl.HTTPError
+	if !errors.As(err, &he) {
+		return false
+	}
+	return strings.Contains(string(he.Body), "prompt is too long")
+}
+
+// StatusError represents an HTTP error from the Anthropic API without exposing httpcl internals.
+type StatusError struct {
+	Op         string
+	StatusCode int
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("%s: %d %s", e.Op, e.StatusCode, http.StatusText(e.StatusCode))
+}
+
+func mapErr(op string, err error) error {
+	var he *httpcl.HTTPError
+	if !errors.As(err, &he) {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return &StatusError{Op: op, StatusCode: he.StatusCode}
+}
 
 // Client is an Anthropic Messages API client.
 type Client struct {
@@ -27,7 +62,7 @@ func New() (*Client, error) {
 		if err != nil {
 			return nil, fmt.Errorf("resolve config: %w", err)
 		}
-		return nil, fmt.Errorf("ANTHROPIC_API_KEY environment variable or config file is required")
+		return nil, ErrKeyNotFound
 	}
 
 	baseURL := os.Getenv("ANTHROPIC_BASE_URL")
@@ -90,7 +125,10 @@ func (c *Client) Ask(ctx context.Context, model string, maxTokens int, prompt st
 
 	_, err := c.http.Call(ctx, req)
 	if err != nil {
-		return "", fmt.Errorf("anthropic messages: %w", err)
+		if isTokenLimitErr(err) {
+			return "", fmt.Errorf("anthropic messages: %w", ErrTokenLimit)
+		}
+		return "", mapErr("anthropic messages", err)
 	}
 
 	for _, block := range resp.Content {
@@ -99,14 +137,4 @@ func (c *Client) Ask(ctx context.Context, model string, maxTokens int, prompt st
 		}
 	}
 	return "", fmt.Errorf("no text content in Anthropic response")
-}
-
-// IsTokenLimitError reports whether err is an Anthropic API error indicating
-// that the prompt exceeds the model's context window.
-func IsTokenLimitError(err error) bool {
-	var he *httpcl.HTTPError
-	if !errors.As(err, &he) {
-		return false
-	}
-	return strings.Contains(string(he.Body), "prompt is too long")
 }

--- a/internal/buildprompt/buildprompt_test.go
+++ b/internal/buildprompt/buildprompt_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http/httptest"
 	"os"
@@ -314,7 +315,7 @@ func TestResolveOrgAndRepos(t *testing.T) {
 	t.Run("org without repos errors", func(t *testing.T) {
 		_, _, err := ResolveOrgAndRepos("my-org", "", "")
 		assert.Assert(t, err != nil)
-		assert.Assert(t, strings.Contains(err.Error(), "--repos"))
+		assert.Assert(t, errors.Is(err, ErrReposRequired))
 	})
 
 	t.Run("auto-detect from git remote", func(t *testing.T) {

--- a/internal/buildprompt/orchestrator.go
+++ b/internal/buildprompt/orchestrator.go
@@ -2,6 +2,7 @@ package buildprompt
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -53,7 +54,7 @@ func analyzeWithRetry(ctx context.Context, client *anthropic.Client, groups []Re
 			return analysis, nil
 		}
 
-		if !anthropic.IsTokenLimitError(err) {
+		if !errors.Is(err, anthropic.ErrTokenLimit) {
 			return "", err
 		}
 

--- a/internal/buildprompt/steps.go
+++ b/internal/buildprompt/steps.go
@@ -3,6 +3,7 @@ package buildprompt
 import (
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,12 +16,15 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
 )
 
+// ErrReposRequired indicates --repos must be provided when --org is used.
+var ErrReposRequired = errors.New("repos is required when org is provided")
+
 // ResolveOrgAndRepos resolves the org and repos from flags or git remote.
 func ResolveOrgAndRepos(org string, repos string, workDir string) (string, []string, error) {
 	repoList := splitRepos(repos)
 
 	if org != "" && len(repoList) == 0 {
-		return "", nil, fmt.Errorf("--repos is required when --org is provided. Omit --org to auto-detect from git remote")
+		return "", nil, ErrReposRequired
 	}
 
 	if org != "" {

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -2,6 +2,7 @@ package circleci
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -9,6 +10,33 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 )
+
+// ErrTokenNotFound indicates no CircleCI token was found in env or config.
+var ErrTokenNotFound = errors.New("api token not found")
+
+// ErrNotAuthorized indicates the request was rejected (401/403).
+var ErrNotAuthorized = errors.New("not authorized")
+
+// StatusError represents an HTTP error from the CircleCI API without exposing httpcl internals.
+type StatusError struct {
+	Op         string
+	StatusCode int
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("%s: %d %s", e.Op, e.StatusCode, http.StatusText(e.StatusCode))
+}
+
+func mapErr(op string, err error) error {
+	var he *httpcl.HTTPError
+	if !errors.As(err, &he) {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	if he.StatusCode == http.StatusUnauthorized || he.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("%s: %w", op, ErrNotAuthorized)
+	}
+	return &StatusError{Op: op, StatusCode: he.StatusCode}
+}
 
 type Client struct {
 	cl *httpcl.Client
@@ -22,7 +50,7 @@ func NewClient() (*Client, error) {
 		if err != nil {
 			return nil, fmt.Errorf("resolve config: %w", err)
 		}
-		return nil, fmt.Errorf("circleci token not found: set CIRCLE_TOKEN or run 'chunk auth set circleci'")
+		return nil, ErrTokenNotFound
 	}
 
 	baseURL := os.Getenv("CIRCLECI_BASE_URL")
@@ -42,7 +70,10 @@ func NewClient() (*Client, error) {
 // GetCurrentUser calls GET /api/v2/me to validate the token.
 func (c *Client) GetCurrentUser(ctx context.Context) error {
 	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v2/me"))
-	return err
+	if err != nil {
+		return mapErr("get current user", err)
+	}
+	return nil
 }
 
 func (c *Client) ListSandboxes(ctx context.Context, orgID string) ([]Sandbox, error) {
@@ -52,7 +83,7 @@ func (c *Client) ListSandboxes(ctx context.Context, orgID string) ([]Sandbox, er
 		httpcl.JSONDecoder(&resp),
 	))
 	if err != nil {
-		return nil, fmt.Errorf("list sandboxes: %w", err)
+		return nil, mapErr("list sandboxes", err)
 	}
 	return resp.Items, nil
 }
@@ -70,7 +101,7 @@ func (c *Client) CreateSandbox(ctx context.Context, orgID, name, provider, image
 		httpcl.JSONDecoder(&resp),
 	))
 	if err != nil {
-		return nil, fmt.Errorf("create sandbox: %w", err)
+		return nil, mapErr("create sandbox", err)
 	}
 	return &resp, nil
 }
@@ -83,7 +114,7 @@ func (c *Client) AddSSHKey(ctx context.Context, sandboxID, publicKey string) (*A
 		httpcl.JSONDecoder(&resp),
 	))
 	if err != nil {
-		return nil, fmt.Errorf("add ssh key: %w", err)
+		return nil, mapErr("add ssh key", err)
 	}
 	return &resp, nil
 }
@@ -99,7 +130,7 @@ func (c *Client) Exec(ctx context.Context, sandboxID, command string, args []str
 		httpcl.JSONDecoder(&resp),
 	))
 	if err != nil {
-		return nil, fmt.Errorf("exec: %w", err)
+		return nil, mapErr("exec", err)
 	}
 	return &resp, nil
 }
@@ -111,7 +142,7 @@ func (c *Client) CreateSnapshot(ctx context.Context, sandboxID, name string) (*S
 		httpcl.JSONDecoder(&resp),
 	))
 	if err != nil {
-		return nil, fmt.Errorf("create snapshot: %w", err)
+		return nil, mapErr("create snapshot", err)
 	}
 	return &resp, nil
 }
@@ -123,7 +154,7 @@ func (c *Client) GetSnapshot(ctx context.Context, id string) (*Snapshot, error) 
 		httpcl.JSONDecoder(&resp),
 	))
 	if err != nil {
-		return nil, fmt.Errorf("get snapshot: %w", err)
+		return nil, mapErr("get snapshot", err)
 	}
 	return &resp, nil
 }
@@ -136,7 +167,7 @@ func (c *Client) TriggerRun(ctx context.Context, orgID, projectID string, body T
 		httpcl.JSONDecoder(&resp),
 	))
 	if err != nil {
-		return nil, fmt.Errorf("trigger run: %w", err)
+		return nil, mapErr("trigger run", err)
 	}
 	return &resp, nil
 }

--- a/internal/circleci/projects.go
+++ b/internal/circleci/projects.go
@@ -39,7 +39,7 @@ func (c *Client) ListFollowedProjects(ctx context.Context) ([]FollowedProject, e
 		httpcl.JSONDecoder(&resp),
 	))
 	if err != nil {
-		return nil, fmt.Errorf("list followed projects: %w", err)
+		return nil, mapErr("list followed projects", err)
 	}
 	return resp, nil
 }
@@ -51,7 +51,7 @@ func (c *Client) ListCollaborations(ctx context.Context) ([]Collaboration, error
 		httpcl.JSONDecoder(&resp),
 	))
 	if err != nil {
-		return nil, fmt.Errorf("list collaborations: %w", err)
+		return nil, mapErr("list collaborations", err)
 	}
 	return resp, nil
 }
@@ -64,7 +64,7 @@ func (c *Client) GetProjectBySlug(ctx context.Context, slug string) (*ProjectDet
 		httpcl.JSONDecoder(&resp),
 	))
 	if err != nil {
-		return nil, fmt.Errorf("get project by slug: %w", err)
+		return nil, mapErr("get project by slug", err)
 	}
 	return &resp, nil
 }

--- a/internal/cmd/authhelper.go
+++ b/internal/cmd/authhelper.go
@@ -16,6 +16,12 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
 
+const (
+	suggestionCircleCIAuth  = "Set CIRCLE_TOKEN or run 'chunk auth set circleci'."
+	suggestionAnthropicAuth = "Set ANTHROPIC_API_KEY or run 'chunk auth set anthropic'."
+	suggestionGitHubAuth    = "Set GITHUB_TOKEN or run 'chunk auth set github'."
+)
+
 func printSaveHint(streams iostream.Streams, label string) {
 	if cfgPath, err := config.Path(); err == nil {
 		streams.ErrPrintln(ui.Dim(fmt.Sprintf("%s will be saved to user config (%s, mode 0600)", label, cfgPath)))
@@ -52,7 +58,7 @@ func ensureCircleCIClient(ctx context.Context, streams iostream.Streams, prompte
 		if errors.Is(err, tui.ErrNoTTY) {
 			return nil, &userError{
 				msg:        "CircleCI token required.",
-				suggestion: "Set CIRCLE_TOKEN or run 'chunk auth set circleci'.",
+				suggestion: suggestionCircleCIAuth,
 				err:        err,
 			}
 		}
@@ -62,7 +68,7 @@ func ensureCircleCIClient(ctx context.Context, streams iostream.Streams, prompte
 	if token == "" {
 		return nil, &userError{
 			msg:        "CircleCI token required.",
-			suggestion: "Set CIRCLE_TOKEN or run 'chunk auth set circleci'.",
+			suggestion: suggestionCircleCIAuth,
 			errMsg:     "empty token entered",
 		}
 	}
@@ -76,7 +82,15 @@ func ensureCircleCIClient(ctx context.Context, streams iostream.Streams, prompte
 		return nil, err
 	}
 	printSaved(streams, "CircleCI token")
-	return circleci.NewClient()
+	client, err = circleci.NewClient()
+	if errors.Is(err, circleci.ErrTokenNotFound) {
+		return nil, &userError{
+			msg:        "CircleCI token not found.",
+			suggestion: suggestionCircleCIAuth,
+			err:        err,
+		}
+	}
+	return client, err
 }
 
 // ensureAnthropicClient resolves or interactively prompts for an Anthropic API
@@ -101,7 +115,7 @@ func ensureAnthropicClient(ctx context.Context, streams iostream.Streams, prompt
 		if errors.Is(err, tui.ErrNoTTY) {
 			return nil, &userError{
 				msg:        "Anthropic API key required.",
-				suggestion: "Set ANTHROPIC_API_KEY or run 'chunk auth set anthropic'.",
+				suggestion: suggestionAnthropicAuth,
 				err:        err,
 			}
 		}
@@ -111,7 +125,7 @@ func ensureAnthropicClient(ctx context.Context, streams iostream.Streams, prompt
 	if key == "" {
 		return nil, &userError{
 			msg:        "Anthropic API key required.",
-			suggestion: "Set ANTHROPIC_API_KEY or run 'chunk auth set anthropic'.",
+			suggestion: suggestionAnthropicAuth,
 			errMsg:     "empty key entered",
 		}
 	}
@@ -133,7 +147,15 @@ func ensureAnthropicClient(ctx context.Context, streams iostream.Streams, prompt
 		return nil, err
 	}
 	printSaved(streams, "Anthropic API key")
-	return anthropic.New()
+	client, err = anthropic.New()
+	if errors.Is(err, anthropic.ErrKeyNotFound) {
+		return nil, &userError{
+			msg:        "Anthropic API key not found.",
+			suggestion: suggestionAnthropicAuth,
+			err:        err,
+		}
+	}
+	return client, err
 }
 
 // ensureGitHubClient resolves or interactively prompts for a GitHub token,
@@ -159,7 +181,7 @@ func ensureGitHubClient(ctx context.Context, streams iostream.Streams, prompter 
 		if errors.Is(err, tui.ErrNoTTY) {
 			return nil, &userError{
 				msg:        "GitHub token required.",
-				suggestion: "Set GITHUB_TOKEN or run 'chunk auth set github'.",
+				suggestion: suggestionGitHubAuth,
 				err:        err,
 			}
 		}
@@ -169,7 +191,7 @@ func ensureGitHubClient(ctx context.Context, streams iostream.Streams, prompter 
 	if token == "" {
 		return nil, &userError{
 			msg:        "GitHub token required.",
-			suggestion: "Set GITHUB_TOKEN or run 'chunk auth set github'.",
+			suggestion: suggestionGitHubAuth,
 			errMsg:     "empty token entered",
 		}
 	}
@@ -183,5 +205,13 @@ func ensureGitHubClient(ctx context.Context, streams iostream.Streams, prompter 
 		return nil, err
 	}
 	printSaved(streams, "GitHub token")
-	return github.New(logStatus)
+	client, err = github.New(logStatus)
+	if errors.Is(err, github.ErrTokenNotFound) {
+		return nil, &userError{
+			msg:        "GitHub token not found.",
+			suggestion: suggestionGitHubAuth,
+			err:        err,
+		}
+	}
+	return client, err
 }

--- a/internal/cmd/buildprompt.go
+++ b/internal/cmd/buildprompt.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/buildprompt"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/github"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
@@ -41,6 +43,13 @@ func newBuildPromptCmd() *cobra.Command {
 			}
 			resolvedOrg, resolvedRepos, err := buildprompt.ResolveOrgAndRepos(org, repos, cwd)
 			if err != nil {
+				if errors.Is(err, buildprompt.ErrReposRequired) {
+					return &userError{
+						msg:        "--repos is required when --org is provided.",
+						suggestion: "Omit --org to auto-detect from git remote.",
+						err:        err,
+					}
+				}
 				return &userError{msg: "Could not determine org and repos.", suggestion: "Use --org and --repos flags.", err: err}
 			}
 
@@ -87,7 +96,24 @@ func newBuildPromptCmd() *cobra.Command {
 				Status:             newStatusFunc(streams),
 			}
 
-			return buildprompt.Run(cmd.Context(), opts, ghClient, anthropicClient)
+			if err := buildprompt.Run(cmd.Context(), opts, ghClient, anthropicClient); err != nil {
+				if e, ok := errors.AsType[*github.RetryError](err); ok {
+					if e.ServerError {
+						return &userError{
+							msg:        "GitHub API returned a server error.",
+							suggestion: "Try again in a few minutes.",
+							err:        err,
+						}
+					}
+					return &userError{
+						msg:        fmt.Sprintf("GitHub API request failed after %d retries.", e.Retries),
+						suggestion: "Check your network connection and try again.",
+						err:        err,
+					}
+				}
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,7 +15,6 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/envbuilder"
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
-	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/sandbox"
 	"github.com/CircleCI-Public/chunk-cli/internal/secrets"
@@ -80,8 +80,8 @@ func orgPicker(ctx context.Context, client *circleci.Client) func() (string, err
 	return func() (string, error) {
 		collabs, err := client.ListCollaborations(ctx)
 		if err != nil {
-			if httpcl.HasStatusCode(err, 401, 403) {
-				return "", &userError{msg: "Not authorized.", suggestion: "Check your CircleCI token and try again.", err: err}
+			if err := notAuthorized("list organizations", err); err != nil {
+				return "", err
 			}
 			return "", &userError{
 				msg:        "Could not list organizations.",
@@ -126,12 +126,8 @@ func newSandboxListCmd() *cobra.Command {
 			}
 			sandboxes, err := sandbox.List(cmd.Context(), client, resolvedOrgID)
 			if err != nil {
-				if httpcl.HasStatusCode(err, 401, 403) {
-					return &userError{
-						msg:        "Not authorized to list sandboxes.",
-						suggestion: "Check your CircleCI token and try again.",
-						err:        err,
-					}
+				if err := notAuthorized("list sandboxes", err); err != nil {
+					return err
 				}
 				return &userError{
 					msg:        "Could not list sandboxes.",
@@ -186,12 +182,8 @@ environment variable (e.g. CHUNK_SANDBOX_PROVIDER=unikraft).`,
 			}
 			sb, err := sandbox.Create(cmd.Context(), client, resolvedOrgID, name, provider, image)
 			if err != nil {
-				if httpcl.HasStatusCode(err, 401, 403) {
-					return &userError{
-						msg:        "Not authorized to create sandboxes.",
-						suggestion: "Check your CircleCI token and try again.",
-						err:        err,
-					}
+				if err := notAuthorized("create sandboxes", err); err != nil {
+					return err
 				}
 				return &userError{
 					msg:        "Could not create the sandbox.",
@@ -240,12 +232,8 @@ func newSandboxExecCmd() *cobra.Command {
 			allArgs = append(allArgs, args...)
 			resp, err := sandbox.Exec(cmd.Context(), client, sandboxID, command, allArgs)
 			if err != nil {
-				if httpcl.HasStatusCode(err, 401, 403) {
-					return &userError{
-						msg:        "Not authorized to execute commands.",
-						suggestion: "Check your CircleCI token and try again.",
-						err:        err,
-					}
+				if err := notAuthorized("execute commands", err); err != nil {
+					return err
 				}
 				return err
 			}
@@ -284,10 +272,25 @@ func newSandboxAddSSHKeyCmd() *cobra.Command {
 			}
 			resp, err := sandbox.AddSSHKey(cmd.Context(), client, sandboxID, publicKey, publicKeyFile)
 			if err != nil {
-				if httpcl.HasStatusCode(err, 401, 403) {
+				if err := notAuthorized("add SSH keys", err); err != nil {
+					return err
+				}
+				switch {
+				case errors.Is(err, sandbox.ErrPrivateKeyProvided):
 					return &userError{
-						msg:        "Not authorized to add SSH keys.",
-						suggestion: "Check your CircleCI token and try again.",
+						msg:        "The provided key is a private key.",
+						suggestion: "Provide a public key instead.",
+						err:        err,
+					}
+				case errors.Is(err, sandbox.ErrMutuallyExclusiveKeys):
+					return &userError{
+						msg: "--public-key and --public-key-file are mutually exclusive.",
+						err: err,
+					}
+				case errors.Is(err, sandbox.ErrPublicKeyRequired):
+					return &userError{
+						msg:        "A public key is required.",
+						suggestion: "Pass --public-key or --public-key-file.",
 						err:        err,
 					}
 				}
@@ -352,12 +355,11 @@ func newSandboxSSHCmd() *cobra.Command {
 			envVars = resolved
 			err = sandbox.SSH(cmd.Context(), client, sandboxID, identityFile, authSock, args, envVars, io)
 			if err != nil {
-				if httpcl.HasStatusCode(err, 401, 403) {
-					return &userError{
-						msg:        "Not authorized to connect via SSH.",
-						suggestion: "Check your CircleCI token and try again.",
-						err:        err,
-					}
+				if err := sshSessionError(err); err != nil {
+					return err
+				}
+				if err := notAuthorized("connect via SSH", err); err != nil {
+					return err
 				}
 				return err
 			}
@@ -392,12 +394,18 @@ func newSandboxSyncCmd() *cobra.Command {
 			}
 			err = sandbox.Sync(cmd.Context(), client, sandboxID, identityFile, authSock, workdir, newStatusFunc(io))
 			if err != nil {
-				if httpcl.HasStatusCode(err, 401, 403) {
+				if _, ok := errors.AsType[*sandbox.RemoteBaseError](err); ok {
 					return &userError{
-						msg:        "Not authorized to sync files.",
-						suggestion: "Check your CircleCI token and try again.",
+						msg:        "Could not resolve remote base.",
+						suggestion: "Push your branch or ensure the repository has a remote configured.",
 						err:        err,
 					}
+				}
+				if err := sshSessionError(err); err != nil {
+					return err
+				}
+				if err := notAuthorized("sync files", err); err != nil {
+					return err
 				}
 				return err
 			}

--- a/internal/cmd/usererr.go
+++ b/internal/cmd/usererr.go
@@ -1,5 +1,51 @@
 package cmd
 
+import (
+	"errors"
+	"fmt"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/sandbox"
+)
+
+const suggestionReauth = "Check your CircleCI token and try again."
+
+func notAuthorized(action string, err error) error {
+	if !errors.Is(err, circleci.ErrNotAuthorized) {
+		return nil
+	}
+	return &userError{
+		msg:        fmt.Sprintf("Not authorized to %s.", action),
+		suggestion: suggestionReauth,
+		err:        err,
+	}
+}
+
+func sshSessionError(err error) error {
+	if e, ok := errors.AsType[*sandbox.KeyNotFoundError](err); ok {
+		return &userError{
+			msg:        fmt.Sprintf("SSH key not found: %s", e.Path),
+			suggestion: fmt.Sprintf("Generate one with: ssh-keygen -t ed25519 -f %s\nOr pass --identity-file to use an existing key.", e.Path),
+			err:        err,
+		}
+	}
+	if e, ok := errors.AsType[*sandbox.PublicKeyNotFoundError](err); ok {
+		return &userError{
+			msg:        fmt.Sprintf("SSH public key not found: %s", e.KeyPath),
+			suggestion: fmt.Sprintf("Generate a new keypair with: ssh-keygen -t ed25519 -f %s", e.IdentityFile),
+			err:        err,
+		}
+	}
+	if errors.Is(err, sandbox.ErrAuthSockNotSet) {
+		return &userError{
+			msg:        "SSH agent not available.",
+			suggestion: "Set SSH_AUTH_SOCK or pass --identity-file.",
+			err:        err,
+		}
+	}
+	return nil
+}
+
 type userError struct {
 	msg        string
 	detail     string

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -108,7 +109,7 @@ func newValidateCmd() *cobra.Command {
 			}
 
 			if dryRun {
-				return validate.RunDryRun(cfg, name, statusFn)
+				return mapValidateError(validate.RunDryRun(cfg, name, statusFn))
 			}
 
 			if remote {
@@ -154,11 +155,11 @@ func newValidateCmd() *cobra.Command {
 						return err
 					}
 				}
-				return validate.RunNamed(cmd.Context(), workDir, name, forceRun, cfg, statusFn, streams)
+				return mapValidateError(validate.RunNamed(cmd.Context(), workDir, name, forceRun, cfg, statusFn, streams))
 			}
 
 			// Run all
-			return validate.RunAll(cmd.Context(), workDir, forceRun, cfg, statusFn, streams)
+			return mapValidateError(validate.RunAll(cmd.Context(), workDir, forceRun, cfg, statusFn, streams))
 		},
 	}
 
@@ -175,6 +176,17 @@ func newValidateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&projectDir, "project", "", "Override project directory")
 
 	return cmd
+}
+
+func mapValidateError(err error) error {
+	if errors.Is(err, validate.ErrNotConfigured) {
+		return &userError{
+			msg:        "No validate commands configured.",
+			suggestion: "Run 'chunk init' first.",
+			err:        err,
+		}
+	}
+	return err
 }
 
 func runRemoteValidate(ctx context.Context, sandboxID, identityFile, workdir string, cfg *config.ProjectConfig, streams iostream.Streams) error {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -2,7 +2,9 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
@@ -34,7 +36,7 @@ func New(logStatus func(string)) (*Client, error) {
 		if err != nil {
 			return nil, fmt.Errorf("resolve config: %w", err)
 		}
-		return nil, fmt.Errorf("GitHub token not found: set GITHUB_TOKEN or run 'chunk auth set github'")
+		return nil, ErrTokenNotFound
 	}
 
 	baseURL := os.Getenv("GITHUB_API_URL")
@@ -58,6 +60,30 @@ type graphQLRequest struct {
 	Variables map[string]any `json:"variables,omitempty"`
 }
 
+// StatusError represents an HTTP error from the GitHub API without exposing httpcl internals.
+type StatusError struct {
+	Op         string
+	StatusCode int
+}
+
+func (e *StatusError) Error() string {
+	if e.Op != "" {
+		return fmt.Sprintf("%s: %d %s", e.Op, e.StatusCode, http.StatusText(e.StatusCode))
+	}
+	return fmt.Sprintf("%d %s", e.StatusCode, http.StatusText(e.StatusCode))
+}
+
+func mapErr(op string, err error) error {
+	var he *httpcl.HTTPError
+	if !errors.As(err, &he) {
+		if op == "" {
+			return err
+		}
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return &StatusError{Op: op, StatusCode: he.StatusCode}
+}
+
 // do executes a GraphQL query and decodes the response into dest.
 func (c *Client) do(ctx context.Context, query string, vars map[string]any, dest any) error {
 	req := httpcl.NewRequest("POST", "/graphql",
@@ -79,7 +105,7 @@ func (c *Client) ValidateOrg(ctx context.Context, org string) error {
 
 	err := c.do(ctx, `query($org: String!) { organization(login: $org) { login } }`, map[string]any{"org": org}, &resp)
 	if err != nil {
-		return fmt.Errorf("validate org: %w", err)
+		return mapErr("validate org", err)
 	}
 	if hasResolutionError(resp.Errors) {
 		return fmt.Errorf("organization %q not found or not accessible", org)
@@ -92,5 +118,8 @@ func (c *Client) CheckRateLimit(ctx context.Context) error {
 	var resp graphQLResponse[struct {
 		RateLimit RateLimit `json:"rateLimit"`
 	}]
-	return c.do(ctx, `{ rateLimit { remaining resetAt } }`, nil, &resp)
+	if err := c.do(ctx, `{ rateLimit { remaining resetAt } }`, nil, &resp); err != nil {
+		return mapErr("check rate limit", err)
+	}
+	return nil
 }

--- a/internal/github/errors.go
+++ b/internal/github/errors.go
@@ -1,0 +1,28 @@
+package github
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrTokenNotFound indicates no GitHub token was found in env or config.
+var ErrTokenNotFound = errors.New("api token not found")
+
+// RetryError indicates that a GitHub API request failed after exhausting retries.
+type RetryError struct {
+	Retries     int
+	ServerError bool // true when GitHub returned HTML error pages (500/503)
+	Err         error
+}
+
+func (e *RetryError) Error() string {
+	if e.ServerError {
+		return fmt.Sprintf("api server error after %d retries", e.Retries)
+	}
+	if e.Err != nil {
+		return fmt.Sprintf("api request failed after %d retries: %v", e.Retries, e.Err)
+	}
+	return fmt.Sprintf("api request failed after %d retries", e.Retries)
+}
+
+func (e *RetryError) Unwrap() error { return e.Err }

--- a/internal/github/repos.go
+++ b/internal/github/repos.go
@@ -24,7 +24,7 @@ func (c *Client) FetchOrgRepos(ctx context.Context, org string, filterRepos []st
 
 		var resp graphQLResponse[OrgReposData]
 		if err := c.do(ctx, orgReposQuery, vars, &resp); err != nil {
-			return nil, fmt.Errorf("fetch org repos: %w", err)
+			return nil, mapErr("fetch org repos", err)
 		}
 		if hasResolutionError(resp.Errors) {
 			return nil, fmt.Errorf("could not resolve organization %q", org)

--- a/internal/github/retry.go
+++ b/internal/github/retry.go
@@ -81,7 +81,7 @@ func (c *Client) doWithRetry(ctx context.Context, query string, vars map[string]
 			return nil
 		}
 		if !isRetryable(err) {
-			return err
+			return mapErr("", err)
 		}
 
 		lastErr = err
@@ -96,9 +96,9 @@ func (c *Client) doWithRetry(ctx context.Context, query string, vars map[string]
 	}
 
 	if lastErr != nil && isHTMLError(lastErr.Error()) {
-		return fmt.Errorf("GitHub API returned server error after %d retries — try again in a few minutes", maxRetries)
+		return &RetryError{Retries: maxRetries, ServerError: true}
 	}
-	return fmt.Errorf("GitHub API request failed after %d retries: %w", maxRetries, lastErr)
+	return &RetryError{Retries: maxRetries, Err: mapErr("", lastErr)}
 }
 
 // waitForRateLimit sleeps until the rate limit resets if remaining is below the threshold.

--- a/internal/sandbox/errors.go
+++ b/internal/sandbox/errors.go
@@ -1,0 +1,47 @@
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrMutuallyExclusiveKeys indicates both a key string and key file were provided.
+	ErrMutuallyExclusiveKeys = errors.New("public key and public key file are mutually exclusive")
+	// ErrPublicKeyRequired indicates neither a key string nor key file was provided.
+	ErrPublicKeyRequired = errors.New("public key is required")
+	// ErrPrivateKeyProvided indicates a private key was given where a public key was expected.
+	ErrPrivateKeyProvided = errors.New("provided key is a private key")
+	// ErrAuthSockNotSet indicates the SSH agent socket is not configured.
+	ErrAuthSockNotSet = errors.New("ssh auth socket not set")
+)
+
+// KeyNotFoundError indicates the SSH private key file does not exist.
+type KeyNotFoundError struct {
+	Path string
+}
+
+func (e *KeyNotFoundError) Error() string {
+	return fmt.Sprintf("ssh key not found: %s", e.Path)
+}
+
+// PublicKeyNotFoundError indicates the SSH public key file does not exist.
+type PublicKeyNotFoundError struct {
+	KeyPath      string
+	IdentityFile string
+}
+
+func (e *PublicKeyNotFoundError) Error() string {
+	return fmt.Sprintf("ssh public key not found: %s", e.KeyPath)
+}
+
+// RemoteBaseError indicates the remote merge base could not be resolved.
+type RemoteBaseError struct {
+	Err error
+}
+
+func (e *RemoteBaseError) Error() string {
+	return fmt.Sprintf("could not resolve remote base: %v", e.Err)
+}
+
+func (e *RemoteBaseError) Unwrap() error { return e.Err }

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -24,10 +24,10 @@ func Exec(ctx context.Context, client *circleci.Client, sandboxID, command strin
 
 func AddSSHKey(ctx context.Context, client *circleci.Client, sandboxID, publicKey, publicKeyFile string) (*circleci.AddSSHKeyResponse, error) {
 	if publicKey != "" && publicKeyFile != "" {
-		return nil, fmt.Errorf("--public-key and --public-key-file are mutually exclusive")
+		return nil, ErrMutuallyExclusiveKeys
 	}
 	if publicKey == "" && publicKeyFile == "" {
-		return nil, fmt.Errorf("either --public-key or --public-key-file is required")
+		return nil, ErrPublicKeyRequired
 	}
 
 	key := publicKey
@@ -40,7 +40,7 @@ func AddSSHKey(ctx context.Context, client *circleci.Client, sandboxID, publicKe
 	}
 
 	if strings.Contains(key, "PRIVATE KEY") {
-		return nil, fmt.Errorf("the provided key appears to be a private key; please provide a public key instead")
+		return nil, ErrPrivateKeyProvided
 	}
 
 	return client.AddSSHKey(ctx, sandboxID, key)

--- a/internal/sandbox/session.go
+++ b/internal/sandbox/session.go
@@ -61,14 +61,14 @@ func OpenSession(ctx context.Context, client *circleci.Client, sandboxID, identi
 	}
 
 	if _, err := os.Stat(identityFile); err != nil {
-		return nil, fmt.Errorf("SSH key not found: %s\nGenerate one with: ssh-keygen -t ed25519 -f %s\nOr pass --identity-file to use an existing key", identityFile, identityFile)
+		return nil, &KeyNotFoundError{Path: identityFile}
 	}
 
 	pubKeyPath := identityFile + ".pub"
 	pubKeyData, err := os.ReadFile(pubKeyPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("SSH public key not found: %s\nThe public key must be co-located with the private key.\nGenerate a new keypair with: ssh-keygen -t ed25519 -f %s", pubKeyPath, identityFile)
+			return nil, &PublicKeyNotFoundError{KeyPath: pubKeyPath, IdentityFile: identityFile}
 		}
 		return nil, fmt.Errorf("read public key: %w", err)
 	}
@@ -109,7 +109,7 @@ func agentPublicKey(ctx context.Context, authSock string) (_ string, err error) 
 // the agent client and the underlying connection. The caller must close conn.
 func dialAgent(ctx context.Context, authSock string) (agent.ExtendedAgent, net.Conn, error) {
 	if authSock == "" {
-		return nil, nil, fmt.Errorf("SSH_AUTH_SOCK not set")
+		return nil, nil, ErrAuthSockNotSet
 	}
 	var d net.Dialer
 	conn, err := d.DialContext(ctx, "unix", authSock)

--- a/internal/sandbox/ssh.go
+++ b/internal/sandbox/ssh.go
@@ -134,7 +134,7 @@ func dialSSH(ctx context.Context, session *Session) (*sshConn, error) {
 			_ = resp.Body.Close()
 		}
 		cleanup()
-		return nil, fmt.Errorf("WebSocket connect to %s: %w", wsURL, err)
+		return nil, fmt.Errorf("websocket connect to %s: %w", wsURL, err)
 	}
 
 	netConn := websocket.NetConn(ctx, wsConn, websocket.MessageBinary)
@@ -148,7 +148,7 @@ func dialSSH(ctx context.Context, session *Session) (*sshConn, error) {
 	if err != nil {
 		_ = netConn.Close()
 		cleanup()
-		return nil, fmt.Errorf("SSH handshake: %w", err)
+		return nil, fmt.Errorf("ssh handshake: %w", err)
 	}
 
 	return &sshConn{Client: ssh.NewClient(conn, chans, reqs), cleanup: cleanup}, nil
@@ -179,7 +179,7 @@ func ExecOverSSH(ctx context.Context, session *Session, command string, stdin io
 
 	sess, err := client.NewSession()
 	if err != nil {
-		return nil, fmt.Errorf("SSH session: %w", err)
+		return nil, fmt.Errorf("ssh session: %w", err)
 	}
 	defer func() { _ = sess.Close() }()
 
@@ -201,7 +201,7 @@ func ExecOverSSH(ctx context.Context, session *Session, command string, stdin io
 		if errors.As(err, &exitErr) {
 			exitCode = exitErr.ExitStatus()
 		} else {
-			return nil, fmt.Errorf("SSH exec: %w", err)
+			return nil, fmt.Errorf("ssh exec: %w", err)
 		}
 	}
 
@@ -225,7 +225,7 @@ func InteractiveShell(ctx context.Context, session *Session, envVars map[string]
 
 	sess, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("SSH session: %w", err)
+		return fmt.Errorf("ssh session: %w", err)
 	}
 	defer closer.ErrorHandler(sess, &err)
 

--- a/internal/sandbox/ssh_ws_test.go
+++ b/internal/sandbox/ssh_ws_test.go
@@ -73,8 +73,8 @@ func TestDialSSHWebSocketConnectionRefused(t *testing.T) {
 
 	_, err := sandbox.ExecOverSSH(context.Background(), session, "echo hi", nil, nil)
 	assert.Assert(t, err != nil)
-	assert.Assert(t, strings.Contains(err.Error(), "WebSocket connect"),
-		"expected WebSocket connect error, got: %v", err)
+	assert.Assert(t, strings.Contains(err.Error(), "websocket connect"),
+		"expected websocket connect error, got: %v", err)
 }
 
 // TestDialSSHWebSocketHostKeyMismatch verifies that a tampered known_hosts

--- a/internal/sandbox/sync.go
+++ b/internal/sandbox/sync.go
@@ -114,7 +114,7 @@ func Sync(ctx context.Context, client *circleci.Client, sandboxID, identityFile,
 
 	base, err := gitutil.MergeBase()
 	if err != nil {
-		return fmt.Errorf("could not resolve remote base: %w\nPush your branch or ensure the repository has a remote configured", err)
+		return &RemoteBaseError{Err: err}
 	}
 
 	patch, err := gitutil.GeneratePatch(base)

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -14,6 +14,9 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 )
 
+// ErrNotConfigured indicates no validate commands are configured.
+var ErrNotConfigured = errors.New("no validate commands configured")
+
 // shellEscape wraps arg in single quotes for safe use in a POSIX sh -c command.
 func shellEscape(arg string) string {
 	return "'" + strings.ReplaceAll(arg, "'", "'\\''") + "'"
@@ -107,7 +110,7 @@ func RunNamed(ctx context.Context, workDir, name string, force bool, cfg *config
 // RunAll runs all configured commands with optional cache bypass.
 func RunAll(ctx context.Context, workDir string, force bool, cfg *config.ProjectConfig, status iostream.StatusFunc, streams iostream.Streams) error {
 	if !cfg.HasCommands() {
-		return fmt.Errorf("no validate commands configured, run 'chunk init' first")
+		return ErrNotConfigured
 	}
 
 	for i, c := range cfg.Commands {
@@ -138,7 +141,7 @@ func RunAll(ctx context.Context, workDir string, force bool, cfg *config.Project
 // RunDryRun prints commands without executing them.
 func RunDryRun(cfg *config.ProjectConfig, name string, status iostream.StatusFunc) error {
 	if !cfg.HasCommands() {
-		return fmt.Errorf("no validate commands configured, run 'chunk init' first")
+		return ErrNotConfigured
 	}
 
 	commands := cfg.Commands


### PR DESCRIPTION
## Summary
- Move usererror to cmd package scope
- Replace usererr helpers with struct literals
- Replace human-facing error strings in internal packages with typed/sentinel errors
- Inline sentinel-only errors.go files into main package file
- Use `errors.AsType` (Go 1.26), lowercase internal error strings, remove product names
- Dedup error mappings: `notAuthorized`, `sshSessionError`, `mapValidateError` helpers, auth suggestion consts