### PR TITLE
Fix Snapshot struct org_id field to match API

### DIFF
--- a/internal/circleci/types.go
+++ b/internal/circleci/types.go
@@ -60,10 +60,10 @@ type CreateSidecarRequest struct {
 }
 
 type Snapshot struct {
-	ID             string `json:"id"`
-	OrganizationID string `json:"organization_id"`
-	Name           string `json:"name"`
-	Tag            string `json:"tag,omitempty"`
+	ID    string `json:"id"`
+	OrgID string `json:"org_id"`
+	Name  string `json:"name"`
+	Tag   string `json:"tag,omitempty"`
 }
 
 type CreateSnapshotRequest struct {

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -33,10 +33,10 @@ type Sidecar struct {
 }
 
 type Snapshot struct {
-	ID             string `json:"id"`
-	OrganizationID string `json:"organization_id"`
-	Name           string `json:"name"`
-	Tag            string `json:"tag,omitempty"`
+	ID    string `json:"id"`
+	OrgID string `json:"org_id"`
+	Name  string `json:"name"`
+	Tag   string `json:"tag,omitempty"`
 }
 
 type RunResponse struct {


### PR DESCRIPTION
## Summary
- `Snapshot.OrganizationID` (`json:"organization_id"`) → `Snapshot.OrgID` (`json:"org_id"`) to match what the provisioner actually returns
- Same fix applied to fakes Snapshot struct

🤖 Generated with [Claude Code](https://claude.com/claude-code)