### PR TITLE
Track active snapshot after sidecar setup

### DIFF
--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -781,9 +781,26 @@ Example:
 
 			// Step 6: Create snapshot.
 			if !skipSnapshot {
-				if err := sidecarSetupSnapshot(cmd.Context(), client, sidecarID, scDisplayName, snapshotName, status); err != nil {
+				snap, err := sidecarSetupSnapshot(cmd.Context(), client, sidecarID, scDisplayName, snapshotName, status)
+				if err != nil {
 					return err
 				}
+
+				// Step 7: Record snapshot, persist image to config, clear active sidecar.
+				if saveErr := sidecar.SaveActiveSnapshot(sidecar.ActiveSnapshot{ID: snap.ID, Name: snap.Name}); saveErr != nil {
+					streams.ErrPrintf("warning: could not save active snapshot: %v\n", saveErr)
+				}
+				if cfg.Validation == nil {
+					cfg.Validation = &config.ValidationConfig{}
+				}
+				cfg.Validation.SidecarImage = snap.ID
+				if saveErr := config.SaveProjectConfig(dir, cfg); saveErr != nil {
+					streams.ErrPrintf("warning: could not save snapshot ID to project config: %v\n", saveErr)
+				}
+				if clearErr := sidecar.ClearActive(); clearErr != nil {
+					streams.ErrPrintf("warning: could not clear active sidecar: %v\n", clearErr)
+				}
+				status(iostream.LevelDone, fmt.Sprintf("Snapshot ID saved. Create a new sidecar from this snapshot with: chunk sidecar create --image %s", snap.ID))
 			}
 
 			return nil
@@ -968,7 +985,7 @@ func sidecarSetupSnapshot(
 	client *circleci.Client,
 	sidecarID, scDisplayName, snapshotName string,
 	status iostream.StatusFunc,
-) error {
+) (*circleci.Snapshot, error) {
 	if snapshotName == "" {
 		if scDisplayName != "" {
 			snapshotName = scDisplayName + "-setup"
@@ -979,12 +996,12 @@ func sidecarSetupSnapshot(
 	status(iostream.LevelStep, fmt.Sprintf("Creating snapshot %q...", snapshotName))
 	snap, err := client.CreateSnapshot(ctx, sidecarID, snapshotName)
 	if err != nil {
-		return &userError{
+		return nil, &userError{
 			msg:        "Could not create the snapshot.",
 			suggestion: "Check your network connection and try again.",
 			err:        err,
 		}
 	}
 	status(iostream.LevelDone, fmt.Sprintf("Snapshot created: %s (%s)", snap.Name, snap.ID))
-	return nil
+	return snap, nil
 }

--- a/internal/sidecar/snapshot.go
+++ b/internal/sidecar/snapshot.go
@@ -1,0 +1,97 @@
+package sidecar
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+)
+
+// ActiveSnapshot holds the most recently created snapshot for a project.
+type ActiveSnapshot struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+}
+
+func snapshotFileName() string {
+	if id := os.Getenv(config.EnvClaudeSession); id != "" {
+		return "snapshot." + id + ".json"
+	}
+	return "snapshot.json"
+}
+
+// LoadActiveSnapshot walks up from cwd looking for .chunk/snapshot.json. Returns nil if not found.
+func LoadActiveSnapshot() (*ActiveSnapshot, error) {
+	path, err := findSnapshotFile()
+	if err != nil {
+		return nil, err
+	}
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var a ActiveSnapshot
+	if err := json.Unmarshal(data, &a); err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+// SaveActiveSnapshot writes .chunk/snapshot.json into the same directory as the active sidecar file.
+func SaveActiveSnapshot(a ActiveSnapshot) error {
+	dir, err := saveDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(a)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, snapshotFileName()), data, 0o644)
+}
+
+// ClearActiveSnapshot removes the .chunk/snapshot.json file found by walking up from cwd.
+func ClearActiveSnapshot() error {
+	path, err := findSnapshotFile()
+	if err != nil {
+		return err
+	}
+	if path == "" {
+		return nil
+	}
+	return os.Remove(path)
+}
+
+// findSnapshotFile walks up from cwd looking for .chunk/snapshot.json, returning the path or "".
+// Bounded by the git root, same as findSidecarFile.
+func findSnapshotFile() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	gitRoot, _ := findGitRoot()
+	for {
+		candidate := filepath.Join(dir, ".chunk", snapshotFileName())
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		if gitRoot == "" || dir == gitRoot {
+			return "", nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", nil
+		}
+		dir = parent
+	}
+}

--- a/internal/sidecar/snapshot_test.go
+++ b/internal/sidecar/snapshot_test.go
@@ -1,0 +1,122 @@
+package sidecar
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+)
+
+func TestSaveAndLoadActiveSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	want := ActiveSnapshot{ID: "snap-abc", Name: "my-snap"}
+	assert.NilError(t, SaveActiveSnapshot(want))
+
+	got, err := LoadActiveSnapshot()
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil, "expected non-nil ActiveSnapshot")
+	assert.Equal(t, got.ID, want.ID)
+	assert.Equal(t, got.Name, want.Name)
+}
+
+func TestLoadActiveSnapshotReturnsNilWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	got, err := LoadActiveSnapshot()
+	assert.NilError(t, err)
+	assert.Assert(t, got == nil, "expected nil when no snapshot file")
+}
+
+func TestClearActiveSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	assert.NilError(t, SaveActiveSnapshot(ActiveSnapshot{ID: "snap-xyz"}))
+
+	got, err := LoadActiveSnapshot()
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+
+	assert.NilError(t, ClearActiveSnapshot())
+
+	got, err = LoadActiveSnapshot()
+	assert.NilError(t, err)
+	assert.Assert(t, got == nil)
+}
+
+func TestClearActiveSnapshotNoopWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	assert.NilError(t, ClearActiveSnapshot())
+}
+
+func TestSnapshotSessionKeyed(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Save without a session — generic file.
+	assert.NilError(t, SaveActiveSnapshot(ActiveSnapshot{ID: "snap-generic"}))
+
+	// With a session ID set, load should return nil (isolated from the generic file).
+	t.Setenv(config.EnvClaudeSession, "sess-abc")
+	got, err := LoadActiveSnapshot()
+	assert.NilError(t, err)
+	assert.Assert(t, got == nil, "session-keyed load should not see generic file")
+
+	// Save under the session.
+	assert.NilError(t, SaveActiveSnapshot(ActiveSnapshot{ID: "snap-session"}))
+
+	got, err = LoadActiveSnapshot()
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+	assert.Equal(t, got.ID, "snap-session")
+
+	// Without the session env var, the original generic file is still intact.
+	t.Setenv(config.EnvClaudeSession, "")
+	got, err = LoadActiveSnapshot()
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+	assert.Equal(t, got.ID, "snap-generic")
+}
+
+func TestLoadActiveSnapshotWalksUpToParent(t *testing.T) {
+	parent := t.TempDir()
+	child := filepath.Join(parent, "sub", "dir")
+	assert.NilError(t, os.MkdirAll(child, 0o755))
+
+	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".git"), 0o755))
+	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".chunk"), 0o755))
+	data := []byte(`{"id":"snap-parent","name":"parent-snap"}`)
+	assert.NilError(t, os.WriteFile(filepath.Join(parent, ".chunk", "snapshot.json"), data, 0o644))
+
+	t.Chdir(child)
+
+	got, err := LoadActiveSnapshot()
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+	assert.Equal(t, got.ID, "snap-parent")
+}
+
+func TestLoadActiveSnapshotStopsAtGitRoot(t *testing.T) {
+	grandparent := t.TempDir()
+	parent := filepath.Join(grandparent, "repo")
+	child := filepath.Join(parent, "sub")
+	assert.NilError(t, os.MkdirAll(child, 0o755))
+	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".git"), 0o755))
+	assert.NilError(t, os.MkdirAll(filepath.Join(grandparent, ".chunk"), 0o755))
+	data := []byte(`{"id":"snap-grandparent"}`)
+	assert.NilError(t, os.WriteFile(filepath.Join(grandparent, ".chunk", "snapshot.json"), data, 0o644))
+
+	t.Chdir(child)
+
+	got, err := LoadActiveSnapshot()
+	assert.NilError(t, err)
+	assert.Assert(t, got == nil, "walk should not cross the git root boundary")
+}


### PR DESCRIPTION
## Summary

- After `chunk sidecar setup` snapshots the sidecar, the snapshot ID is now persisted to `.chunk/snapshot.json` (session-keyed, same pattern as `sidecar.json`)
- Snapshot ID is also written to `validation.sidecarImage` in `.chunk/config.json` so `chunk validate --remote` auto-creates new sidecars from the snapshot instead of from scratch
- Active sidecar is cleared after snapshotting — the snapshotted sidecar is a template, not a general-purpose worker

## New flow

```
chunk sidecar setup        # create → install → snapshot → clear active sidecar
                           # writes .chunk/snapshot.json + config.json validation.sidecarImage
chunk sidecar create       # user creates a fresh worker sidecar (from snapshot via --image)
chunk validate --remote    # auto-creates worker from snapshot if no active sidecar
```

## Notes

- `ValidationConfig` struct is also added on `webster/remote-validation-commands` — trivial merge conflict when both land
- Phase 4 (annotating `sidecar list` with snapshot info) intentionally skipped — would require local tracking we don't want to rely on

## Test plan

- [x] `SaveActiveSnapshot` / `LoadActiveSnapshot` round-trip
- [x] `ClearActiveSnapshot` removes file
- [x] Session-keyed filename via `CLAUDE_SESSION_ID`
- [x] Git-root-bounded walk
- [ ] `chunk sidecar setup` end-to-end with real sidecar

🤖 Generated with [Claude Code](https://claude.com/claude-code)