### PR TITLE
Fix issues found via mutation testing

### DIFF
--- a/internal/github/reviews_test.go
+++ b/internal/github/reviews_test.go
@@ -1,6 +1,116 @@
 package github
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+// TestProcessPR_ExcludesAuthorSelfReview verifies that review activity and
+// comment details contributed by the PR author themselves are not counted.
+// MUT-011 caught this gap by inverting the prAuthor check so that author
+// comments were always included.
+func TestProcessPR_ExcludesAuthorSelfReview(t *testing.T) {
+	pr := PRNode{
+		Number:    42,
+		Title:     "My PR",
+		URL:       "https://github.com/org/repo/pull/42",
+		State:     "OPEN",
+		UpdatedAt: "2026-01-01T00:00:00Z",
+		Author:    &Author{Login: "alice"},
+		Reviews: struct {
+			Nodes []ReviewNode `json:"nodes"`
+		}{
+			Nodes: []ReviewNode{
+				// alice reviews her own PR — should be excluded
+				{Author: &Author{Login: "alice"}, State: "APPROVED", CreatedAt: "2026-01-01T00:00:00Z"},
+				// bob is a genuine reviewer — should be included
+				{Author: &Author{Login: "bob"}, State: "CHANGES_REQUESTED", CreatedAt: "2026-01-01T00:00:00Z"},
+			},
+		},
+		ReviewThreads: struct {
+			Nodes []struct {
+				Comments struct {
+					Nodes []CommentNode `json:"nodes"`
+				} `json:"comments"`
+			} `json:"nodes"`
+		}{
+			Nodes: []struct {
+				Comments struct {
+					Nodes []CommentNode `json:"nodes"`
+				} `json:"comments"`
+			}{
+				{Comments: struct {
+					Nodes []CommentNode `json:"nodes"`
+				}{Nodes: []CommentNode{
+					// alice comments on her own PR — should be excluded
+					{Author: &Author{Login: "alice"}, Body: "self-comment", DiffHunk: "@@", CreatedAt: "2026-01-01T00:00:00Z"},
+					// bob comments — should be included
+					{Author: &Author{Login: "bob"}, Body: "nit: rename this", DiffHunk: "@@", CreatedAt: "2026-01-01T00:00:00Z"},
+				}}},
+			},
+		},
+	}
+
+	activityMap := map[string]*UserActivity{}
+	var details []ReviewCommentDetail
+	processPR(pr, time.Time{}, "my-repo", activityMap, &details)
+
+	if _, ok := activityMap["alice"]; ok {
+		t.Error("PR author alice should not appear in reviewer activity")
+	}
+	bob, ok := activityMap["bob"]
+	if !ok {
+		t.Fatal("expected bob to appear in reviewer activity")
+	}
+	if bob.ChangesRequested != 1 {
+		t.Errorf("bob.ChangesRequested: got %d, want 1", bob.ChangesRequested)
+	}
+	if bob.ReviewComments != 1 {
+		t.Errorf("bob.ReviewComments: got %d, want 1", bob.ReviewComments)
+	}
+
+	for _, d := range details {
+		if d.Reviewer == "alice" {
+			t.Error("PR author alice should not appear in review details")
+		}
+	}
+	if len(details) != 1 {
+		t.Errorf("expected 1 detail entry (bob), got %d", len(details))
+	}
+}
+
+// TestProcessPR_ExcludesAuthorSelfReview_CaseInsensitive verifies that the
+// author check is case-insensitive: if the PR author is "Alice" and the
+// reviewer login is "alice", the review is still excluded.
+func TestProcessPR_ExcludesAuthorSelfReview_CaseInsensitive(t *testing.T) {
+	pr := PRNode{
+		Number:    1,
+		UpdatedAt: "2026-01-01T00:00:00Z",
+		Author:    &Author{Login: "Alice"}, // mixed-case author
+		Reviews: struct {
+			Nodes []ReviewNode `json:"nodes"`
+		}{
+			Nodes: []ReviewNode{
+				{Author: &Author{Login: "alice"}, State: "APPROVED", CreatedAt: "2026-01-01T00:00:00Z"},
+			},
+		},
+		ReviewThreads: struct {
+			Nodes []struct {
+				Comments struct {
+					Nodes []CommentNode `json:"nodes"`
+				} `json:"comments"`
+			} `json:"nodes"`
+		}{},
+	}
+
+	activityMap := map[string]*UserActivity{}
+	var details []ReviewCommentDetail
+	processPR(pr, time.Time{}, "repo", activityMap, &details)
+
+	if _, ok := activityMap["alice"]; ok {
+		t.Error("lowercase 'alice' should be excluded when PR author is 'Alice'")
+	}
+}
 
 func TestIsBot(t *testing.T) {
 	tests := []struct {

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -1,0 +1,54 @@
+package settings
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+)
+
+func TestBuildHookTimeoutDefaultsToSixty(t *testing.T) {
+	// A command with Timeout: 0 must produce a non-zero timeout in the generated
+	// hook entry — the default of 60s must be applied. MUT-006 caught this gap by
+	// changing the default to 0, which causes Claude Code to treat the hook as
+	// having no timeout limit.
+	cmds := []config.Command{
+		{Name: "test", Run: "go test ./...", Timeout: 0},
+	}
+	data, err := Build(cmds)
+	assert.NilError(t, err)
+
+	var s map[string]interface{}
+	assert.NilError(t, json.Unmarshal(data, &s))
+
+	hooks := s["hooks"].(map[string]interface{})
+	preToolUse := hooks["PreToolUse"].([]interface{})
+	group := preToolUse[0].(map[string]interface{})
+	entries := group["hooks"].([]interface{})
+	entry := entries[0].(map[string]interface{})
+
+	timeout, _ := entry["timeout"].(float64)
+	assert.Assert(t, timeout == 60, "expected default hook timeout of 60 for command with Timeout: 0, got: %v", timeout)
+}
+
+func TestBuildHookTimeoutRespectsExplicitValue(t *testing.T) {
+	cmds := []config.Command{
+		{Name: "lint", Run: "golangci-lint run", Timeout: 120},
+	}
+	data, err := Build(cmds)
+	assert.NilError(t, err)
+
+	var s map[string]interface{}
+	assert.NilError(t, json.Unmarshal(data, &s))
+
+	hooks := s["hooks"].(map[string]interface{})
+	preToolUse := hooks["PreToolUse"].([]interface{})
+	group := preToolUse[0].(map[string]interface{})
+	entries := group["hooks"].([]interface{})
+	entry := entries[0].(map[string]interface{})
+
+	timeout, _ := entry["timeout"].(float64)
+	assert.Assert(t, timeout == 120, "expected explicit timeout of 120, got: %v", timeout)
+}

--- a/internal/sidecar/sync_test.go
+++ b/internal/sidecar/sync_test.go
@@ -1,0 +1,66 @@
+package sidecar_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/gitrepo"
+)
+
+// TestSync_NonApplyFailureReturnsImmediately verifies that Sync does not send a
+// "rm -rf" cleanup command when syncWorkspace fails for a reason other than a
+// git-apply failure. MUT-013 caught this gap by inverting the errApplyFailed
+// check, which caused Sync to retry (and rm -rf the remote workspace) for all
+// failure types, not just patch-apply failures.
+func TestSync_NonApplyFailureReturnsImmediately(t *testing.T) {
+	keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+
+	// SSH server: all commands succeed (exitCode 0), so mkdir-p and test-d pass.
+	// syncWorkspace then calls gitutil.MergeBase(), which fails because the test
+	// repo has no upstream tracking branch — a non-errApplyFailed error.
+	sshSrv := fakes.NewSSHServer(t, pubKey)
+	sshSrv.SetResult("", 0)
+
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = sshSrv.Addr()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	// Isolated HOME so OpenSession resolves known_hosts to a writable temp path.
+	t.Setenv(config.EnvHome, t.TempDir())
+	// Isolated XDG_DATA_HOME so sidecar state files don't bleed across tests.
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
+
+	repoDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	t.Chdir(repoDir)
+
+	cl := newClient(t, srv.URL)
+	noopStatus := iostream.StatusFunc(func(_ iostream.Level, _ string) {})
+
+	err := sidecar.Sync(context.Background(), cl, "sb-1", keyFile, "", "", noopStatus)
+
+	// Sync must return an error (MergeBase failed — no upstream branch).
+	assert.Assert(t, err != nil, "expected Sync to return an error")
+
+	// The error must be a RemoteBaseError, not an apply failure.
+	var remoteBaseErr *sidecar.RemoteBaseError
+	assert.Assert(t, errors.As(err, &remoteBaseErr),
+		"expected RemoteBaseError, got: %T %v", err, err)
+
+	// Critically: no rm -rf must have been sent. With MUT-013, Sync would treat
+	// the RemoteBaseError as a retryable apply failure and issue a rm -rf before
+	// the second syncWorkspace attempt.
+	for _, cmd := range sshSrv.Commands() {
+		assert.Assert(t, !strings.Contains(cmd, "rm -rf"),
+			"Sync must not send rm -rf for non-apply failures; got command: %q", cmd)
+	}
+}


### PR DESCRIPTION
The following 3 issues discovered via mutation testing are now covered:

1. internal/settings/settings_test.go — TestBuildHookTimeoutDefaultsToSixty catches MUT-006: verifies that Build applies the 60s default when Timeout: 0.
2. internal/github/reviews_test.go — TestProcessPR_ExcludesAuthorSelfReview and its case-insensitive variant catch MUT-011: verifies that PR author self-reviews are excluded from activityMap and details.
3. internal/sidecar/sync_test.go — TestSync_NonApplyFailureReturnsImmediately catches MUT-013: verifies that Sync returns immediately on a RemoteBaseError without sending rm -rf, distinguishing the non-apply failure path from the apply-failed retry path.