### PR TITLE
Be clearer on what is happening with ssh timeout

### DIFF
--- a/internal/cmd/usererr.go
+++ b/internal/cmd/usererr.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -41,6 +42,13 @@ func sshSessionError(err error) error {
 		return &userError{
 			msg:        "SSH agent not available.",
 			suggestion: "Set " + config.EnvSSHAuthSock + " or pass --identity-file.",
+			err:        err,
+		}
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return &userError{
+			msg:        "Request timed out.",
+			suggestion: "Try again. This request may time out on initial key registration.",
 			err:        err,
 		}
 	}


### PR DESCRIPTION
You know I love a good "context deadline exceeded" but this call is idempotent and, in my case, had successfully stored the key such that retry succeeded instantly.

There's likely a better approach here, but I don't think this makes the situation worse...