### PR TITLE
Send versioned User-Agent on all HTTP requests

### DIFF
--- a/internal/anthropic/client.go
+++ b/internal/anthropic/client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	"github.com/CircleCI-Public/chunk-cli/internal/version"
 )
 
 var (
@@ -39,7 +40,7 @@ func New(cfg Config) (*Client, error) {
 		BaseURL:        cfg.BaseURL,
 		AuthToken:      cfg.APIKey,
 		AuthHeader:     "x-api-key",
-		UserAgent:      "chunk-cli",
+		UserAgent:      version.UserAgent(),
 		Timeout:        5 * time.Minute,
 		DisableRetries: true,
 	})

--- a/internal/authprompt/authprompt.go
+++ b/internal/authprompt/authprompt.go
@@ -11,6 +11,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/github"
 	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	"github.com/CircleCI-Public/chunk-cli/internal/version"
 )
 
 // ErrNeedsAuth is returned by Resolve* functions when no credentials are
@@ -28,6 +29,7 @@ func ValidateCircleCIToken(ctx context.Context, token, baseURL string) error {
 		BaseURL:    baseURL,
 		AuthToken:  token,
 		AuthHeader: "Circle-Token",
+		UserAgent:  version.UserAgent(),
 	})
 	_, err := cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v2/me"))
 	if err != nil {
@@ -49,6 +51,7 @@ func ValidateAPIKey(ctx context.Context, apiKey, baseURL string) error {
 		BaseURL:    baseURL,
 		AuthToken:  apiKey,
 		AuthHeader: "x-api-key",
+		UserAgent:  version.UserAgent(),
 	})
 	type msg struct {
 		Role    string `json:"role"`
@@ -160,7 +163,7 @@ func ValidateGitHubToken(ctx context.Context, token, baseURL string) error {
 		BaseURL:    baseURL,
 		AuthToken:  "token " + token,
 		AuthHeader: "Authorization",
-		UserAgent:  "chunk-cli",
+		UserAgent:  version.UserAgent(),
 	})
 	_, err := cl.Call(ctx, hc.NewRequest(http.MethodGet, "/user"))
 	if err != nil {

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	"github.com/CircleCI-Public/chunk-cli/internal/version"
 )
 
 // ErrTokenNotFound indicates no CircleCI token was found in env or config.
@@ -35,6 +36,7 @@ func NewClient(cfg Config) (*Client, error) {
 		BaseURL:    cfg.BaseURL,
 		AuthToken:  cfg.Token,
 		AuthHeader: "Circle-Token",
+		UserAgent:  version.UserAgent(),
 	})
 	return &Client{cl: cl}, nil
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	"github.com/CircleCI-Public/chunk-cli/internal/version"
 )
 
 type Config struct {
@@ -37,7 +38,7 @@ func New(cfg Config) (*Client, error) {
 		BaseURL:    cfg.BaseURL,
 		AuthToken:  "token " + cfg.Token,
 		AuthHeader: "Authorization",
-		UserAgent:  "chunk-cli",
+		UserAgent:  version.UserAgent(),
 	})
 	return &Client{http: c, logStatus: cfg.LogStatus}, nil
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+import "fmt"
+
+// Value is set via ldflags at build time (e.g. -X main.version=...).
+// main.go copies the value here at startup so internal packages can use it.
+var Value = "dev"
+
+func UserAgent() string {
+	return fmt.Sprintf("Chunk-CLI (%s)", Value)
+}

--- a/main.go
+++ b/main.go
@@ -7,12 +7,14 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/cmd"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+	appversion "github.com/CircleCI-Public/chunk-cli/internal/version"
 )
 
 var version = "dev"
 
 func main() {
 	rewriteColonSyntax()
+	appversion.Value = version
 
 	rootCmd := cmd.NewRootCmd(version)
 	if err := rootCmd.Execute(); err != nil {


### PR DESCRIPTION
## Summary
- Add `internal/version` package with settable `Value` and `UserAgent()` helper returning `Chunk-CLI (<version>)`
- Set version from build-flag variable in `main.go` at startup
- All 6 `httpcl.New` call sites now use `version.UserAgent()` — fixes missing header on CircleCI and auth-prompt clients