### PR TITLE
Fix inaccurate error messages in auth validation and sidecar

### DIFF
--- a/internal/cmd/authhelper.go
+++ b/internal/cmd/authhelper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/anthropic"
@@ -11,6 +12,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/github"
+	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
@@ -74,7 +76,10 @@ func ensureCircleCIClient(ctx context.Context, streams iostream.Streams, prompte
 
 	streams.ErrPrintln(ui.Dim("Validating CircleCI token..."))
 	if err := authprompt.ValidateCircleCIToken(ctx, token, rc.CircleCIBaseURL); err != nil {
-		return nil, fmt.Errorf("invalid CircleCI token: %w", err)
+		if hc.HasStatusCode(err, http.StatusUnauthorized) {
+			return nil, fmt.Errorf("invalid CircleCI token: %w", err)
+		}
+		return nil, fmt.Errorf("could not validate CircleCI token: %w", err)
 	}
 
 	if err := authprompt.SaveCircleCIToken(token); err != nil {
@@ -133,7 +138,10 @@ func ensureAnthropicClient(ctx context.Context, streams iostream.Streams, prompt
 
 	streams.ErrPrintln(ui.Dim("Validating API key..."))
 	if err := authprompt.ValidateAPIKey(ctx, key, rc.AnthropicBaseURL); err != nil {
-		return nil, fmt.Errorf("invalid Anthropic API key: %w", err)
+		if hc.HasStatusCode(err, http.StatusUnauthorized, http.StatusForbidden) {
+			return nil, fmt.Errorf("invalid Anthropic API key: %w", err)
+		}
+		return nil, fmt.Errorf("could not validate Anthropic API key: %w", err)
 	}
 
 	if err := authprompt.SaveAnthropicKey(key); err != nil {
@@ -185,7 +193,10 @@ func ensureGitHubClient(ctx context.Context, streams iostream.Streams, prompter 
 
 	streams.ErrPrintln(ui.Dim("Validating GitHub token..."))
 	if err := authprompt.ValidateGitHubToken(ctx, token, rc.GitHubAPIURL); err != nil {
-		return nil, fmt.Errorf("invalid GitHub token: %w", err)
+		if hc.HasStatusCode(err, http.StatusUnauthorized) {
+			return nil, fmt.Errorf("invalid GitHub token: %w", err)
+		}
+		return nil, fmt.Errorf("could not validate GitHub token: %w", err)
 	}
 
 	if err := authprompt.SaveGitHubToken(token); err != nil {

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -394,7 +394,7 @@ func newSidecarSyncCmd() *cobra.Command {
 				if _, ok := errors.AsType[*sidecar.RemoteBaseError](err); ok {
 					return &userError{
 						msg:        "Could not resolve remote base.",
-						suggestion: "Push your branch or ensure the repository has a remote configured.",
+						suggestion: "Push your branch to the remote before syncing.",
 						err:        err,
 					}
 				}
@@ -842,7 +842,7 @@ func sidecarSetupSync(
 	if _, ok := errors.AsType[*sidecar.RemoteBaseError](err); ok {
 		return &userError{
 			msg:        "Could not resolve remote base.",
-			suggestion: "Push your branch or ensure the repository has a remote configured.",
+			suggestion: "Push your branch to the remote before syncing.",
 			err:        err,
 		}
 	}

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -70,7 +70,7 @@ func SSH(ctx context.Context, client *circleci.Client, sidecarID, identityFile, 
 		_, _ = fmt.Fprint(io.Err, result.Stderr)
 	}
 	if result.ExitCode != 0 {
-		return fmt.Errorf("command exited with status %d", result.ExitCode)
+		return fmt.Errorf("%q exited with status %d", command, result.ExitCode)
 	}
 	return nil
 }

--- a/internal/sidecar/sync.go
+++ b/internal/sidecar/sync.go
@@ -181,7 +181,7 @@ func syncWorkspace(ctx context.Context, status iostream.StatusFunc, org, repo, r
 		if detail == "" {
 			detail = "git reset exited with a non-zero status"
 		}
-		return fmt.Errorf("reset failed (exit code: %d): %s", resetResult.ExitCode, detail)
+		return fmt.Errorf("git reset failed (exit code: %d): %s", resetResult.ExitCode, detail)
 	}
 
 	applyCmd := fmt.Sprintf("git -C %s apply", ShellEscape(repoPath))

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -195,7 +195,7 @@ func runCommand(ctx context.Context, workDir, name, command string, timeoutSec i
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() != 0 {
-			return fmt.Errorf("%s command failed", name)
+			return fmt.Errorf("%s command failed with exit code %d", name, exitErr.ExitCode())
 		}
 		return fmt.Errorf("%s: %w", name, err)
 	}


### PR DESCRIPTION
## Summary

- **Auth validation conflated bad credentials with connectivity failures.** Any error from the three validate functions — including network timeouts — previously said "invalid token". Now only a 401/403 produces that message; other failures say "could not validate", pointing users at the real problem.
- **Sidecar sync suggestion was ambiguous.** Tightened "Push your branch or ensure the repository has a remote configured." to "Push your branch to the remote before syncing."
- **SSH and git failure messages lacked actionable detail.** Added command name and exit code to SSH errors, `git` prefix to reset failures, and exit code to validate command failures.

## Test plan

- [ ] Bad token (401) → "invalid \<service\> token"
- [ ] No network → "could not validate \<service\> token"
- [ ] Sidecar sync with no remote shows updated suggestion
- [ ] `chunk sidecar ssh` failure shows command name and exit code

🤖 Generated with [Claude Code](https://claude.com/claude-code)