### PR TITLE
Add error, config, and UI patterns to ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,7 +99,60 @@ Three-step pipeline orchestrated by `buildprompt.Run()`:
 - Generation step: `claude-opus-4-6`
 - Overridable via `--analyze-model` / `--prompt-model` flags
 
-## Configuration Resolution
+## Configuration and Environment Variables
+
+### Single source of truth for env var names
+
+Define every environment variable name as a `const` in the `config`
+package. Use these constants in user-facing messages and `t.Setenv` calls.
+Never use bare `os.Getenv("CIRCLE_TOKEN")` strings.
+
+```go
+const (
+    EnvCircleToken     = "CIRCLE_TOKEN"
+    EnvAnthropicAPIKey = "ANTHROPIC_API_KEY"
+    EnvGitHubToken     = "GITHUB_TOKEN"
+    EnvModel           = "CODE_REVIEW_CLI_MODEL"
+    // ...
+)
+```
+
+### Struct-based env loading
+
+Declare all environment variables once in an `EnvVars` struct with `env`
+struct tags (via `go-envconfig`). Express defaults as tag values, not
+if-empty checks:
+
+```go
+type EnvVars struct {
+    CircleToken      string `env:"CIRCLE_TOKEN"`
+    CircleCIBaseURL  string `env:"CIRCLECI_BASE_URL,default=https://circleci.com"`
+    AnthropicAPIKey  string `env:"ANTHROPIC_API_KEY"`
+    AnthropicBaseURL string `env:"ANTHROPIC_BASE_URL,default=https://api.anthropic.com"`
+    // ...
+}
+```
+
+`LoadEnv(ctx)` populates the struct via `envconfig.Process`.
+
+When adding a new environment variable:
+1. Add a `const Env...` for user-facing messages and test code.
+2. Add a field to `EnvVars` with an `env` tag (and `default=` if needed).
+3. Wire it into `Resolve()` or consume it from the struct directly.
+
+### Layered resolution with explicit precedence
+
+Config resolves through a strict priority chain:
+
+    flag > env var > config file > default
+
+`Resolve()` returns a `ResolvedConfig` struct. Each value is paired with
+a source string (e.g. `"Environment variable (CIRCLE_TOKEN)"`) so
+status/diagnostic output can show where the value came from.
+
+Not all values support all layers — for example, CircleCI and GitHub
+tokens have no flag, so their chain is `env var > config file`. The
+Anthropic API key and model support the full chain.
 
 User config lives at `~/.chunk/config.json`:
 
@@ -110,9 +163,23 @@ User config lives at `~/.chunk/config.json`:
 }
 ```
 
-Resolution priority:
-- API key: flag > config file > `ANTHROPIC_API_KEY` env var
-- Model: flag > config file > built-in default
+### Client constructors accept config, not env
+
+Client `New()` functions receive values from the resolved config. They
+must not call `os.Getenv` themselves. This keeps env reading centralised
+in `config.Resolve` and makes clients testable.
+
+### Environment variable reference
+
+| Variable | Used by | Purpose |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | anthropic, config, validate | Anthropic authentication |
+| `ANTHROPIC_BASE_URL` | anthropic, validate | API endpoint override |
+| `GITHUB_TOKEN` | github | GitHub authentication |
+| `GITHUB_API_URL` | github | GitHub API endpoint override |
+| `CIRCLE_TOKEN` / `CIRCLECI_TOKEN` | circleci | CircleCI authentication |
+| `CIRCLECI_BASE_URL` | circleci | CircleCI endpoint override |
+| `CLAUDE_PROJECT_DIR` | init | IDE-provided project directory |
 
 ## Pre-Commit Hooks
 
@@ -134,21 +201,135 @@ Shared HTTP infrastructure used by `anthropic/`, `circleci/`, and `github/`:
 
 ## Error Handling
 
-- Business logic returns `usererr.Error` for user-facing messages
-- `fmt.Errorf("context: %w", err)` for error wrapping
-- `main()` catches errors and prints the appropriate message
+### Two-tier error model
 
-## Environment Variables
+Every error returned from a command carries two perspectives:
 
-| Variable | Used by | Purpose |
-|---|---|---|
-| `ANTHROPIC_API_KEY` | anthropic, config, validate | Anthropic authentication |
-| `ANTHROPIC_BASE_URL` | anthropic, validate | API endpoint override |
-| `GITHUB_TOKEN` | github | GitHub authentication |
-| `GITHUB_API_URL` | github | GitHub API endpoint override |
-| `CIRCLE_TOKEN` / `CIRCLECI_TOKEN` | circleci | CircleCI authentication |
-| `CIRCLECI_BASE_URL` | circleci | CircleCI endpoint override |
-| `CLAUDE_PROJECT_DIR` | init | IDE-provided project directory |
+1. **Developer error** — the wrapped `error` chain for logs and debugging.
+2. **User-facing message** — a plain-English sentence shown on stderr.
+
+The `userError` struct in `internal/cmd/usererr.go` satisfies both `error`
+and a set of display interfaces:
+
+```go
+type userError struct {
+    msg        string // brief user-facing headline
+    detail     string // optional clarification
+    suggestion string // optional actionable hint
+    err        error  // underlying Go error (for errors.Is / As)
+}
+
+func (e *userError) UserMessage() string  { return e.msg }
+func (e *userError) Detail() string       { return e.detail }
+func (e *userError) Suggestion() string   { return e.suggestion }
+func (e *userError) Unwrap() error        { return e.err }
+```
+
+The display interfaces (`UserMessage`, `Detail`, `Suggestion`) are checked
+via type assertion at the top-level error handler — they are not imported
+as a named interface. This keeps the error type private to `cmd`.
+
+### Single error-rendering boundary
+
+All formatting happens in `main()`, never inside command handlers:
+
+```go
+func main() {
+    if err := rootCmd.Execute(); err != nil {
+        msg, detail, suggestion := errorDetails(err)
+        fmt.Fprint(os.Stderr, ui.FormatError(msg, detail, suggestion))
+        os.Exit(1)
+    }
+}
+```
+
+`errorDetails` probes the error for the three display interfaces via duck
+typing, then falls back to sensible defaults (the raw `.Error()` string
+as detail, pattern-matched hints as suggestion).
+
+Rules:
+- Command handlers must never call `ui.FormatError` or print styled error
+  text themselves. Return the error; let the boundary format it.
+- Never use a sentinel "silent" error to suppress output. Every non-nil
+  error produces output through the single boundary.
+- Helpers like `notAuthorized(action, err)` and `sshSessionError(err)` can
+  inspect an error and return a `*userError` (or nil to signal "not my
+  error"). The caller chains them:
+  ```go
+  if err := notAuthorized("sync files", err); err != nil { return err }
+  ```
+
+### Typed package-level errors
+
+API client packages export sentinel errors and typed error structs so
+callers use `errors.Is` / `errors.As` instead of string matching:
+
+```go
+// internal/anthropic
+var ErrKeyNotFound = errors.New("api key not found")
+var ErrTokenLimit  = errors.New("prompt exceeds context window")
+
+type StatusError struct {
+    Op         string
+    StatusCode int
+}
+```
+
+HTTP client packages must not leak the shared `httpcl.HTTPError` type to
+callers. Instead, wrap it into a package-local `StatusError` via a
+`mapErr` helper:
+
+```go
+func mapErr(op string, err error) error {
+    var he *hc.HTTPError
+    if !errors.As(err, &he) { return err }
+    return &StatusError{Op: op, StatusCode: he.StatusCode}
+}
+```
+
+## Display and UI Decoupling
+
+### Business logic never imports `ui`
+
+The `ui` package owns all ANSI styling (`Bold`, `Dim`, `Red`, `Green`,
+`Warning`, `Success`, `FormatError`). Business logic in `internal/` must
+not import it.
+
+Use **callback injection** for progress reporting via `iostream.StatusFunc`:
+
+```go
+// iostream/status.go
+type Level int
+const (
+    LevelStep Level = iota
+    LevelInfo
+    LevelWarn
+    LevelDone
+)
+type StatusFunc func(level Level, msg string)
+```
+
+The `cmd` layer wires the callback to styled output:
+
+```go
+func newStatusFunc(streams iostream.Streams) iostream.StatusFunc {
+    return func(level iostream.Level, msg string) {
+        switch level {
+        case iostream.LevelStep:
+            streams.ErrPrintln(ui.Bold(msg))
+        case iostream.LevelInfo:
+            streams.ErrPrintf("  %s\n", ui.Dim(msg))
+        case iostream.LevelWarn:
+            streams.ErrPrintf("  %s\n", ui.Warning(msg))
+        case iostream.LevelDone:
+            streams.ErrPrintf("  %s\n", ui.Success(msg))
+        }
+    }
+}
+```
+
+Business logic accepts `StatusFunc` as a parameter and calls it for
+progress output. Tests can pass a no-op or capturing stub.
 
 # Test Assertions
 


### PR DESCRIPTION
## Summary
- Expand error handling: two-tier model, single rendering boundary, typed package errors with mapErr
- Expand configuration: env const pattern, struct-based loading via go-envconfig, layered precedence, client constructors accept config not env
- Add display/UI decoupling: StatusFunc callback injection, business logic never imports ui
- Fix config precedence bug (was flag>config>env, now correctly flag>env>config>default)
- Move environment variable reference table into the combined config section

🤖 Generated with [Claude Code](https://claude.com/claude-code)