### PR TITLE
Use go-envconfig to load all env vars

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/coder/websocket v1.8.14
 	github.com/gin-gonic/gin v1.12.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
+	github.com/sethvargo/go-envconfig v1.3.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/crypto v0.50.0
 	golang.org/x/term v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -601,6 +601,8 @@ github.com/securego/gosec/v2 v2.24.8-0.20260309165252-619ce2117e08 h1:AoLtJX4WUt
 github.com/securego/gosec/v2 v2.24.8-0.20260309165252-619ce2117e08/go.mod h1:+XLCJiRE95ga77XInNELh2M6zQP+PdqiT9Zpm0D9Wpk=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/sethvargo/go-envconfig v1.3.0 h1:gJs+Fuv8+f05omTpwWIu6KmuseFAXKrIaOZSh8RMt0U=
+github.com/sethvargo/go-envconfig v1.3.0/go.mod h1:JLd0KFWQYzyENqnEPWWZ49i4vzZo/6nRidxI8YvGiHw=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,12 +1,15 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"strings"
+
+	"github.com/sethvargo/go-envconfig"
 )
 
 // Model constants define the Claude models used for different operations.
@@ -48,6 +51,38 @@ const (
 	EnvXDGStateHome  = "XDG_STATE_HOME"
 	EnvClaudeSession = "CLAUDE_SESSION_ID"
 )
+
+// EnvVars holds all environment variables the application reads.
+//
+//nolint:gosec // env var names, not credentials
+type EnvVars struct {
+	CircleToken      string `env:"CIRCLE_TOKEN"`
+	CircleCIToken    string `env:"CIRCLECI_TOKEN"`
+	CircleCIBaseURL  string `env:"CIRCLECI_BASE_URL,default=https://circleci.com"`
+	AnthropicAPIKey  string `env:"ANTHROPIC_API_KEY"`
+	AnthropicBaseURL string `env:"ANTHROPIC_BASE_URL,default=https://api.anthropic.com"`
+	GitHubToken      string `env:"GITHUB_TOKEN"`
+	GitHubAPIURL     string `env:"GITHUB_API_URL,default=https://api.github.com"`
+	Model            string `env:"CODE_REVIEW_CLI_MODEL"`
+	CircleCIOrgID    string `env:"CIRCLECI_ORG_ID"`
+	SandboxProvider  string `env:"CHUNK_SANDBOX_PROVIDER"`
+	Home             string `env:"HOME"`
+	Shell            string `env:"SHELL"`
+	SSHAuthSock      string `env:"SSH_AUTH_SOCK"`
+	NoColor          string `env:"NO_COLOR"`
+	XDGConfigHome    string `env:"XDG_CONFIG_HOME"`
+	XDGStateHome     string `env:"XDG_STATE_HOME"`
+	ClaudeSession    string `env:"CLAUDE_SESSION_ID"`
+}
+
+// LoadEnv populates an EnvVars struct from the process environment.
+func LoadEnv(ctx context.Context) (EnvVars, error) {
+	var env EnvVars
+	if err := envconfig.Process(ctx, &env); err != nil {
+		return EnvVars{}, fmt.Errorf("load environment: %w", err)
+	}
+	return env, nil
+}
 
 // UserConfig is the on-disk JSON config.
 type UserConfig struct {
@@ -148,17 +183,22 @@ func Clear(key string) error {
 func Resolve(flagAPIKey, flagModel string) (ResolvedConfig, error) {
 	cfg, err := Load()
 
+	env, envErr := LoadEnv(context.Background())
+	if envErr != nil {
+		return ResolvedConfig{}, envErr
+	}
+
 	rc := ResolvedConfig{
 		AnalyzeModel: AnalyzeModel,
 		PromptModel:  PromptModel,
 	}
 
 	switch {
-	case os.Getenv(EnvCircleToken) != "":
-		rc.CircleCIToken = os.Getenv(EnvCircleToken)
+	case env.CircleToken != "":
+		rc.CircleCIToken = env.CircleToken
 		rc.CircleCITokenSource = "Environment variable (" + EnvCircleToken + ")"
-	case os.Getenv(EnvCircleCIToken) != "":
-		rc.CircleCIToken = os.Getenv(EnvCircleCIToken)
+	case env.CircleCIToken != "":
+		rc.CircleCIToken = env.CircleCIToken
 		rc.CircleCITokenSource = "Environment variable (" + EnvCircleCIToken + ")"
 	case cfg.CircleCIToken != "":
 		rc.CircleCIToken = cfg.CircleCIToken
@@ -169,8 +209,8 @@ func Resolve(flagAPIKey, flagModel string) (ResolvedConfig, error) {
 	case flagAPIKey != "":
 		rc.AnthropicAPIKey = flagAPIKey
 		rc.AnthropicAPIKeySource = "Flag"
-	case os.Getenv(EnvAnthropicAPIKey) != "":
-		rc.AnthropicAPIKey = os.Getenv(EnvAnthropicAPIKey)
+	case env.AnthropicAPIKey != "":
+		rc.AnthropicAPIKey = env.AnthropicAPIKey
 		rc.AnthropicAPIKeySource = "Environment variable"
 	case cfg.AnthropicAPIKey != "":
 		rc.AnthropicAPIKey = cfg.AnthropicAPIKey
@@ -178,8 +218,8 @@ func Resolve(flagAPIKey, flagModel string) (ResolvedConfig, error) {
 	}
 
 	switch {
-	case os.Getenv(EnvGitHubToken) != "":
-		rc.GitHubToken = os.Getenv(EnvGitHubToken)
+	case env.GitHubToken != "":
+		rc.GitHubToken = env.GitHubToken
 		rc.GitHubTokenSource = "Environment variable (" + EnvGitHubToken + ")"
 	case cfg.GitHubToken != "":
 		rc.GitHubToken = cfg.GitHubToken
@@ -190,8 +230,8 @@ func Resolve(flagAPIKey, flagModel string) (ResolvedConfig, error) {
 	case flagModel != "":
 		rc.Model = flagModel
 		rc.ModelSource = "Flag"
-	case os.Getenv(EnvModel) != "":
-		rc.Model = os.Getenv(EnvModel)
+	case env.Model != "":
+		rc.Model = env.Model
 		rc.ModelSource = "Environment variable"
 	case cfg.Model != "":
 		rc.Model = cfg.Model
@@ -201,18 +241,9 @@ func Resolve(flagAPIKey, flagModel string) (ResolvedConfig, error) {
 		rc.ModelSource = "Default"
 	}
 
-	rc.CircleCIBaseURL = os.Getenv(EnvCircleCIBaseURL)
-	if rc.CircleCIBaseURL == "" {
-		rc.CircleCIBaseURL = "https://circleci.com"
-	}
-	rc.AnthropicBaseURL = os.Getenv(EnvAnthropicBaseURL)
-	if rc.AnthropicBaseURL == "" {
-		rc.AnthropicBaseURL = "https://api.anthropic.com"
-	}
-	rc.GitHubAPIURL = os.Getenv(EnvGitHubAPIURL)
-	if rc.GitHubAPIURL == "" {
-		rc.GitHubAPIURL = "https://api.github.com"
-	}
+	rc.CircleCIBaseURL = env.CircleCIBaseURL
+	rc.AnthropicBaseURL = env.AnthropicBaseURL
+	rc.GitHubAPIURL = env.GitHubAPIURL
 
 	return rc, err
 }


### PR DESCRIPTION
## Summary
- Centralise env vars into config constants
- Add `EnvVars` struct with `sethvargo/go-envconfig` tags covering all 17 env vars
- Add `LoadEnv(ctx)` to populate the struct from the process environment
- `Resolve()` uses `LoadEnv` instead of scattered `os.Getenv` calls; base URL defaults move to struct tags
- Constants kept for user-facing messages