### PR TITLE
Validate snapshot name length against 255-character API limit

### DIFF
--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -640,6 +640,9 @@ func newSidecarSnapshotCreateCmd() *cobra.Command {
 		Short: "Create a snapshot of a sidecar",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
+			if len(name) > 255 {
+				return fmt.Errorf("snapshot name must be 255 characters or fewer (got %d)", len(name))
+			}
 			if err := resolveSidecarID(&sidecarID); err != nil {
 				return err
 			}
@@ -657,7 +660,7 @@ func newSidecarSnapshotCreateCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&sidecarID, "sidecar-id", "", "Sidecar ID (defaults to active sidecar)")
-	cmd.Flags().StringVar(&name, "name", "", "Snapshot name")
+	cmd.Flags().StringVar(&name, "name", "", "Snapshot name (max 255 characters)")
 	_ = cmd.MarkFlagRequired("name")
 
 	return cmd

--- a/internal/cmd/sidecar_test.go
+++ b/internal/cmd/sidecar_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSnapshotCreateNameTooLong(t *testing.T) {
+	cmd := newSidecarSnapshotCreateCmd()
+	cmd.SetOut(nil)
+	cmd.SetErr(nil)
+
+	longName := strings.Repeat("a", 256)
+	cmd.SetArgs([]string{"--name", longName})
+
+	err := cmd.Execute()
+	assert.ErrorContains(t, err, "255 characters or fewer")
+	assert.ErrorContains(t, err, "256")
+}
+
+func TestSnapshotCreateNameAtLimit(t *testing.T) {
+	cmd := newSidecarSnapshotCreateCmd()
+
+	exactName := strings.Repeat("a", 255)
+	cmd.SetArgs([]string{"--name", exactName})
+
+	// Passes name validation; fails later on sidecar ID resolution (no active sidecar).
+	// We just confirm it does NOT return the length error.
+	err := cmd.Execute()
+	if err != nil {
+		assert.Assert(t, !strings.Contains(err.Error(), "255 characters or fewer"),
+			"unexpected length validation error for 255-char name: %v", err)
+	}
+}

--- a/skills/chunk-sidecar/SKILL.md
+++ b/skills/chunk-sidecar/SKILL.md
@@ -53,7 +53,7 @@ This step produces a reusable snapshot so future sessions boot fast. Follow it w
 
 1. `chunk sidecar setup --dir . --name <name>` — detects the stack, syncs files, and runs install steps on the sidecar.
 2. Verify the sidecar is working correctly: `chunk validate`. This uses per-command routing — commands marked `remote: true` run on the sidecar, the rest run locally. If any command fails with a missing binary or dependency, see Troubleshooting below, then re-run `chunk validate` until it passes.
-3. Snapshot the working sidecar: `chunk sidecar snapshot create --name <snapshot-name>`. This captures the configured state and returns a snapshot ID. **Always snapshot after confirming the sidecar is working — do not skip this step.**
+3. Snapshot the working sidecar: `chunk sidecar snapshot create --name <snapshot-name>`. This captures the configured state and returns a snapshot ID. **Always snapshot after confirming the sidecar is working — do not skip this step.** Snapshot names are limited to 255 characters; the CLI will reject longer names before making the API call.
 4. Record the snapshot ID in `.chunk/config.json`: `chunk config set validation.sidecarImage <snapshot-id>`.
 5. Create a **new** sidecar from the snapshot and set it as active — this is the clean environment you will use going forward:
    ```


### PR DESCRIPTION
## Summary

- Adds a CLI-side check that rejects snapshot names longer than 255 characters before making any API call, returning a clear error with the actual length
- Updates the `--name` flag description to document the limit
- Notes the 255-character limit in the `chunk-sidecar` skill so agents know to stay within it
- Adds tests for the boundary: >255 chars is rejected, exactly 255 chars passes validation

## Test plan

- [x] `go test -race ./internal/cmd/ -run TestSnapshotCreate` passes
- [x] `chunk sidecar snapshot create --name <256-char-string>` returns `snapshot name must be 255 characters or fewer (got 256)`
- [ ] `chunk sidecar snapshot create --name <255-char-string>` proceeds past validation (fails on auth if no token, not on length)

🤖 Generated with [Claude Code](https://claude.com/claude-code)