### PR TITLE
Fix sidecar session isolation: read session ID from hook payload

### DIFF
--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -3,8 +3,10 @@ package acceptance
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"net/http/httptest"
 	"os"
 	"os/exec"
@@ -392,4 +394,61 @@ func TestValidateRunRemoteUsesSSH(t *testing.T) {
 	// HTTP exec must NOT be called — SSH is used instead.
 	execReqs := filterByPath(reqs, "/api/v2/sidecar/instances/sidecar-123/exec")
 	assert.Equal(t, len(execReqs), 0, "expected 0 HTTP exec requests (SSH should be used)")
+}
+
+// writeRemoteProjectConfig writes a config with a single remote command.
+func writeRemoteProjectConfig(t *testing.T, workDir string) {
+	t.Helper()
+	chunkDir := filepath.Join(workDir, ".chunk")
+	assert.NilError(t, os.MkdirAll(chunkDir, 0o755))
+	cfg := `{"commands":[{"name":"test","run":"true","remote":true}]}`
+	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), []byte(cfg), 0o644))
+}
+
+// writeSidecarState writes a session-keyed sidecar state file into the test
+// environment's XDG data directory for the given project root.
+func writeSidecarState(t *testing.T, e *testenv.TestEnv, projectRoot, sessionID, sidecarID string) {
+	t.Helper()
+	// Resolve symlinks so the hash matches what os.Getwd() returns in the subprocess.
+	// On macOS, t.TempDir() returns /var/folders/... but os.Getwd() resolves to /private/var/...
+	realRoot, err := filepath.EvalSymlinks(projectRoot)
+	assert.NilError(t, err)
+	// Compute the data dir directly from e.HomeDir so we don't touch the parent process env.
+	// This mirrors config.ProjectDataDir: <XDG_DATA_HOME>/chunk/<sha256(root)>
+	sum := sha256.Sum256([]byte(filepath.Clean(realRoot)))
+	dir := filepath.Join(e.HomeDir, ".local", "share", "chunk", fmt.Sprintf("%x", sum))
+	assert.NilError(t, os.MkdirAll(dir, 0o755))
+	filename := "sidecar." + sessionID + ".json"
+	data := []byte(`{"sidecar_id":"` + sidecarID + `"}`)
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, filename), data, 0o644))
+}
+
+// TestValidateHookMode_SessionIsolation verifies that two concurrent Claude
+// sessions each see their own sidecar state rather than sharing one file.
+func TestValidateHookMode_SessionIsolation(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	writeRemoteProjectConfig(t, workDir)
+	// Add an untracked file so the working tree is dirty and validate runs.
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "dirty.txt"), []byte("x"), 0o644))
+
+	envA := testenv.NewTestEnv(t)
+	envB := testenv.NewTestEnv(t)
+
+	writeSidecarState(t, envA, workDir, "sess-a", "sidecar-aaa")
+	writeSidecarState(t, envB, workDir, "sess-b", "sidecar-bbb")
+
+	resultA := binary.RunCLIWithStdin(t, []string{"validate"}, envA, workDir,
+		hookStdin(t, "sess-a", true))
+	resultB := binary.RunCLIWithStdin(t, []string{"validate"}, envB, workDir,
+		hookStdin(t, "sess-b", true))
+
+	assert.Assert(t, strings.Contains(resultA.Stderr, "sidecar-aaa"),
+		"session A should load sidecar-aaa; stderr: %s", resultA.Stderr)
+	assert.Assert(t, !strings.Contains(resultA.Stderr, "sidecar-bbb"),
+		"session A should not see sidecar-bbb; stderr: %s", resultA.Stderr)
+
+	assert.Assert(t, strings.Contains(resultB.Stderr, "sidecar-bbb"),
+		"session B should load sidecar-bbb; stderr: %s", resultB.Stderr)
+	assert.Assert(t, !strings.Contains(resultB.Stderr, "sidecar-aaa"),
+		"session B should not see sidecar-aaa; stderr: %s", resultB.Stderr)
 }

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -52,11 +52,11 @@ func newSidecarCmd() *cobra.Command {
 }
 
 // resolveSidecarID fills in sidecarID from the active sidecar file if it is empty.
-func resolveSidecarID(sidecarID *string) error {
+func resolveSidecarID(ctx context.Context, sidecarID *string) error {
 	if *sidecarID != "" {
 		return nil
 	}
-	active, err := sidecar.LoadActive()
+	active, err := sidecar.LoadActive(ctx)
 	if err != nil {
 		return &userError{msg: "Could not load the active sidecar.", suggestion: configFilePermHint, err: err}
 	}
@@ -190,7 +190,7 @@ func newSidecarCreateCmd() *cobra.Command {
 				}
 			}
 			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Created sidecar %s (%s)", sb.Name, sb.ID)))
-			if err := sidecar.SaveActive(sidecar.ActiveSidecar{SidecarID: sb.ID, Name: sb.Name}); err != nil {
+			if err := sidecar.SaveActive(cmd.Context(), sidecar.ActiveSidecar{SidecarID: sb.ID, Name: sb.Name}); err != nil {
 				io.ErrPrintf("warning: could not save active sidecar: %v\n", err)
 			} else {
 				io.ErrPrintf("Set %s as active sidecar\n", sb.ID)
@@ -216,7 +216,7 @@ func newSidecarExecCmd() *cobra.Command {
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
-			if err := resolveSidecarID(&sidecarID); err != nil {
+			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
 				return err
 			}
 			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
@@ -260,7 +260,7 @@ func newSidecarAddSSHKeyCmd() *cobra.Command {
 		Short: "Add an SSH public key to a sidecar",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			if err := resolveSidecarID(&sidecarID); err != nil {
+			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
 				return err
 			}
 			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
@@ -315,7 +315,7 @@ func newSidecarSSHCmd() *cobra.Command {
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
-			if err := resolveSidecarID(&sidecarID); err != nil {
+			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
 				return err
 			}
 			authSock := os.Getenv(config.EnvSSHAuthSock)
@@ -381,7 +381,7 @@ func newSidecarSyncCmd() *cobra.Command {
 		Short: "Sync files to a sidecar",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			if err := resolveSidecarID(&sidecarID); err != nil {
+			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
 				return err
 			}
 			authSock := os.Getenv(config.EnvSSHAuthSock)
@@ -427,7 +427,7 @@ func newSidecarUseCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
-			if err := sidecar.SaveActive(sidecar.ActiveSidecar{SidecarID: args[0]}); err != nil {
+			if err := sidecar.SaveActive(cmd.Context(), sidecar.ActiveSidecar{SidecarID: args[0]}); err != nil {
 				return &userError{msg: "Could not save the active sidecar.", suggestion: configFilePermHint, err: err}
 			}
 			io.ErrPrintf("Set %s as active sidecar\n", args[0])
@@ -442,7 +442,7 @@ func newSidecarCurrentCmd() *cobra.Command {
 		Short: "Show the active sidecar",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			active, err := sidecar.LoadActive()
+			active, err := sidecar.LoadActive(cmd.Context())
 			if err != nil {
 				return &userError{msg: "Could not load the active sidecar.", suggestion: configFilePermHint, err: err}
 			}
@@ -466,7 +466,7 @@ func newSidecarForgetCmd() *cobra.Command {
 		Short: "Clear the active sidecar",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			if err := sidecar.ClearActive(); err != nil {
+			if err := sidecar.ClearActive(cmd.Context()); err != nil {
 				return &userError{msg: "Could not clear the active sidecar.", suggestion: configFilePermHint, err: err}
 			}
 			io.ErrPrintln("Active sidecar cleared")
@@ -649,7 +649,7 @@ snapshot with 'chunk sidecar create --image <snapshot-id>'.`,
 			if len(name) > 255 {
 				return fmt.Errorf("snapshot name must be 255 characters or fewer (got %d)", len(name))
 			}
-			if err := resolveSidecarID(&sidecarID); err != nil {
+			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
 				return err
 			}
 			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
@@ -669,8 +669,8 @@ snapshot with 'chunk sidecar create --image <snapshot-id>'.`,
 			}
 			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Deleted sidecar %s", sidecarID)))
 
-			if active, lerr := sidecar.LoadActive(); lerr == nil && active != nil && active.SidecarID == sidecarID {
-				if cerr := sidecar.ClearActive(); cerr != nil {
+			if active, lerr := sidecar.LoadActive(cmd.Context()); lerr == nil && active != nil && active.SidecarID == sidecarID {
+				if cerr := sidecar.ClearActive(cmd.Context()); cerr != nil {
 					io.ErrPrintf("Warning: could not clear active sidecar state: %v\n", cerr)
 				}
 			}
@@ -822,7 +822,7 @@ func sidecarSetupResolveSidecar(
 	status iostream.StatusFunc,
 	streams iostream.Streams,
 ) (id, displayName, workspace string, err error) {
-	active, err := sidecar.LoadActive()
+	active, err := sidecar.LoadActive(ctx)
 	if err != nil {
 		return "", "", "", &userError{msg: "Could not load the active sidecar.", suggestion: configFilePermHint, err: err}
 	}
@@ -849,7 +849,7 @@ func sidecarSetupResolveSidecar(
 			err:        err,
 		}
 	}
-	if saveErr := sidecar.SaveActive(sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); saveErr != nil {
+	if saveErr := sidecar.SaveActive(ctx, sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); saveErr != nil {
 		streams.ErrPrintf("warning: could not save active sidecar: %v\n", saveErr)
 	}
 	status(iostream.LevelDone, fmt.Sprintf("Created sidecar %s (%s)", sc.Name, sc.ID))
@@ -917,7 +917,7 @@ func sidecarSetupRunSetup(
 
 	ws := workspace
 	if ws == "" {
-		if active, lerr := sidecar.LoadActive(); lerr == nil && active != nil && active.Workspace != "" {
+		if active, lerr := sidecar.LoadActive(ctx); lerr == nil && active != nil && active.Workspace != "" {
 			ws = active.Workspace
 		}
 	}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/session"
 	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
 	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
@@ -83,7 +84,9 @@ func newValidateCmd() *cobra.Command {
 			}
 
 			hook := detectHook(cmd.InOrStdin())
+			ctx := cmd.Context()
 			if hook != nil {
+				ctx = session.WithID(ctx, hook.sessionID)
 				if !hook.stopHookActive {
 					validate.ResetAttempts(hook.sessionID)
 				}
@@ -145,18 +148,18 @@ func newValidateCmd() *cobra.Command {
 
 			if remote {
 				// --remote: force all commands to sidecar, creating one if needed.
-				if err := resolveOrCreateSidecarID(cmd.Context(), &sidecarID, orgID, image, workDir, streams); err != nil {
+				if err := resolveOrCreateSidecarID(ctx, &sidecarID, orgID, image, workDir, streams); err != nil {
 					return err
 				}
 				statusFn(iostream.LevelInfo, fmt.Sprintf("running all commands on sidecar %s", sidecarID))
 			} else if cfg.HasRemoteCommands() {
 				// Per-command remote: use active sidecar if available.
-				if active, err := sidecar.LoadActive(); err == nil && active != nil {
+				if active, err := sidecar.LoadActive(ctx); err == nil && active != nil {
 					sidecarID = active.SidecarID
 					statusFn(iostream.LevelInfo, fmt.Sprintf("using sidecar %s for remote commands", sidecarID))
 				} else if hook != nil {
 					// In Stop hook context: auto-create a sandbox if possible.
-					if err := resolveOrCreateSidecarID(cmd.Context(), &sidecarID, orgID, image, workDir, streams); err != nil {
+					if err := resolveOrCreateSidecarID(ctx, &sidecarID, orgID, image, workDir, streams); err != nil {
 						streams.ErrPrintf("warning: no sandbox available (%v); run 'chunk config set orgID <id>' to enable remote validation, running locally instead\n", err)
 					}
 				} else {
@@ -164,7 +167,7 @@ func newValidateCmd() *cobra.Command {
 				}
 			}
 
-			execErr := runValidate(cmd.Context(), workDir, name, inlineCmd, save, sidecarID, identityFile, workdir, allRemote, cfg, statusFn, streams)
+			execErr := runValidate(ctx, workDir, name, inlineCmd, save, sidecarID, identityFile, workdir, allRemote, cfg, statusFn, streams)
 
 			if hook != nil {
 				maxAttempts := cfg.StopHookMaxAttempts
@@ -322,7 +325,7 @@ func openSSHSession(ctx context.Context, sidecarID, identityFile, workdir string
 	}
 	dest := workdir
 	if dest == "" {
-		if active, err := sidecar.LoadActive(); err == nil && active != nil && active.Workspace != "" {
+		if active, err := sidecar.LoadActive(ctx); err == nil && active != nil && active.Workspace != "" {
 			dest = active.Workspace
 		} else {
 			dest = "./workspace"
@@ -382,7 +385,7 @@ func resolveOrCreateSidecarID(ctx context.Context, sidecarID *string, orgID, ima
 	if *sidecarID != "" {
 		return nil
 	}
-	active, err := sidecar.LoadActive()
+	active, err := sidecar.LoadActive(ctx)
 	if err != nil {
 		return &userError{msg: "Could not load the active sidecar.", suggestion: configFilePermHint, err: err}
 	}
@@ -417,7 +420,7 @@ func resolveOrCreateSidecarID(ctx context.Context, sidecarID *string, orgID, ima
 			err:        err,
 		}
 	}
-	if saveErr := sidecar.SaveActive(sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); saveErr != nil {
+	if saveErr := sidecar.SaveActive(ctx, sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); saveErr != nil {
 		streams.ErrPrintf("warning: could not save active sidecar: %v\n", saveErr)
 	}
 	// Persist the org ID so future sandbox creation skips the picker.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,7 +49,6 @@ const (
 	EnvXDGConfigHome = "XDG_CONFIG_HOME"
 	EnvXDGStateHome  = "XDG_STATE_HOME"
 	EnvXDGDataHome   = "XDG_DATA_HOME"
-	EnvClaudeSession = "CLAUDE_SESSION_ID"
 )
 
 // EnvVars holds all environment variables the application reads.
@@ -72,7 +71,6 @@ type EnvVars struct {
 	XDGConfigHome    string `env:"XDG_CONFIG_HOME"`
 	XDGStateHome     string `env:"XDG_STATE_HOME"`
 	XDGDataHome      string `env:"XDG_DATA_HOME"`
-	ClaudeSession    string `env:"CLAUDE_SESSION_ID"`
 }
 
 // LoadEnv populates an EnvVars struct from the process environment.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,0 +1,17 @@
+package session
+
+import "context"
+
+// key is unexported so no other package can construct it, guaranteeing no collisions.
+type key struct{}
+
+// WithID returns a new context carrying the given Claude session ID.
+func WithID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, key{}, id)
+}
+
+// IDFromCtx returns the Claude session ID stored in ctx, or "" if not set.
+func IDFromCtx(ctx context.Context) string {
+	id, _ := ctx.Value(key{}).(string)
+	return id
+}

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -1,12 +1,14 @@
 package sidecar
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/session"
 )
 
 // ActiveSidecar holds the currently active sidecar for a project.
@@ -16,12 +18,12 @@ type ActiveSidecar struct {
 	Workspace string `json:"workspace,omitempty"`
 }
 
-// sidecarFileName returns the name of the sidecar state file. When
-// CLAUDE_SESSION_ID is set the file is keyed to that session so concurrent
-// Claude sessions in the same repo each maintain their own active sidecar.
-func sidecarFileName() string {
-	if id := os.Getenv(config.EnvClaudeSession); id != "" {
-		return "sidecar." + id + ".json"
+// sidecarFileName returns the name of the sidecar state file. When sessionID
+// is non-empty the file is keyed to that session so concurrent Claude sessions
+// in the same repo each maintain their own active sidecar.
+func sidecarFileName(sessionID string) string {
+	if sessionID != "" {
+		return "sidecar." + sessionID + ".json"
 	}
 	return "sidecar.json"
 }
@@ -37,17 +39,17 @@ func StateDir() (string, error) {
 
 // LoadActive reads the active sidecar for the current project from XDG_DATA_HOME.
 // Returns nil if not found.
-func LoadActive() (*ActiveSidecar, error) {
+func LoadActive(ctx context.Context) (*ActiveSidecar, error) {
 	dir, err := saveDir()
 	if err != nil {
 		return nil, err
 	}
-	return LoadActiveFrom(dir)
+	return LoadActiveFrom(ctx, dir)
 }
 
 // LoadActiveFrom reads the active sidecar from dir.
-func LoadActiveFrom(dir string) (*ActiveSidecar, error) {
-	path, err := findSidecarFile(dir)
+func LoadActiveFrom(ctx context.Context, dir string) (*ActiveSidecar, error) {
+	path, err := findSidecarFile(dir, session.IDFromCtx(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -66,16 +68,16 @@ func LoadActiveFrom(dir string) (*ActiveSidecar, error) {
 }
 
 // SaveActive writes the active sidecar to XDG_DATA_HOME for the current project.
-func SaveActive(a ActiveSidecar) error {
+func SaveActive(ctx context.Context, a ActiveSidecar) error {
 	dir, err := saveDir()
 	if err != nil {
 		return err
 	}
-	return SaveActiveTo(dir, a)
+	return SaveActiveTo(ctx, dir, a)
 }
 
 // SaveActiveTo writes the active sidecar to dir.
-func SaveActiveTo(dir string, a ActiveSidecar) error {
+func SaveActiveTo(ctx context.Context, dir string, a ActiveSidecar) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
@@ -83,7 +85,7 @@ func SaveActiveTo(dir string, a ActiveSidecar) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dir, sidecarFileName()), data, 0o644)
+	return os.WriteFile(filepath.Join(dir, sidecarFileName(session.IDFromCtx(ctx))), data, 0o644)
 }
 
 // saveDir returns the XDG_DATA_HOME directory for the current project.
@@ -123,17 +125,17 @@ func findGitRoot() (string, error) {
 }
 
 // ClearActive removes the active sidecar state file.
-func ClearActive() error {
+func ClearActive(ctx context.Context) error {
 	dir, err := saveDir()
 	if err != nil {
 		return err
 	}
-	return ClearActiveFrom(dir)
+	return ClearActiveFrom(ctx, dir)
 }
 
 // ClearActiveFrom removes the active sidecar state file in dir.
-func ClearActiveFrom(dir string) error {
-	path, err := findSidecarFile(dir)
+func ClearActiveFrom(ctx context.Context, dir string) error {
+	path, err := findSidecarFile(dir, session.IDFromCtx(ctx))
 	if err != nil {
 		return err
 	}
@@ -144,8 +146,8 @@ func ClearActiveFrom(dir string) error {
 }
 
 // findSidecarFile returns the sidecar state file path in dir, or "" if it doesn't exist.
-func findSidecarFile(dir string) (string, error) {
-	return statOrEmpty(filepath.Join(dir, sidecarFileName()))
+func findSidecarFile(dir, sessionID string) (string, error) {
+	return statOrEmpty(filepath.Join(dir, sidecarFileName(sessionID)))
 }
 
 // statOrEmpty returns path if it exists, "" if it does not, or an error for other failures.

--- a/internal/sidecar/active_test.go
+++ b/internal/sidecar/active_test.go
@@ -1,6 +1,7 @@
 package sidecar
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/session"
 )
 
 func TestSaveActiveWritesToXDGDataPath(t *testing.T) {
@@ -18,7 +20,7 @@ func TestSaveActiveWritesToXDGDataPath(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-1"}))
+	assert.NilError(t, SaveActive(context.Background(), ActiveSidecar{SidecarID: "sb-1"}))
 
 	// Must not appear inside the project's .chunk directory.
 	_, err := os.Stat(filepath.Join(dir, ".chunk", "sidecar.json"))
@@ -53,11 +55,12 @@ func TestSaveAndLoadActive(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
+	ctx := context.Background()
 	want := ActiveSidecar{SidecarID: "sb-abc", Name: "my-box"}
-	err := SaveActive(want)
+	err := SaveActive(ctx, want)
 	assert.NilError(t, err)
 
-	got, err := LoadActive()
+	got, err := LoadActive(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil, "expected non-nil ActiveSidecar")
 	assert.Equal(t, got.SidecarID, want.SidecarID)
@@ -69,7 +72,7 @@ func TestLoadActiveReturnsNilWhenMissing(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
-	got, err := LoadActive()
+	got, err := LoadActive(context.Background())
 	assert.NilError(t, err)
 	assert.Assert(t, got == nil, "expected nil when no active sidecar file")
 }
@@ -82,19 +85,21 @@ func TestLoadActiveUsesGitRootAsKey(t *testing.T) {
 
 	setupXDGData(t)
 
+	ctx := context.Background()
+
 	// Save from child — keyed to parent (git root).
 	t.Chdir(child)
-	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-git-root"}))
+	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarID: "sb-git-root"}))
 
 	// Load from child — should find it.
-	got, err := LoadActive()
+	got, err := LoadActive(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 	assert.Equal(t, got.SidecarID, "sb-git-root")
 
 	// Load from parent (the git root) — same project, same file.
 	t.Chdir(parent)
-	got, err = LoadActive()
+	got, err = LoadActive(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 	assert.Equal(t, got.SidecarID, "sb-git-root")
@@ -105,9 +110,10 @@ func TestLoadActiveUsesCwdWhenNoGitRepo(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
-	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-cwd"}))
+	ctx := context.Background()
+	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarID: "sb-cwd"}))
 
-	got, err := LoadActive()
+	got, err := LoadActive(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 	assert.Equal(t, got.SidecarID, "sb-cwd")
@@ -118,15 +124,16 @@ func TestClearActive(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
-	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-xyz"}))
+	ctx := context.Background()
+	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarID: "sb-xyz"}))
 
-	got, err := LoadActive()
+	got, err := LoadActive(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 
-	assert.NilError(t, ClearActive())
+	assert.NilError(t, ClearActive(ctx))
 
-	got, err = LoadActive()
+	got, err = LoadActive(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got == nil)
 }
@@ -136,26 +143,27 @@ func TestSessionKeyedSidecar(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
-	// Save without a session — generic file.
-	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-generic"}))
+	ctx := context.Background()
+	sessCtx := session.WithID(ctx, "sess-abc")
 
-	// With a session ID set, load should return nil (isolated from the generic file).
-	t.Setenv(config.EnvClaudeSession, "sess-abc")
-	got, err := LoadActive()
+	// Save without a session — generic file.
+	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarID: "sb-generic"}))
+
+	// Session-keyed load should not see the generic file.
+	got, err := LoadActive(sessCtx)
 	assert.NilError(t, err)
 	assert.Assert(t, got == nil, "session-keyed load should not see generic file")
 
 	// Save under the session.
-	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-session"}))
+	assert.NilError(t, SaveActive(sessCtx, ActiveSidecar{SidecarID: "sb-session"}))
 
-	got, err = LoadActive()
+	got, err = LoadActive(sessCtx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 	assert.Equal(t, got.SidecarID, "sb-session")
 
-	// Without the session env var, the original generic file is still intact.
-	t.Setenv(config.EnvClaudeSession, "")
-	got, err = LoadActive()
+	// Without the session, the original generic file is still intact.
+	got, err = LoadActive(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 	assert.Equal(t, got.SidecarID, "sb-generic")
@@ -166,7 +174,7 @@ func TestClearActiveNoopWhenMissing(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
-	assert.NilError(t, ClearActive())
+	assert.NilError(t, ClearActive(context.Background()))
 }
 
 func TestWorkspaceFieldRoundTrip(t *testing.T) {
@@ -174,10 +182,11 @@ func TestWorkspaceFieldRoundTrip(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
+	ctx := context.Background()
 	want := ActiveSidecar{SidecarID: "sb-1", Name: "test", Workspace: "/workspace/myrepo"}
-	assert.NilError(t, SaveActive(want))
+	assert.NilError(t, SaveActive(ctx, want))
 
-	got, err := LoadActive()
+	got, err := LoadActive(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 	assert.Equal(t, got.Workspace, want.Workspace)
@@ -189,11 +198,12 @@ func TestWorkspaceOmittedWhenEmpty(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
-	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-1"}))
+	ctx := context.Background()
+	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarID: "sb-1"}))
 
 	stateDir, err := saveDir()
 	assert.NilError(t, err)
-	data, err := os.ReadFile(filepath.Join(stateDir, sidecarFileName()))
+	data, err := os.ReadFile(filepath.Join(stateDir, sidecarFileName("")))
 	assert.NilError(t, err)
 	assert.Assert(t, !strings.Contains(string(data), "workspace"), "empty workspace should be omitted from JSON")
 }
@@ -203,9 +213,10 @@ func TestResolveWorkspaceCLIFlagWins(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
-	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-1", Workspace: "/workspace/saved"}))
+	ctx := context.Background()
+	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarID: "sb-1", Workspace: "/workspace/saved"}))
 
-	got := resolveWorkspace("/workspace/override", "myrepo")
+	got := resolveWorkspace(ctx, "/workspace/override", "myrepo")
 	assert.Equal(t, got, "/workspace/override")
 }
 
@@ -214,9 +225,10 @@ func TestResolveWorkspaceSidecarFallback(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
-	assert.NilError(t, SaveActive(ActiveSidecar{SidecarID: "sb-1", Workspace: "/workspace/saved"}))
+	ctx := context.Background()
+	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarID: "sb-1", Workspace: "/workspace/saved"}))
 
-	got := resolveWorkspace("", "myrepo")
+	got := resolveWorkspace(ctx, "", "myrepo")
 	assert.Equal(t, got, "/workspace/saved")
 }
 
@@ -225,6 +237,6 @@ func TestResolveWorkspaceDefaultFallback(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
-	got := resolveWorkspace("", "myrepo")
+	got := resolveWorkspace(context.Background(), "", "myrepo")
 	assert.Equal(t, got, "./workspace/myrepo")
 }

--- a/internal/sidecar/snapshot.go
+++ b/internal/sidecar/snapshot.go
@@ -1,11 +1,12 @@
 package sidecar
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/session"
 )
 
 // ActiveSnapshot holds the most recently created snapshot for a project.
@@ -14,26 +15,26 @@ type ActiveSnapshot struct {
 	Name string `json:"name,omitempty"`
 }
 
-func snapshotFileName() string {
-	if id := os.Getenv(config.EnvClaudeSession); id != "" {
-		return "snapshot." + id + ".json"
+func snapshotFileName(sessionID string) string {
+	if sessionID != "" {
+		return "snapshot." + sessionID + ".json"
 	}
 	return "snapshot.json"
 }
 
 // LoadActiveSnapshot reads the active snapshot for the current project from XDG_DATA_HOME.
 // Returns nil if not found.
-func LoadActiveSnapshot() (*ActiveSnapshot, error) {
+func LoadActiveSnapshot(ctx context.Context) (*ActiveSnapshot, error) {
 	dir, err := StateDir()
 	if err != nil {
 		return nil, err
 	}
-	return LoadSnapshotFrom(dir)
+	return LoadSnapshotFrom(ctx, dir)
 }
 
 // LoadSnapshotFrom reads the active snapshot from dir.
-func LoadSnapshotFrom(dir string) (*ActiveSnapshot, error) {
-	path, err := findSnapshotFile(dir)
+func LoadSnapshotFrom(ctx context.Context, dir string) (*ActiveSnapshot, error) {
+	path, err := findSnapshotFile(dir, session.IDFromCtx(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -52,16 +53,16 @@ func LoadSnapshotFrom(dir string) (*ActiveSnapshot, error) {
 }
 
 // SaveActiveSnapshot writes the active snapshot to XDG_DATA_HOME for the current project.
-func SaveActiveSnapshot(a ActiveSnapshot) error {
+func SaveActiveSnapshot(ctx context.Context, a ActiveSnapshot) error {
 	dir, err := StateDir()
 	if err != nil {
 		return err
 	}
-	return SaveSnapshotTo(dir, a)
+	return SaveSnapshotTo(ctx, dir, a)
 }
 
 // SaveSnapshotTo writes the active snapshot to dir.
-func SaveSnapshotTo(dir string, a ActiveSnapshot) error {
+func SaveSnapshotTo(ctx context.Context, dir string, a ActiveSnapshot) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
@@ -69,21 +70,21 @@ func SaveSnapshotTo(dir string, a ActiveSnapshot) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dir, snapshotFileName()), data, 0o644)
+	return os.WriteFile(filepath.Join(dir, snapshotFileName(session.IDFromCtx(ctx))), data, 0o644)
 }
 
 // ClearActiveSnapshot removes the active snapshot state file.
-func ClearActiveSnapshot() error {
+func ClearActiveSnapshot(ctx context.Context) error {
 	dir, err := StateDir()
 	if err != nil {
 		return err
 	}
-	return ClearSnapshotFrom(dir)
+	return ClearSnapshotFrom(ctx, dir)
 }
 
 // ClearSnapshotFrom removes the active snapshot state file in dir.
-func ClearSnapshotFrom(dir string) error {
-	path, err := findSnapshotFile(dir)
+func ClearSnapshotFrom(ctx context.Context, dir string) error {
+	path, err := findSnapshotFile(dir, session.IDFromCtx(ctx))
 	if err != nil {
 		return err
 	}
@@ -94,6 +95,6 @@ func ClearSnapshotFrom(dir string) error {
 }
 
 // findSnapshotFile returns the snapshot state file path in dir, or "" if it doesn't exist.
-func findSnapshotFile(dir string) (string, error) {
-	return statOrEmpty(filepath.Join(dir, snapshotFileName()))
+func findSnapshotFile(dir, sessionID string) (string, error) {
+	return statOrEmpty(filepath.Join(dir, snapshotFileName(sessionID)))
 }

--- a/internal/sidecar/snapshot_test.go
+++ b/internal/sidecar/snapshot_test.go
@@ -1,11 +1,12 @@
 package sidecar
 
 import (
+	"context"
 	"testing"
 
 	"gotest.tools/v3/assert"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/session"
 )
 
 func TestSaveAndLoadActiveSnapshot(t *testing.T) {
@@ -13,10 +14,11 @@ func TestSaveAndLoadActiveSnapshot(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
+	ctx := context.Background()
 	want := ActiveSnapshot{ID: "snap-abc", Name: "my-snap"}
-	assert.NilError(t, SaveActiveSnapshot(want))
+	assert.NilError(t, SaveActiveSnapshot(ctx, want))
 
-	got, err := LoadActiveSnapshot()
+	got, err := LoadActiveSnapshot(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil, "expected non-nil ActiveSnapshot")
 	assert.Equal(t, got.ID, want.ID)
@@ -28,7 +30,7 @@ func TestLoadActiveSnapshotReturnsNilWhenMissing(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
-	got, err := LoadActiveSnapshot()
+	got, err := LoadActiveSnapshot(context.Background())
 	assert.NilError(t, err)
 	assert.Assert(t, got == nil, "expected nil when no snapshot file")
 }
@@ -38,15 +40,16 @@ func TestClearActiveSnapshot(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
-	assert.NilError(t, SaveActiveSnapshot(ActiveSnapshot{ID: "snap-xyz"}))
+	ctx := context.Background()
+	assert.NilError(t, SaveActiveSnapshot(ctx, ActiveSnapshot{ID: "snap-xyz"}))
 
-	got, err := LoadActiveSnapshot()
+	got, err := LoadActiveSnapshot(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 
-	assert.NilError(t, ClearActiveSnapshot())
+	assert.NilError(t, ClearActiveSnapshot(ctx))
 
-	got, err = LoadActiveSnapshot()
+	got, err = LoadActiveSnapshot(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got == nil)
 }
@@ -56,7 +59,7 @@ func TestClearActiveSnapshotNoopWhenMissing(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
-	assert.NilError(t, ClearActiveSnapshot())
+	assert.NilError(t, ClearActiveSnapshot(context.Background()))
 }
 
 func TestSnapshotSessionKeyed(t *testing.T) {
@@ -64,26 +67,27 @@ func TestSnapshotSessionKeyed(t *testing.T) {
 	t.Chdir(dir)
 	setupXDGData(t)
 
-	// Save without a session — generic file.
-	assert.NilError(t, SaveActiveSnapshot(ActiveSnapshot{ID: "snap-generic"}))
+	ctx := context.Background()
+	sessCtx := session.WithID(ctx, "sess-abc")
 
-	// With a session ID set, load should return nil (isolated from the generic file).
-	t.Setenv(config.EnvClaudeSession, "sess-abc")
-	got, err := LoadActiveSnapshot()
+	// Save without a session — generic file.
+	assert.NilError(t, SaveActiveSnapshot(ctx, ActiveSnapshot{ID: "snap-generic"}))
+
+	// Session-keyed load should not see the generic file.
+	got, err := LoadActiveSnapshot(sessCtx)
 	assert.NilError(t, err)
 	assert.Assert(t, got == nil, "session-keyed load should not see generic file")
 
 	// Save under the session.
-	assert.NilError(t, SaveActiveSnapshot(ActiveSnapshot{ID: "snap-session"}))
+	assert.NilError(t, SaveActiveSnapshot(sessCtx, ActiveSnapshot{ID: "snap-session"}))
 
-	got, err = LoadActiveSnapshot()
+	got, err = LoadActiveSnapshot(sessCtx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 	assert.Equal(t, got.ID, "snap-session")
 
-	// Without the session env var, the original generic file is still intact.
-	t.Setenv(config.EnvClaudeSession, "")
-	got, err = LoadActiveSnapshot()
+	// Without the session, the original generic file is still intact.
+	got, err = LoadActiveSnapshot(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 	assert.Equal(t, got.ID, "snap-generic")

--- a/internal/sidecar/sync.go
+++ b/internal/sidecar/sync.go
@@ -18,11 +18,11 @@ const workspaceDir = "./workspace"
 
 // resolveWorkspace determines the workspace path. Priority:
 // 1. CLI --workdir flag  2. sidecar.json workspace  3. default.
-func resolveWorkspace(cliWorkdir, repo string) string {
+func resolveWorkspace(ctx context.Context, cliWorkdir, repo string) string {
 	if cliWorkdir != "" {
 		return cliWorkdir
 	}
-	if active, err := LoadActive(); err == nil && active != nil && active.Workspace != "" {
+	if active, err := LoadActive(ctx); err == nil && active != nil && active.Workspace != "" {
 		return active.Workspace
 	}
 	return workspaceDir + "/" + repo
@@ -30,8 +30,8 @@ func resolveWorkspace(cliWorkdir, repo string) string {
 
 // persistWorkspace saves the resolved workspace back to the sidecar file if it
 // differs from the current value.
-func persistWorkspace(workspace string) error {
-	active, err := LoadActive()
+func persistWorkspace(ctx context.Context, workspace string) error {
+	active, err := LoadActive(ctx)
 	if err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func persistWorkspace(workspace string) error {
 		return nil
 	}
 	active.Workspace = workspace
-	return SaveActive(*active)
+	return SaveActive(ctx, *active)
 }
 
 // Sync synchronises local changes to a sidecar over SSH.
@@ -64,9 +64,9 @@ func Sync(ctx context.Context,
 		return fmt.Errorf("sync: %w", err)
 	}
 
-	repoPath := resolveWorkspace(workdir, repo)
+	repoPath := resolveWorkspace(ctx, workdir, repo)
 
-	if err := persistWorkspace(repoPath); err != nil {
+	if err := persistWorkspace(ctx, repoPath); err != nil {
 		status(iostream.LevelWarn, fmt.Sprintf("Could not save workspace: %v", err))
 	}
 


### PR DESCRIPTION
## Summary

- `CLAUDE_SESSION_ID` was never actually set by Claude Code, so concurrent sessions always shared `sidecar.json` and the per-session isolation never worked
- Introduces `internal/session` package to own the context key (`WithID` / `IDFromCtx`) — callers don't need to know the storage details
- `cmd/validate` already parsed `session_id` from the Stop hook payload; now it enriches the context with it so the sidecar state functions automatically key to the right file
- Interactive CLI commands (`sidecar use`, `sidecar create`, etc.) pass context without a session ID and continue using the shared `sidecar.json`
- Removes the now-unused `EnvClaudeSession` constant from `internal/config`

## Test plan

- [ ] `TestSessionKeyedSidecar` (unit) — verifies session-keyed vs shared file isolation at the `sidecar` package level
- [ ] `TestValidateHookMode_SessionIsolation` (acceptance) — verifies two concurrent Claude sessions each load their own sidecar state when running as a Stop hook
- [ ] Full test suite passes: `task test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)