### PR TITLE
[FACT-110] Sandbox set up in chunk cli

### DIFF
--- a/envbuilder/envbuilder.go
+++ b/envbuilder/envbuilder.go
@@ -49,6 +49,19 @@ type Environment struct {
 	ImageVersion string   `json:"image_version"`
 }
 
+// BinaryPaths returns colon-separated PATH prefixes needed for the detected stack.
+// cimg images set these via Docker ENV which e2b does not propagate to SSH sessions.
+func (e *Environment) BinaryPaths() string {
+	switch e.Stack {
+	case stackGo:
+		return "/usr/local/go/bin:/home/circleci/go/bin"
+	case stackJavaScript, stackTypeScript:
+		return "/home/circleci/.yarn/bin"
+	default:
+		return ""
+	}
+}
+
 func fileExists(dir, name string) bool {
 	_, err := os.Stat(filepath.Join(dir, name))
 	return err == nil

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -714,145 +714,35 @@ Example:
 			// Step 2: Resolve or create sidecar.
 			var scDisplayName string
 			if sidecarID == "" {
-				active, err := sidecar.LoadActive()
-				if err != nil {
-					return &userError{msg: "Could not load the active sidecar.", suggestion: configFilePermHint, err: err}
-				}
-				if active != nil {
-					sidecarID = active.SidecarID
-					scDisplayName = active.Name
-					status(iostream.LevelInfo, fmt.Sprintf("using active sidecar %s", sidecarID))
-				} else {
-					if name == "" {
-						return &userError{
-							msg:        "No active sidecar and --name not provided.",
-							suggestion: "Pass --name to create a new sidecar, or run 'chunk sidecar use <id>'.",
-							errMsg:     "no active sidecar and --name not provided",
-						}
-					}
-					resolvedOrgID, err := resolveOrgID(orgID, orgPicker(cmd.Context(), client))
-					if err != nil {
-						return err
-					}
-					provider := os.Getenv(config.EnvSidecarProvider)
-					if provider == "" {
-						provider = defaultProvider
-					}
-					status(iostream.LevelStep, fmt.Sprintf("Creating sidecar %q...", name))
-					sc, err := sidecar.Create(cmd.Context(), client, resolvedOrgID, name, provider, "")
-					if err != nil {
-						if err := notAuthorized("create sidecars", err); err != nil {
-							return err
-						}
-						return &userError{
-							msg:        "Could not create the sidecar.",
-							suggestion: "Check your network connection and try again.",
-							err:        err,
-						}
-					}
-					sidecarID = sc.ID
-					scDisplayName = sc.Name
-					if err := sidecar.SaveActive(sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); err != nil {
-						streams.ErrPrintf("warning: could not save active sidecar: %v\n", err)
-					}
-					status(iostream.LevelDone, fmt.Sprintf("Created sidecar %s (%s)", sc.Name, sc.ID))
+				var resolveErr error
+				sidecarID, scDisplayName, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, name, status, streams)
+				if resolveErr != nil {
+					return resolveErr
 				}
 			}
 
 			// Step 3: Ensure SSH key exists (generate if missing and no explicit key given).
-			if identityFile == "" {
-				keyPath := sidecar.DefaultKeyPath()
-				if _, err := os.Stat(keyPath); os.IsNotExist(err) {
-					status(iostream.LevelStep, fmt.Sprintf("Generating SSH key at %s...", keyPath))
-					if err := sidecar.GenerateKeyPair(keyPath); err != nil {
-						return &userError{msg: "Could not generate SSH key.", err: err}
-					}
-					status(iostream.LevelDone, "SSH key generated")
-				}
+			if err := sidecarSetupEnsureSSHKey(identityFile, status); err != nil {
+				return err
 			}
 
 			// Step 4: Sync files to sidecar.
 			if !skipSync {
-				status(iostream.LevelStep, "Syncing files to sidecar...")
-				if err := sidecar.Sync(cmd.Context(), client, sidecarID, identityFile, authSock, "", status); err != nil {
-					if _, ok := errors.AsType[*sidecar.RemoteBaseError](err); ok {
-						return &userError{
-							msg:        "Could not resolve remote base.",
-							suggestion: "Push your branch or ensure the repository has a remote configured.",
-							err:        err,
-						}
-					}
-					if err := sshSessionError(err); err != nil {
-						return err
-					}
-					if err := notAuthorized("sync files", err); err != nil {
-						return err
-					}
+				if err := sidecarSetupSync(cmd.Context(), client, sidecarID, identityFile, authSock, status); err != nil {
 					return err
 				}
 			}
 
 			// Step 5: Run install command over SSH.
-			if env.Install == "" {
-				status(iostream.LevelInfo, "No install command detected, skipping")
-			} else {
-				status(iostream.LevelStep, fmt.Sprintf("Running install: %s", env.Install))
-				session, err := sidecar.OpenSession(cmd.Context(), client, sidecarID, identityFile, authSock)
-				if err != nil {
-					if err := sshSessionError(err); err != nil {
-						return err
-					}
-					return err
-				}
-				// Run from the synced workspace directory so package managers can
-				// find their manifest files (go.mod, package.json, etc.).
-				workspaceCmd := env.Install
-				if active, err := sidecar.LoadActive(); err == nil && active != nil && active.Workspace != "" {
-					workspaceCmd = "cd " + sidecar.ShellEscape(active.Workspace) + " && " + env.Install
-				}
-				loginCmd := "bash -l -c " + sidecar.ShellEscape(workspaceCmd)
-				result, err := sidecar.ExecOverSSH(cmd.Context(), session, loginCmd, nil, nil)
-				if err != nil {
-					if err := sshSessionError(err); err != nil {
-						return err
-					}
-					return err
-				}
-				if result.Stdout != "" {
-					streams.Printf("%s", result.Stdout)
-				}
-				if result.Stderr != "" {
-					streams.ErrPrintf("%s", result.Stderr)
-				}
-				if result.ExitCode != 0 {
-					return &userError{
-						msg:        fmt.Sprintf("Install command exited with status %d.", result.ExitCode),
-						suggestion: "Check the output above for details.",
-						errMsg:     fmt.Sprintf("install command exited with status %d", result.ExitCode),
-					}
-				}
-				status(iostream.LevelDone, "Install complete")
+			if err := sidecarSetupRunInstall(cmd.Context(), client, sidecarID, identityFile, authSock, env, streams, status); err != nil {
+				return err
 			}
 
 			// Step 6: Create snapshot.
 			if !skipSnapshot {
-				if snapshotName == "" {
-					if scDisplayName != "" {
-						snapshotName = scDisplayName + "-setup"
-					} else {
-						snapshotName = sidecarID[:8] + "-setup"
-					}
+				if err := sidecarSetupSnapshot(cmd.Context(), client, sidecarID, scDisplayName, snapshotName, status); err != nil {
+					return err
 				}
-				status(iostream.LevelStep, fmt.Sprintf("Creating snapshot %q...", snapshotName))
-				snap, err := client.CreateSnapshot(cmd.Context(), sidecarID, snapshotName)
-				if err != nil {
-					return &userError{
-						msg:        "Could not create the snapshot.",
-						suggestion: "Check your network connection and try again.",
-						err:        err,
-					}
-				}
-				status(iostream.LevelDone, fmt.Sprintf("Snapshot created: %s (%s)", snap.Name, snap.ID))
 			}
 
 			return nil
@@ -869,4 +759,172 @@ Example:
 	cmd.Flags().BoolVar(&skipSnapshot, "skip-snapshot", false, "Skip creating a snapshot after install")
 
 	return cmd
+}
+
+func sidecarSetupResolveSidecar(
+	ctx context.Context,
+	client *circleci.Client,
+	orgID, name string,
+	status iostream.StatusFunc,
+	streams iostream.Streams,
+) (sidecarID, displayName string, err error) {
+	active, err := sidecar.LoadActive()
+	if err != nil {
+		return "", "", &userError{msg: "Could not load the active sidecar.", suggestion: configFilePermHint, err: err}
+	}
+	if active != nil {
+		status(iostream.LevelInfo, fmt.Sprintf("using active sidecar %s", active.SidecarID))
+		return active.SidecarID, active.Name, nil
+	}
+	if name == "" {
+		return "", "", &userError{
+			msg:        "No active sidecar and --name not provided.",
+			suggestion: "Pass --name to create a new sidecar, or run 'chunk sidecar use <id>'.",
+			errMsg:     "no active sidecar and --name not provided",
+		}
+	}
+	resolvedOrgID, err := resolveOrgID(orgID, orgPicker(ctx, client))
+	if err != nil {
+		return "", "", err
+	}
+	provider := os.Getenv(config.EnvSidecarProvider)
+	if provider == "" {
+		provider = defaultProvider
+	}
+	status(iostream.LevelStep, fmt.Sprintf("Creating sidecar %q...", name))
+	sc, err := sidecar.Create(ctx, client, resolvedOrgID, name, provider, "")
+	if err != nil {
+		if authErr := notAuthorized("create sidecars", err); authErr != nil {
+			return "", "", authErr
+		}
+		return "", "", &userError{
+			msg:        "Could not create the sidecar.",
+			suggestion: "Check your network connection and try again.",
+			err:        err,
+		}
+	}
+	if saveErr := sidecar.SaveActive(sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); saveErr != nil {
+		streams.ErrPrintf("warning: could not save active sidecar: %v\n", saveErr)
+	}
+	status(iostream.LevelDone, fmt.Sprintf("Created sidecar %s (%s)", sc.Name, sc.ID))
+	return sc.ID, sc.Name, nil
+}
+
+func sidecarSetupEnsureSSHKey(identityFile string, status iostream.StatusFunc) error {
+	if identityFile != "" {
+		return nil
+	}
+	keyPath := sidecar.DefaultKeyPath()
+	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+		status(iostream.LevelStep, fmt.Sprintf("Generating SSH key at %s...", keyPath))
+		if err := sidecar.GenerateKeyPair(keyPath); err != nil {
+			return &userError{msg: "Could not generate SSH key.", err: err}
+		}
+		status(iostream.LevelDone, "SSH key generated")
+	}
+	return nil
+}
+
+func sidecarSetupSync(
+	ctx context.Context,
+	client *circleci.Client,
+	sidecarID, identityFile, authSock string,
+	status iostream.StatusFunc,
+) error {
+	status(iostream.LevelStep, "Syncing files to sidecar...")
+	err := sidecar.Sync(ctx, client, sidecarID, identityFile, authSock, "", status)
+	if err == nil {
+		return nil
+	}
+	if _, ok := errors.AsType[*sidecar.RemoteBaseError](err); ok {
+		return &userError{
+			msg:        "Could not resolve remote base.",
+			suggestion: "Push your branch or ensure the repository has a remote configured.",
+			err:        err,
+		}
+	}
+	if authErr := sshSessionError(err); authErr != nil {
+		return authErr
+	}
+	if authErr := notAuthorized("sync files", err); authErr != nil {
+		return authErr
+	}
+	return err
+}
+
+func sidecarSetupRunInstall(
+	ctx context.Context,
+	client *circleci.Client,
+	sidecarID, identityFile, authSock string,
+	env *envbuilder.Environment,
+	streams iostream.Streams,
+	status iostream.StatusFunc,
+) error {
+	if env.Install == "" {
+		status(iostream.LevelInfo, "No install command detected, skipping")
+		return nil
+	}
+	status(iostream.LevelStep, fmt.Sprintf("Running install: %s", env.Install))
+	session, err := sidecar.OpenSession(ctx, client, sidecarID, identityFile, authSock)
+	if err != nil {
+		if sessErr := sshSessionError(err); sessErr != nil {
+			return sessErr
+		}
+		return err
+	}
+	// Run from the synced workspace directory so package managers can
+	// find their manifest files (go.mod, package.json, etc.).
+	workspaceCmd := env.Install
+	if active, err := sidecar.LoadActive(); err == nil && active != nil && active.Workspace != "" {
+		workspaceCmd = "cd " + sidecar.ShellEscape(active.Workspace) + " && " + env.Install
+	}
+	loginCmd := "bash -l -c " + sidecar.ShellEscape(workspaceCmd)
+	result, err := sidecar.ExecOverSSH(ctx, session, loginCmd, nil, nil)
+	if err != nil {
+		if sessErr := sshSessionError(err); sessErr != nil {
+			return sessErr
+		}
+		return err
+	}
+	if result.Stdout != "" {
+		streams.Printf("%s", result.Stdout)
+	}
+	if result.Stderr != "" {
+		streams.ErrPrintf("%s", result.Stderr)
+	}
+	if result.ExitCode != 0 {
+		return &userError{
+			msg:        fmt.Sprintf("Install command exited with status %d.", result.ExitCode),
+			suggestion: "Check the output above for details.",
+			errMsg:     fmt.Sprintf("install command exited with status %d", result.ExitCode),
+		}
+	}
+	status(iostream.LevelDone, "Install complete")
+	return nil
+}
+
+func sidecarSetupSnapshot(
+	ctx context.Context,
+	client *circleci.Client,
+	sidecarID, scDisplayName, snapshotName string,
+	status iostream.StatusFunc,
+) error {
+	if snapshotName == "" {
+		if scDisplayName != "" {
+			snapshotName = scDisplayName + "-setup"
+		} else {
+			snapshotName = sidecarID[:8] + "-setup"
+		}
+	}
+	status(iostream.LevelStep, fmt.Sprintf("Creating snapshot %q...", snapshotName))
+	snap, err := client.CreateSnapshot(ctx, sidecarID, snapshotName)
+	if err != nil {
+		return &userError{
+			msg:        "Could not create the snapshot.",
+			suggestion: "Check your network connection and try again.",
+			err:        err,
+		}
+	}
+	status(iostream.LevelDone, fmt.Sprintf("Snapshot created: %s (%s)", snap.Name, snap.ID))
+	return nil
 }

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -41,6 +41,7 @@ func newSidecarCmd() *cobra.Command {
 	cmd.AddCommand(newSidecarCurrentCmd())
 	cmd.AddCommand(newSidecarForgetCmd())
 	cmd.AddCommand(newSidecarSnapshotCmd())
+	cmd.AddCommand(newSidecarSetupCmd())
 
 	return cmd
 }
@@ -668,6 +669,204 @@ func newSidecarSnapshotGetCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	return cmd
+}
+
+func newSidecarSetupCmd() *cobra.Command {
+	var sidecarID, orgID, name, identityFile, snapshotName, dir string
+	var skipSync, skipSnapshot bool
+
+	cmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Detect environment, run install in a sidecar, and snapshot",
+		Long: `Detect the tech stack in --dir, sync files, run the install command
+in a sidecar, and create a snapshot of the prepared environment.
+
+If no active sidecar is set, pass --org-id and --name to create one first.
+
+Example:
+  chunk sidecar setup --dir .
+  chunk sidecar setup --dir . --name my-sidecar --org-id <org-id>`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			streams := iostream.FromCmd(cmd)
+			status := newStatusFunc(streams)
+			authSock := os.Getenv("SSH_AUTH_SOCK")
+
+			client, err := ensureCircleCIClient(cmd.Context(), streams, tui.PromptHidden)
+			if err != nil {
+				return err
+			}
+
+			// Step 1: Detect environment.
+			status(iostream.LevelStep, fmt.Sprintf("Detecting environment in %s...", dir))
+			env, err := envbuilder.DetectEnvironment(cmd.Context(), dir)
+			if err != nil {
+				return &userError{
+					msg:        "Could not detect the environment.",
+					suggestion: "Check the directory contains a supported project.",
+					err:        err,
+				}
+			}
+			status(iostream.LevelInfo, fmt.Sprintf("stack: %s", env.Stack))
+			status(iostream.LevelInfo, fmt.Sprintf("install: %s", env.Install))
+
+			// Step 2: Resolve or create sidecar.
+			var scDisplayName string
+			if sidecarID == "" {
+				active, err := sidecar.LoadActive()
+				if err != nil {
+					return &userError{msg: "Could not load the active sidecar.", suggestion: configFilePermHint, err: err}
+				}
+				if active != nil {
+					sidecarID = active.SidecarID
+					scDisplayName = active.Name
+					status(iostream.LevelInfo, fmt.Sprintf("using active sidecar %s", sidecarID))
+				} else {
+					if name == "" {
+						return &userError{
+							msg:        "No active sidecar and --name not provided.",
+							suggestion: "Pass --name to create a new sidecar, or run 'chunk sidecar use <id>'.",
+							errMsg:     "no active sidecar and --name not provided",
+						}
+					}
+					resolvedOrgID, err := resolveOrgID(orgID, orgPicker(cmd.Context(), client))
+					if err != nil {
+						return err
+					}
+					provider := os.Getenv(config.EnvSidecarProvider)
+					if provider == "" {
+						provider = defaultProvider
+					}
+					status(iostream.LevelStep, fmt.Sprintf("Creating sidecar %q...", name))
+					sc, err := sidecar.Create(cmd.Context(), client, resolvedOrgID, name, provider, "")
+					if err != nil {
+						if err := notAuthorized("create sidecars", err); err != nil {
+							return err
+						}
+						return &userError{
+							msg:        "Could not create the sidecar.",
+							suggestion: "Check your network connection and try again.",
+							err:        err,
+						}
+					}
+					sidecarID = sc.ID
+					scDisplayName = sc.Name
+					if err := sidecar.SaveActive(sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); err != nil {
+						streams.ErrPrintf("warning: could not save active sidecar: %v\n", err)
+					}
+					status(iostream.LevelDone, fmt.Sprintf("Created sidecar %s (%s)", sc.Name, sc.ID))
+				}
+			}
+
+			// Step 3: Ensure SSH key exists (generate if missing and no explicit key given).
+			if identityFile == "" {
+				keyPath := sidecar.DefaultKeyPath()
+				if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+					status(iostream.LevelStep, fmt.Sprintf("Generating SSH key at %s...", keyPath))
+					if err := sidecar.GenerateKeyPair(keyPath); err != nil {
+						return &userError{msg: "Could not generate SSH key.", err: err}
+					}
+					status(iostream.LevelDone, "SSH key generated")
+				}
+			}
+
+			// Step 4: Sync files to sidecar.
+			if !skipSync {
+				status(iostream.LevelStep, "Syncing files to sidecar...")
+				if err := sidecar.Sync(cmd.Context(), client, sidecarID, identityFile, authSock, "", status); err != nil {
+					if _, ok := errors.AsType[*sidecar.RemoteBaseError](err); ok {
+						return &userError{
+							msg:        "Could not resolve remote base.",
+							suggestion: "Push your branch or ensure the repository has a remote configured.",
+							err:        err,
+						}
+					}
+					if err := sshSessionError(err); err != nil {
+						return err
+					}
+					if err := notAuthorized("sync files", err); err != nil {
+						return err
+					}
+					return err
+				}
+			}
+
+			// Step 5: Run install command over SSH.
+			if env.Install == "" {
+				status(iostream.LevelInfo, "No install command detected, skipping")
+			} else {
+				status(iostream.LevelStep, fmt.Sprintf("Running install: %s", env.Install))
+				session, err := sidecar.OpenSession(cmd.Context(), client, sidecarID, identityFile, authSock)
+				if err != nil {
+					if err := sshSessionError(err); err != nil {
+						return err
+					}
+					return err
+				}
+				// Run from the synced workspace directory so package managers can
+				// find their manifest files (go.mod, package.json, etc.).
+				workspaceCmd := env.Install
+				if active, err := sidecar.LoadActive(); err == nil && active != nil && active.Workspace != "" {
+					workspaceCmd = "cd " + sidecar.ShellEscape(active.Workspace) + " && " + env.Install
+				}
+				loginCmd := "bash -l -c " + sidecar.ShellEscape(workspaceCmd)
+				result, err := sidecar.ExecOverSSH(cmd.Context(), session, loginCmd, nil, nil)
+				if err != nil {
+					if err := sshSessionError(err); err != nil {
+						return err
+					}
+					return err
+				}
+				if result.Stdout != "" {
+					streams.Printf("%s", result.Stdout)
+				}
+				if result.Stderr != "" {
+					streams.ErrPrintf("%s", result.Stderr)
+				}
+				if result.ExitCode != 0 {
+					return &userError{
+						msg:        fmt.Sprintf("Install command exited with status %d.", result.ExitCode),
+						suggestion: "Check the output above for details.",
+						errMsg:     fmt.Sprintf("install command exited with status %d", result.ExitCode),
+					}
+				}
+				status(iostream.LevelDone, "Install complete")
+			}
+
+			// Step 6: Create snapshot.
+			if !skipSnapshot {
+				if snapshotName == "" {
+					if scDisplayName != "" {
+						snapshotName = scDisplayName + "-setup"
+					} else {
+						snapshotName = sidecarID[:8] + "-setup"
+					}
+				}
+				status(iostream.LevelStep, fmt.Sprintf("Creating snapshot %q...", snapshotName))
+				snap, err := client.CreateSnapshot(cmd.Context(), sidecarID, snapshotName)
+				if err != nil {
+					return &userError{
+						msg:        "Could not create the snapshot.",
+						suggestion: "Check your network connection and try again.",
+						err:        err,
+					}
+				}
+				status(iostream.LevelDone, fmt.Sprintf("Snapshot created: %s (%s)", snap.Name, snap.ID))
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&dir, "dir", ".", "Directory to detect environment in")
+	cmd.Flags().StringVar(&sidecarID, "sidecar-id", "", "Sidecar ID (defaults to active sidecar)")
+	cmd.Flags().StringVar(&orgID, "org-id", "", "Organization ID (used when creating a new sidecar)")
+	cmd.Flags().StringVar(&name, "name", "", "Sidecar name (used when creating a new sidecar)")
+	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file")
+	cmd.Flags().StringVar(&snapshotName, "snapshot-name", "", "Snapshot name (defaults to <sidecar-name>-setup)")
+	cmd.Flags().BoolVar(&skipSync, "skip-sync", false, "Skip syncing files to the sidecar")
+	cmd.Flags().BoolVar(&skipSnapshot, "skip-snapshot", false, "Skip creating a snapshot after install")
 
 	return cmd
 }

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -712,10 +712,14 @@ Example:
 			status(iostream.LevelInfo, fmt.Sprintf("install: %s", env.Install))
 
 			// Step 2: Resolve or create sidecar.
-			var scDisplayName string
+			provider := os.Getenv(config.EnvSidecarProvider)
+			if provider == "" {
+				provider = defaultProvider
+			}
+			var scDisplayName, workspace string
 			if sidecarID == "" {
 				var resolveErr error
-				sidecarID, scDisplayName, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, name, status, streams)
+				sidecarID, scDisplayName, workspace, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, name, provider, status, streams)
 				if resolveErr != nil {
 					return resolveErr
 				}
@@ -734,7 +738,7 @@ Example:
 			}
 
 			// Step 5: Run install command over SSH.
-			if err := sidecarSetupRunInstall(cmd.Context(), client, sidecarID, identityFile, authSock, env, streams, status); err != nil {
+			if err := sidecarSetupRunInstall(cmd.Context(), client, sidecarID, identityFile, authSock, env, workspace, streams, status); err != nil {
 				return err
 			}
 
@@ -764,20 +768,20 @@ Example:
 func sidecarSetupResolveSidecar(
 	ctx context.Context,
 	client *circleci.Client,
-	orgID, name string,
+	orgID, name, provider string,
 	status iostream.StatusFunc,
 	streams iostream.Streams,
-) (sidecarID, displayName string, err error) {
+) (id, displayName, workspace string, err error) {
 	active, err := sidecar.LoadActive()
 	if err != nil {
-		return "", "", &userError{msg: "Could not load the active sidecar.", suggestion: configFilePermHint, err: err}
+		return "", "", "", &userError{msg: "Could not load the active sidecar.", suggestion: configFilePermHint, err: err}
 	}
 	if active != nil {
 		status(iostream.LevelInfo, fmt.Sprintf("using active sidecar %s", active.SidecarID))
-		return active.SidecarID, active.Name, nil
+		return active.SidecarID, active.Name, active.Workspace, nil
 	}
 	if name == "" {
-		return "", "", &userError{
+		return "", "", "", &userError{
 			msg:        "No active sidecar and --name not provided.",
 			suggestion: "Pass --name to create a new sidecar, or run 'chunk sidecar use <id>'.",
 			errMsg:     "no active sidecar and --name not provided",
@@ -785,19 +789,15 @@ func sidecarSetupResolveSidecar(
 	}
 	resolvedOrgID, err := resolveOrgID(orgID, orgPicker(ctx, client))
 	if err != nil {
-		return "", "", err
-	}
-	provider := os.Getenv(config.EnvSidecarProvider)
-	if provider == "" {
-		provider = defaultProvider
+		return "", "", "", err
 	}
 	status(iostream.LevelStep, fmt.Sprintf("Creating sidecar %q...", name))
 	sc, err := sidecar.Create(ctx, client, resolvedOrgID, name, provider, "")
 	if err != nil {
 		if authErr := notAuthorized("create sidecars", err); authErr != nil {
-			return "", "", authErr
+			return "", "", "", authErr
 		}
-		return "", "", &userError{
+		return "", "", "", &userError{
 			msg:        "Could not create the sidecar.",
 			suggestion: "Check your network connection and try again.",
 			err:        err,
@@ -807,14 +807,17 @@ func sidecarSetupResolveSidecar(
 		streams.ErrPrintf("warning: could not save active sidecar: %v\n", saveErr)
 	}
 	status(iostream.LevelDone, fmt.Sprintf("Created sidecar %s (%s)", sc.Name, sc.ID))
-	return sc.ID, sc.Name, nil
+	return sc.ID, sc.Name, "", nil
 }
 
 func sidecarSetupEnsureSSHKey(identityFile string, status iostream.StatusFunc) error {
 	if identityFile != "" {
 		return nil
 	}
-	keyPath := sidecar.DefaultKeyPath()
+	keyPath, err := sidecar.DefaultKeyPath()
+	if err != nil {
+		return &userError{msg: "Could not determine SSH key path.", err: err}
+	}
 	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 		status(iostream.LevelStep, fmt.Sprintf("Generating SSH key at %s...", keyPath))
 		if err := sidecar.GenerateKeyPair(keyPath); err != nil {
@@ -857,6 +860,7 @@ func sidecarSetupRunInstall(
 	client *circleci.Client,
 	sidecarID, identityFile, authSock string,
 	env *envbuilder.Environment,
+	workspace string,
 	streams iostream.Streams,
 	status iostream.StatusFunc,
 ) error {
@@ -875,8 +879,14 @@ func sidecarSetupRunInstall(
 	// Run from the synced workspace directory so package managers can
 	// find their manifest files (go.mod, package.json, etc.).
 	workspaceCmd := env.Install
-	if active, err := sidecar.LoadActive(); err == nil && active != nil && active.Workspace != "" {
-		workspaceCmd = "cd " + sidecar.ShellEscape(active.Workspace) + " && " + env.Install
+	ws := workspace
+	if ws == "" {
+		if active, lerr := sidecar.LoadActive(); lerr == nil && active != nil && active.Workspace != "" {
+			ws = active.Workspace
+		}
+	}
+	if ws != "" {
+		workspaceCmd = "cd " + sidecar.ShellEscape(ws) + " && " + env.Install
 	}
 	loginCmd := "bash -l -c " + sidecar.ShellEscape(workspaceCmd)
 	result, err := sidecar.ExecOverSSH(ctx, session, loginCmd, nil, nil)
@@ -913,7 +923,7 @@ func sidecarSetupSnapshot(
 		if scDisplayName != "" {
 			snapshotName = scDisplayName + "-setup"
 		} else {
-			snapshotName = sidecarID[:8] + "-setup"
+			snapshotName = sidecarID[:min(len(sidecarID), 8)] + "-setup"
 		}
 	}
 	status(iostream.LevelStep, fmt.Sprintf("Creating snapshot %q...", snapshotName))

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -888,6 +888,11 @@ func sidecarSetupRunInstall(
 	if ws != "" {
 		workspaceCmd = "cd " + sidecar.ShellEscape(ws) + " && " + env.Install
 	}
+	// cimg images set PATH via Docker ENV which e2b does not propagate to SSH
+	// sessions, so prepend the stack's binary locations explicitly.
+	if paths := env.BinaryPaths(); paths != "" {
+		workspaceCmd = "export PATH=" + paths + ":$PATH && " + workspaceCmd
+	}
 	loginCmd := "bash -l -c " + sidecar.ShellEscape(workspaceCmd)
 	result, err := sidecar.ExecOverSSH(ctx, session, loginCmd, nil, nil)
 	if err != nil {

--- a/internal/sidecar/session.go
+++ b/internal/sidecar/session.go
@@ -2,6 +2,10 @@ package sidecar
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net"
 	"os"
@@ -21,6 +25,43 @@ const (
 	defaultSSHUser = "user"
 	knownHostsFile = "chunk_ai_known_hosts"
 )
+
+// DefaultKeyPath returns the default SSH private key path used by chunk.
+func DefaultKeyPath() string {
+	return filepath.Join(os.Getenv("HOME"), ".ssh", defaultKeyName)
+}
+
+// GenerateKeyPair generates an ed25519 keypair and writes the private key to
+// path and the public key to path+".pub". The .ssh directory is created if it
+// does not exist.
+func GenerateKeyPair(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create .ssh directory: %w", err)
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generate key: %w", err)
+	}
+
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return fmt.Errorf("marshal private key: %w", err)
+	}
+	privPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+	if err := os.WriteFile(path, privPEM, 0o600); err != nil {
+		return fmt.Errorf("write private key: %w", err)
+	}
+
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		return fmt.Errorf("create public key: %w", err)
+	}
+	if err := os.WriteFile(path+".pub", ssh.MarshalAuthorizedKey(sshPub), 0o644); err != nil {
+		return fmt.Errorf("write public key: %w", err)
+	}
+	return nil
+}
 
 // Session holds the info needed to SSH into a sidecar.
 // It is a plain value type with no open connections or resources to close.

--- a/internal/sidecar/session.go
+++ b/internal/sidecar/session.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/closer"
-	"github.com/CircleCI-Public/chunk-cli/internal/config"
 )
 
 const (
@@ -27,8 +26,12 @@ const (
 )
 
 // DefaultKeyPath returns the default SSH private key path used by chunk.
-func DefaultKeyPath() string {
-	return filepath.Join(os.Getenv("HOME"), ".ssh", defaultKeyName)
+func DefaultKeyPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return filepath.Join(home, ".ssh", defaultKeyName), nil
 }
 
 // GenerateKeyPair generates an ed25519 keypair and writes the private key to
@@ -78,7 +81,11 @@ type Session struct {
 // authSock is the SSH_AUTH_SOCK path; when non-empty and no identityFile is
 // given, the agent is tried first.
 func OpenSession(ctx context.Context, client *circleci.Client, sidecarID, identityFile, authSock string) (*Session, error) {
-	sshDir := filepath.Join(os.Getenv(config.EnvHome), ".ssh")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home directory: %w", err)
+	}
+	sshDir := filepath.Join(home, ".ssh")
 
 	// When no identity file is specified, try the ssh-agent first.
 	if identityFile == "" && authSock != "" {


### PR DESCRIPTION
## Summary
  - Adds `chunk sandbox setup` — detects the tech stack, syncs files to a sandbox, runs the install command, and creates a snapshot
  - Runs the install in a login shell (`bash -l`) so PATH entries from `~/.profile` (e.g. `/usr/local/go/bin`) are available
  - `cd`s to the synced workspace directory before install so package managers can find their manifest files (`go.mod`, `package.json`, etc.)

  ## Test plan
  - [ ] `chunk sandbox setup --dir .` on a Go project with Go pre-installed — install runs and snapshot is created
  - [ ] `--skip-sync` skips the sync step
  - [ ] `--skip-snapshot` skips snapshot creation
  - [ ] No active sandbox + `--name` + `--org-id` creates a new sandbox first