### PR TITLE
fix(validate): --cmd runs on sandbox when --remote or --sandbox-id is set

### DIFF
--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -95,6 +95,14 @@ func newValidateCmd() *cobra.Command {
 					}
 					streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", cmdName)))
 				}
+				if remote {
+					if err := resolveSandboxID(&sandboxID); err != nil {
+						return err
+					}
+				}
+				if sandboxID != "" {
+					return runRemoteInlineValidate(cmd.Context(), sandboxID, identityFile, workdir, cmdName, inlineCmd, streams)
+				}
 				return validate.RunInline(cmd.Context(), workDir, cmdName, inlineCmd, forceRun, statusFn, streams)
 			}
 
@@ -202,4 +210,31 @@ func runRemoteValidate(ctx context.Context, sandboxID, identityFile, workdir str
 		}
 		return result.Stdout, result.Stderr, result.ExitCode, nil
 	}, cfg, dest, streams)
+}
+
+func runRemoteInlineValidate(ctx context.Context, sandboxID, identityFile, workdir, name, command string, streams iostream.Streams) error {
+	client, err := ensureCircleCIClient(ctx, streams, tui.PromptHidden)
+	if err != nil {
+		return err
+	}
+	authSock := os.Getenv("SSH_AUTH_SOCK")
+	session, err := sandbox.OpenSession(ctx, client, sandboxID, identityFile, authSock)
+	if err != nil {
+		return &userError{msg: "Could not open SSH session to sandbox.", err: err}
+	}
+	dest := workdir
+	if dest == "" {
+		if active, err := sandbox.LoadActive(); err == nil && active != nil && active.Workspace != "" {
+			dest = active.Workspace
+		} else {
+			dest = "./workspace"
+		}
+	}
+	return validate.RunRemoteInline(ctx, func(ctx context.Context, script string) (string, string, int, error) {
+		result, err := sandbox.ExecOverSSH(ctx, session, "sh -c "+sandbox.ShellEscape(script), nil, nil)
+		if err != nil {
+			return "", "", 0, err
+		}
+		return result.Stdout, result.Stderr, result.ExitCode, nil
+	}, name, command, dest, streams)
 }

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -177,6 +177,25 @@ func RunRemote(ctx context.Context, exec func(ctx context.Context, script string
 	return nil
 }
 
+// RunRemoteInline runs a single inline command on a remote sandbox via SSH.
+func RunRemoteInline(ctx context.Context, exec func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), name, command, dest string, streams iostream.Streams) error {
+	script := "cd " + shellEscape(dest) + " && " + command
+	stdout, stderr, exitCode, err := exec(ctx, script)
+	if err != nil {
+		return fmt.Errorf("remote %s: %w", name, err)
+	}
+	if stdout != "" {
+		_, _ = fmt.Fprint(streams.Out, stdout)
+	}
+	if stderr != "" {
+		_, _ = fmt.Fprint(streams.Err, stderr)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("remote %s failed with exit code %d", name, exitCode)
+	}
+	return nil
+}
+
 func runAndCache(ctx context.Context, workDir, name, command, fileExt string, timeoutSec int, status iostream.StatusFunc, streams iostream.Streams) error {
 	status(iostream.LevelInfo, fmt.Sprintf("Running %s: %s", name, command))
 

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -513,6 +513,42 @@ func TestRunRemoteSSH(t *testing.T) {
 	})
 }
 
+func TestRunRemoteInline(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var capturedScript string
+		execFn := func(_ context.Context, script string) (string, string, int, error) {
+			capturedScript = script
+			return "inline output\n", "", 0, nil
+		}
+		streams, out, _ := newStreams()
+
+		assert.NilError(t, RunRemoteInline(context.Background(), execFn, "custom", "echo hello", "/workspace/repo", streams))
+		assert.Assert(t, strings.Contains(out.String(), "inline output"), "got: %s", out.String())
+		assert.Assert(t, strings.HasPrefix(capturedScript, "cd '/workspace/repo' &&"), "got: %s", capturedScript)
+	})
+
+	t.Run("non-zero exit code", func(t *testing.T) {
+		execFn := func(_ context.Context, _ string) (string, string, int, error) {
+			return "", "", 1, nil
+		}
+		streams, _, _ := newStreams()
+
+		err := RunRemoteInline(context.Background(), execFn, "custom", "false", "/workspace", streams)
+		assert.ErrorContains(t, err, "remote custom failed")
+	})
+
+	t.Run("exec error", func(t *testing.T) {
+		execFn := func(_ context.Context, _ string) (string, string, int, error) {
+			return "", "", 0, fmt.Errorf("connection lost")
+		}
+		streams, _, _ := newStreams()
+
+		err := RunRemoteInline(context.Background(), execFn, "custom", "echo hi", "/workspace", streams)
+		assert.ErrorContains(t, err, "remote custom")
+		assert.ErrorContains(t, err, "connection lost")
+	})
+}
+
 func initGitRepo(t *testing.T, dir string) {
 	t.Helper()
 	for _, args := range [][]string{


### PR DESCRIPTION
## Summary

- `validate --cmd` was silently ignoring `--remote` and `--sandbox-id`, always running the inline command locally
- The inline-command path returned early before the sandbox check was reached
- Adds `RunRemoteInline` to the validate package and a `runRemoteInlineValidate` helper in the cmd layer, mirroring the existing `runRemoteValidate` pattern for config-based commands

## Test plan

- [ ] `RunRemoteInline` unit tests cover success, non-zero exit, and exec error cases
- [ ] `validate --cmd "uname -a" --remote` returns `linux/x86_64` (not `darwin/arm64`)
- [ ] `validate --cmd "..." --sandbox-id <id>` runs on the sandbox
- [ ] `validate --cmd "..."` without sandbox flags still runs locally
- [ ] All existing tests pass (`task test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)