### PR TITLE
Remove auto-snapshot from sidecar setup

### DIFF
--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -755,10 +755,8 @@ Example:
 			}
 			var workspace string
 			if sidecarID == "" {
-				var scDisplayName string
 				var resolveErr error
-				sidecarID, scDisplayName, workspace, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, name, provider, status, streams)
-				_ = scDisplayName
+				sidecarID, _, workspace, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, name, provider, status, streams)
 				if resolveErr != nil {
 					return resolveErr
 				}
@@ -957,30 +955,4 @@ func sidecarSetupRunSetup(
 		status(iostream.LevelDone, fmt.Sprintf("Step %q complete", step.Name))
 	}
 	return nil
-}
-
-func sidecarSetupSnapshot(
-	ctx context.Context,
-	client *circleci.Client,
-	sidecarID, scDisplayName, snapshotName string,
-	status iostream.StatusFunc,
-) (*circleci.Snapshot, error) {
-	if snapshotName == "" {
-		if scDisplayName != "" {
-			snapshotName = scDisplayName + "-setup"
-		} else {
-			snapshotName = sidecarID[:min(len(sidecarID), 8)] + "-setup"
-		}
-	}
-	status(iostream.LevelStep, fmt.Sprintf("Creating snapshot %q...", snapshotName))
-	snap, err := client.CreateSnapshot(ctx, sidecarID, snapshotName)
-	if err != nil {
-		return nil, &userError{
-			msg:        "Could not create the snapshot.",
-			suggestion: "Check your network connection and try again.",
-			err:        err,
-		}
-	}
-	status(iostream.LevelDone, fmt.Sprintf("Snapshot created: %s (%s)", snap.Name, snap.ID))
-	return snap, nil
 }

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -691,8 +691,8 @@ func newSidecarSnapshotGetCmd() *cobra.Command {
 }
 
 func newSidecarSetupCmd() *cobra.Command {
-	var sidecarID, orgID, name, identityFile, snapshotName, dir string
-	var skipSync, skipSnapshot, force bool
+	var sidecarID, orgID, name, identityFile, dir string
+	var skipSync, force bool
 
 	cmd := &cobra.Command{
 		Use:   "setup",
@@ -753,10 +753,12 @@ Example:
 			if provider == "" {
 				provider = defaultProvider
 			}
-			var scDisplayName, workspace string
+			var workspace string
 			if sidecarID == "" {
+				var scDisplayName string
 				var resolveErr error
 				sidecarID, scDisplayName, workspace, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, name, provider, status, streams)
+				_ = scDisplayName
 				if resolveErr != nil {
 					return resolveErr
 				}
@@ -779,29 +781,8 @@ Example:
 				return err
 			}
 
-			// Step 6: Create snapshot.
-			if !skipSnapshot {
-				snap, err := sidecarSetupSnapshot(cmd.Context(), client, sidecarID, scDisplayName, snapshotName, status)
-				if err != nil {
-					return err
-				}
-
-				// Step 7: Record snapshot, persist image to config, clear active sidecar.
-				if saveErr := sidecar.SaveActiveSnapshot(sidecar.ActiveSnapshot{ID: snap.ID, Name: snap.Name}); saveErr != nil {
-					streams.ErrPrintf("warning: could not save active snapshot: %v\n", saveErr)
-				}
-				if cfg.Validation == nil {
-					cfg.Validation = &config.ValidationConfig{}
-				}
-				cfg.Validation.SidecarImage = snap.ID
-				if saveErr := config.SaveProjectConfig(dir, cfg); saveErr != nil {
-					streams.ErrPrintf("warning: could not save snapshot ID to project config: %v\n", saveErr)
-				}
-				if clearErr := sidecar.ClearActive(); clearErr != nil {
-					streams.ErrPrintf("warning: could not clear active sidecar: %v\n", clearErr)
-				}
-				status(iostream.LevelDone, fmt.Sprintf("Snapshot ID saved. Create a new sidecar from this snapshot with: chunk sidecar create --image %s", snap.ID))
-			}
+			streams.ErrPrintf("\nSetup complete. Verify the sidecar is working correctly, then snapshot it:\n")
+			streams.ErrPrintf("  chunk sidecar snapshot create --name <snapshot-name>\n\n")
 
 			return nil
 		},
@@ -812,9 +793,7 @@ Example:
 	cmd.Flags().StringVar(&orgID, "org-id", "", "Organization ID (used when creating a new sidecar)")
 	cmd.Flags().StringVar(&name, "name", "", "Sidecar name (used when creating a new sidecar)")
 	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file")
-	cmd.Flags().StringVar(&snapshotName, "snapshot-name", "", "Snapshot name (defaults to <sidecar-name>-setup)")
 	cmd.Flags().BoolVar(&skipSync, "skip-sync", false, "Skip syncing files to the sidecar")
-	cmd.Flags().BoolVar(&skipSnapshot, "skip-snapshot", false, "Skip creating a snapshot after install")
 	cmd.Flags().BoolVar(&force, "force", false, "Re-detect environment even if cached in .chunk/config.json")
 
 	return cmd

--- a/skills/chunk-sidecar/SKILL.md
+++ b/skills/chunk-sidecar/SKILL.md
@@ -39,14 +39,12 @@ Run `chunk sidecar current`. Three cases:
 
 ## Step 3: One-time setup
 
-Skip this step unless the user explicitly asks to "prep the sidecar", "snapshot it", "set up the environment", or similar. This is a one-time flow that produces a reusable snapshot so future sessions boot fast.
+Skip this step unless the user explicitly asks to "prep the sidecar", "set up the environment", or similar. This is a one-time flow that produces a reusable snapshot so future sessions boot fast.
 
-1. `chunk sidecar env` — detects the tech stack and emits a JSON environment spec.
-2. Review the spec with the user.
-3. `chunk sidecar env | chunk sidecar build --tag <image-tag>` — writes `Dockerfile.test` and builds an image.
-4. `chunk sidecar create --name <name> --image <image-tag>` — creates a sidecar from that image.
-5. Install any extra deps over SSH: `chunk sidecar ssh -- bash -c "<install commands>"`.
-6. `chunk sidecar snapshot create --name <checkpoint-name>` — captures the configured state and returns a snapshot ID.
+1. `chunk sidecar setup --dir . --name <name>` — detects the stack, syncs files, and runs install steps on the sidecar. Prompts to create a sidecar if none is active.
+2. Verify the sidecar is working correctly by running a validate command against it directly: `chunk validate --remote --sidecar-id <sidecar-id>`. Use the exact sidecar ID from step 1.
+3. Once confirmed working, snapshot the sidecar: `chunk sidecar snapshot create --name <snapshot-name>`. This captures the configured state and returns a snapshot ID. **Always snapshot after confirming the sidecar is working — do not skip this step.**
+4. Record the snapshot ID in `.chunk/config.json` under `validation.sidecarImage` so future sidecars boot from it: `chunk config set validation.sidecarImage <snapshot-id>`.
 
 Future sessions boot from the snapshot: `chunk sidecar create --name <new-name> --image <snapshot-id>`.
 


### PR DESCRIPTION
## Summary

- `chunk sidecar setup` no longer automatically snapshots after install — it now prints an explicit instruction to the user to snapshot once they've verified the sidecar is working
- Removed `--skip-snapshot` and `--snapshot-name` flags (no longer needed)
- Updated `chunk-sidecar` skill to make snapshotting a required explicit step after validation is confirmed, using `chunk validate --remote --sidecar-id <id>` to target the specific sidecar

## Motivation

Auto-snapshotting was problematic because snapshotting removes the agent to keep a clean state, but the sidecar stays active. This confused the distinction between a template sidecar (post-snapshot) and a general-purpose worker. Making the snapshot an explicit user-confirmed step keeps the two roles clearly separated.

## New flow

```
chunk sidecar setup --dir .              # install steps only, prints next-step guidance
chunk validate --remote --sidecar-id <id>  # verify it works
chunk sidecar snapshot create --name <name>  # explicit snapshot once confirmed
chunk config set validation.sidecarImage <snapshot-id>  # persist for future workers
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)