### PR TITLE
Auto-create sidecar from config image for per-command remote routing

### DIFF
--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -394,7 +394,7 @@ func TestValidateRunRemoteUsesSSH(t *testing.T) {
 	assert.Equal(t, len(execReqs), 0, "expected 0 HTTP exec requests (SSH should be used)")
 }
 
-func TestValidateAutoCreatesSidecarFromConfigImage(t *testing.T) {
+func TestValidateAutoCreatesSidecar(t *testing.T) {
 	// Verify that chunk validate (no --remote) auto-creates a sidecar using the
 	// image stored in validation.sidecarImage when no active sidecar exists.
 	cci := fakes.NewFakeCircleCI()

--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -393,3 +393,61 @@ func TestValidateRunRemoteUsesSSH(t *testing.T) {
 	execReqs := filterByPath(reqs, "/api/v2/sidecar/instances/sidecar-123/exec")
 	assert.Equal(t, len(execReqs), 0, "expected 0 HTTP exec requests (SSH should be used)")
 }
+
+func TestValidateAutoCreatesSidecarFromConfigImage(t *testing.T) {
+	// Verify that chunk validate (no --remote) auto-creates a sidecar using the
+	// image stored in validation.sidecarImage when no active sidecar exists.
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = "127.0.0.1" // SSH will fail — no real server at port 2222
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+
+	// Write a config with a remote command and a snapshot image reference.
+	chunkDir := filepath.Join(workDir, ".chunk")
+	assert.NilError(t, os.MkdirAll(chunkDir, 0o755))
+	cfg := map[string]interface{}{
+		"commands": []map[string]interface{}{
+			{"name": "test", "run": "echo test-output", "remote": true},
+		},
+		"validation": map[string]interface{}{
+			"sidecarImage": "my-snapshot-abc123",
+		},
+	}
+	data, err := json.Marshal(cfg)
+	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), data, 0o644))
+
+	sshDir := filepath.Join(t.TempDir(), ".ssh")
+	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
+	identityFile := filepath.Join(sshDir, "chunk_ai")
+	assert.NilError(t, generateTestSSHKey(t, identityFile))
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	env.Extra["CIRCLECI_ORG_ID"] = "org-aaa"
+
+	result := binary.RunCLI(t, []string{
+		"validate",
+		"--identity-file", identityFile,
+	}, env, workDir)
+
+	// SSH to 127.0.0.1:2222 fails — expected, but a sidecar must have been created first.
+	assert.Assert(t, result.ExitCode != 0, "expected failure because no SSH server is running")
+
+	reqs := cci.Recorder.AllRequests()
+
+	// A sidecar must have been created with the configured image.
+	createReqs := filterByPath(reqs, "/api/v2/sidecar/instances")
+	assert.Equal(t, len(createReqs), 1, "expected 1 create-sidecar request; got: %v", reqs)
+
+	var body map[string]interface{}
+	assert.NilError(t, json.Unmarshal(createReqs[0].Body, &body))
+	assert.Equal(t, body["image"], "my-snapshot-abc123", "expected sidecar image from config")
+	assert.Equal(t, body["org_id"], "org-aaa", "expected org from CIRCLECI_ORG_ID")
+
+	// AddSSHKey must be called on the newly created sidecar — proves it was used.
+	addKeyReqs := filterByPath(reqs, "/api/v2/sidecar/instances/sidecar-new-123/ssh/add-key")
+	assert.Equal(t, len(addKeyReqs), 1, "expected 1 add-key request for newly created sidecar; got: %v", reqs)
+}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -150,7 +150,7 @@ func newValidateCmd() *cobra.Command {
 				}
 				statusFn(iostream.LevelInfo, fmt.Sprintf("running all commands on sidecar %s", sidecarID))
 			} else if cfg.HasRemoteCommands() {
-				resolvePerCommandSidecarID(cmd.Context(), &sidecarID, orgID, image, workDir, hook, streams, statusFn)
+				resolveSidecar(cmd.Context(), &sidecarID, orgID, image, workDir, hook, streams)
 			}
 
 			execErr := runValidate(cmd.Context(), workDir, name, inlineCmd, save, sidecarID, identityFile, workdir, allRemote, cfg, statusFn, streams)
@@ -365,11 +365,12 @@ func resolveImage(name string, cfg *config.ProjectConfig) string {
 	return ""
 }
 
-// resolvePerCommandSidecarID fills sidecarID for per-command remote routing
+// resolveSidecar fills sidecarID for per-command remote routing
 // (i.e. when --remote is not set but some commands have Remote:true).
 // It uses the active sidecar when available, auto-creates one when a sidecar
 // image is configured or the caller is a Stop hook, and warns otherwise.
-func resolvePerCommandSidecarID(ctx context.Context, sidecarID *string, orgID, image, workDir string, hook *hookContext, streams iostream.Streams, statusFn iostream.StatusFunc) {
+func resolveSidecar(ctx context.Context, sidecarID *string, orgID, image, workDir string, hook *hookContext, streams iostream.Streams) {
+	statusFn := newStatusFunc(streams)
 	if active, err := sidecar.LoadActive(); err == nil && active != nil {
 		*sidecarID = active.SidecarID
 		statusFn(iostream.LevelInfo, fmt.Sprintf("using sidecar %s for remote commands", *sidecarID))

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -150,18 +150,7 @@ func newValidateCmd() *cobra.Command {
 				}
 				statusFn(iostream.LevelInfo, fmt.Sprintf("running all commands on sidecar %s", sidecarID))
 			} else if cfg.HasRemoteCommands() {
-				// Per-command remote: use active sidecar if available.
-				if active, err := sidecar.LoadActive(); err == nil && active != nil {
-					sidecarID = active.SidecarID
-					statusFn(iostream.LevelInfo, fmt.Sprintf("using sidecar %s for remote commands", sidecarID))
-				} else if hook != nil {
-					// In Stop hook context: auto-create a sandbox if possible.
-					if err := resolveOrCreateSidecarID(cmd.Context(), &sidecarID, orgID, image, workDir, streams); err != nil {
-						streams.ErrPrintf("warning: no sandbox available (%v); run 'chunk config set orgID <id>' to enable remote validation, running locally instead\n", err)
-					}
-				} else {
-					statusFn(iostream.LevelWarn, "no active sidecar found — remote commands will run locally")
-				}
+				resolvePerCommandSidecarID(cmd.Context(), &sidecarID, orgID, image, workDir, hook, streams, statusFn)
 			}
 
 			execErr := runValidate(cmd.Context(), workDir, name, inlineCmd, save, sidecarID, identityFile, workdir, allRemote, cfg, statusFn, streams)
@@ -374,6 +363,27 @@ func resolveImage(name string, cfg *config.ProjectConfig) string {
 		return cfg.Validation.SidecarImage
 	}
 	return ""
+}
+
+// resolvePerCommandSidecarID fills sidecarID for per-command remote routing
+// (i.e. when --remote is not set but some commands have Remote:true).
+// It uses the active sidecar when available, auto-creates one when a sidecar
+// image is configured or the caller is a Stop hook, and warns otherwise.
+func resolvePerCommandSidecarID(ctx context.Context, sidecarID *string, orgID, image, workDir string, hook *hookContext, streams iostream.Streams, statusFn iostream.StatusFunc) {
+	if active, err := sidecar.LoadActive(); err == nil && active != nil {
+		*sidecarID = active.SidecarID
+		statusFn(iostream.LevelInfo, fmt.Sprintf("using sidecar %s for remote commands", *sidecarID))
+		return
+	}
+	if hook != nil || image != "" {
+		// In Stop hook context, or when a sidecar image is configured: auto-create
+		// from the stored snapshot so remote commands get the prepared environment.
+		if err := resolveOrCreateSidecarID(ctx, sidecarID, orgID, image, workDir, streams); err != nil {
+			streams.ErrPrintf("warning: no sandbox available (%v); run 'chunk config set orgID <id>' to enable remote validation, running locally instead\n", err)
+		}
+		return
+	}
+	statusFn(iostream.LevelWarn, "no active sidecar found — remote commands will run locally")
 }
 
 // resolveOrCreateSidecarID fills sidecarID from the active sidecar, or creates


### PR DESCRIPTION
## Summary

- When `validation.sidecarImage` is configured and a command is marked `remote: true`, `chunk validate` now auto-creates a sidecar even when not running in a Stop hook context
- Previously, auto-creation only fired in the Stop hook path (`hook != nil`); running `chunk validate` directly would fall through to "no active sidecar found — remote commands will run locally"
- Extracted the per-command sidecar resolution into `resolvePerCommandSidecarID` to make the branching logic easier to follow

## Test plan

- [ ] `TestValidateAutoCreatesSidecar` — verifies a sidecar is created using the configured image, the correct org is passed, and the new sidecar is actually used (add-key called on it)
- [ ] Existing `TestValidateRunRemoteUsesSSH` continues to pass (explicit `--sidecar-id` path unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)