### PR TITLE
Add RouteParams to httpcl, alias imports as hc

### DIFF
--- a/envbuilder/envbuilder.go
+++ b/envbuilder/envbuilder.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 )
 
 const (
@@ -146,7 +146,7 @@ var otpMajorInLineRe = regexp.MustCompile(`\b([2-9]\d)\b`)
 // be matched by versionTagRe.
 var cimgBaseDateTagRe = regexp.MustCompile(`^(\d{4})\.(\d{2})(?:\.(\d+))?$`)
 
-var dockerHubClient = httpcl.New(httpcl.Config{})
+var dockerHubClient = hc.New(hc.Config{})
 
 type dockerHubTagsResponse struct {
 	Results []struct {
@@ -158,7 +158,7 @@ type dockerHubTagsResponse struct {
 // fetchRawTags paginates the Docker Hub tag API for image and returns all tag
 // name strings up to a limit of 300. Official single-component image names
 // (e.g. "elixir") are automatically mapped to "library/elixir".
-func fetchRawTags(ctx context.Context, client *httpcl.Client, image string) ([]string, error) {
+func fetchRawTags(ctx context.Context, client *hc.Client, image string) ([]string, error) {
 	apiImage := image
 	if !strings.Contains(image, "/") {
 		apiImage = "library/" + image
@@ -172,7 +172,7 @@ func fetchRawTags(ctx context.Context, client *httpcl.Client, image string) ([]s
 	)
 	for route != "" && len(tags) < 300 {
 		var page dockerHubTagsResponse
-		if _, err := client.Call(ctx, httpcl.NewRequest("GET", route, httpcl.JSONDecoder(&page))); err != nil {
+		if _, err := client.Call(ctx, hc.NewRequest("GET", route, hc.JSONDecoder(&page))); err != nil {
 			return nil, fmt.Errorf("docker hub request failed: %w", err)
 		}
 		for _, tag := range page.Results {
@@ -183,7 +183,7 @@ func fetchRawTags(ctx context.Context, client *httpcl.Client, image string) ([]s
 	return tags, nil
 }
 
-func fetchAllImageVersions(ctx context.Context, client *httpcl.Client, image string) ([]string, error) {
+func fetchAllImageVersions(ctx context.Context, client *hc.Client, image string) ([]string, error) {
 	raw, err := fetchRawTags(ctx, client, image)
 	if err != nil {
 		return nil, err
@@ -203,7 +203,7 @@ func fetchAllImageVersions(ctx context.Context, client *httpcl.Client, image str
 	return allTags, nil
 }
 
-func fetchLatestImageVersion(ctx context.Context, client *httpcl.Client, image string) (string, error) {
+func fetchLatestImageVersion(ctx context.Context, client *hc.Client, image string) (string, error) {
 	allTags, err := fetchAllImageVersions(ctx, client, image)
 	if err != nil {
 		return "", err
@@ -211,7 +211,7 @@ func fetchLatestImageVersion(ctx context.Context, client *httpcl.Client, image s
 	return highestVersion(allTags), nil
 }
 
-func fetchLatestImageVersionWithConstraint(ctx context.Context, client *httpcl.Client, image string, maxMajor int) (string, error) {
+func fetchLatestImageVersionWithConstraint(ctx context.Context, client *hc.Client, image string, maxMajor int) (string, error) {
 	allTags, err := fetchAllImageVersions(ctx, client, image)
 	if err != nil {
 		return "", err
@@ -239,7 +239,7 @@ func fetchLatestImageVersionWithConstraint(ctx context.Context, client *httpcl.C
 // whose major.minor is no greater than maxMajor.maxMinor. This is used to cap
 // language runtimes at a known-compatible minor release (e.g. Python 3.13 when
 // a dependency like uvloop does not yet support 3.14+).
-func fetchLatestImageVersionWithMajorMinorConstraint(ctx context.Context, client *httpcl.Client, image string, maxMajor, maxMinor int) (string, error) {
+func fetchLatestImageVersionWithMajorMinorConstraint(ctx context.Context, client *hc.Client, image string, maxMajor, maxMinor int) (string, error) {
 	allTags, err := fetchAllImageVersions(ctx, client, image)
 	if err != nil {
 		return "", err
@@ -273,7 +273,7 @@ func fetchLatestImageVersionWithMajorMinorConstraint(ctx context.Context, client
 // behaviour that breaks test suites written against OTP 26.
 // Falls back to fetchLatestImageVersionWithMajorMinorConstraint when no matching
 // OTP-specific tag is found.
-func fetchElixirOTPImageVersion(ctx context.Context, client *httpcl.Client, image string, maxMajor, maxMinor, otpMajor int) (string, error) {
+func fetchElixirOTPImageVersion(ctx context.Context, client *hc.Client, image string, maxMajor, maxMinor, otpMajor int) (string, error) {
 	allTags, err := fetchRawTags(ctx, client, image)
 	if err != nil {
 		return "", err
@@ -318,7 +318,7 @@ func fetchElixirOTPImageVersion(ctx context.Context, client *httpcl.Client, imag
 
 // fetchLatestCimgBaseDateVersion fetches the most recent cimg/base tag, which
 // uses a "YYYY.MM" or "YYYY.MM.N" date format rather than semver.
-func fetchLatestCimgBaseDateVersion(ctx context.Context, client *httpcl.Client, image string) (string, error) {
+func fetchLatestCimgBaseDateVersion(ctx context.Context, client *hc.Client, image string) (string, error) {
 	raw, err := fetchRawTags(ctx, client, image)
 	if err != nil {
 		return "", err
@@ -2323,7 +2323,7 @@ func detectHaskellGHCVersionFromCI(dir string) (major, minor int) {
 }
 
 // detectImageVersion fetches the appropriate CircleCI image version for the detected stack.
-func detectImageVersion(ctx context.Context, client *httpcl.Client, dir, stack, image, install string) (string, error) {
+func detectImageVersion(ctx context.Context, client *hc.Client, dir, stack, image, install string) (string, error) {
 	switch stack {
 	case stackGo:
 		// Cap to the major.minor declared in go.mod. Go 1.23 is used as a floor

--- a/envbuilder/envbuilder_test.go
+++ b/envbuilder/envbuilder_test.go
@@ -12,7 +12,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 )
 
 // --- pure function tests ---
@@ -837,10 +837,10 @@ func (f *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return rr.Result(), nil
 }
 
-// newFakeDockerHubClient returns a *httpcl.Client whose HTTP calls are handled
+// newFakeDockerHubClient returns a *hc.Client whose HTTP calls are handled
 // by the provided handler instead of hitting the real Docker Hub.
-func newFakeDockerHubClient(handler http.Handler) *httpcl.Client {
-	return httpcl.New(httpcl.Config{Transport: &fakeTransport{handler: handler}})
+func newFakeDockerHubClient(handler http.Handler) *hc.Client {
+	return hc.New(hc.Config{Transport: &fakeTransport{handler: handler}})
 }
 
 func TestFetchAllImageVersions(t *testing.T) {

--- a/internal/anthropic/client.go
+++ b/internal/anthropic/client.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 )
 
 var (
@@ -18,14 +18,6 @@ var (
 	// ErrTokenLimit indicates the prompt exceeds the model's context window.
 	ErrTokenLimit = errors.New("prompt exceeds context window")
 )
-
-func isTokenLimitErr(err error) bool {
-	var he *httpcl.HTTPError
-	if !errors.As(err, &he) {
-		return false
-	}
-	return strings.Contains(string(he.Body), "prompt is too long")
-}
 
 // StatusError represents an HTTP error from the Anthropic API without exposing httpcl internals.
 type StatusError struct {
@@ -37,14 +29,6 @@ func (e *StatusError) Error() string {
 	return fmt.Sprintf("%s: %d %s", e.Op, e.StatusCode, http.StatusText(e.StatusCode))
 }
 
-func mapErr(op string, err error) error {
-	var he *httpcl.HTTPError
-	if !errors.As(err, &he) {
-		return fmt.Errorf("%s: %w", op, err)
-	}
-	return &StatusError{Op: op, StatusCode: he.StatusCode}
-}
-
 type Config struct {
 	APIKey  string
 	BaseURL string
@@ -52,14 +36,14 @@ type Config struct {
 
 // Client is an Anthropic Messages API client.
 type Client struct {
-	http *httpcl.Client
+	http *hc.Client
 }
 
 func New(cfg Config) (*Client, error) {
 	if cfg.APIKey == "" {
 		return nil, ErrKeyNotFound
 	}
-	c := httpcl.New(httpcl.Config{
+	c := hc.New(hc.Config{
 		BaseURL:        cfg.BaseURL,
 		AuthToken:      cfg.APIKey,
 		AuthHeader:     "x-api-key",
@@ -105,10 +89,10 @@ func (c *Client) Ask(ctx context.Context, model string, maxTokens int, prompt st
 	if len(system) > 0 {
 		body.System = system[0]
 	}
-	req := httpcl.NewRequest("POST", "/v1/messages",
-		httpcl.Body(body),
-		httpcl.Header("anthropic-version", "2023-06-01"),
-		httpcl.JSONDecoder(&resp),
+	req := hc.NewRequest("POST", "/v1/messages",
+		hc.Body(body),
+		hc.Header("anthropic-version", "2023-06-01"),
+		hc.JSONDecoder(&resp),
 	)
 
 	_, err := c.http.Call(ctx, req)
@@ -125,4 +109,20 @@ func (c *Client) Ask(ctx context.Context, model string, maxTokens int, prompt st
 		}
 	}
 	return "", fmt.Errorf("no text content in Anthropic response")
+}
+
+func isTokenLimitErr(err error) bool {
+	var he *hc.HTTPError
+	if !errors.As(err, &he) {
+		return false
+	}
+	return strings.Contains(string(he.Body), "prompt is too long")
+}
+
+func mapErr(op string, err error) error {
+	var he *hc.HTTPError
+	if !errors.As(err, &he) {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return &StatusError{Op: op, StatusCode: he.StatusCode}
 }

--- a/internal/authprompt/authprompt.go
+++ b/internal/authprompt/authprompt.go
@@ -10,7 +10,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/github"
-	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 )
 
 // ErrNeedsAuth is returned by Resolve* functions when no credentials are
@@ -24,14 +24,14 @@ func ValidateCircleCIToken(ctx context.Context, token, baseURL string) error {
 	if baseURL == "" {
 		baseURL = "https://circleci.com"
 	}
-	cl := httpcl.New(httpcl.Config{
+	cl := hc.New(hc.Config{
 		BaseURL:    baseURL,
 		AuthToken:  token,
 		AuthHeader: "Circle-Token",
 	})
-	_, err := cl.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v2/me"))
+	_, err := cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v2/me"))
 	if err != nil {
-		if httpcl.HasStatusCode(err, http.StatusTooManyRequests) {
+		if hc.HasStatusCode(err, http.StatusTooManyRequests) {
 			return nil
 		}
 		return err
@@ -45,7 +45,7 @@ func ValidateAPIKey(ctx context.Context, apiKey, baseURL string) error {
 	if baseURL == "" {
 		baseURL = "https://api.anthropic.com"
 	}
-	cl := httpcl.New(httpcl.Config{
+	cl := hc.New(hc.Config{
 		BaseURL:    baseURL,
 		AuthToken:  apiKey,
 		AuthHeader: "x-api-key",
@@ -61,12 +61,12 @@ func ValidateAPIKey(ctx context.Context, apiKey, baseURL string) error {
 		Model:    config.ValidationModel,
 		Messages: []msg{{Role: "user", Content: "auth test"}},
 	}
-	_, err := cl.Call(ctx, httpcl.NewRequest(http.MethodPost, "/v1/messages/count_tokens",
-		httpcl.Body(body),
-		httpcl.Header("anthropic-version", "2023-06-01"),
+	_, err := cl.Call(ctx, hc.NewRequest(http.MethodPost, "/v1/messages/count_tokens",
+		hc.Body(body),
+		hc.Header("anthropic-version", "2023-06-01"),
 	))
 	if err != nil {
-		if httpcl.HasStatusCode(err, http.StatusTooManyRequests) {
+		if hc.HasStatusCode(err, http.StatusTooManyRequests) {
 			return nil
 		}
 		return err
@@ -156,15 +156,15 @@ func ValidateGitHubToken(ctx context.Context, token, baseURL string) error {
 	if baseURL == "" {
 		baseURL = "https://api.github.com"
 	}
-	cl := httpcl.New(httpcl.Config{
+	cl := hc.New(hc.Config{
 		BaseURL:    baseURL,
 		AuthToken:  "token " + token,
 		AuthHeader: "Authorization",
 		UserAgent:  "chunk-cli",
 	})
-	_, err := cl.Call(ctx, httpcl.NewRequest(http.MethodGet, "/user"))
+	_, err := cl.Call(ctx, hc.NewRequest(http.MethodGet, "/user"))
 	if err != nil {
-		if httpcl.HasStatusCode(err, http.StatusTooManyRequests) {
+		if hc.HasStatusCode(err, http.StatusTooManyRequests) {
 			return nil
 		}
 		return err

--- a/internal/circleci/circleci_test.go
+++ b/internal/circleci/circleci_test.go
@@ -7,14 +7,14 @@ import (
 
 	"gotest.tools/v3/assert"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 )
 
 // newTestClient creates a Client pointed at the given test server.
 func newTestClient(t *testing.T, url string) *Client {
 	t.Helper()
-	cl := httpcl.New(httpcl.Config{
+	cl := hc.New(hc.Config{
 		BaseURL:    url,
 		AuthToken:  "test-token",
 		AuthHeader: "Circle-Token",
@@ -309,7 +309,7 @@ func TestAuthRequired(t *testing.T) {
 	defer srv.Close()
 
 	// Create a client with no auth token to trigger 401.
-	cl := httpcl.New(httpcl.Config{
+	cl := hc.New(hc.Config{
 		BaseURL: srv.URL,
 	})
 	client := &Client{cl: cl}

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 )
 
 // ErrTokenNotFound indicates no CircleCI token was found in env or config.
@@ -25,31 +25,20 @@ func (e *StatusError) Error() string {
 	return fmt.Sprintf("%s: %d %s", e.Op, e.StatusCode, http.StatusText(e.StatusCode))
 }
 
-func mapErr(op string, err error) error {
-	var he *httpcl.HTTPError
-	if !errors.As(err, &he) {
-		return fmt.Errorf("%s: %w", op, err)
-	}
-	if he.StatusCode == http.StatusUnauthorized || he.StatusCode == http.StatusForbidden {
-		return fmt.Errorf("%s: %w", op, ErrNotAuthorized)
-	}
-	return &StatusError{Op: op, StatusCode: he.StatusCode}
-}
-
 type Config struct {
 	Token   string
 	BaseURL string
 }
 
 type Client struct {
-	cl *httpcl.Client
+	cl *hc.Client
 }
 
 func NewClient(cfg Config) (*Client, error) {
 	if cfg.Token == "" {
 		return nil, ErrTokenNotFound
 	}
-	cl := httpcl.New(httpcl.Config{
+	cl := hc.New(hc.Config{
 		BaseURL:    cfg.BaseURL,
 		AuthToken:  cfg.Token,
 		AuthHeader: "Circle-Token",
@@ -59,7 +48,7 @@ func NewClient(cfg Config) (*Client, error) {
 
 // GetCurrentUser calls GET /api/v2/me to validate the token.
 func (c *Client) GetCurrentUser(ctx context.Context) error {
-	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v2/me"))
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v2/me"))
 	if err != nil {
 		return mapErr("get current user", err)
 	}
@@ -68,9 +57,9 @@ func (c *Client) GetCurrentUser(ctx context.Context) error {
 
 func (c *Client) ListSandboxes(ctx context.Context, orgID string) ([]Sandbox, error) {
 	var resp listSandboxesResponse
-	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v2/sandbox/instances",
-		httpcl.QueryParam("org_id", orgID),
-		httpcl.JSONDecoder(&resp),
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v2/sandbox/instances",
+		hc.QueryParam("org_id", orgID),
+		hc.JSONDecoder(&resp),
 	))
 	if err != nil {
 		return nil, mapErr("list sandboxes", err)
@@ -86,9 +75,9 @@ func (c *Client) CreateSandbox(ctx context.Context, orgID, name, provider, image
 		Image:    image,
 	}
 	var resp Sandbox
-	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodPost, "/api/v2/sandbox/instances",
-		httpcl.Body(body),
-		httpcl.JSONDecoder(&resp),
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodPost, "/api/v2/sandbox/instances",
+		hc.Body(body),
+		hc.JSONDecoder(&resp),
 	))
 	if err != nil {
 		return nil, mapErr("create sandbox", err)
@@ -98,10 +87,10 @@ func (c *Client) CreateSandbox(ctx context.Context, orgID, name, provider, image
 
 func (c *Client) AddSSHKey(ctx context.Context, sandboxID, publicKey string) (*AddSSHKeyResponse, error) {
 	var resp AddSSHKeyResponse
-	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodPost,
-		fmt.Sprintf("/api/v2/sandbox/instances/%s/ssh/add-key", sandboxID),
-		httpcl.Body(AddSSHKeyRequest{PublicKey: publicKey}),
-		httpcl.JSONDecoder(&resp),
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodPost, "/api/v2/sandbox/instances/%s/ssh/add-key",
+		hc.RouteParams(sandboxID),
+		hc.Body(AddSSHKeyRequest{PublicKey: publicKey}),
+		hc.JSONDecoder(&resp),
 	))
 	if err != nil {
 		return nil, mapErr("add ssh key", err)
@@ -111,13 +100,13 @@ func (c *Client) AddSSHKey(ctx context.Context, sandboxID, publicKey string) (*A
 
 func (c *Client) Exec(ctx context.Context, sandboxID, command string, args []string) (*ExecResponse, error) {
 	var resp ExecResponse
-	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodPost,
-		fmt.Sprintf("/api/v2/sandbox/instances/%s/exec", sandboxID),
-		httpcl.Body(ExecRequest{
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodPost, "/api/v2/sandbox/instances/%s/exec",
+		hc.RouteParams(sandboxID),
+		hc.Body(ExecRequest{
 			Command: command,
 			Args:    args,
 		}),
-		httpcl.JSONDecoder(&resp),
+		hc.JSONDecoder(&resp),
 	))
 	if err != nil {
 		return nil, mapErr("exec", err)
@@ -127,9 +116,9 @@ func (c *Client) Exec(ctx context.Context, sandboxID, command string, args []str
 
 func (c *Client) CreateSnapshot(ctx context.Context, sandboxID, name string) (*Snapshot, error) {
 	var resp Snapshot
-	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodPost, "/api/v2/sandbox/snapshots",
-		httpcl.Body(CreateSnapshotRequest{SandboxID: sandboxID, Name: name}),
-		httpcl.JSONDecoder(&resp),
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodPost, "/api/v2/sandbox/snapshots",
+		hc.Body(CreateSnapshotRequest{SandboxID: sandboxID, Name: name}),
+		hc.JSONDecoder(&resp),
 	))
 	if err != nil {
 		return nil, mapErr("create snapshot", err)
@@ -139,9 +128,9 @@ func (c *Client) CreateSnapshot(ctx context.Context, sandboxID, name string) (*S
 
 func (c *Client) GetSnapshot(ctx context.Context, id string) (*Snapshot, error) {
 	var resp Snapshot
-	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodGet,
-		fmt.Sprintf("/api/v2/sandbox/snapshots/%s", id),
-		httpcl.JSONDecoder(&resp),
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v2/sandbox/snapshots/%s",
+		hc.RouteParams(id),
+		hc.JSONDecoder(&resp),
 	))
 	if err != nil {
 		return nil, mapErr("get snapshot", err)
@@ -151,13 +140,24 @@ func (c *Client) GetSnapshot(ctx context.Context, id string) (*Snapshot, error) 
 
 func (c *Client) TriggerRun(ctx context.Context, orgID, projectID string, body TriggerRunRequest) (*RunResponse, error) {
 	var resp RunResponse
-	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodPost,
-		fmt.Sprintf("/api/v2/agents/org/%s/project/%s/runs", orgID, projectID),
-		httpcl.Body(body),
-		httpcl.JSONDecoder(&resp),
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodPost, "/api/v2/agents/org/%s/project/%s/runs",
+		hc.RouteParams(orgID, projectID),
+		hc.Body(body),
+		hc.JSONDecoder(&resp),
 	))
 	if err != nil {
 		return nil, mapErr("trigger run", err)
 	}
 	return &resp, nil
+}
+
+func mapErr(op string, err error) error {
+	var he *hc.HTTPError
+	if !errors.As(err, &he) {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	if he.StatusCode == http.StatusUnauthorized || he.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("%s: %w", op, ErrNotAuthorized)
+	}
+	return &StatusError{Op: op, StatusCode: he.StatusCode}
 }

--- a/internal/circleci/projects.go
+++ b/internal/circleci/projects.go
@@ -2,10 +2,9 @@ package circleci
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 )
 
 // FollowedProject represents a project returned by the v1.1 API.
@@ -35,8 +34,8 @@ type ProjectDetail struct {
 // ListFollowedProjects returns projects the user follows.
 func (c *Client) ListFollowedProjects(ctx context.Context) ([]FollowedProject, error) {
 	var resp []FollowedProject
-	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v1.1/projects",
-		httpcl.JSONDecoder(&resp),
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v1.1/projects",
+		hc.JSONDecoder(&resp),
 	))
 	if err != nil {
 		return nil, mapErr("list followed projects", err)
@@ -47,8 +46,8 @@ func (c *Client) ListFollowedProjects(ctx context.Context) ([]FollowedProject, e
 // ListCollaborations returns organizations the user belongs to.
 func (c *Client) ListCollaborations(ctx context.Context) ([]Collaboration, error) {
 	var resp []Collaboration
-	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodGet, "/api/v2/me/collaborations",
-		httpcl.JSONDecoder(&resp),
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v2/me/collaborations",
+		hc.JSONDecoder(&resp),
 	))
 	if err != nil {
 		return nil, mapErr("list collaborations", err)
@@ -59,9 +58,9 @@ func (c *Client) ListCollaborations(ctx context.Context) ([]Collaboration, error
 // GetProjectBySlug fetches project details by slug (e.g. "gh/org/repo").
 func (c *Client) GetProjectBySlug(ctx context.Context, slug string) (*ProjectDetail, error) {
 	var resp ProjectDetail
-	_, err := c.cl.Call(ctx, httpcl.NewRequest(http.MethodGet,
-		fmt.Sprintf("/api/v2/project/%s", slug),
-		httpcl.JSONDecoder(&resp),
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v2/project/%s",
+		hc.RouteParams(slug),
+		hc.JSONDecoder(&resp),
 	))
 	if err != nil {
 		return nil, mapErr("get project by slug", err)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 )
 
 type Config struct {
@@ -18,7 +18,7 @@ type Config struct {
 
 // Client is a GitHub GraphQL API client.
 type Client struct {
-	http *httpcl.Client
+	http *hc.Client
 
 	// retryDelayOverride, if non-zero, replaces the exponential backoff
 	// delay in doWithRetry. Intended for tests only.
@@ -34,7 +34,7 @@ func New(cfg Config) (*Client, error) {
 	if cfg.Token == "" {
 		return nil, ErrTokenNotFound
 	}
-	c := httpcl.New(httpcl.Config{
+	c := hc.New(hc.Config{
 		BaseURL:    cfg.BaseURL,
 		AuthToken:  "token " + cfg.Token,
 		AuthHeader: "Authorization",
@@ -60,28 +60,6 @@ func (e *StatusError) Error() string {
 		return fmt.Sprintf("%s: %d %s", e.Op, e.StatusCode, http.StatusText(e.StatusCode))
 	}
 	return fmt.Sprintf("%d %s", e.StatusCode, http.StatusText(e.StatusCode))
-}
-
-func mapErr(op string, err error) error {
-	var he *httpcl.HTTPError
-	if !errors.As(err, &he) {
-		if op == "" {
-			return err
-		}
-		return fmt.Errorf("%s: %w", op, err)
-	}
-	return &StatusError{Op: op, StatusCode: he.StatusCode}
-}
-
-// do executes a GraphQL query and decodes the response into dest.
-func (c *Client) do(ctx context.Context, query string, vars map[string]any, dest any) error {
-	req := httpcl.NewRequest("POST", "/graphql",
-		httpcl.Body(graphQLRequest{Query: query, Variables: vars}),
-		httpcl.JSONDecoder(dest),
-	)
-
-	_, err := c.http.Call(ctx, req)
-	return err
 }
 
 // ValidateOrg checks that the org is accessible.
@@ -111,4 +89,25 @@ func (c *Client) CheckRateLimit(ctx context.Context) error {
 		return mapErr("check rate limit", err)
 	}
 	return nil
+}
+
+func (c *Client) do(ctx context.Context, query string, vars map[string]any, dest any) error {
+	req := hc.NewRequest("POST", "/graphql",
+		hc.Body(graphQLRequest{Query: query, Variables: vars}),
+		hc.JSONDecoder(dest),
+	)
+
+	_, err := c.http.Call(ctx, req)
+	return err
+}
+
+func mapErr(op string, err error) error {
+	var he *hc.HTTPError
+	if !errors.As(err, &he) {
+		if op == "" {
+			return err
+		}
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return &StatusError{Op: op, StatusCode: he.StatusCode}
 }

--- a/internal/github/retry.go
+++ b/internal/github/retry.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 )
 
 const (
@@ -32,7 +32,7 @@ func isRetryable(err error) bool {
 	}
 
 	// HTTP 5xx errors
-	var httpErr *httpcl.HTTPError
+	var httpErr *hc.HTTPError
 	if errors.As(err, &httpErr) && httpErr.StatusCode >= 500 {
 		return true
 	}

--- a/internal/github/retry_test.go
+++ b/internal/github/retry_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 )
 
 func TestIsRetryable(t *testing.T) {
@@ -26,10 +26,10 @@ func TestIsRetryable(t *testing.T) {
 		{"wrapped deadline", fmt.Errorf("fetch: %w", context.DeadlineExceeded), true},
 		{"html error", fmt.Errorf("<!DOCTYPE html>"), true},
 		{"unicorn error", fmt.Errorf("Unicorn! GitHub is down"), true},
-		{"http 500", &httpcl.HTTPError{StatusCode: 500}, true},
-		{"http 503", &httpcl.HTTPError{StatusCode: 503}, true},
-		{"http 400", &httpcl.HTTPError{StatusCode: 400}, false},
-		{"http 401", &httpcl.HTTPError{StatusCode: 401}, false},
+		{"http 500", &hc.HTTPError{StatusCode: 500}, true},
+		{"http 503", &hc.HTTPError{StatusCode: 503}, true},
+		{"http 400", &hc.HTTPError{StatusCode: 400}, false},
+		{"http 401", &hc.HTTPError{StatusCode: 401}, false},
 		{"json decode html", fmt.Errorf("httpcl: decode response: invalid character '<' looking for beginning of value"), true},
 	}
 

--- a/internal/httpcl/client.go
+++ b/internal/httpcl/client.go
@@ -82,7 +82,7 @@ func New(cfg Config) *Client {
 // Non-2xx responses return an *HTTPError. If a decoder is set and the
 // response is 2xx, the response body is decoded.
 func (c *Client) Call(ctx context.Context, r Request) (int, error) {
-	u, err := url.Parse(c.baseURL + r.route)
+	u, err := url.Parse(c.baseURL + r.URL())
 	if err != nil {
 		return 0, fmt.Errorf("httpcl: bad url: %w", err)
 	}

--- a/internal/httpcl/client_test.go
+++ b/internal/httpcl/client_test.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 )
 
 func TestCallJSONRoundTrip(t *testing.T) {
@@ -37,15 +37,15 @@ func TestCallJSONRoundTrip(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := httpcl.New(httpcl.Config{
+	c := hc.New(hc.Config{
 		BaseURL:   srv.URL,
 		AuthToken: "test-token",
 	})
 
 	var resp respBody
-	status, err := c.Call(context.Background(), httpcl.NewRequest("POST", "/test",
-		httpcl.Body(reqBody{Name: "world"}),
-		httpcl.JSONDecoder(&resp),
+	status, err := c.Call(context.Background(), hc.NewRequest("POST", "/test",
+		hc.Body(reqBody{Name: "world"}),
+		hc.JSONDecoder(&resp),
 	))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -65,13 +65,13 @@ func TestCallHTTPError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := httpcl.New(httpcl.Config{BaseURL: srv.URL})
+	c := hc.New(hc.Config{BaseURL: srv.URL})
 
-	status, err := c.Call(context.Background(), httpcl.NewRequest("GET", "/missing"))
+	status, err := c.Call(context.Background(), hc.NewRequest("GET", "/missing"))
 	if status != 404 {
 		t.Fatalf("expected 404, got %d", status)
 	}
-	if !httpcl.HasStatusCode(err, http.StatusNotFound) {
+	if !hc.HasStatusCode(err, http.StatusNotFound) {
 		t.Fatalf("expected HTTPError with 404, got %v", err)
 	}
 }
@@ -85,12 +85,12 @@ func TestDisableRetries(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := httpcl.New(httpcl.Config{
+	c := hc.New(hc.Config{
 		BaseURL:        srv.URL,
 		DisableRetries: true,
 	})
 
-	_, err := c.Call(context.Background(), httpcl.NewRequest("GET", "/"))
+	_, err := c.Call(context.Background(), hc.NewRequest("GET", "/"))
 	if err == nil {
 		t.Fatal("expected error for 503 response")
 	}
@@ -108,13 +108,59 @@ func TestCallCustomAuthHeader(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := httpcl.New(httpcl.Config{
+	c := hc.New(hc.Config{
 		BaseURL:    srv.URL,
 		AuthToken:  "my-key",
 		AuthHeader: "x-api-key",
 	})
 
-	status, err := c.Call(context.Background(), httpcl.NewRequest("GET", "/"))
+	status, err := c.Call(context.Background(), hc.NewRequest("GET", "/"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("expected 200, got %d", status)
+	}
+}
+
+func TestRouteParams(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/sandbox/instances/sb-42/exec" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := hc.New(hc.Config{BaseURL: srv.URL, DisableRetries: true})
+
+	status, err := c.Call(context.Background(), hc.NewRequest("GET",
+		"/api/v2/sandbox/instances/%s/exec",
+		hc.RouteParams("sb-42"),
+	))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("expected 200, got %d", status)
+	}
+}
+
+func TestRouteParamsMultiple(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/agents/org/org-1/project/proj-2/runs" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := hc.New(hc.Config{BaseURL: srv.URL, DisableRetries: true})
+
+	status, err := c.Call(context.Background(), hc.NewRequest("POST",
+		"/api/v2/agents/org/%s/project/%s/runs",
+		hc.RouteParams("org-1", "proj-2"),
+	))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/httpcl/request.go
+++ b/internal/httpcl/request.go
@@ -2,6 +2,7 @@ package httpcl
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -12,10 +13,19 @@ import (
 type Request struct {
 	method  string
 	route   string
+	url     string
 	body    any
 	decoder func(io.Reader) error
 	headers http.Header
 	query   url.Values
+}
+
+// URL returns the resolved URL (after RouteParams) or the raw route.
+func (r Request) URL() string {
+	if r.url != "" {
+		return r.url
+	}
+	return r.route
 }
 
 // NewRequest creates a request with functional options.
@@ -54,4 +64,11 @@ func Header(key, val string) func(*Request) {
 // QueryParam sets a single query parameter.
 func QueryParam(key, val string) func(*Request) {
 	return func(r *Request) { r.query.Set(key, val) }
+}
+
+// RouteParams fills route template placeholders (%s, %d, etc.) with the given values.
+func RouteParams(params ...any) func(*Request) {
+	return func(r *Request) {
+		r.url = fmt.Sprintf(r.route, params...)
+	}
 }


### PR DESCRIPTION
## Summary
- Add `RouteParams` functional option to `httpcl.Request` for filling route template placeholders, matching the backplane-go pattern
- Replace all `fmt.Sprintf` URL constructions at call sites with `RouteParams`
- Alias all `httpcl` imports as `hc` across the codebase