### PR TITLE
validate: auto-use active sidecar for current session

### DIFF
--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -471,6 +471,123 @@ func TestValidateHookAutoDetectsSessionSidecar(t *testing.T) {
 	assert.Equal(t, len(addKeyReqs), 1, "expected add-key request for session-keyed sidecar")
 }
 
+// writeRemoteProjectConfig writes a single-command config with the Remote flag set.
+func writeRemoteProjectConfig(t *testing.T, workDir, cmdName, cmdRun string) {
+	t.Helper()
+	chunkDir := filepath.Join(workDir, ".chunk")
+	assert.NilError(t, os.MkdirAll(chunkDir, 0o755))
+	type command struct {
+		Name   string `json:"name"`
+		Run    string `json:"run"`
+		Remote bool   `json:"remote"`
+	}
+	config := map[string]any{
+		"commands": []command{{Name: cmdName, Run: cmdRun, Remote: true}},
+	}
+	data, err := json.Marshal(config)
+	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), data, 0o644))
+}
+
+// TestValidateRemoteCommandAutoCreatesSidecar verifies that when a command is
+// marked remote:true and no sidecar exists, validate auto-creates one and
+// routes that command to it via SSH.
+func TestValidateRemoteCommandAutoCreatesSidecar(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = "127.0.0.1" // causes SSH handshake to fail — expected
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	writeRemoteProjectConfig(t, workDir, "build", "make build")
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	env.Extra["CIRCLECI_ORG_ID"] = "org-123"
+	generateHomeSSHKey(t, env)
+
+	result := binary.RunCLI(t, []string{"validate"}, env, workDir)
+
+	// SSH will fail (no server), but we verify the auto-create path was taken.
+	assert.Assert(t, result.ExitCode != 0, "expected failure because no SSH server is running")
+
+	// AddSSHKey must be called for the auto-created sidecar.
+	addKeyReqs := filterByPath(cci.Recorder.AllRequests(), "/api/v2/sidecar/instances/sidecar-new-123/ssh/add-key")
+	assert.Equal(t, len(addKeyReqs), 1, "expected SSH to be attempted on the auto-created sidecar; stderr: %s", result.Stderr)
+}
+
+// TestValidateHookRemoteCommandAutoCreatesSessionSidecar verifies that when
+// running as a Stop hook, a remote:true command triggers auto-creation of a
+// session-keyed sidecar file.
+func TestValidateHookRemoteCommandAutoCreatesSessionSidecar(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = "127.0.0.1"
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	writeRemoteProjectConfig(t, workDir, "build", "make build")
+	// Write an untracked file so the hook sees a dirty tree.
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "dirty.txt"), []byte("x"), 0o644))
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	env.Extra["CIRCLECI_ORG_ID"] = "org-123"
+	generateHomeSSHKey(t, env)
+
+	result := binary.RunCLIWithStdin(t, []string{"validate"}, env, workDir,
+		hookStdin(t, "sess-remote", false))
+
+	// SSH fails (no server) — expected.
+	assert.Assert(t, result.ExitCode != 0, "expected failure because no SSH server is running")
+
+	// AddSSHKey must be called for the auto-created sidecar.
+	addKeyReqs := filterByPath(cci.Recorder.AllRequests(), "/api/v2/sidecar/instances/sidecar-new-123/ssh/add-key")
+	assert.Equal(t, len(addKeyReqs), 1, "expected SSH to be attempted on auto-created sidecar; stderr: %s", result.Stderr)
+
+	// The sidecar must be saved as a session-keyed file, not generic sidecar.json.
+	sessionFile := filepath.Join(workDir, ".chunk", "sidecar.sess-remote.json")
+	_, err := os.Stat(sessionFile)
+	assert.NilError(t, err, "expected session-keyed sidecar file to be created at %s", sessionFile)
+}
+
+// TestValidateRemoteCommandUsesExistingSidecar verifies that when a command is
+// marked remote:true and an active sidecar.json already exists, validate uses
+// that sidecar for the remote command (per-command routing, not remoteAll).
+func TestValidateRemoteCommandUsesExistingSidecar(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = "127.0.0.1"
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	writeRemoteProjectConfig(t, workDir, "build", "make build")
+	writeSidecarFile(t, workDir, "sidecar.json", "sidecar-existing")
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	generateHomeSSHKey(t, env)
+
+	result := binary.RunCLI(t, []string{"validate"}, env, workDir)
+
+	// SSH will fail (no server), but the path through OpenSession is what matters.
+	assert.Assert(t, result.ExitCode != 0, "expected failure because no SSH server is running")
+
+	// SSH add-key must be called for the existing sidecar.
+	addKeyReqs := filterByPath(cci.Recorder.AllRequests(), "/api/v2/sidecar/instances/sidecar-existing/ssh/add-key")
+	assert.Equal(t, len(addKeyReqs), 1, "expected SSH to be attempted on the existing sidecar; stderr: %s", result.Stderr)
+
+	// No new sidecar should be created.
+	createReqs := filterByPath(cci.Recorder.AllRequests(), "/api/v2/sidecar/instances")
+	var createPOSTs int
+	for _, r := range createReqs {
+		if r.Method == "POST" {
+			createPOSTs++
+		}
+	}
+	assert.Equal(t, createPOSTs, 0, "expected no new sidecar creation when one already exists")
+}
+
 // TestValidateHookDoesNotUseGenericSidecarForSession verifies that when running
 // as a Stop hook with a session ID, validate does NOT pick up a generic
 // sidecar.json — it only uses a session-keyed file.

--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -393,3 +393,107 @@ func TestValidateRunRemoteUsesSSH(t *testing.T) {
 	execReqs := filterByPath(reqs, "/api/v2/sidecar/instances/sidecar-123/exec")
 	assert.Equal(t, len(execReqs), 0, "expected 0 HTTP exec requests (SSH should be used)")
 }
+
+// writeSidecarFile writes a sidecar state file into workDir/.chunk/<filename>.
+func writeSidecarFile(t *testing.T, workDir, filename, sidecarID string) {
+	t.Helper()
+	chunkDir := filepath.Join(workDir, ".chunk")
+	assert.NilError(t, os.MkdirAll(chunkDir, 0o755))
+	data := []byte(`{"sidecar_id":"` + sidecarID + `"}`)
+	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, filename), data, 0o644))
+}
+
+// generateHomeSSHKey writes a chunk_ai keypair into env.HomeDir/.ssh so that
+// OpenSession can load it when no --identity-file flag is provided.
+func generateHomeSSHKey(t *testing.T, env *testenv.TestEnv) string {
+	t.Helper()
+	sshDir := filepath.Join(env.HomeDir, ".ssh")
+	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
+	keyPath := filepath.Join(sshDir, "chunk_ai")
+	assert.NilError(t, generateTestSSHKey(t, keyPath))
+	return keyPath
+}
+
+// TestValidateAutoDetectsActiveSidecar verifies that validate routes to the
+// SSH path when a sidecar.json is present in the project, without requiring
+// --remote or --sidecar-id.
+func TestValidateAutoDetectsActiveSidecar(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = "127.0.0.1" // causes SSH handshake to fail — expected
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	writeProjectConfig(t, workDir, "echo install", "echo test")
+	writeSidecarFile(t, workDir, "sidecar.json", "sidecar-auto")
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	generateHomeSSHKey(t, env)
+
+	result := binary.RunCLI(t, []string{"validate"}, env, workDir)
+
+	// SSH will fail (no server), but the path through OpenSession is what matters.
+	assert.Assert(t, result.ExitCode != 0, "expected failure because no SSH server is running")
+
+	// "using active sidecar" should appear in stderr output.
+	assert.Assert(t, strings.Contains(result.Stderr, "sidecar-auto"),
+		"expected sidecar ID in output, got: %s", result.Stderr)
+
+	// AddSSHKey must have been called — proves SSH path was taken automatically.
+	addKeyReqs := filterByPath(cci.Recorder.AllRequests(), "/api/v2/sidecar/instances/sidecar-auto/ssh/add-key")
+	assert.Equal(t, len(addKeyReqs), 1, "expected add-key request for auto-detected sidecar")
+}
+
+// TestValidateHookAutoDetectsSessionSidecar verifies that when running as a
+// Stop hook with a session ID, validate picks up the session-keyed sidecar
+// file and routes to SSH.
+func TestValidateHookAutoDetectsSessionSidecar(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = "127.0.0.1"
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	writeProjectConfig(t, workDir, "echo install", "echo test")
+	writeSidecarFile(t, workDir, "sidecar.sess-hook.json", "sidecar-session")
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	generateHomeSSHKey(t, env)
+
+	result := binary.RunCLIWithStdin(t, []string{"validate"}, env, workDir,
+		hookStdin(t, "sess-hook", false))
+
+	assert.Assert(t, result.ExitCode != 0, "expected failure because no SSH server is running")
+
+	addKeyReqs := filterByPath(cci.Recorder.AllRequests(), "/api/v2/sidecar/instances/sidecar-session/ssh/add-key")
+	assert.Equal(t, len(addKeyReqs), 1, "expected add-key request for session-keyed sidecar")
+}
+
+// TestValidateHookDoesNotUseGenericSidecarForSession verifies that when running
+// as a Stop hook with a session ID, validate does NOT pick up a generic
+// sidecar.json — it only uses a session-keyed file.
+func TestValidateHookDoesNotUseGenericSidecarForSession(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	writeProjectConfig(t, workDir, "true", "true")
+	// Only a generic sidecar.json — no session-specific file.
+	writeSidecarFile(t, workDir, "sidecar.json", "sidecar-generic")
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLIWithStdin(t, []string{"validate"}, env, workDir,
+		hookStdin(t, "sess-other", false))
+
+	// Commands succeed locally → hook returns exit 0.
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	// AddSSHKey must NOT be called — session had no matching sidecar file.
+	addKeyReqs := filterByPath(cci.Recorder.AllRequests(), "/api/v2/sidecar/instances/sidecar-generic/ssh/add-key")
+	assert.Equal(t, len(addKeyReqs), 0, "expected no SSH requests when session sidecar file is absent")
+}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -305,6 +305,10 @@ func resolveSidecarForValidate(ctx context.Context, sidecarID string, remote boo
 		if hook == nil {
 			statusFn(iostream.LevelInfo, fmt.Sprintf("using active sidecar %s", active.SidecarID))
 		}
+		if hasRemoteCommands(cfg, name) {
+			// Some commands are marked remote: route only those to the sidecar.
+			return active.SidecarID, false, nil
+		}
 		return active.SidecarID, true, nil
 	}
 	// Per-command remote: auto-provision when some commands require remote execution.
@@ -374,7 +378,11 @@ func ensureRemoteSidecar(ctx context.Context, workDir string, hook *hookContext,
 		}
 		return "", &userError{msg: "Could not create sidecar for remote commands.", err: err}
 	}
-	if saveErr := sidecar.SaveActive(sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); saveErr != nil {
+	sessionID := ""
+	if hook != nil {
+		sessionID = hook.sessionID
+	}
+	if saveErr := sidecar.SaveActiveForSession(sessionID, sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); saveErr != nil {
 		streams.ErrPrintf("warning: could not save active sidecar: %v\n", saveErr)
 	}
 	statusFn(iostream.LevelDone, fmt.Sprintf("Created sidecar %s (%s)", sc.Name, sc.ID))

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -135,13 +136,14 @@ func newValidateCmd() *cobra.Command {
 				return mapValidateError(validate.RunDryRun(cfg, name, statusFn))
 			}
 
-			if remote {
-				if err := resolveSidecarID(&sidecarID); err != nil {
-					return err
-				}
+			var remoteAll bool
+			var resolveErr error
+			sidecarID, remoteAll, resolveErr = resolveSidecarForValidate(cmd.Context(), sidecarID, remote, hook, workDir, cfg, name, inlineCmd, streams, statusFn)
+			if resolveErr != nil {
+				return resolveErr
 			}
 
-			execErr := runValidate(cmd.Context(), workDir, name, inlineCmd, save, sidecarID, identityFile, workdir, cfg, statusFn, streams)
+			execErr := runValidate(cmd.Context(), workDir, name, inlineCmd, save, sidecarID, identityFile, workdir, remoteAll, cfg, statusFn, streams)
 
 			if hook != nil {
 				maxAttempts := cfg.StopHookMaxAttempts
@@ -169,7 +171,10 @@ func newValidateCmd() *cobra.Command {
 
 // runValidate dispatches to the appropriate Run* function based on the
 // provided options. It is shared by both direct and hook invocations.
-func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool, sidecarID, identityFile, workdir string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+// When remoteAll is true and sidecarID is non-empty, all commands run on the
+// sidecar. When remoteAll is false, only commands with Remote:true are routed
+// to the sidecar and the rest run locally.
+func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool, sidecarID, identityFile, workdir string, remoteAll bool, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	// --cmd: inline command
 	if inlineCmd != "" {
 		cmdName := name
@@ -198,7 +203,10 @@ func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool
 		if err != nil {
 			return err
 		}
-		return validate.RunRemote(ctx, execFn, cfg, name, dest, streams)
+		if remoteAll {
+			return validate.RunRemote(ctx, execFn, cfg, name, dest, streams)
+		}
+		return validate.RunMixed(ctx, workDir, execFn, cfg, name, dest, statusFn, streams)
 	}
 
 	// Named command
@@ -268,6 +276,109 @@ func openSSHSession(ctx context.Context, sidecarID, identityFile, workdir string
 		return result.Stdout, result.Stderr, result.ExitCode, nil
 	}
 	return execFn, dest, nil
+}
+
+// resolveSidecarForValidate determines the sidecarID and remoteAll flag for a
+// validate run. remoteAll is true when all commands should run on the sidecar
+// (explicit --sidecar-id/--remote flag or an existing active sidecar); false
+// when only commands with Remote:true are routed (auto-provisioned sidecar).
+func resolveSidecarForValidate(ctx context.Context, sidecarID string, remote bool, hook *hookContext, workDir string, cfg *config.ProjectConfig, name, inlineCmd string, streams iostream.Streams, statusFn iostream.StatusFunc) (id string, remoteAll bool, err error) {
+	// Explicit --sidecar-id: route all commands to sidecar.
+	if sidecarID != "" {
+		return sidecarID, true, nil
+	}
+	// --remote: resolve from active sidecar file.
+	if remote {
+		if err := resolveSidecarID(&sidecarID); err != nil {
+			return "", false, err
+		}
+		return sidecarID, true, nil
+	}
+	// Auto-use the active sidecar for the current session.
+	var active *sidecar.ActiveSidecar
+	if hook != nil && hook.sessionID != "" {
+		active, _ = sidecar.LoadForSession(hook.sessionID)
+	} else {
+		active, _ = sidecar.LoadActive()
+	}
+	if active != nil {
+		if hook == nil {
+			statusFn(iostream.LevelInfo, fmt.Sprintf("using active sidecar %s", active.SidecarID))
+		}
+		return active.SidecarID, true, nil
+	}
+	// Per-command remote: auto-provision when some commands require remote execution.
+	if inlineCmd == "" && hasRemoteCommands(cfg, name) {
+		id, provisionErr := ensureRemoteSidecar(ctx, workDir, hook, streams, statusFn)
+		if provisionErr != nil {
+			return "", false, provisionErr
+		}
+		return id, false, nil // remoteAll=false: only Remote:true commands go to sidecar
+	}
+	return "", false, nil
+}
+
+// hasRemoteCommands reports whether the named command (or any command when
+// name is empty) has the Remote flag set.
+func hasRemoteCommands(cfg *config.ProjectConfig, name string) bool {
+	if name != "" {
+		c := cfg.FindCommand(name)
+		return c != nil && c.Remote
+	}
+	for _, c := range cfg.Commands {
+		if c.Remote {
+			return true
+		}
+	}
+	return false
+}
+
+// ensureRemoteSidecar returns a sidecarID for remote command execution.
+// It loads the active sidecar when one is already set, otherwise creates a new
+// one using CIRCLECI_ORG_ID and a name derived from workDir.
+func ensureRemoteSidecar(ctx context.Context, workDir string, hook *hookContext, streams iostream.Streams, statusFn iostream.StatusFunc) (string, error) {
+	var active *sidecar.ActiveSidecar
+	if hook != nil && hook.sessionID != "" {
+		active, _ = sidecar.LoadForSession(hook.sessionID)
+	}
+	if active == nil {
+		active, _ = sidecar.LoadActive()
+	}
+	if active != nil {
+		return active.SidecarID, nil
+	}
+
+	// No active sidecar: auto-create one.
+	client, err := ensureCircleCIClient(ctx, streams, tui.PromptHidden)
+	if err != nil {
+		return "", fmt.Errorf("cannot provision sidecar for remote commands: %w", err)
+	}
+	orgID := os.Getenv(config.EnvCircleCIOrgID)
+	if orgID == "" {
+		return "", &userError{
+			msg:        "No active sidecar and CIRCLECI_ORG_ID is not set.",
+			suggestion: "Set CIRCLECI_ORG_ID, or run 'chunk sidecar use <id>' to specify a sidecar.",
+			errMsg:     "no active sidecar and CIRCLECI_ORG_ID not set",
+		}
+	}
+	name := filepath.Base(workDir)
+	provider := os.Getenv(config.EnvSidecarProvider)
+	if provider == "" {
+		provider = defaultProvider
+	}
+	statusFn(iostream.LevelStep, fmt.Sprintf("Creating sidecar %q for remote commands...", name))
+	sc, err := sidecar.Create(ctx, client, orgID, name, provider, "")
+	if err != nil {
+		if authErr := notAuthorized("create sidecars", err); authErr != nil {
+			return "", authErr
+		}
+		return "", &userError{msg: "Could not create sidecar for remote commands.", err: err}
+	}
+	if saveErr := sidecar.SaveActive(sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); saveErr != nil {
+		streams.ErrPrintf("warning: could not save active sidecar: %v\n", saveErr)
+	}
+	statusFn(iostream.LevelDone, fmt.Sprintf("Created sidecar %s (%s)", sc.Name, sc.ID))
+	return sc.ID, nil
 }
 
 func mapValidateError(err error) error {

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+)
+
+func TestDetectHookParsesSessionID(t *testing.T) {
+	payload := `{"session_id":"sess-abc","stop_hook_active":false}`
+	got := detectHook(strings.NewReader(payload))
+	assert.Assert(t, got != nil)
+	assert.Equal(t, got.sessionID, "sess-abc")
+	assert.Equal(t, got.stopHookActive, false)
+}
+
+func TestDetectHookParsesStopHookActive(t *testing.T) {
+	payload := `{"session_id":"sess-xyz","stop_hook_active":true}`
+	got := detectHook(strings.NewReader(payload))
+	assert.Assert(t, got != nil)
+	assert.Equal(t, got.sessionID, "sess-xyz")
+	assert.Equal(t, got.stopHookActive, true)
+}
+
+func TestDetectHookNilWhenNoSessionID(t *testing.T) {
+	payload := `{"stop_hook_active":true}`
+	got := detectHook(strings.NewReader(payload))
+	assert.Assert(t, got == nil, "missing session_id should return nil")
+}
+
+func TestDetectHookNilOnEmptyInput(t *testing.T) {
+	got := detectHook(strings.NewReader(""))
+	assert.Assert(t, got == nil)
+}
+
+func TestDetectHookNilOnInvalidJSON(t *testing.T) {
+	got := detectHook(strings.NewReader("not json"))
+	assert.Assert(t, got == nil)
+}
+
+func TestHasRemoteCommands(t *testing.T) {
+	cfg := &config.ProjectConfig{Commands: []config.Command{
+		{Name: "lint", Run: "golangci-lint run"},
+		{Name: "test", Run: "go test ./...", Remote: true},
+	}}
+
+	assert.Assert(t, hasRemoteCommands(cfg, ""), "should detect remote command in full list")
+	assert.Assert(t, hasRemoteCommands(cfg, "test"), "named remote command should return true")
+	assert.Assert(t, !hasRemoteCommands(cfg, "lint"), "named local command should return false")
+
+	localOnly := &config.ProjectConfig{Commands: []config.Command{
+		{Name: "lint", Run: "golangci-lint run"},
+	}}
+	assert.Assert(t, !hasRemoteCommands(localOnly, ""), "no remote commands should return false")
+}

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -24,6 +24,7 @@ type Command struct {
 	Limit   int    `json:"limit,omitempty"`
 	Always  bool   `json:"always,omitempty"`
 	Staged  bool   `json:"staged,omitempty"`
+	Remote  bool   `json:"remote,omitempty"`
 }
 
 // TaskConfig holds task delegation configuration.

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -64,6 +64,17 @@ func loadActiveNamed(filename string) (*ActiveSidecar, error) {
 // parent directory it is updated in place; otherwise the file is created in
 // cwd's .chunk/ directory.
 func SaveActive(a ActiveSidecar) error {
+	return SaveActiveForSession("", a)
+}
+
+// SaveActiveForSession writes the sidecar state file. When sessionID is
+// non-empty the file is keyed to that session (sidecar.<sessionID>.json);
+// otherwise the env-derived filename is used (see sidecarFileName).
+func SaveActiveForSession(sessionID string, a ActiveSidecar) error {
+	filename := sidecarFileName()
+	if sessionID != "" {
+		filename = "sidecar." + sessionID + ".json"
+	}
 	dir, err := saveDir()
 	if err != nil {
 		return err
@@ -75,7 +86,7 @@ func SaveActive(a ActiveSidecar) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dir, sidecarFileName()), data, 0o644)
+	return os.WriteFile(filepath.Join(dir, filename), data, 0o644)
 }
 
 // saveDir returns the .chunk directory to write into. It prefers an existing

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -90,6 +90,25 @@ func RunDryRun(cfg *config.ProjectConfig, name string, status iostream.StatusFun
 	return nil
 }
 
+// runRemoteCommand executes a single command on a remote sidecar via execFn.
+func runRemoteCommand(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), name, command, dest string, streams iostream.Streams) error {
+	script := "cd " + shellEscape(dest) + " && " + command
+	stdout, stderr, exitCode, err := execFn(ctx, script)
+	if err != nil {
+		return fmt.Errorf("remote %s: %w", name, err)
+	}
+	if stdout != "" {
+		_, _ = fmt.Fprint(streams.Out, stdout)
+	}
+	if stderr != "" {
+		_, _ = fmt.Fprint(streams.Err, stderr)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("remote %s failed with exit code %d", name, exitCode)
+	}
+	return nil
+}
+
 // RunRemote runs commands on a remote sidecar via SSH.
 // If name is non-empty, only the named command is run.
 func RunRemote(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), cfg *config.ProjectConfig, name, dest string, streams iostream.Streams) error {
@@ -102,19 +121,42 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 		commands = []config.Command{*c}
 	}
 	for _, c := range commands {
-		script := "cd " + shellEscape(dest) + " && " + c.Run
-		stdout, stderr, exitCode, err := execFn(ctx, script)
+		if err := runRemoteCommand(ctx, execFn, c.Name, c.Run, dest, streams); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RunMixed runs commands, routing each one based on its Remote flag.
+// Commands with Remote:true run via execFn on dest; others run locally in workDir.
+// Stops at the first failure, logging skipped commands via status.
+func RunMixed(ctx context.Context, workDir string, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), cfg *config.ProjectConfig, name, dest string, status iostream.StatusFunc, streams iostream.Streams) error {
+	if !cfg.HasCommands() {
+		return ErrNotConfigured
+	}
+
+	commands := cfg.Commands
+	if name != "" {
+		c := cfg.FindCommand(name)
+		if c == nil {
+			return fmt.Errorf("command %q not configured", name)
+		}
+		commands = []config.Command{*c}
+	}
+
+	for i, c := range commands {
+		var err error
+		if c.Remote {
+			err = runRemoteCommand(ctx, execFn, c.Name, c.Run, dest, streams)
+		} else {
+			err = runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, status, streams)
+		}
 		if err != nil {
-			return fmt.Errorf("remote %s: %w", c.Name, err)
-		}
-		if stdout != "" {
-			_, _ = fmt.Fprint(streams.Out, stdout)
-		}
-		if stderr != "" {
-			_, _ = fmt.Fprint(streams.Err, stderr)
-		}
-		if exitCode != 0 {
-			return fmt.Errorf("remote %s failed with exit code %d", c.Name, exitCode)
+			for j := i + 1; j < len(commands); j++ {
+				status(iostream.LevelWarn, fmt.Sprintf("%s: skipped (%s failed)", commands[j].Name, c.Name))
+			}
+			return err
 		}
 	}
 	return nil

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -460,6 +460,113 @@ func TestRunRemoteSSH(t *testing.T) {
 	})
 }
 
+// --- RunMixed tests ---
+
+func TestRunMixed(t *testing.T) {
+	t.Run("all local when no remote flag", func(t *testing.T) {
+		cfg := &config.ProjectConfig{Commands: []config.Command{
+			{Name: "install", Run: "echo installed"},
+			{Name: "test", Run: "echo tested"},
+		}}
+		execCalled := 0
+		execFn := func(_ context.Context, _ string) (string, string, int, error) {
+			execCalled++
+			return "", "", 0, nil
+		}
+		streams, out, _ := newStreams()
+		var statusBuf bytes.Buffer
+
+		assert.NilError(t, RunMixed(context.Background(), ".", execFn, cfg, "", "/workspace", testStatus(&statusBuf), streams))
+		assert.Equal(t, execCalled, 0, "no remote commands should have been executed")
+		assert.Assert(t, strings.Contains(out.String(), "installed"), "got: %s", out.String())
+		assert.Assert(t, strings.Contains(out.String(), "tested"), "got: %s", out.String())
+	})
+
+	t.Run("remote commands use execFn", func(t *testing.T) {
+		cfg := &config.ProjectConfig{Commands: []config.Command{
+			{Name: "lint", Run: "echo lint"},
+			{Name: "test", Run: "echo test", Remote: true},
+		}}
+		var capturedScripts []string
+		execFn := func(_ context.Context, script string) (string, string, int, error) {
+			capturedScripts = append(capturedScripts, script)
+			return "remote output\n", "", 0, nil
+		}
+		streams, out, _ := newStreams()
+		var statusBuf bytes.Buffer
+
+		assert.NilError(t, RunMixed(context.Background(), ".", execFn, cfg, "", "/workspace", testStatus(&statusBuf), streams))
+		assert.Equal(t, len(capturedScripts), 1, "only remote command should use execFn")
+		assert.Assert(t, strings.Contains(capturedScripts[0], "echo test"), "got: %s", capturedScripts[0])
+		assert.Assert(t, strings.Contains(out.String(), "remote output"), "got: %s", out.String())
+		assert.Assert(t, strings.Contains(out.String(), "lint"), "local output should appear, got: %s", out.String())
+	})
+
+	t.Run("stops on local failure", func(t *testing.T) {
+		cfg := &config.ProjectConfig{Commands: []config.Command{
+			{Name: "lint", Run: "false"},
+			{Name: "test", Run: "echo test", Remote: true},
+		}}
+		execCalled := 0
+		execFn := func(_ context.Context, _ string) (string, string, int, error) {
+			execCalled++
+			return "", "", 0, nil
+		}
+		streams, _, _ := newStreams()
+		var statusBuf bytes.Buffer
+
+		err := RunMixed(context.Background(), ".", execFn, cfg, "", "/workspace", testStatus(&statusBuf), streams)
+		assert.ErrorContains(t, err, "lint command failed")
+		assert.Equal(t, execCalled, 0, "remote command should be skipped after local failure")
+		assert.Assert(t, strings.Contains(statusBuf.String(), "test: skipped"), "got: %s", statusBuf.String())
+	})
+
+	t.Run("stops on remote failure", func(t *testing.T) {
+		cfg := &config.ProjectConfig{Commands: []config.Command{
+			{Name: "test", Run: "false", Remote: true},
+			{Name: "lint", Run: "echo lint"},
+		}}
+		execFn := func(_ context.Context, _ string) (string, string, int, error) {
+			return "", "", 1, nil
+		}
+		streams, _, _ := newStreams()
+		var statusBuf bytes.Buffer
+
+		err := RunMixed(context.Background(), ".", execFn, cfg, "", "/workspace", testStatus(&statusBuf), streams)
+		assert.ErrorContains(t, err, "remote test failed")
+		assert.Assert(t, strings.Contains(statusBuf.String(), "lint: skipped"), "got: %s", statusBuf.String())
+	})
+
+	t.Run("no commands returns error", func(t *testing.T) {
+		cfg := &config.ProjectConfig{}
+		execFn := func(_ context.Context, _ string) (string, string, int, error) {
+			return "", "", 0, nil
+		}
+		streams, _, _ := newStreams()
+		var statusBuf bytes.Buffer
+
+		err := RunMixed(context.Background(), ".", execFn, cfg, "", "/workspace", testStatus(&statusBuf), streams)
+		assert.ErrorContains(t, err, "no validate commands")
+	})
+
+	t.Run("named remote command", func(t *testing.T) {
+		cfg := &config.ProjectConfig{Commands: []config.Command{
+			{Name: "install", Run: "echo install"},
+			{Name: "test", Run: "echo test", Remote: true},
+		}}
+		var capturedScripts []string
+		execFn := func(_ context.Context, script string) (string, string, int, error) {
+			capturedScripts = append(capturedScripts, script)
+			return "", "", 0, nil
+		}
+		streams, _, _ := newStreams()
+		var statusBuf bytes.Buffer
+
+		assert.NilError(t, RunMixed(context.Background(), ".", execFn, cfg, "test", "/workspace", testStatus(&statusBuf), streams))
+		assert.Equal(t, len(capturedScripts), 1)
+	})
+}
+
 func TestRunRemoteInline(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		var capturedScript string


### PR DESCRIPTION
## Summary

- `validate` now automatically routes to a sidecar when one is active for the current session — no `--remote` or `--sidecar-id` flag required
- In hook context, uses the `session_id` from the stdin payload to call `sidecar.LoadForSession`, keeping sessions isolated without env var dependency
- Outside hook context, falls back to `sidecar.LoadActive()` and prints `"using active sidecar <id>"` to stderr
- Adds `detectHook` unit tests and 3 acceptance tests covering: auto-detection from `sidecar.json`, session-keyed lookup in hook mode, and session isolation (generic file not used for a different session)

Stacks on #284.

## Test plan

- [ ] `go test ./internal/cmd/...` — new `TestDetectHook*` tests pass
- [ ] `go test -run 'TestValidateAutoDetects|TestValidateHook' ./acceptance/...` — 3 new acceptance tests pass
- [ ] `go test -run 'TestValidate' ./acceptance/...` — full validate suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)