### PR TITLE
Make sidecar --name optional with random name generation

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -172,7 +172,8 @@ The agent loads your team's prompt, diffs the changes, and returns filtered find
 Sidecars let you run validations in a clean cloud environment. The typical loop:
 
 ```bash
-# One-time: create a sidecar
+# One-time: create a sidecar (--name is optional; a random name is generated if omitted)
+chunk sidecar create
 chunk sidecar create --name my-sidecar
 
 # Set it as active
@@ -201,7 +202,7 @@ Auto-detect your tech stack and build a sidecar image for it:
 ```bash
 chunk sidecar env                                    # detect stack, save to config
 chunk sidecar env | chunk sidecar build --tag myimg  # build Docker image
-chunk sidecar create --name my-sidecar --image myimg
+chunk sidecar create --image myimg                   # name auto-generated
 ```
 
 ### Snapshots
@@ -211,7 +212,7 @@ Capture a configured environment so future sidecars boot fast:
 ```bash
 chunk sidecar snapshot create --name checkpoint
 # Later:
-chunk sidecar create --name new-sidecar --image <snapshot-id>
+chunk sidecar create --image <snapshot-id>           # name auto-generated
 ```
 
 ---

--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dnephin/pflag v1.0.7 // indirect
+	github.com/dustinkirkland/golang-petname v0.0.0-20260215035315-f0c533e9ce9b // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/coder/websocket v1.8.14
+	github.com/dustinkirkland/golang-petname v0.0.0-20260215035315-f0c533e9ce9b
 	github.com/gin-gonic/gin v1.12.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/sethvargo/go-envconfig v1.3.0
@@ -89,7 +90,6 @@ require (
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dnephin/pflag v1.0.7 // indirect
-	github.com/dustinkirkland/golang-petname v0.0.0-20260215035315-f0c533e9ce9b // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,8 @@ github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZ
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnephin/pflag v1.0.7 h1:oxONGlWxhmUct0YzKTgrpQv9AUA1wtPBn7zuSjJqptk=
 github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Zm7OQE=
+github.com/dustinkirkland/golang-petname v0.0.0-20260215035315-f0c533e9ce9b h1:qZ21OofI7zneC9dOEqul4FmIWz/YjJJMrf6fL7jrFYQ=
+github.com/dustinkirkland/golang-petname v0.0.0-20260215035315-f0c533e9ce9b/go.mod h1:8AuBTZBRSFqEYBPYULd+NN474/zZBLP+6WeT5S9xlAc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/chunk-cli/envbuilder"
@@ -22,6 +23,10 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
+
+func randomSidecarName() string {
+	return petname.Generate(3, "-")
+}
 
 func newSidecarCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -166,6 +171,9 @@ func newSidecarCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if name == "" {
+				name = randomSidecarName()
+			}
 			resolvedOrgID, err := resolveOrgID(orgID, orgPicker(cmd.Context(), client))
 			if err != nil {
 				return err
@@ -192,9 +200,8 @@ func newSidecarCreateCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&orgID, "org-id", "", "Organization ID")
-	cmd.Flags().StringVar(&name, "name", "", "Sidecar name")
+	cmd.Flags().StringVar(&name, "name", "", "Sidecar name (auto-generated if not provided)")
 	cmd.Flags().StringVar(&image, "image", "", "E2B template ID or container image")
-	_ = cmd.MarkFlagRequired("name")
 
 	return cmd
 }
@@ -805,11 +812,7 @@ func sidecarSetupResolveSidecar(
 		return active.SidecarID, active.Name, active.Workspace, nil
 	}
 	if name == "" {
-		return "", "", "", &userError{
-			msg:        "No active sidecar and --name not provided.",
-			suggestion: "Pass --name to create a new sidecar, or run 'chunk sidecar use <id>'.",
-			errMsg:     "no active sidecar and --name not provided",
-		}
+		name = randomSidecarName()
 	}
 	resolvedOrgID, err := resolveOrgID(orgID, orgPicker(ctx, client))
 	if err != nil {

--- a/skills/chunk-sidecar/SKILL.md
+++ b/skills/chunk-sidecar/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: chunk-sidecar
 description: Use when the user says "validate on the sidecar", "run tests on the sidecar", "sync to sidecar", "sidecar dev loop", "check this on the sidecar", "validate remotely", or when you have made edits and want to verify them on a remote `chunk` sidecar instead of running locally. Also covers creating sidecars, snapshotting a configured environment, and customizing the sidecar image via `chunk sidecar`.
-version: 1.1.0
+version: 1.2.0
 allowed-tools:
   - Bash(chunk --version)
   - Bash(chunk auth status)
@@ -36,28 +36,28 @@ Run `chunk sidecar current`. Three cases:
 - **It prints a sidecar** — use it; go to Step 4.
 - **No active sidecar, and `validation.sidecarImage` is set in `.chunk/config.json`** — create a new sidecar from the snapshot, sync, and go straight to Step 4:
   ```
-  chunk sidecar create --name <name> --org-id <orgID> --image <sidecarImage>
+  chunk sidecar create --org-id <orgID> --image <sidecarImage>
   chunk sidecar sync
   ```
   Read `orgID` and `validation.sidecarImage` from `.chunk/config.json`. Ask the user for the org ID if it is not present in the config.
 - **No active sidecar, no `sidecarImage` configured** — full environment setup is needed. Inform the user, confirm the org ID (read from `.chunk/config.json` or ask), create a sidecar, then go to Step 3:
   ```
-  chunk sidecar create --name <name> --org-id <orgID>
+  chunk sidecar create --org-id <orgID>
   ```
 
-Always pass `--org-id` to `chunk sidecar create` — interactive org selection does not work in Claude sessions.
+Always pass `--org-id` to `chunk sidecar create` — interactive org selection does not work in Claude sessions. `--name` is optional; a random adjective-adverb-noun name (e.g. `happy-quickly-tesla`) is generated automatically if omitted.
 
 ## Step 3: One-time setup
 
 This step produces a reusable snapshot so future sessions boot fast. Follow it whenever a fresh sidecar has no snapshot to boot from (Step 2 case 3).
 
-1. `chunk sidecar setup --dir . --name <name>` — detects the stack, syncs files, and runs install steps on the sidecar.
+1. `chunk sidecar setup --dir .` — detects the stack, syncs files, and runs install steps on the sidecar. Pass `--name <name>` if you want a specific name; otherwise one is generated automatically.
 2. Verify the sidecar is working correctly: `chunk validate`. This uses per-command routing — commands marked `remote: true` run on the sidecar, the rest run locally. If any command fails with a missing binary or dependency, see Troubleshooting below, then re-run `chunk validate` until it passes.
 3. Snapshot the working sidecar: `chunk sidecar snapshot create --name <snapshot-name>`. This captures the configured state and returns a snapshot ID. **Always snapshot after confirming the sidecar is working — do not skip this step.** Snapshot names are limited to 255 characters; the CLI will reject longer names before making the API call.
 4. Record the snapshot ID in `.chunk/config.json`: `chunk config set validation.sidecarImage <snapshot-id>`.
 5. Create a **new** sidecar from the snapshot and set it as active — this is the clean environment you will use going forward:
    ```
-   chunk sidecar create --name <new-name> --org-id <orgID> --image <snapshot-id>
+   chunk sidecar create --org-id <orgID> --image <snapshot-id>
    chunk sidecar sync
    ```
 6. Re-verify with `chunk validate` to confirm the snapshot-booted sidecar is healthy before entering the loop.


### PR DESCRIPTION
## Summary

- `--name` is no longer required on `chunk sidecar create` or `chunk sidecar setup` — a random adjective-adverb-noun name (e.g. `happy-quickly-tesla`) is generated automatically when omitted using [`golang-petname`](https://github.com/dustinkirkland/golang-petname)
- Updates `chunk-sidecar` skill (v1.1.0 → v1.2.0) to remove `--name` from all example commands and document the auto-generation behaviour
- Updates `docs/GETTING_STARTED.md` to show `--name` as optional in sidecar creation examples

## Test plan

- [x] `chunk sidecar create` (no `--name`) succeeds and prints a generated name
- [x] `chunk sidecar create --name my-sidecar` still works with an explicit name
- [x] `chunk sidecar setup` (no `--name`, no active sidecar) creates a sidecar with a generated name
- [x] `task build && task test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)