### PR TITLE
Remove sidecar provider selection

### DIFF
--- a/internal/circleci/circleci_test.go
+++ b/internal/circleci/circleci_test.go
@@ -108,7 +108,7 @@ func TestCreateSidecar(t *testing.T) {
 	client := newTestClient(t, srv.URL)
 	ctx := context.Background()
 
-	sb, err := client.CreateSidecar(ctx, "org-1", "my-sidecar", "", "ubuntu:22.04")
+	sb, err := client.CreateSidecar(ctx, "org-1", "my-sidecar", "ubuntu:22.04")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -323,7 +323,7 @@ func TestAuthRequired(t *testing.T) {
 	})
 
 	t.Run("CreateSidecar", func(t *testing.T) {
-		_, err := client.CreateSidecar(ctx, "org-1", "name", "", "image")
+		_, err := client.CreateSidecar(ctx, "org-1", "name", "image")
 		if err == nil {
 			t.Fatal("expected error")
 		}

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -62,12 +62,11 @@ func (c *Client) ListSidecars(ctx context.Context, orgID string) ([]Sidecar, err
 	return resp.Items, nil
 }
 
-func (c *Client) CreateSidecar(ctx context.Context, orgID, name, provider, image string) (*Sidecar, error) {
+func (c *Client) CreateSidecar(ctx context.Context, orgID, name, image string) (*Sidecar, error) {
 	body := CreateSidecarRequest{
-		OrgID:    orgID,
-		Name:     name,
-		Provider: provider,
-		Image:    image,
+		OrgID: orgID,
+		Name:  name,
+		Image: image,
 	}
 	var resp Sidecar
 	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodPost, "/api/v2/sidecar/instances",

--- a/internal/circleci/types.go
+++ b/internal/circleci/types.go
@@ -53,10 +53,9 @@ type RunResponse struct {
 }
 
 type CreateSidecarRequest struct {
-	OrgID    string `json:"org_id"`
-	Name     string `json:"name"`
-	Provider string `json:"provider,omitempty"`
-	Image    string `json:"image,omitempty"`
+	OrgID string `json:"org_id"`
+	Name  string `json:"name"`
+	Image string `json:"image,omitempty"`
 }
 
 type Snapshot struct {

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -153,16 +153,13 @@ func newSidecarListCmd() *cobra.Command {
 	return cmd
 }
 
-const defaultProvider = "e2b"
-
 func newSidecarCreateCmd() *cobra.Command {
 	var orgID, name, image string
 
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a sidecar",
-		Long: "Create a sidecar.\n\nThe sidecar backend defaults to e2b. Override with the " + config.EnvSidecarProvider +
-			"\nenvironment variable (e.g. " + config.EnvSidecarProvider + "=unikraft).",
+		Long:  "Create a sidecar.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
@@ -173,11 +170,7 @@ func newSidecarCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			provider := os.Getenv(config.EnvSidecarProvider)
-			if provider == "" {
-				provider = defaultProvider
-			}
-			sb, err := sidecar.Create(cmd.Context(), client, resolvedOrgID, name, provider, image)
+			sb, err := sidecar.Create(cmd.Context(), client, resolvedOrgID, name, image)
 			if err != nil {
 				if err := notAuthorized("create sidecars", err); err != nil {
 					return err
@@ -752,14 +745,10 @@ Example:
 			status(iostream.LevelInfo, fmt.Sprintf("stack: %s", env.Stack))
 
 			// Step 2: Resolve or create sidecar.
-			provider := os.Getenv(config.EnvSidecarProvider)
-			if provider == "" {
-				provider = defaultProvider
-			}
 			var workspace string
 			if sidecarID == "" {
 				var resolveErr error
-				sidecarID, _, workspace, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, name, provider, status, streams)
+				sidecarID, _, workspace, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, name, status, streams)
 				if resolveErr != nil {
 					return resolveErr
 				}
@@ -803,7 +792,7 @@ Example:
 func sidecarSetupResolveSidecar(
 	ctx context.Context,
 	client *circleci.Client,
-	orgID, name, provider string,
+	orgID, name string,
 	status iostream.StatusFunc,
 	streams iostream.Streams,
 ) (id, displayName, workspace string, err error) {
@@ -827,7 +816,7 @@ func sidecarSetupResolveSidecar(
 		return "", "", "", err
 	}
 	status(iostream.LevelStep, fmt.Sprintf("Creating sidecar %q...", name))
-	sc, err := sidecar.Create(ctx, client, resolvedOrgID, name, provider, "")
+	sc, err := sidecar.Create(ctx, client, resolvedOrgID, name, "")
 	if err != nil {
 		if authErr := notAuthorized("create sidecars", err); authErr != nil {
 			return "", "", "", authErr

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -405,12 +405,8 @@ func resolveOrCreateSidecarID(ctx context.Context, sidecarID *string, orgID, ima
 	if err != nil {
 		return err
 	}
-	provider := os.Getenv(config.EnvSidecarProvider)
-	if provider == "" {
-		provider = defaultProvider
-	}
 	sandboxName := filepath.Base(workDir) + "-validate"
-	sc, err := sidecar.Create(ctx, client, resolvedOrgID, sandboxName, provider, image)
+	sc, err := sidecar.Create(ctx, client, resolvedOrgID, sandboxName, image)
 	if err != nil {
 		if authErr := notAuthorized("create sidecars", err); authErr != nil {
 			return authErr

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,7 +38,6 @@ const (
 	EnvGitHubAPIURL     = "GITHUB_API_URL"
 	EnvModel            = "CODE_REVIEW_CLI_MODEL"
 	EnvCircleCIOrgID    = "CIRCLECI_ORG_ID"
-	EnvSidecarProvider  = "CHUNK_SIDECAR_PROVIDER"
 )
 
 // System/standard environment variable names.
@@ -66,7 +65,6 @@ type EnvVars struct {
 	GitHubAPIURL     string `env:"GITHUB_API_URL,default=https://api.github.com"`
 	Model            string `env:"CODE_REVIEW_CLI_MODEL"`
 	CircleCIOrgID    string `env:"CIRCLECI_ORG_ID"`
-	SidecarProvider  string `env:"CHUNK_SIDECAR_PROVIDER"`
 	Home             string `env:"HOME"`
 	Shell            string `env:"SHELL"`
 	SSHAuthSock      string `env:"SSH_AUTH_SOCK"`

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -14,8 +14,8 @@ func List(ctx context.Context, client *circleci.Client, orgID string) ([]circlec
 	return client.ListSidecars(ctx, orgID)
 }
 
-func Create(ctx context.Context, client *circleci.Client, orgID, name, provider, image string) (*circleci.Sidecar, error) {
-	return client.CreateSidecar(ctx, orgID, name, provider, image)
+func Create(ctx context.Context, client *circleci.Client, orgID, name, image string) (*circleci.Sidecar, error) {
+	return client.CreateSidecar(ctx, orgID, name, image)
 }
 
 func Exec(ctx context.Context, client *circleci.Client, sidecarID, command string, args []string) (*circleci.ExecResponse, error) {

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -79,7 +79,7 @@ func TestCreate(t *testing.T) {
 	cl := newClient(t, srv.URL)
 	ctx := context.Background()
 
-	sb, err := sidecar.Create(ctx, cl, "org-1", "my-sidecar", "e2b", "ubuntu:22.04")
+	sb, err := sidecar.Create(ctx, cl, "org-1", "my-sidecar", "ubuntu:22.04")
 	assert.NilError(t, err)
 	assert.Equal(t, sb.ID, "sidecar-new-123")
 	assert.Equal(t, sb.Name, "my-sidecar")


### PR DESCRIPTION
## Summary

- Removes `CHUNK_SIDECAR_PROVIDER` env var, `defaultProvider` constant, and all `provider` parameters throughout the call stack
- Drops `Provider` field from `CreateSidecarRequest` — the public API only supports one backend and no longer accepts a provider choice
- Removes the user-facing help text that mentioned e2b and the env var override

## Test plan

- [x] `task test` passes
- [x] `task lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)