### PR TITLE
[FACT-130] Move sidecar state from .chunk/ to XDG_DATA_HOME

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ chunk-cli/
     ├── anthropic/             # Anthropic Messages API client
     ├── buildprompt/           # Three-step pipeline: discover → analyze → generate
     ├── circleci/              # CircleCI REST API client
-    ├── config/                # User config (~/.chunk/config.json)
+    ├── config/                # User config (XDG_CONFIG_HOME/chunk/config.json)
     ├── github/                # GitHub GraphQL client (reviews, repos)
     ├── gitremote/             # Git remote URL parsing for org/repo detection
     ├── gitutil/               # Git utility helpers
@@ -154,7 +154,7 @@ Not all values support all layers — for example, CircleCI and GitHub
 tokens have no flag, so their chain is `env var > config file`. The
 Anthropic API key and model support the full chain.
 
-User config lives at `~/.chunk/config.json`:
+User config lives at `$XDG_CONFIG_HOME/chunk/config.json` (default: `~/.config/chunk/config.json`):
 
 ```json
 {
@@ -180,6 +180,8 @@ in `config.Resolve` and makes clients testable.
 | `CIRCLE_TOKEN` / `CIRCLECI_TOKEN` | circleci | CircleCI authentication |
 | `CIRCLECI_BASE_URL` | circleci | CircleCI endpoint override |
 | `CLAUDE_PROJECT_DIR` | init | IDE-provided project directory |
+| `XDG_CONFIG_HOME` | config | User config directory (default: `~/.config`) |
+| `XDG_DATA_HOME` | sidecar | Per-project state directory (default: `~/.local/share`) |
 
 ## Pre-Commit Hooks
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -63,7 +63,7 @@ Check status at any time:
 chunk auth status
 ```
 
-Credentials are stored in `~/.chunk/config.json`. You can also set them as environment variables:
+Credentials are stored in `~/.config/chunk/config.json` (respects `XDG_CONFIG_HOME`). You can also set them as environment variables:
 
 | Variable | Used by |
 |---|---|
@@ -182,6 +182,8 @@ chunk sidecar use <id>
 chunk sidecar sync           # push local changes to sidecar
 chunk validate --remote      # run validate commands on sidecar
 ```
+
+The active sidecar and snapshot state are stored in `$XDG_DATA_HOME/chunk/<project>/` (default: `~/.local/share/chunk/<project>/`) — never inside the repo. The project key is derived from the git root path.
 
 Or hand this off to the `chunk-sidecar` skill:
 

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -104,7 +104,7 @@ Agent: syncing local changes...
        ✓ all validations passed
 ```
 
-**Parallel sessions**: When multiple Claude sessions are open in the same repo, each session automatically targets its own sidecar via `.chunk/sidecar.<session-id>.json`. No manual configuration is needed.
+**Parallel sessions**: When multiple Claude sessions are open in the same repo, each session automatically targets its own sidecar. State is keyed by `CLAUDE_SESSION_ID` and stored in `XDG_DATA_HOME` (see Architecture docs). No manual configuration is needed.
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,7 @@ const (
 	EnvNoColor       = "NO_COLOR"
 	EnvXDGConfigHome = "XDG_CONFIG_HOME"
 	EnvXDGStateHome  = "XDG_STATE_HOME"
+	EnvXDGDataHome   = "XDG_DATA_HOME"
 	EnvClaudeSession = "CLAUDE_SESSION_ID"
 )
 
@@ -72,6 +73,7 @@ type EnvVars struct {
 	NoColor          string `env:"NO_COLOR"`
 	XDGConfigHome    string `env:"XDG_CONFIG_HOME"`
 	XDGStateHome     string `env:"XDG_STATE_HOME"`
+	XDGDataHome      string `env:"XDG_DATA_HOME"`
 	ClaudeSession    string `env:"CLAUDE_SESSION_ID"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,14 +20,15 @@ func setupTempConfig(t *testing.T) string {
 // --- ProjectDataDir ---
 
 func TestProjectDataDir_RootedUnderXDG(t *testing.T) {
-	t.Setenv(EnvXDGDataHome, "/tmp/xdg-data")
+	xdgHome := t.TempDir()
+	t.Setenv(EnvXDGDataHome, xdgHome)
 	d, err := ProjectDataDir("/home/user/myproject")
 	assert.NilError(t, err)
-	assert.Assert(t, strings.HasPrefix(d, "/tmp/xdg-data/chunk/"), "expected path under XDG data dir, got %s", d)
+	assert.Assert(t, strings.HasPrefix(d, filepath.Join(xdgHome, "chunk")), "expected path under XDG data dir, got %s", d)
 }
 
 func TestProjectDataDir_Deterministic(t *testing.T) {
-	t.Setenv(EnvXDGDataHome, "/tmp/xdg-data")
+	t.Setenv(EnvXDGDataHome, t.TempDir())
 	d1, err := ProjectDataDir("/home/user/myproject")
 	assert.NilError(t, err)
 	d2, err := ProjectDataDir("/home/user/myproject")
@@ -37,7 +38,7 @@ func TestProjectDataDir_Deterministic(t *testing.T) {
 
 func TestProjectDataDir_CollisionFree(t *testing.T) {
 	// /foo/bar and /foo-bar would produce the same key ("foo-bar") without hashing.
-	t.Setenv(EnvXDGDataHome, "/tmp/xdg-data")
+	t.Setenv(EnvXDGDataHome, t.TempDir())
 	dSlash, err := ProjectDataDir("/foo/bar")
 	assert.NilError(t, err)
 	dHyphen, err := ProjectDataDir("/foo-bar")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -14,6 +15,34 @@ func setupTempConfig(t *testing.T) string {
 	dir := t.TempDir()
 	t.Setenv(EnvXDGConfigHome, dir)
 	return dir
+}
+
+// --- ProjectDataDir ---
+
+func TestProjectDataDir_RootedUnderXDG(t *testing.T) {
+	t.Setenv(EnvXDGDataHome, "/tmp/xdg-data")
+	d, err := ProjectDataDir("/home/user/myproject")
+	assert.NilError(t, err)
+	assert.Assert(t, strings.HasPrefix(d, "/tmp/xdg-data/chunk/"), "expected path under XDG data dir, got %s", d)
+}
+
+func TestProjectDataDir_Deterministic(t *testing.T) {
+	t.Setenv(EnvXDGDataHome, "/tmp/xdg-data")
+	d1, err := ProjectDataDir("/home/user/myproject")
+	assert.NilError(t, err)
+	d2, err := ProjectDataDir("/home/user/myproject")
+	assert.NilError(t, err)
+	assert.Equal(t, d1, d2)
+}
+
+func TestProjectDataDir_CollisionFree(t *testing.T) {
+	// /foo/bar and /foo-bar would produce the same key ("foo-bar") without hashing.
+	t.Setenv(EnvXDGDataHome, "/tmp/xdg-data")
+	dSlash, err := ProjectDataDir("/foo/bar")
+	assert.NilError(t, err)
+	dHyphen, err := ProjectDataDir("/foo-bar")
+	assert.NilError(t, err)
+	assert.Assert(t, dSlash != dHyphen, "paths that differ only by separator vs hyphen must not collide: %s", dSlash)
 }
 
 // --- Dir / Path ---

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -35,6 +36,27 @@ func Path() (string, error) {
 	return filepath.Join(d, "config.json"), nil
 }
 
+// AppData returns the chunk data directory, respecting XDG_DATA_HOME.
+func AppData() (string, error) {
+	dh, err := dataHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dh, appName), nil
+}
+
+// ProjectDataDir returns the per-project data directory keyed by projectRoot.
+// The directory name is the hex-encoded SHA-256 of the cleaned absolute path,
+// which is guaranteed collision-free across all valid path strings.
+func ProjectDataDir(projectRoot string) (string, error) {
+	base, err := AppData()
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(filepath.Clean(projectRoot)))
+	return filepath.Join(base, fmt.Sprintf("%x", sum)), nil
+}
+
 func configHome() (string, error) {
 	if v := os.Getenv(EnvXDGConfigHome); v != "" {
 		return v, nil
@@ -55,4 +77,15 @@ func stateHome() (string, error) {
 		return "", fmt.Errorf("resolve state home: %w", err)
 	}
 	return filepath.Join(home, ".local", "state"), nil
+}
+
+func dataHome() (string, error) {
+	if v := os.Getenv(EnvXDGDataHome); v != "" {
+		return v, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve data home: %w", err)
+	}
+	return filepath.Join(home, ".local", "share"), nil
 }

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -26,6 +26,15 @@ func sidecarFileName() string {
 	return "sidecar.json"
 }
 
+// StateDir returns the XDG_DATA_HOME directory for the current project.
+// Callers performing multiple sidecar or snapshot operations can resolve once
+// and pass the result to the dir-accepting variants (LoadActiveFrom, SaveActiveTo,
+// ClearActiveFrom, LoadSnapshotFrom, SaveSnapshotTo, ClearSnapshotFrom) to avoid
+// repeated filesystem walks.
+func StateDir() (string, error) {
+	return saveDir()
+}
+
 // LoadActive reads the active sidecar for the current project from XDG_DATA_HOME.
 // Returns nil if not found.
 func LoadActive() (*ActiveSidecar, error) {
@@ -33,6 +42,11 @@ func LoadActive() (*ActiveSidecar, error) {
 	if err != nil {
 		return nil, err
 	}
+	return LoadActiveFrom(dir)
+}
+
+// LoadActiveFrom reads the active sidecar from dir.
+func LoadActiveFrom(dir string) (*ActiveSidecar, error) {
 	path, err := findSidecarFile(dir)
 	if err != nil {
 		return nil, err
@@ -57,6 +71,11 @@ func SaveActive(a ActiveSidecar) error {
 	if err != nil {
 		return err
 	}
+	return SaveActiveTo(dir, a)
+}
+
+// SaveActiveTo writes the active sidecar to dir.
+func SaveActiveTo(dir string, a ActiveSidecar) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
@@ -109,6 +128,11 @@ func ClearActive() error {
 	if err != nil {
 		return err
 	}
+	return ClearActiveFrom(dir)
+}
+
+// ClearActiveFrom removes the active sidecar state file in dir.
+func ClearActiveFrom(dir string) error {
 	path, err := findSidecarFile(dir)
 	if err != nil {
 		return err

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -26,9 +26,14 @@ func sidecarFileName() string {
 	return "sidecar.json"
 }
 
-// LoadActive walks up from cwd looking for .chunk/sidecar.json. Returns nil if not found.
+// LoadActive reads the active sidecar for the current project from XDG_DATA_HOME.
+// Returns nil if not found.
 func LoadActive() (*ActiveSidecar, error) {
-	path, err := findSidecarFile()
+	dir, err := saveDir()
+	if err != nil {
+		return nil, err
+	}
+	path, err := findSidecarFile(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -46,9 +51,7 @@ func LoadActive() (*ActiveSidecar, error) {
 	return &a, nil
 }
 
-// SaveActive writes .chunk/sidecar.json. If the file already exists in a
-// parent directory it is updated in place; otherwise the file is created in
-// cwd's .chunk/ directory.
+// SaveActive writes the active sidecar to XDG_DATA_HOME for the current project.
 func SaveActive(a ActiveSidecar) error {
 	dir, err := saveDir()
 	if err != nil {
@@ -64,25 +67,21 @@ func SaveActive(a ActiveSidecar) error {
 	return os.WriteFile(filepath.Join(dir, sidecarFileName()), data, 0o644)
 }
 
-// saveDir returns the .chunk directory to write into. It prefers an existing
-// .chunk/sidecar.json found by walking upward; otherwise walks up to find the
-// git root and uses that; falls back to cwd/.chunk when not in a git repo.
+// saveDir returns the XDG_DATA_HOME directory for the current project.
 func saveDir() (string, error) {
-	existing, err := findSidecarFile()
+	root, err := projectRoot()
 	if err != nil {
 		return "", err
 	}
-	if existing != "" {
-		return filepath.Dir(existing), nil
-	}
+	return config.ProjectDataDir(root)
+}
+
+// projectRoot returns the git root when inside a git repo, otherwise cwd.
+func projectRoot() (string, error) {
 	if root, err := findGitRoot(); err == nil && root != "" {
-		return filepath.Join(root, ".chunk"), nil
+		return root, nil
 	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(cwd, ".chunk"), nil
+	return os.Getwd()
 }
 
 // findGitRoot walks up from cwd and returns the first directory containing .git,
@@ -104,9 +103,13 @@ func findGitRoot() (string, error) {
 	}
 }
 
-// ClearActive removes the .chunk/sidecar.json file found by walking up from cwd.
+// ClearActive removes the active sidecar state file.
 func ClearActive() error {
-	path, err := findSidecarFile()
+	dir, err := saveDir()
+	if err != nil {
+		return err
+	}
+	path, err := findSidecarFile(dir)
 	if err != nil {
 		return err
 	}
@@ -116,31 +119,19 @@ func ClearActive() error {
 	return os.Remove(path)
 }
 
-// findSidecarFile walks up from cwd looking for .chunk/sidecar.json, returning the path or "".
-// When inside a git repository the walk is bounded by the repository root (the directory
-// containing .git); files above that root are never considered. When not inside any git
-// repository only the current directory is checked.
-func findSidecarFile() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
+// findSidecarFile returns the sidecar state file path in dir, or "" if it doesn't exist.
+func findSidecarFile(dir string) (string, error) {
+	return statOrEmpty(filepath.Join(dir, sidecarFileName()))
+}
+
+// statOrEmpty returns path if it exists, "" if it does not, or an error for other failures.
+func statOrEmpty(path string) (string, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return path, nil
 	}
-	gitRoot, _ := findGitRoot()
-	for {
-		candidate := filepath.Join(dir, ".chunk", sidecarFileName())
-		if _, err := os.Stat(candidate); err == nil {
-			return candidate, nil
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return "", err
-		}
-		// Stop at the git root (or immediately if not in a git repo).
-		if gitRoot == "" || dir == gitRoot {
-			return "", nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", nil
-		}
-		dir = parent
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
 	}
+	return "", err
 }

--- a/internal/sidecar/active_test.go
+++ b/internal/sidecar/active_test.go
@@ -31,6 +31,18 @@ func TestSaveActiveWritesToXDGDataPath(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func TestStatOrEmptyPermissionsError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping: root bypasses file permission checks")
+	}
+	dir := t.TempDir()
+	assert.NilError(t, os.Chmod(dir, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	_, err := statOrEmpty(filepath.Join(dir, "sidecar.json"))
+	assert.Assert(t, err != nil, "expected error for inaccessible directory, got nil")
+}
+
 func setupXDGData(t *testing.T) {
 	t.Helper()
 	t.Setenv(config.EnvXDGDataHome, t.TempDir())

--- a/internal/sidecar/active_test.go
+++ b/internal/sidecar/active_test.go
@@ -11,9 +11,35 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 )
 
+func TestSaveActiveWritesToXDGDataPath(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv(config.EnvXDGDataHome, dataHome)
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-1"}))
+
+	// Must not appear inside the project's .chunk directory.
+	_, err := os.Stat(filepath.Join(dir, ".chunk", "sidecar.json"))
+	assert.Assert(t, os.IsNotExist(err), "sidecar.json must not be written inside .chunk/")
+
+	// Must appear at the deterministic XDG data path.
+	expected, err := config.ProjectDataDir(dir)
+	assert.NilError(t, err)
+	_, err = os.Stat(filepath.Join(expected, "sidecar.json"))
+	assert.NilError(t, err)
+}
+
+func setupXDGData(t *testing.T) {
+	t.Helper()
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
+}
+
 func TestSaveAndLoadActive(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+	setupXDGData(t)
 
 	want := ActiveSidecar{SidecarID: "sb-abc", Name: "my-box"}
 	err := SaveActive(want)
@@ -29,90 +55,65 @@ func TestSaveAndLoadActive(t *testing.T) {
 func TestLoadActiveReturnsNilWhenMissing(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+	setupXDGData(t)
 
 	got, err := LoadActive()
 	assert.NilError(t, err)
 	assert.Assert(t, got == nil, "expected nil when no active sidecar file")
 }
 
-func TestLoadActiveWalksUpToParent(t *testing.T) {
+func TestLoadActiveUsesGitRootAsKey(t *testing.T) {
 	parent := t.TempDir()
 	child := filepath.Join(parent, "sub", "dir")
 	assert.NilError(t, os.MkdirAll(child, 0o755))
-
-	// Mark parent as a git root so the walk doesn't escape it.
 	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".git"), 0o755))
 
-	// Write .chunk/sidecar in parent
-	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".chunk"), 0o755))
-	data := []byte(`{"sidecar_id":"sb-parent","name":"parent-box"}`)
-	assert.NilError(t, os.WriteFile(filepath.Join(parent, ".chunk", "sidecar.json"), data, 0o644))
+	setupXDGData(t)
 
-	// cd into child — should still find the parent's file
+	// Save from child — keyed to parent (git root).
 	t.Chdir(child)
+	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-git-root"}))
+
+	// Load from child — should find it.
+	got, err := LoadActive()
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+	assert.Equal(t, got.SidecarID, "sb-git-root")
+
+	// Load from parent (the git root) — same project, same file.
+	t.Chdir(parent)
+	got, err = LoadActive()
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+	assert.Equal(t, got.SidecarID, "sb-git-root")
+}
+
+func TestLoadActiveUsesCwdWhenNoGitRepo(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	setupXDGData(t)
+
+	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-cwd"}))
 
 	got, err := LoadActive()
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
-	assert.Equal(t, got.SidecarID, "sb-parent")
-}
-
-func TestLoadActiveStopsAtGitRoot(t *testing.T) {
-	// grandparent has .chunk/sidecar; parent has .git; cwd is child of parent.
-	// The walk should stop at parent and not find grandparent's file.
-	grandparent := t.TempDir()
-	parent := filepath.Join(grandparent, "repo")
-	child := filepath.Join(parent, "sub")
-	assert.NilError(t, os.MkdirAll(child, 0o755))
-
-	// .git lives in parent (the repo root)
-	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".git"), 0o755))
-
-	// .chunk/sidecar lives in grandparent (above the repo root)
-	assert.NilError(t, os.MkdirAll(filepath.Join(grandparent, ".chunk"), 0o755))
-	data := []byte(`{"sidecar_id":"sb-grandparent"}`)
-	assert.NilError(t, os.WriteFile(filepath.Join(grandparent, ".chunk", "sidecar.json"), data, 0o644))
-
-	t.Chdir(child)
-
-	got, err := LoadActive()
-	assert.NilError(t, err)
-	assert.Assert(t, got == nil, "walk should not cross the git root boundary")
-}
-
-func TestLoadActiveNoGitRepo(t *testing.T) {
-	// No .git anywhere — only the cwd itself is checked.
-	parent := t.TempDir()
-	child := filepath.Join(parent, "sub")
-	assert.NilError(t, os.MkdirAll(child, 0o755))
-
-	// .chunk/sidecar in parent but no .git anywhere
-	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".chunk"), 0o755))
-	data := []byte(`{"sidecar_id":"sb-parent"}`)
-	assert.NilError(t, os.WriteFile(filepath.Join(parent, ".chunk", "sidecar.json"), data, 0o644))
-
-	t.Chdir(child)
-
-	// Without .git the walk stops at cwd, so the parent file is not found.
-	got, err := LoadActive()
-	assert.NilError(t, err)
-	assert.Assert(t, got == nil, "without a git repo the walk should not go above cwd")
+	assert.Equal(t, got.SidecarID, "sb-cwd")
 }
 
 func TestClearActive(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+	setupXDGData(t)
 
 	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-xyz"}))
 
-	// File should exist
 	got, err := LoadActive()
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 
 	assert.NilError(t, ClearActive())
 
-	// Should be gone now
 	got, err = LoadActive()
 	assert.NilError(t, err)
 	assert.Assert(t, got == nil)
@@ -121,6 +122,7 @@ func TestClearActive(t *testing.T) {
 func TestSessionKeyedSidecar(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+	setupXDGData(t)
 
 	// Save without a session — generic file.
 	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-generic"}))
@@ -150,41 +152,15 @@ func TestSessionKeyedSidecar(t *testing.T) {
 func TestClearActiveNoopWhenMissing(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+	setupXDGData(t)
 
 	assert.NilError(t, ClearActive())
-}
-
-func TestSaveActiveUpdatesParentFile(t *testing.T) {
-	parent := t.TempDir()
-	child := filepath.Join(parent, "sub")
-	assert.NilError(t, os.MkdirAll(child, 0o755))
-
-	// Mark parent as the git root so the walk can reach it.
-	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".git"), 0o755))
-
-	// Write an existing .chunk/sidecar in parent
-	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".chunk"), 0o755))
-	initial := []byte(`{"sidecar_id":"sb-old"}`)
-	assert.NilError(t, os.WriteFile(filepath.Join(parent, ".chunk", "sidecar.json"), initial, 0o644))
-
-	// Save from child — should update parent's file, not create child's
-	t.Chdir(child)
-	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-new"}))
-
-	// Child should have no .chunk dir
-	_, err := os.Stat(filepath.Join(child, ".chunk"))
-	assert.Assert(t, os.IsNotExist(err), "expected no .chunk in child")
-
-	// Parent's file should be updated
-	got, err := LoadActive()
-	assert.NilError(t, err)
-	assert.Assert(t, got != nil)
-	assert.Equal(t, got.SidecarID, "sb-new")
 }
 
 func TestWorkspaceFieldRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+	setupXDGData(t)
 
 	want := ActiveSidecar{SidecarID: "sb-1", Name: "test", Workspace: "/workspace/myrepo"}
 	assert.NilError(t, SaveActive(want))
@@ -199,10 +175,13 @@ func TestWorkspaceFieldRoundTrip(t *testing.T) {
 func TestWorkspaceOmittedWhenEmpty(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+	setupXDGData(t)
 
 	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-1"}))
 
-	data, err := os.ReadFile(filepath.Join(dir, ".chunk", sidecarFileName()))
+	stateDir, err := saveDir()
+	assert.NilError(t, err)
+	data, err := os.ReadFile(filepath.Join(stateDir, sidecarFileName()))
 	assert.NilError(t, err)
 	assert.Assert(t, !strings.Contains(string(data), "workspace"), "empty workspace should be omitted from JSON")
 }
@@ -210,6 +189,7 @@ func TestWorkspaceOmittedWhenEmpty(t *testing.T) {
 func TestResolveWorkspaceCLIFlagWins(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+	setupXDGData(t)
 
 	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-1", Workspace: "/workspace/saved"}))
 
@@ -220,6 +200,7 @@ func TestResolveWorkspaceCLIFlagWins(t *testing.T) {
 func TestResolveWorkspaceSidecarFallback(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+	setupXDGData(t)
 
 	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-1", Workspace: "/workspace/saved"}))
 
@@ -230,6 +211,7 @@ func TestResolveWorkspaceSidecarFallback(t *testing.T) {
 func TestResolveWorkspaceDefaultFallback(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+	setupXDGData(t)
 
 	got := resolveWorkspace("", "myrepo")
 	assert.Equal(t, got, "./workspace/myrepo")

--- a/internal/sidecar/snapshot.go
+++ b/internal/sidecar/snapshot.go
@@ -2,7 +2,6 @@ package sidecar
 
 import (
 	"encoding/json"
-	"errors"
 	"os"
 	"path/filepath"
 
@@ -22,9 +21,14 @@ func snapshotFileName() string {
 	return "snapshot.json"
 }
 
-// LoadActiveSnapshot walks up from cwd looking for .chunk/snapshot.json. Returns nil if not found.
+// LoadActiveSnapshot reads the active snapshot for the current project from XDG_DATA_HOME.
+// Returns nil if not found.
 func LoadActiveSnapshot() (*ActiveSnapshot, error) {
-	path, err := findSnapshotFile()
+	dir, err := saveDir()
+	if err != nil {
+		return nil, err
+	}
+	path, err := findSnapshotFile(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +46,7 @@ func LoadActiveSnapshot() (*ActiveSnapshot, error) {
 	return &a, nil
 }
 
-// SaveActiveSnapshot writes .chunk/snapshot.json into the same directory as the active sidecar file.
+// SaveActiveSnapshot writes the active snapshot to XDG_DATA_HOME for the current project.
 func SaveActiveSnapshot(a ActiveSnapshot) error {
 	dir, err := saveDir()
 	if err != nil {
@@ -58,9 +62,13 @@ func SaveActiveSnapshot(a ActiveSnapshot) error {
 	return os.WriteFile(filepath.Join(dir, snapshotFileName()), data, 0o644)
 }
 
-// ClearActiveSnapshot removes the .chunk/snapshot.json file found by walking up from cwd.
+// ClearActiveSnapshot removes the active snapshot state file.
 func ClearActiveSnapshot() error {
-	path, err := findSnapshotFile()
+	dir, err := saveDir()
+	if err != nil {
+		return err
+	}
+	path, err := findSnapshotFile(dir)
 	if err != nil {
 		return err
 	}
@@ -70,28 +78,7 @@ func ClearActiveSnapshot() error {
 	return os.Remove(path)
 }
 
-// findSnapshotFile walks up from cwd looking for .chunk/snapshot.json, returning the path or "".
-// Bounded by the git root, same as findSidecarFile.
-func findSnapshotFile() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	gitRoot, _ := findGitRoot()
-	for {
-		candidate := filepath.Join(dir, ".chunk", snapshotFileName())
-		if _, err := os.Stat(candidate); err == nil {
-			return candidate, nil
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return "", err
-		}
-		if gitRoot == "" || dir == gitRoot {
-			return "", nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", nil
-		}
-		dir = parent
-	}
+// findSnapshotFile returns the snapshot state file path in dir, or "" if it doesn't exist.
+func findSnapshotFile(dir string) (string, error) {
+	return statOrEmpty(filepath.Join(dir, snapshotFileName()))
 }

--- a/internal/sidecar/snapshot.go
+++ b/internal/sidecar/snapshot.go
@@ -24,10 +24,15 @@ func snapshotFileName() string {
 // LoadActiveSnapshot reads the active snapshot for the current project from XDG_DATA_HOME.
 // Returns nil if not found.
 func LoadActiveSnapshot() (*ActiveSnapshot, error) {
-	dir, err := saveDir()
+	dir, err := StateDir()
 	if err != nil {
 		return nil, err
 	}
+	return LoadSnapshotFrom(dir)
+}
+
+// LoadSnapshotFrom reads the active snapshot from dir.
+func LoadSnapshotFrom(dir string) (*ActiveSnapshot, error) {
 	path, err := findSnapshotFile(dir)
 	if err != nil {
 		return nil, err
@@ -48,10 +53,15 @@ func LoadActiveSnapshot() (*ActiveSnapshot, error) {
 
 // SaveActiveSnapshot writes the active snapshot to XDG_DATA_HOME for the current project.
 func SaveActiveSnapshot(a ActiveSnapshot) error {
-	dir, err := saveDir()
+	dir, err := StateDir()
 	if err != nil {
 		return err
 	}
+	return SaveSnapshotTo(dir, a)
+}
+
+// SaveSnapshotTo writes the active snapshot to dir.
+func SaveSnapshotTo(dir string, a ActiveSnapshot) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
@@ -64,10 +74,15 @@ func SaveActiveSnapshot(a ActiveSnapshot) error {
 
 // ClearActiveSnapshot removes the active snapshot state file.
 func ClearActiveSnapshot() error {
-	dir, err := saveDir()
+	dir, err := StateDir()
 	if err != nil {
 		return err
 	}
+	return ClearSnapshotFrom(dir)
+}
+
+// ClearSnapshotFrom removes the active snapshot state file in dir.
+func ClearSnapshotFrom(dir string) error {
 	path, err := findSnapshotFile(dir)
 	if err != nil {
 		return err

--- a/internal/sidecar/snapshot_test.go
+++ b/internal/sidecar/snapshot_test.go
@@ -1,8 +1,6 @@
 package sidecar
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -13,6 +11,7 @@ import (
 func TestSaveAndLoadActiveSnapshot(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+	setupXDGData(t)
 
 	want := ActiveSnapshot{ID: "snap-abc", Name: "my-snap"}
 	assert.NilError(t, SaveActiveSnapshot(want))
@@ -27,6 +26,7 @@ func TestSaveAndLoadActiveSnapshot(t *testing.T) {
 func TestLoadActiveSnapshotReturnsNilWhenMissing(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+	setupXDGData(t)
 
 	got, err := LoadActiveSnapshot()
 	assert.NilError(t, err)
@@ -36,6 +36,7 @@ func TestLoadActiveSnapshotReturnsNilWhenMissing(t *testing.T) {
 func TestClearActiveSnapshot(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+	setupXDGData(t)
 
 	assert.NilError(t, SaveActiveSnapshot(ActiveSnapshot{ID: "snap-xyz"}))
 
@@ -53,6 +54,7 @@ func TestClearActiveSnapshot(t *testing.T) {
 func TestClearActiveSnapshotNoopWhenMissing(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+	setupXDGData(t)
 
 	assert.NilError(t, ClearActiveSnapshot())
 }
@@ -60,6 +62,7 @@ func TestClearActiveSnapshotNoopWhenMissing(t *testing.T) {
 func TestSnapshotSessionKeyed(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+	setupXDGData(t)
 
 	// Save without a session — generic file.
 	assert.NilError(t, SaveActiveSnapshot(ActiveSnapshot{ID: "snap-generic"}))
@@ -84,39 +87,4 @@ func TestSnapshotSessionKeyed(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 	assert.Equal(t, got.ID, "snap-generic")
-}
-
-func TestLoadActiveSnapshotWalksUpToParent(t *testing.T) {
-	parent := t.TempDir()
-	child := filepath.Join(parent, "sub", "dir")
-	assert.NilError(t, os.MkdirAll(child, 0o755))
-
-	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".git"), 0o755))
-	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".chunk"), 0o755))
-	data := []byte(`{"id":"snap-parent","name":"parent-snap"}`)
-	assert.NilError(t, os.WriteFile(filepath.Join(parent, ".chunk", "snapshot.json"), data, 0o644))
-
-	t.Chdir(child)
-
-	got, err := LoadActiveSnapshot()
-	assert.NilError(t, err)
-	assert.Assert(t, got != nil)
-	assert.Equal(t, got.ID, "snap-parent")
-}
-
-func TestLoadActiveSnapshotStopsAtGitRoot(t *testing.T) {
-	grandparent := t.TempDir()
-	parent := filepath.Join(grandparent, "repo")
-	child := filepath.Join(parent, "sub")
-	assert.NilError(t, os.MkdirAll(child, 0o755))
-	assert.NilError(t, os.MkdirAll(filepath.Join(parent, ".git"), 0o755))
-	assert.NilError(t, os.MkdirAll(filepath.Join(grandparent, ".chunk"), 0o755))
-	data := []byte(`{"id":"snap-grandparent"}`)
-	assert.NilError(t, os.WriteFile(filepath.Join(grandparent, ".chunk", "snapshot.json"), data, 0o644))
-
-	t.Chdir(child)
-
-	got, err := LoadActiveSnapshot()
-	assert.NilError(t, err)
-	assert.Assert(t, got == nil, "walk should not cross the git root boundary")
 }

--- a/internal/testing/env/env.go
+++ b/internal/testing/env/env.go
@@ -35,10 +35,12 @@ func NewTestEnv(t *testing.T) *TestEnv {
 // Environ returns the environment as a []string for exec.Cmd.Env.
 func (e *TestEnv) Environ() []string {
 	configDir := filepath.Join(e.HomeDir, ".config")
+	dataDir := filepath.Join(e.HomeDir, ".local", "share")
 
 	env := []string{
 		fmt.Sprintf("HOME=%s", e.HomeDir),
 		fmt.Sprintf("XDG_CONFIG_HOME=%s", configDir),
+		fmt.Sprintf("XDG_DATA_HOME=%s", dataDir),
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 		"SHELL=/bin/zsh",
 		"NO_COLOR=1",


### PR DESCRIPTION
## Summary

- Sidecar and snapshot state files move from `.chunk/sidecar.json` / `.chunk/snapshot.json` inside the repo to `$XDG_DATA_HOME/chunk/<hash>/`, keeping the working tree clean
- Project key is a SHA-256 hash of the canonical git root path — collision-free by construction (replaces a dash-encoding scheme that had real collision cases)
- `findSidecarFile` / `findSnapshotFile` now accept the data directory as a parameter, eliminating redundant `saveDir()` / `projectRoot()` resolution per operation
- `XDG_DATA_HOME` added to `EnvVars`, `EnvXDGDataHome` constant, and `TestEnv.Environ()` for acceptance tests
- Docs updated: architecture table, getting-started credentials path, skills parallel-sessions note
- Test fixes: `setupXGData` typo → `setupXDGData`; added `TestSaveActiveWritesToXDGDataPath` and `TestProjectDataDir_{RootedUnderXDG,Deterministic,CollisionFree}`

## Test plan

- [x] `task test` passes with `-race`
- [x] `task acceptance-test` passes
- [x] Manually verify `chunk sidecar set` no longer creates `.chunk/sidecar.json` in the repo
- [ ] Verify state persists across `cd` into subdirectories of the same git repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)