### PR TITLE
Remote validation: route commands to sidecar with auto-creation

### DIFF
--- a/.chunk/config.json
+++ b/.chunk/config.json
@@ -6,7 +6,8 @@
       "role": "gate",
       "fileExt": ".go",
       "timeout": 300,
-      "limit": 3
+      "limit": 3,
+      "remote": true
     },
     {
       "name": "test-changed",
@@ -46,7 +47,7 @@
       },
       {
         "name": "system",
-        "command": "sudo apt-get update \u0026\u0026 sudo apt-get install -y git --no-install-recommends \u0026\u0026 sudo rm -rf /var/lib/apt/lists/*"
+        "command": "sudo apt-get update && sudo apt-get install -y git --no-install-recommends && sudo rm -rf /var/lib/apt/lists/*"
       },
       {
         "name": "install",
@@ -55,5 +56,6 @@
     ],
     "image": "cimg/go",
     "image_version": "1.26.2"
-  }
+  },
+  "orgID": "f22b6566-597d-46d5-ba74-99ef5bb3d85c"
 }

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -85,6 +85,8 @@ func newConfigSetCmd() *cobra.Command {
 						projCfg.Validation = &config.ValidationConfig{}
 					}
 					projCfg.Validation.SidecarImage = value
+				default:
+					return fmt.Errorf("internal: unhandled project config key %q", key)
 				}
 				if err := config.SaveProjectConfig(workDir, projCfg); err != nil {
 					return &userError{msg: "Could not save project configuration.", suggestion: configFilePermHint, err: err}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -61,16 +62,35 @@ func newConfigSetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "set <key> <value>",
 		Short: "Set a config value",
-		Long:  "Set a config value (model). Use 'chunk auth set <provider>' to store credentials with validation.",
+		Long:  "Set a config value. Use 'chunk auth set <provider>' to store credentials with validation.\n\nUser keys: model\nProject keys: orgID",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
 			key, value := args[0], args[1]
 
+			if config.ValidProjectConfigKeys[key] {
+				workDir, err := os.Getwd()
+				if err != nil {
+					return err
+				}
+				projCfg, err := config.LoadProjectConfig(workDir)
+				if err != nil {
+					projCfg = &config.ProjectConfig{}
+				}
+				if key == "orgID" {
+					projCfg.OrgID = value
+				}
+				if err := config.SaveProjectConfig(workDir, projCfg); err != nil {
+					return &userError{msg: "Could not save project configuration.", suggestion: configFilePermHint, err: err}
+				}
+				io.Printf("%s\n", ui.Success(fmt.Sprintf("Set %s to %s", key, value)))
+				return nil
+			}
+
 			if !config.ValidConfigKeys[key] {
 				return &userError{
 					msg:    fmt.Sprintf("Unknown config key: %q.", key),
-					detail: "Supported keys: model.",
+					detail: "Supported keys: model, orgID.",
 					errMsg: fmt.Sprintf("unknown config key %q", key),
 				}
 			}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -62,7 +62,7 @@ func newConfigSetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "set <key> <value>",
 		Short: "Set a config value",
-		Long:  "Set a config value. Use 'chunk auth set <provider>' to store credentials with validation.\n\nUser keys: model\nProject keys: orgID",
+		Long:  "Set a config value. Use 'chunk auth set <provider>' to store credentials with validation.\n\nUser keys: model\nProject keys: orgID, validation.sidecarImage",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
@@ -77,8 +77,14 @@ func newConfigSetCmd() *cobra.Command {
 				if err != nil {
 					projCfg = &config.ProjectConfig{}
 				}
-				if key == "orgID" {
+				switch key {
+				case "orgID":
 					projCfg.OrgID = value
+				case "validation.sidecarImage":
+					if projCfg.Validation == nil {
+						projCfg.Validation = &config.ValidationConfig{}
+					}
+					projCfg.Validation.SidecarImage = value
 				}
 				if err := config.SaveProjectConfig(workDir, projCfg); err != nil {
 					return &userError{msg: "Could not save project configuration.", suggestion: configFilePermHint, err: err}
@@ -90,7 +96,7 @@ func newConfigSetCmd() *cobra.Command {
 			if !config.ValidConfigKeys[key] {
 				return &userError{
 					msg:    fmt.Sprintf("Unknown config key: %q.", key),
-					detail: "Supported keys: model, orgID.",
+					detail: "Supported keys: model, orgID, validation.sidecarImage.",
 					errMsg: fmt.Sprintf("unknown config key %q", key),
 				}
 			}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -136,13 +136,35 @@ func newValidateCmd() *cobra.Command {
 				return mapValidateError(validate.RunDryRun(cfg, name, statusFn))
 			}
 
+			// allRemote is true when the caller explicitly targets the sidecar
+			// (--remote or --sidecar-id), meaning every command runs there.
+			// Per-command routing only applies when the sidecar is resolved implicitly.
+			allRemote := remote || sidecarID != ""
+
+			image := resolveImage(name, cfg)
+
 			if remote {
-				if err := resolveOrCreateSidecarID(cmd.Context(), &sidecarID, orgID, workDir, streams); err != nil {
+				// --remote: force all commands to sidecar, creating one if needed.
+				if err := resolveOrCreateSidecarID(cmd.Context(), &sidecarID, orgID, image, workDir, streams); err != nil {
 					return err
+				}
+				statusFn(iostream.LevelInfo, fmt.Sprintf("running all commands on sidecar %s", sidecarID))
+			} else if cfg.HasRemoteCommands() {
+				// Per-command remote: use active sidecar if available.
+				if active, err := sidecar.LoadActive(); err == nil && active != nil {
+					sidecarID = active.SidecarID
+					statusFn(iostream.LevelInfo, fmt.Sprintf("using sidecar %s for remote commands", sidecarID))
+				} else if hook != nil {
+					// In Stop hook context: auto-create a sandbox if possible.
+					if err := resolveOrCreateSidecarID(cmd.Context(), &sidecarID, orgID, image, workDir, streams); err != nil {
+						streams.ErrPrintf("warning: no sandbox available (%v); run 'chunk config set orgID <id>' to enable remote validation, running locally instead\n", err)
+					}
+				} else {
+					statusFn(iostream.LevelWarn, "no active sidecar found — remote commands will run locally")
 				}
 			}
 
-			execErr := runValidate(cmd.Context(), workDir, name, inlineCmd, save, sidecarID, identityFile, workdir, cfg, statusFn, streams)
+			execErr := runValidate(cmd.Context(), workDir, name, inlineCmd, save, sidecarID, identityFile, workdir, allRemote, cfg, statusFn, streams)
 
 			if hook != nil {
 				maxAttempts := cfg.StopHookMaxAttempts
@@ -171,8 +193,10 @@ func newValidateCmd() *cobra.Command {
 
 // runValidate dispatches to the appropriate Run* function based on the
 // provided options. It is shared by both direct and hook invocations.
-func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool, sidecarID, identityFile, workdir string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
-	// --cmd: inline command
+// allRemote is true when --remote is passed explicitly (all commands run on the
+// sidecar); false means only commands with Remote:true are routed to the sidecar.
+func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool, sidecarID, identityFile, workdir string, allRemote bool, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+	// --cmd: inline command (always local in per-command mode)
 	if inlineCmd != "" {
 		cmdName := name
 		if cmdName == "" {
@@ -184,7 +208,7 @@ func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool
 			}
 			streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", cmdName)))
 		}
-		if sidecarID != "" {
+		if sidecarID != "" && allRemote {
 			execFn, dest, err := openSSHSession(ctx, sidecarID, identityFile, workdir, streams)
 			if err != nil {
 				return err
@@ -194,13 +218,53 @@ func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool
 		return validate.RunInline(ctx, workDir, cmdName, inlineCmd, statusFn, streams)
 	}
 
-	// Remote execution
-	if sidecarID != "" {
+	// All-remote execution (--remote flag): send everything to the sidecar.
+	if sidecarID != "" && allRemote {
 		execFn, dest, err := openSSHSession(ctx, sidecarID, identityFile, workdir, streams)
 		if err != nil {
 			return err
 		}
 		return validate.RunRemote(ctx, execFn, cfg, name, dest, streams)
+	}
+
+	// Per-command remote routing: commands with Remote:true go to the sidecar,
+	// the rest run locally.
+	if sidecarID != "" {
+		if name != "" {
+			if cmd := cfg.FindCommand(name); cmd != nil && cmd.Remote {
+				statusFn(iostream.LevelInfo, fmt.Sprintf("running %s on sidecar %s", name, sidecarID))
+				execFn, dest, err := openSSHSession(ctx, sidecarID, identityFile, workdir, streams)
+				if err != nil {
+					return err
+				}
+				return validate.RunRemote(ctx, execFn, cfg, name, dest, streams)
+			}
+			statusFn(iostream.LevelInfo, fmt.Sprintf("running %s locally (not marked remote)", name))
+			// Named command is not marked remote; fall through to local execution.
+		} else {
+			remoteCfg, localCfg := splitByRemote(cfg)
+			if len(remoteCfg.Commands) > 0 {
+				names := commandNames(remoteCfg.Commands)
+				statusFn(iostream.LevelInfo, fmt.Sprintf("running on sidecar %s: %s", sidecarID, names))
+			}
+			if len(localCfg.Commands) > 0 {
+				statusFn(iostream.LevelInfo, fmt.Sprintf("running locally: %s", commandNames(localCfg.Commands)))
+			}
+			var runErr error
+			if len(remoteCfg.Commands) > 0 {
+				execFn, dest, err := openSSHSession(ctx, sidecarID, identityFile, workdir, streams)
+				if err != nil {
+					return err
+				}
+				runErr = validate.RunRemote(ctx, execFn, remoteCfg, "", dest, streams)
+			}
+			if len(localCfg.Commands) > 0 {
+				if err := mapValidateError(validate.RunAll(ctx, workDir, localCfg, statusFn, streams)); err != nil && runErr == nil {
+					runErr = err
+				}
+			}
+			return runErr
+		}
 	}
 
 	// Named command
@@ -272,9 +336,47 @@ func openSSHSession(ctx context.Context, sidecarID, identityFile, workdir string
 	return execFn, dest, nil
 }
 
+// splitByRemote partitions cfg.Commands into two configs: one containing only
+// commands with Remote:true, and one containing the rest.
+func splitByRemote(cfg *config.ProjectConfig) (remote, local *config.ProjectConfig) {
+	remote = &config.ProjectConfig{}
+	local = &config.ProjectConfig{}
+	for _, cmd := range cfg.Commands {
+		if cmd.Remote {
+			remote.Commands = append(remote.Commands, cmd)
+		} else {
+			local.Commands = append(local.Commands, cmd)
+		}
+	}
+	return remote, local
+}
+
+// commandNames returns a comma-separated list of command names.
+func commandNames(cmds []config.Command) string {
+	names := make([]string, len(cmds))
+	for i, c := range cmds {
+		names[i] = c.Name
+	}
+	return strings.Join(names, ", ")
+}
+
+// resolveImage returns the sidecar image to use for sandbox creation.
+// A per-command sidecarImage takes precedence over the project-level default.
+func resolveImage(name string, cfg *config.ProjectConfig) string {
+	if name != "" && cfg != nil {
+		if cmd := cfg.FindCommand(name); cmd != nil && cmd.SidecarImage != "" {
+			return cmd.SidecarImage
+		}
+	}
+	if cfg != nil && cfg.Validation != nil {
+		return cfg.Validation.SidecarImage
+	}
+	return ""
+}
+
 // resolveOrCreateSidecarID fills sidecarID from the active sidecar, or creates
 // a new sandbox when none is configured.
-func resolveOrCreateSidecarID(ctx context.Context, sidecarID *string, orgID, workDir string, streams iostream.Streams) error {
+func resolveOrCreateSidecarID(ctx context.Context, sidecarID *string, orgID, image, workDir string, streams iostream.Streams) error {
 	if *sidecarID != "" {
 		return nil
 	}
@@ -305,8 +407,8 @@ func resolveOrCreateSidecarID(ctx context.Context, sidecarID *string, orgID, wor
 	if provider == "" {
 		provider = defaultProvider
 	}
-	name := filepath.Base(workDir) + "-validate"
-	sc, err := sidecar.Create(ctx, client, resolvedOrgID, name, provider, "")
+	sandboxName := filepath.Base(workDir) + "-validate"
+	sc, err := sidecar.Create(ctx, client, resolvedOrgID, sandboxName, provider, image)
 	if err != nil {
 		if authErr := notAuthorized("create sidecars", err); authErr != nil {
 			return authErr

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -213,7 +213,7 @@ func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool
 			if err != nil {
 				return err
 			}
-			return validate.RunRemoteInline(ctx, execFn, cmdName, inlineCmd, dest, streams)
+			return validate.RunRemoteInline(ctx, execFn, cmdName, inlineCmd, dest, statusFn, streams)
 		}
 		return validate.RunInline(ctx, workDir, cmdName, inlineCmd, statusFn, streams)
 	}
@@ -224,7 +224,7 @@ func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool
 		if err != nil {
 			return err
 		}
-		return validate.RunRemote(ctx, execFn, cfg, name, dest, streams)
+		return validate.RunRemote(ctx, execFn, cfg, name, dest, statusFn, streams)
 	}
 
 	// Per-command remote routing: commands with Remote:true go to the sidecar,
@@ -237,7 +237,7 @@ func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool
 				if err != nil {
 					return err
 				}
-				return validate.RunRemote(ctx, execFn, cfg, name, dest, streams)
+				return validate.RunRemote(ctx, execFn, cfg, name, dest, statusFn, streams)
 			}
 			statusFn(iostream.LevelInfo, fmt.Sprintf("running %s locally (not marked remote)", name))
 			// Named command is not marked remote; fall through to local execution.
@@ -257,7 +257,7 @@ func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool
 					streams.ErrPrintf("warning: could not reach sidecar (%v); running %s locally instead\n", err, commandNames(remoteCfg.Commands))
 					localCfg.Commands = append(remoteCfg.Commands, localCfg.Commands...)
 				} else {
-					runErr = validate.RunRemote(ctx, execFn, remoteCfg, "", dest, streams)
+					runErr = validate.RunRemote(ctx, execFn, remoteCfg, "", dest, statusFn, streams)
 				}
 			}
 			if len(localCfg.Commands) > 0 {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -254,13 +254,15 @@ func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool
 			if len(remoteCfg.Commands) > 0 {
 				execFn, dest, err := openSSHSession(ctx, sidecarID, identityFile, workdir, streams)
 				if err != nil {
-					return err
+					streams.ErrPrintf("warning: could not reach sidecar (%v); running %s locally instead\n", err, commandNames(remoteCfg.Commands))
+					localCfg.Commands = append(remoteCfg.Commands, localCfg.Commands...)
+				} else {
+					runErr = validate.RunRemote(ctx, execFn, remoteCfg, "", dest, streams)
 				}
-				runErr = validate.RunRemote(ctx, execFn, remoteCfg, "", dest, streams)
 			}
 			if len(localCfg.Commands) > 0 {
-				if err := mapValidateError(validate.RunAll(ctx, workDir, localCfg, statusFn, streams)); err != nil && runErr == nil {
-					runErr = err
+				if err := mapValidateError(validate.RunAll(ctx, workDir, localCfg, statusFn, streams)); err != nil {
+					runErr = errors.Join(runErr, err)
 				}
 			}
 			return runErr

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -60,7 +61,7 @@ func detectHook(r io.Reader) *hookContext {
 }
 
 func newValidateCmd() *cobra.Command {
-	var sidecarID, identityFile, workdir string
+	var sidecarID, identityFile, workdir, orgID string
 	var dryRun, list, save, remote bool
 	var inlineCmd, projectDir string
 
@@ -136,7 +137,7 @@ func newValidateCmd() *cobra.Command {
 			}
 
 			if remote {
-				if err := resolveSidecarID(&sidecarID); err != nil {
+				if err := resolveOrCreateSidecarID(cmd.Context(), &sidecarID, orgID, workDir, streams); err != nil {
 					return err
 				}
 			}
@@ -154,8 +155,9 @@ func newValidateCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&remote, "remote", false, "Run on active sidecar (reads .chunk/sidecar.json)")
+	cmd.Flags().BoolVar(&remote, "remote", false, "Run on active sidecar, or create one if none is set")
 	cmd.Flags().StringVar(&sidecarID, "sidecar-id", "", "Sidecar ID for remote execution")
+	cmd.Flags().StringVar(&orgID, "org-id", "", "Organization ID (used when creating a new sidecar)")
 	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file (uses ssh-agent or ~/.ssh/chunk_ai when omitted)")
 	cmd.Flags().StringVar(&workdir, "workdir", "", "Working directory on sidecar (reads from sidecar.json, defaults to ./workspace)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show commands without executing")
@@ -268,6 +270,70 @@ func openSSHSession(ctx context.Context, sidecarID, identityFile, workdir string
 		return result.Stdout, result.Stderr, result.ExitCode, nil
 	}
 	return execFn, dest, nil
+}
+
+// resolveOrCreateSidecarID fills sidecarID from the active sidecar, or creates
+// a new sandbox when none is configured.
+func resolveOrCreateSidecarID(ctx context.Context, sidecarID *string, orgID, workDir string, streams iostream.Streams) error {
+	if *sidecarID != "" {
+		return nil
+	}
+	active, err := sidecar.LoadActive()
+	if err != nil {
+		return &userError{msg: "Could not load the active sidecar.", suggestion: configFilePermHint, err: err}
+	}
+	if active != nil {
+		*sidecarID = active.SidecarID
+		return nil
+	}
+	streams.ErrPrintf("No active sidecar found, creating a new sandbox...\n")
+	client, err := ensureCircleCIClient(ctx, streams, tui.PromptHidden)
+	if err != nil {
+		return err
+	}
+	// Fallback: read org ID from project config if not provided via flag or env.
+	if orgID == "" {
+		if projCfg, loadErr := config.LoadProjectConfig(workDir); loadErr == nil && projCfg.OrgID != "" {
+			orgID = projCfg.OrgID
+		}
+	}
+	resolvedOrgID, err := resolveOrgID(orgID, orgPicker(ctx, client))
+	if err != nil {
+		return err
+	}
+	provider := os.Getenv(config.EnvSidecarProvider)
+	if provider == "" {
+		provider = defaultProvider
+	}
+	name := filepath.Base(workDir) + "-validate"
+	sc, err := sidecar.Create(ctx, client, resolvedOrgID, name, provider, "")
+	if err != nil {
+		if authErr := notAuthorized("create sidecars", err); authErr != nil {
+			return authErr
+		}
+		return &userError{
+			msg:        "Could not create a sandbox.",
+			suggestion: "Check your network connection or run 'chunk sidecar create' manually.",
+			err:        err,
+		}
+	}
+	if saveErr := sidecar.SaveActive(sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); saveErr != nil {
+		streams.ErrPrintf("warning: could not save active sidecar: %v\n", saveErr)
+	}
+	// Persist the org ID so future sandbox creation skips the picker.
+	projCfg, loadErr := config.LoadProjectConfig(workDir)
+	if loadErr != nil {
+		projCfg = &config.ProjectConfig{}
+	}
+	if projCfg.OrgID == "" {
+		projCfg.OrgID = resolvedOrgID
+		if saveErr := config.SaveProjectConfig(workDir, projCfg); saveErr != nil {
+			streams.ErrPrintf("warning: could not save org ID to project config: %v\n", saveErr)
+		}
+	}
+	streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Created sandbox %s (%s)", sc.Name, sc.ID)))
+	*sidecarID = sc.ID
+	return nil
 }
 
 func mapValidateError(err error) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -256,9 +256,15 @@ func MaskKey(key string) string {
 	return strings.Repeat("*", len(key)-4) + key[len(key)-4:]
 }
 
-// ValidConfigKeys are the keys accepted by "config set".
+// ValidConfigKeys are the keys accepted by "config set" that write to the user config.
 // Credentials (anthropicAPIKey, circleCIToken) are intentionally excluded —
 // users should use "auth set" which validates before storing.
 var ValidConfigKeys = map[string]bool{
 	"model": true,
+}
+
+// ValidProjectConfigKeys are the keys accepted by "config set" that write to
+// the project config (.chunk/config.json).
+var ValidProjectConfigKeys = map[string]bool{
+	"orgID": true,
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -266,5 +266,6 @@ var ValidConfigKeys = map[string]bool{
 // ValidProjectConfigKeys are the keys accepted by "config set" that write to
 // the project config (.chunk/config.json).
 var ValidProjectConfigKeys = map[string]bool{
-	"orgID": true,
+	"orgID":                   true,
+	"validation.sidecarImage": true,
 }

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -18,14 +18,16 @@ const (
 
 // Command is a single validation command.
 type Command struct {
-	Name    string `json:"name"`
-	Run     string `json:"run"`
-	Role    string `json:"role,omitempty"`
-	FileExt string `json:"fileExt,omitempty"`
-	Timeout int    `json:"timeout,omitempty"`
-	Limit   int    `json:"limit,omitempty"`
-	Always  bool   `json:"always,omitempty"`
-	Staged  bool   `json:"staged,omitempty"`
+	Name         string `json:"name"`
+	Run          string `json:"run"`
+	Role         string `json:"role,omitempty"`
+	FileExt      string `json:"fileExt,omitempty"`
+	Timeout      int    `json:"timeout,omitempty"`
+	Limit        int    `json:"limit,omitempty"`
+	Always       bool   `json:"always,omitempty"`
+	Staged       bool   `json:"staged,omitempty"`
+	Remote       bool   `json:"remote,omitempty"`
+	SidecarImage string `json:"sidecarImage,omitempty"`
 }
 
 // TaskConfig holds task delegation configuration.
@@ -43,12 +45,18 @@ type VCSConfig struct {
 	Repo string `json:"repo,omitempty"`
 }
 
+// ValidationConfig holds project-level defaults for validation behaviour.
+type ValidationConfig struct {
+	SidecarImage string `json:"sidecarImage,omitempty"`
+}
+
 // ProjectConfig is the per-repo configuration stored in .chunk/config.json.
 type ProjectConfig struct {
 	Commands            []Command             `json:"commands,omitempty"`
 	Triggers            map[string][]string   `json:"triggers,omitempty"`
 	Tasks               map[string]TaskConfig `json:"tasks,omitempty"`
 	VCS                 *VCSConfig            `json:"vcs,omitempty"`
+	Validation          *ValidationConfig     `json:"validation,omitempty"`
 	OrgID               string                `json:"orgID,omitempty"`
 	StopHookMaxAttempts int                   `json:"stopHookMaxAttempts,omitempty"`
 	Environment         *envspec.Environment  `json:"environment,omitempty"`
@@ -71,6 +79,19 @@ func LoadProjectConfig(workDir string) (*ProjectConfig, error) {
 // HasCommands reports whether any commands are configured.
 func (c *ProjectConfig) HasCommands() bool {
 	return len(c.Commands) > 0
+}
+
+// HasRemoteCommands reports whether any commands are marked for remote execution.
+func (c *ProjectConfig) HasRemoteCommands() bool {
+	if c == nil {
+		return false
+	}
+	for _, cmd := range c.Commands {
+		if cmd.Remote {
+			return true
+		}
+	}
+	return false
 }
 
 // FindCommand returns the command with the given name, or nil if not found.

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -49,6 +49,7 @@ type ProjectConfig struct {
 	Triggers            map[string][]string   `json:"triggers,omitempty"`
 	Tasks               map[string]TaskConfig `json:"tasks,omitempty"`
 	VCS                 *VCSConfig            `json:"vcs,omitempty"`
+	OrgID               string                `json:"orgID,omitempty"`
 	StopHookMaxAttempts int                   `json:"stopHookMaxAttempts,omitempty"`
 	Environment         *envspec.Environment  `json:"environment,omitempty"`
 }

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -92,7 +92,7 @@ func RunDryRun(cfg *config.ProjectConfig, name string, status iostream.StatusFun
 
 // RunRemote runs commands on a remote sidecar via SSH.
 // If name is non-empty, only the named command is run.
-func RunRemote(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), cfg *config.ProjectConfig, name, dest string, streams iostream.Streams) error {
+func RunRemote(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), cfg *config.ProjectConfig, name, dest string, status iostream.StatusFunc, streams iostream.Streams) error {
 	commands := cfg.Commands
 	if name != "" {
 		c := cfg.FindCommand(name)
@@ -103,6 +103,7 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 	}
 	for _, c := range commands {
 		script := "cd " + shellEscape(dest) + " && " + c.Run
+		status(iostream.LevelInfo, fmt.Sprintf("Running %s (remote): %s", c.Name, c.Run))
 		stdout, stderr, exitCode, err := execFn(ctx, script)
 		if err != nil {
 			return fmt.Errorf("remote %s: %w", c.Name, err)
@@ -121,8 +122,9 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 }
 
 // RunRemoteInline runs a single inline command on a remote sidecar via SSH.
-func RunRemoteInline(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), name, command, dest string, streams iostream.Streams) error {
+func RunRemoteInline(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), name, command, dest string, status iostream.StatusFunc, streams iostream.Streams) error {
 	script := "cd " + shellEscape(dest) + " && " + command
+	status(iostream.LevelInfo, fmt.Sprintf("Running %s (remote): %s", name, command))
 	stdout, stderr, exitCode, err := execFn(ctx, script)
 	if err != nil {
 		return fmt.Errorf("remote %s: %w", name, err)

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -281,7 +281,7 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, out, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", streams))
+		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", func(iostream.Level, string) {}, streams))
 		assert.Assert(t, strings.Contains(out.String(), "remote output"), "got: %s", out.String())
 		assert.Equal(t, execCount, 2)
 	})
@@ -296,7 +296,7 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		err := RunRemote(context.Background(), execFn, cfg, "", "/workspace", streams)
+		err := RunRemote(context.Background(), execFn, cfg, "", "/workspace", func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, "remote test failed")
 	})
 
@@ -310,7 +310,7 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, out, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", streams))
+		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", func(iostream.Level, string) {}, streams))
 		assert.Equal(t, out.Len(), 0)
 	})
 
@@ -327,7 +327,7 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "test", "/workspace", streams))
+		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "test", "/workspace", func(iostream.Level, string) {}, streams))
 		assert.Equal(t, len(capturedScripts), 1)
 		assert.Assert(t, strings.Contains(capturedScripts[0], "echo test"), "got: %s", capturedScripts[0])
 	})
@@ -342,7 +342,7 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		err := RunRemote(context.Background(), execFn, cfg, "lint", "/workspace", streams)
+		err := RunRemote(context.Background(), execFn, cfg, "lint", "/workspace", func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, `"lint" not configured`)
 	})
 
@@ -358,7 +358,7 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/custom/path", streams))
+		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/custom/path", func(iostream.Level, string) {}, streams))
 		assert.Assert(t, strings.HasPrefix(capturedScript, "cd '/custom/path' &&"), "got: %s", capturedScript)
 	})
 }
@@ -404,7 +404,7 @@ func TestRunRemoteSSH(t *testing.T) {
 		}}
 		streams, out, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", streams))
+		assert.NilError(t, RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", func(iostream.Level, string) {}, streams))
 		assert.Assert(t, strings.Contains(out.String(), "hello from remote"), "got: %s", out.String())
 		assert.Equal(t, len(sshSrv.Commands()), 1)
 	})
@@ -429,7 +429,7 @@ func TestRunRemoteSSH(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		err = RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", streams)
+		err = RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, "remote test failed")
 	})
 
@@ -454,7 +454,7 @@ func TestRunRemoteSSH(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		err = RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", streams)
+		err = RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, "remote install failed")
 		assert.Equal(t, len(sshSrv.Commands()), 1)
 	})
@@ -469,7 +469,7 @@ func TestRunRemoteInline(t *testing.T) {
 		}
 		streams, out, _ := newStreams()
 
-		assert.NilError(t, RunRemoteInline(context.Background(), execFn, "custom", "echo hello", "/workspace/repo", streams))
+		assert.NilError(t, RunRemoteInline(context.Background(), execFn, "custom", "echo hello", "/workspace/repo", func(iostream.Level, string) {}, streams))
 		assert.Assert(t, strings.Contains(out.String(), "inline output"), "got: %s", out.String())
 		assert.Assert(t, strings.HasPrefix(capturedScript, "cd '/workspace/repo' &&"), "got: %s", capturedScript)
 	})
@@ -480,7 +480,7 @@ func TestRunRemoteInline(t *testing.T) {
 		}
 		streams, _, _ := newStreams()
 
-		err := RunRemoteInline(context.Background(), execFn, "custom", "false", "/workspace", streams)
+		err := RunRemoteInline(context.Background(), execFn, "custom", "false", "/workspace", func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, "remote custom failed")
 	})
 
@@ -490,7 +490,7 @@ func TestRunRemoteInline(t *testing.T) {
 		}
 		streams, _, _ := newStreams()
 
-		err := RunRemoteInline(context.Background(), execFn, "custom", "echo hi", "/workspace", streams)
+		err := RunRemoteInline(context.Background(), execFn, "custom", "echo hi", "/workspace", func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, "remote custom")
 		assert.ErrorContains(t, err, "connection lost")
 	})


### PR DESCRIPTION
## Summary

- `chunk validate` now routes commands marked `\"remote\": true` in `.chunk/config.json` to the active sidecar automatically — no `--remote` flag required
- When `--remote` is passed, all commands run on the sidecar (existing explicit override)
- `chunk validate --remote` auto-creates a sandbox if no active sidecar is set, then saves it for future runs
- Org ID is persisted in `.chunk/config.json` (`orgID` field) so sandbox creation skips the interactive picker on subsequent runs — set it with `chunk config set orgID <id>`
- In Stop hook context, if no sidecar is active and org is configured, one is created automatically; otherwise falls back to local with a warning
- Status messages show which commands are routed to the sidecar vs running locally

## New config fields

**Per-command** (`.chunk/config.json`):
```json
{ "name": "test", "run": "task test", "remote": true }
```

**Project-level** (`.chunk/config.json`):
```json
{ "orgID": "your-circleci-org-id" }
```
Or: `chunk config set orgID <id>`

## Test plan

- [ ] `chunk validate test` with active sidecar routes test to sidecar
- [ ] `chunk validate test` with no sidecar runs locally with warning
- [x] `chunk validate` (run all) splits remote/local commands correctly
- [x] `chunk validate --remote` creates sandbox when none exists
- [x] `chunk config set orgID <id>` persists to `.chunk/config.json`
- [x] Stop hook auto-creates sandbox when org ID is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)