### PR TITLE
Point sidecar feedback to CircleCI Discord and make plans less specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ chunk validate --list       # list configured commands
 
 ### Sidecar Environments
 
-Create and work in cloud sidecar environments. Sidecars are available to CircleCI customers on Performance and Scale plans.
+Create and work in cloud sidecar environments. Sidecars are available to CircleCI customers on a paid plan. Share feedback in the [CircleCI Discord](https://discord.gg/circleci).
 
 ```bash
 # Authenticate


### PR DESCRIPTION
## Summary

- Updates the Sidecar Environments section to reference "a paid plan" instead of "Performance and Scale plans"
- Adds a Discord feedback link (https://discord.gg/circleci) inline in the sidecar intro ahead of launch

## Test plan

- [ ] Verify links render correctly in the GitHub README preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)