### PR TITLE
docs: fix sidecar reference docs ahead of customer rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ chunk sidecar snapshot create|get          Manage sidecar snapshots
 chunk init                                 Initialize project configuration
 chunk validate [name]                      Run quality checks
 chunk skill install|list                   Manage AI agent skills
-chunk task run                             Trigger CI tasks
+chunk task config|run                      Configure and trigger CI tasks
 chunk build-prompt                         Generate review context from PR comments
 chunk completion install|uninstall         Shell completions
 chunk upgrade                              Update CLI

--- a/README.md
+++ b/README.md
@@ -35,6 +35,58 @@ chunk validate tests        # specific command
 chunk validate --list       # list configured commands
 ```
 
+### Sidecar Environments
+
+Create and work in cloud sidecar environments. Sidecars are available to CircleCI customers on Performance and Scale plans.
+
+```bash
+# Authenticate
+chunk auth set circleci
+
+# Create a sidecar (sets it as active automatically)
+chunk sidecar create --name my-sidecar
+
+# Sync local files and validate remotely
+chunk sidecar sync
+chunk validate --remote
+
+# SSH in interactively or run a one-off command
+chunk sidecar ssh
+chunk sidecar ssh -- make test
+```
+
+#### Active sidecar
+
+Most sidecar commands operate on the *active* sidecar so you don't have to pass `--sidecar-id` every time:
+
+```bash
+chunk sidecar use <id>      # set active sidecar
+chunk sidecar current       # show which sidecar is active
+chunk sidecar forget        # clear the active sidecar
+```
+
+#### Environment Detection and Setup
+
+Auto-detect your tech stack, install dependencies, and snapshot the result so future sidecars boot fast:
+
+```bash
+# Detect environment, run install steps, and create a snapshot
+chunk sidecar setup --name my-sidecar
+
+# Or build a local Docker test image from the detected environment
+chunk sidecar env | chunk sidecar build --dir .
+```
+
+#### Snapshots
+
+Capture a configured environment so future sidecars start from a known-good state:
+
+```bash
+chunk sidecar snapshot create --name checkpoint
+# Later:
+chunk sidecar create --name new-sidecar --image <snapshot-id>
+```
+
 ### Context Generation
 
 Generate a review context prompt from your org's GitHub PR comments:
@@ -52,64 +104,22 @@ chunk build-prompt --org myorg --repos api,backend --top 10
 chunk skill install
 ```
 
-### Sidecar Environments (private preview, email ai-feedback@circleci.com)
-
-Create and work in cloud sidecar environments:
-
-```bash
-# Authenticate
-chunk auth set circleci
-
-# Create a sidecar
-chunk sidecar create --name my-sidecar --image ubuntu:22.04
-
-# Sync local files and SSH in
-chunk sidecar sync --sidecar-id <id>
-chunk sidecar ssh --sidecar-id <id>
-
-# Or run a command directly
-chunk sidecar ssh --sidecar-id <id> -- make test
-```
-
-#### Environment Detection and Setup
-
-Auto-detect your tech stack and set up a sidecar with the right dependencies:
-
-```bash
-# Detect environment — saves to .chunk/config.json
-chunk sidecar env --dir .
-
-# Set up a sidecar from the detected environment
-chunk sidecar env setup --name my-sidecar
-
-# Or build a local Docker test image
-chunk sidecar env | chunk sidecar build --dir .
-```
-
-#### Templates
-
-Create reusable sidecar templates from container images:
-
-```bash
-chunk sidecar template create --image ubuntu:22.04 --tag my-template
-chunk sidecar create --name my-sidecar --template-id <template-id>
-```
-
 ## Commands
 
 ```
-chunk auth set|status|remove         Authentication
-chunk sidecar list|create|exec|ssh   Manage cloud sidecar environments
-chunk sidecar sync|env|build         Sync files, detect env, build images
-chunk sidecar env setup              Create sidecar and run setup steps
-chunk sidecar template create        Create sidecar templates
-chunk init                           Initialize project configuration
-chunk validate [name]                Run quality checks
-chunk skill install|list             Manage AI agent skills
-chunk task config|run                Configure and trigger CI tasks
-chunk build-prompt                   Generate review context from PR comments
-chunk completion install|uninstall   Shell completions
-chunk upgrade                        Update CLI
+chunk auth set|status|remove               Authentication
+chunk sidecar list|create|exec|ssh         Manage cloud sidecar environments
+chunk sidecar sync|env|build               Sync files, detect env, build images
+chunk sidecar use|current|forget           Manage active sidecar
+chunk sidecar setup                        Detect env, install deps, snapshot
+chunk sidecar snapshot create|get          Manage sidecar snapshots
+chunk init                                 Initialize project configuration
+chunk validate [name]                      Run quality checks
+chunk skill install|list                   Manage AI agent skills
+chunk task run                             Trigger CI tasks
+chunk build-prompt                         Generate review context from PR comments
+chunk completion install|uninstall         Shell completions
+chunk upgrade                              Update CLI
 ```
 
 See [docs/CLI.md](docs/CLI.md) for the full command and flag reference.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -49,11 +49,10 @@ chunk
 │   [name]                          # Optional: run a specific named command
 │   --dry-run                       # Print commands without executing
 │   --list                          # List all configured commands
-│   --status                        # Check cache only, don't execute
 │   --cmd <command>                 # Run an inline command
 │   --save                          # Save --cmd to config
-│   --force-run                     # Ignore cache, always run
-│   --sidecar-id <id>               # Remote execution in sidecar
+│   --remote                        # Run on the active sidecar
+│   --sidecar-id <id>               # Remote execution in specific sidecar
 │   --identity-file <path>          # SSH identity file for sidecar
 │   --workdir <path>                # Working directory on sidecar
 │   --project <path>                # Override project directory
@@ -63,23 +62,48 @@ chunk
 │   ├── create                      # Create a sidecar
 │   │   --org-id <id>               # Organization ID (required)
 │   │   --name <name>               # Sidecar name (required)
-│   │   --image <image>             # Container image
+│   │   --image <image>             # E2B template ID or container image
+│   ├── use <id>                    # Set the active sidecar for this project
+│   ├── current                     # Show the active sidecar
+│   ├── forget                      # Clear the active sidecar
 │   ├── exec                        # Execute command in sidecar
-│   │   --org-id <id>               # Organization ID (required)
-│   │   --sidecar-id <id>           # Sidecar ID (required)
+│   │   --sidecar-id <id>           # Sidecar ID (defaults to active sidecar)
 │   │   --command <cmd>             # Command to run (required)
 │   │   --args <args>               # Command arguments
 │   ├── add-ssh-key                 # Add SSH key to sidecar
-│   │   --org-id <id>               # Organization ID (required)
-│   │   --sidecar-id <id>           # Sidecar ID (required)
+│   │   --sidecar-id <id>           # Sidecar ID (defaults to active sidecar)
 │   │   --public-key <key>          # SSH public key string
 │   │   --public-key-file <path>    # Path to public key file
 │   ├── ssh                         # SSH into sidecar
-│   │   --sidecar-id <id>           # Sidecar ID (required)
+│   │   --sidecar-id <id>           # Sidecar ID (defaults to active sidecar)
 │   │   --identity-file <path>      # SSH identity file
-│   │   --env-vars KEY=VALUE        # Set env var in remote session (repeatable)
-│   │   --no-env-file               # Skip auto-loading .env.local
-│   └── sync                        # Sync files to sidecar
+│   │   -e / --env KEY=VALUE        # Set env var in remote session (repeatable)
+│   │   --env-file <path>           # Load env file (defaults to .env.local when flag is present)
+│   ├── sync                        # Sync files to sidecar
+│   │   --sidecar-id <id>           # Sidecar ID (defaults to active sidecar)
+│   │   --identity-file <path>      # SSH identity file
+│   │   --workdir <path>            # Destination path on sidecar (auto-detected when omitted)
+│   ├── env                         # Detect tech stack and print environment spec as JSON
+│   │   --dir <path>                # Directory to analyse (default: .)
+│   │   --no-save                   # Print only, do not save to .chunk/config.json
+│   ├── build                       # Generate Dockerfile and build test image from env spec
+│   │   --dir <path>                # Directory to write Dockerfile.test and build from
+│   │   --tag <tag>                 # Image tag (e.g. myapp:latest)
+│   ├── setup                       # Detect env, sync files, run install steps, snapshot
+│   │   --dir <path>                # Directory to detect environment in (default: .)
+│   │   --sidecar-id <id>           # Sidecar ID (defaults to active sidecar)
+│   │   --org-id <id>               # Organization ID (used when creating a new sidecar)
+│   │   --name <name>               # Sidecar name (used when creating a new sidecar)
+│   │   --identity-file <path>      # SSH identity file
+│   │   --snapshot-name <name>      # Snapshot name (defaults to <sidecar-name>-setup)
+│   │   --skip-sync                 # Skip syncing files to the sidecar
+│   │   --skip-snapshot             # Skip creating a snapshot after install
+│   │   --force                     # Re-detect environment even if cached
+│   └── snapshot
+│       ├── create                  # Create a snapshot of a sidecar
+│       │   --sidecar-id <id>       # Sidecar ID (defaults to active sidecar)
+│       │   --name <name>           # Snapshot name (required)
+│       └── get <snapshot-id>       # Get a snapshot by ID
 │
 ├── completion
 │   ├── install                     # Install zsh completion


### PR DESCRIPTION
## Summary

- Remove \"private preview\" label and fix incorrect commands in README (`sidecar env setup` → `sidecar setup`, remove non-existent `sidecar template create`)
- Add active-sidecar (`use`/`current`/`forget`) and `setup`/`snapshot` subcommands to CLI.md — these were fully implemented but undocumented
- Remove stale `--status` and `--force-run` validate flags from CLI.md (removed in #271 with caching refactor)
- Fix SSH env flag (`--env-vars` → `-e`/`--env`) and expand all sidecar subcommand flags in CLI.md
- Move sidecar section above context generation in README Quick Start

## Test plan

- [ ] Verify all commands in README and CLI.md exist in `chunk --help` output
- [ ] Confirm removed flags (`--status`, `--force-run`) are gone from `chunk validate --help`
- [ ] Confirm SSH flag is `-e`/`--env` in `chunk sidecar ssh --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)