### PR TITLE
sidecar: add LoadForSession to look up sidecars by session ID

### DIFF
--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -28,7 +28,21 @@ func sidecarFileName() string {
 
 // LoadActive walks up from cwd looking for .chunk/sidecar.json. Returns nil if not found.
 func LoadActive() (*ActiveSidecar, error) {
-	path, err := findSidecarFile()
+	return loadActiveNamed(sidecarFileName())
+}
+
+// LoadForSession loads the active sidecar for a specific Claude session ID,
+// looking for .chunk/sidecar.<sessionID>.json directly rather than relying on
+// the CLAUDE_SESSION_ID environment variable.
+func LoadForSession(sessionID string) (*ActiveSidecar, error) {
+	if sessionID == "" {
+		return LoadActive()
+	}
+	return loadActiveNamed("sidecar." + sessionID + ".json")
+}
+
+func loadActiveNamed(filename string) (*ActiveSidecar, error) {
+	path, err := findSidecarFileNamed(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -116,18 +130,23 @@ func ClearActive() error {
 	return os.Remove(path)
 }
 
-// findSidecarFile walks up from cwd looking for .chunk/sidecar.json, returning the path or "".
+// findSidecarFile walks up from cwd looking for the active sidecar file.
+func findSidecarFile() (string, error) {
+	return findSidecarFileNamed(sidecarFileName())
+}
+
+// findSidecarFileNamed walks up from cwd looking for .chunk/<name>, returning the path or "".
 // When inside a git repository the walk is bounded by the repository root (the directory
 // containing .git); files above that root are never considered. When not inside any git
 // repository only the current directory is checked.
-func findSidecarFile() (string, error) {
+func findSidecarFileNamed(name string) (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
 		return "", err
 	}
 	gitRoot, _ := findGitRoot()
 	for {
-		candidate := filepath.Join(dir, ".chunk", sidecarFileName())
+		candidate := filepath.Join(dir, ".chunk", name)
 		if _, err := os.Stat(candidate); err == nil {
 			return candidate, nil
 		} else if !errors.Is(err, os.ErrNotExist) {

--- a/internal/sidecar/active_test.go
+++ b/internal/sidecar/active_test.go
@@ -234,3 +234,50 @@ func TestResolveWorkspaceDefaultFallback(t *testing.T) {
 	got := resolveWorkspace("", "myrepo")
 	assert.Equal(t, got, "./workspace/myrepo")
 }
+
+func TestLoadForSessionFindsSessionFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".chunk"), 0o755))
+	data := []byte(`{"sidecar_id":"sb-sess","name":"session-box"}`)
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, ".chunk", "sidecar.sess-123.json"), data, 0o644))
+
+	got, err := LoadForSession("sess-123")
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+	assert.Equal(t, got.SidecarID, "sb-sess")
+}
+
+func TestLoadForSessionDoesNotSeeGenericFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Only a generic sidecar.json exists — session-specific lookup should return nil.
+	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-generic"}))
+
+	got, err := LoadForSession("sess-abc")
+	assert.NilError(t, err)
+	assert.Assert(t, got == nil, "session lookup should not see the generic sidecar file")
+}
+
+func TestLoadForSessionReturnsNilWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	got, err := LoadForSession("sess-xyz")
+	assert.NilError(t, err)
+	assert.Assert(t, got == nil)
+}
+
+func TestLoadForSessionEmptyIDDelegatesToLoadActive(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-generic"}))
+
+	got, err := LoadForSession("")
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+	assert.Equal(t, got.SidecarID, "sb-generic")
+}


### PR DESCRIPTION
## Summary

- Adds `LoadForSession(sessionID string)` which finds `.chunk/sidecar.<id>.json` directly, bypassing the `CLAUDE_SESSION_ID` env var
- Refactors internal file-search into `findSidecarFileNamed` and `loadActiveNamed` so `LoadActive` and `LoadForSession` share the same directory-walk logic
- Adds 4 unit tests covering: finding a session file, not seeing the generic file, missing file, and empty-ID delegation

## Test plan

- [x] `go test ./internal/sidecar/...` — new `TestLoadForSession*` tests pass
- [x] Existing `TestSessionKeyedSidecar` and other active-sidecar tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)