### PR TITLE
Retry sync and keep default error detail

### DIFF
--- a/internal/cmd/sandbox.go
+++ b/internal/cmd/sandbox.go
@@ -403,7 +403,10 @@ func newSandboxSyncCmd() *cobra.Command {
 				if err := notAuthorized("sync files", err); err != nil {
 					return err
 				}
-				return err
+				return &userError{
+					msg: "The sync operation failed.",
+					err: err,
+				}
 			}
 			return nil
 		},

--- a/internal/sandbox/sync.go
+++ b/internal/sandbox/sync.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -45,7 +46,9 @@ func persistWorkspace(workspace string) error {
 // It ensures the workspace base exists, clones the repo into workdir if absent,
 // then resets to the remote base and applies a patch of local changes.
 // workdir overrides the destination path; defaults to /workspace/<repo>.
-func Sync(ctx context.Context, client *circleci.Client, sandboxID, identityFile, authSock, workdir string, status iostream.StatusFunc) error {
+func Sync(ctx context.Context,
+	client *circleci.Client, sandboxID, identityFile, authSock, workdir string, status iostream.StatusFunc) error {
+
 	session, err := OpenSession(ctx, client, sandboxID, identityFile, authSock)
 	if err != nil {
 		return err
@@ -67,6 +70,41 @@ func Sync(ctx context.Context, client *circleci.Client, sandboxID, identityFile,
 		status(iostream.LevelWarn, fmt.Sprintf("Could not save workspace: %v", err))
 	}
 
+	// Try once and exit here if it worked
+	err = syncWorkspace(ctx, status, org, repo, repoPath, session)
+	if err == nil {
+		status(iostream.LevelDone, "Synced")
+		return nil
+	}
+	// We should only try again if the failure was in the apply phase.
+	if !errors.Is(err, errApplyFailed) {
+		return err
+	}
+
+	// Second attempt - after deleting the remote folder
+	status(iostream.LevelWarn, fmt.Sprintf("Local %s/%s drifted from remote: %s (%s) - attempting clean",
+		org, repo, repoPath, err))
+
+	// Delete the remote working directory
+	if result, err := ExecOverSSH(ctx, session, "rm -rf "+ShellEscape(repoPath), nil, nil); err != nil {
+		return fmt.Errorf("sync: rm %s: %w", repoPath, err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("sync: rm %s: %s", repoPath, result.Stderr)
+	}
+
+	if err := syncWorkspace(ctx, status, org, repo, repoPath, session); err != nil {
+		return fmt.Errorf("sync retry: %w", err)
+	}
+
+	status(iostream.LevelDone, "Synced")
+	return nil
+}
+
+var errApplyFailed = errors.New("apply failed")
+
+func syncWorkspace(ctx context.Context, status iostream.StatusFunc, org, repo, repoPath string, session *Session) error {
+	status(iostream.LevelInfo, fmt.Sprintf("Assessing %s/%s on remote: %s...", org, repo, repoPath))
+
 	// Ensure the parent directory exists on the sandbox.
 	parentDir := filepath.Dir(repoPath)
 	if result, err := ExecOverSSH(ctx, session, "mkdir -p "+ShellEscape(parentDir), nil, nil); err != nil {
@@ -75,7 +113,7 @@ func Sync(ctx context.Context, client *circleci.Client, sandboxID, identityFile,
 		return fmt.Errorf("sync: mkdir -p %s: %s", parentDir, result.Stderr)
 	}
 
-	// Clone into /workspace/<repo> if not already present.
+	// Clone into remote workspace if not already present.
 	testResult, err := ExecOverSSH(ctx, session, "test -d "+ShellEscape(repoPath), nil, nil)
 	if err != nil {
 		return fmt.Errorf("sync: check repo dir: %w", err)
@@ -112,6 +150,8 @@ func Sync(ctx context.Context, client *circleci.Client, sandboxID, identityFile,
 		}
 	}
 
+	status(iostream.LevelInfo, fmt.Sprintf("Synchronising local %s/%s to remote: %s...", org, repo, repoPath))
+
 	base, err := gitutil.MergeBase()
 	if err != nil {
 		return &RemoteBaseError{Err: err}
@@ -126,6 +166,8 @@ func Sync(ctx context.Context, client *circleci.Client, sandboxID, identityFile,
 		return nil
 	}
 
+	status(iostream.LevelInfo, fmt.Sprintf("Synchronising %d bytes.", len(patch)))
+
 	resetCmd := fmt.Sprintf(
 		`sh -c "cd %s && git reset --hard %s && git clean -fd"`,
 		ShellEscape(repoPath), ShellEscape(base),
@@ -139,7 +181,7 @@ func Sync(ctx context.Context, client *circleci.Client, sandboxID, identityFile,
 		if detail == "" {
 			detail = "git reset exited with a non-zero status"
 		}
-		return fmt.Errorf("sync failed: %s", detail)
+		return fmt.Errorf("reset failed (exit code: %d): %s", resetResult.ExitCode, detail)
 	}
 
 	applyCmd := fmt.Sprintf("git -C %s apply", ShellEscape(repoPath))
@@ -152,9 +194,7 @@ func Sync(ctx context.Context, client *circleci.Client, sandboxID, identityFile,
 		if detail == "" {
 			detail = "git apply exited with a non-zero status"
 		}
-		return fmt.Errorf("sync failed: %s", detail)
+		return fmt.Errorf("%w (exit code: %d): %s", errApplyFailed, applyResult.ExitCode, detail)
 	}
-
-	status(iostream.LevelDone, "Synced.")
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -30,10 +30,14 @@ func errorDetails(err error) (msg, detail, suggestion string) {
 		msg = um.UserMessage()
 	}
 	if d, ok := err.(interface{ Detail() string }); ok {
-		detail = d.Detail()
+		if d.Detail() != "" {
+			detail = d.Detail()
+		}
 	}
 	if s, ok := err.(interface{ Suggestion() string }); ok {
-		suggestion = s.Suggestion()
+		if s.Suggestion() != "" {
+			suggestion = s.Suggestion()
+		}
 	}
 	return msg, detail, suggestion
 }


### PR DESCRIPTION
fixes git drift :

```
Error: An unknown error occurred.

sync failed: fatal: Could not parse object '3616bdf40d49059c0244d1181be0ef002328cb11'.
```