### PR TITLE
Rewrite upgrade command to use GitHub API directly

### DIFF
--- a/acceptance/upgrade_test.go
+++ b/acceptance/upgrade_test.go
@@ -1,6 +1,12 @@
 package acceptance
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,85 +16,111 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/chunk-cli/internal/testing/env"
+	"github.com/CircleCI-Public/chunk-cli/internal/upgrade"
 )
 
-func TestUpgradeNoGhCLI(t *testing.T) {
-	env := testenv.NewTestEnv(t)
-	// Remove PATH so gh cannot be found
-	env.Extra["PATH"] = "/nonexistent"
-
-	result := binary.RunCLI(t, []string{"upgrade"}, env, env.HomeDir)
-
-	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit when gh is missing")
-	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "gh") || strings.Contains(combined, "cli.github.com"),
-		"expected gh CLI error message, got: %s", combined)
+func makeFakeArchive(t *testing.T) []byte {
+	t.Helper()
+	content := []byte("#!/bin/sh\necho chunk updated\n")
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	hdr := &tar.Header{Name: "chunk", Mode: 0o755, Size: int64(len(content))}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	tw.Close()
+	gz.Close()
+	return buf.Bytes()
 }
 
-func TestUpgradeGhNotAuthenticated(t *testing.T) {
-	env := testenv.NewTestEnv(t)
-	// gh auth status will fail if GH_CONFIG_DIR points to an empty config
-	env.Extra["GH_CONFIG_DIR"] = t.TempDir()
-
-	result := binary.RunCLI(t, []string{"upgrade"}, env, env.HomeDir)
-
-	// gh is available but not authenticated — expect error
-	assert.Assert(t, result.ExitCode != 0,
-		"expected non-zero exit when gh is not authenticated, stdout: %s, stderr: %s",
-		result.Stdout, result.Stderr)
-}
-
-func TestUpgradeExtensionNotInstalled(t *testing.T) {
-	// Create a fake gh script that passes auth but fails on extension upgrade
-	fakeGhDir := t.TempDir()
-	fakeGh := filepath.Join(fakeGhDir, "gh")
-	script := `#!/bin/sh
-if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
-  exit 0
-fi
-if [ "$1" = "extension" ] && [ "$2" = "upgrade" ]; then
-  echo "no extension found" >&2
-  exit 1
-fi
-exit 1
-`
-	err := os.WriteFile(fakeGh, []byte(script), 0o755)
-	assert.NilError(t, err)
-
-	env := testenv.NewTestEnv(t)
-	env.Extra["PATH"] = fakeGhDir
-
-	result := binary.RunCLI(t, []string{"upgrade"}, env, env.HomeDir)
-
-	assert.Assert(t, result.ExitCode != 0,
-		"expected non-zero exit when extension not installed")
-	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "upgrade failed"),
-		"expected 'upgrade failed' error, got: %s", combined)
+func newUpgradeFakeServer(t *testing.T, archive []byte) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/releases/latest") {
+			assetName := upgrade.PlatformAssetName()
+			release := map[string]any{
+				"tag_name": "v9.9.9",
+				"assets": []map[string]any{
+					{
+						"name":                 assetName,
+						"browser_download_url": srv.URL + "/download/" + assetName,
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(release)
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/download/") {
+			w.WriteHeader(http.StatusOK)
+			w.Write(archive)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
 }
 
 func TestUpgradeHappyPath(t *testing.T) {
-	// Create a fake gh script that succeeds for both auth and extension upgrade
-	fakeGhDir := t.TempDir()
-	fakeGh := filepath.Join(fakeGhDir, "gh")
-	script := `#!/bin/sh
-if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
-  exit 0
-fi
-if [ "$1" = "extension" ] && [ "$2" = "upgrade" ]; then
-  exit 0
-fi
-exit 1
-`
-	err := os.WriteFile(fakeGh, []byte(script), 0o755)
-	assert.NilError(t, err)
+	archive := makeFakeArchive(t)
+	srv := newUpgradeFakeServer(t, archive)
+
+	// Redirect the binary replacement to a temp file so we don't overwrite the test binary.
+	installPath := filepath.Join(t.TempDir(), "chunk")
+	if err := os.WriteFile(installPath, []byte("placeholder"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	env := testenv.NewTestEnv(t)
-	env.Extra["PATH"] = fakeGhDir
+	env.GithubURL = srv.URL
+	env.Extra["CHUNK_INSTALL_PATH"] = installPath
 
 	result := binary.RunCLI(t, []string{"upgrade"}, env, env.HomeDir)
 
 	assert.Equal(t, result.ExitCode, 0,
-		"expected successful upgrade, stdout: %s, stderr: %s",
-		result.Stdout, result.Stderr)
+		"expected successful upgrade, stdout: %s, stderr: %s", result.Stdout, result.Stderr)
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "v9.9.9"),
+		"expected version in output, got: %s", combined)
+
+	// Verify the binary was actually replaced.
+	got, err := os.ReadFile(installPath)
+	assert.NilError(t, err)
+	assert.Assert(t, !bytes.Equal(got, []byte("placeholder")),
+		"expected install path to be overwritten")
+}
+
+func TestUpgradeBrewManaged(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	env.Extra["CHUNK_INSTALL_PATH"] = "/opt/homebrew/bin/chunk"
+
+	result := binary.RunCLI(t, []string{"upgrade"}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for brew-managed install")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "Homebrew"),
+		"expected error mentioning Homebrew, got: %s", combined)
+}
+
+func TestUpgradeAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	env := testenv.NewTestEnv(t)
+	env.GithubURL = srv.URL
+
+	result := binary.RunCLI(t, []string{"upgrade"}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit on API error")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "fetch latest release"),
+		"expected error about fetching release, got: %s", combined)
 }

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -1,8 +1,14 @@
 package cmd
 
 import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/upgrade"
 )
 
@@ -10,8 +16,28 @@ func newUpgradeCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "upgrade",
 		Short: "Upgrade chunk to the latest version",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return upgrade.Run()
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			streams := iostream.FromCmd(cmd)
+
+			apiBase := os.Getenv("GITHUB_API_URL")
+			if apiBase == "" {
+				apiBase = "https://api.github.com"
+			}
+
+			installPath := os.Getenv("CHUNK_INSTALL_PATH")
+			if installPath == "" {
+				execPath, err := os.Executable()
+				if err != nil {
+					return fmt.Errorf("find executable: %w", err)
+				}
+				execPath, err = filepath.EvalSymlinks(execPath)
+				if err != nil {
+					return fmt.Errorf("resolve executable path: %w", err)
+				}
+				installPath = execPath
+			}
+
+			return upgrade.Run(streams.Out, http.DefaultClient, apiBase, installPath)
 		},
 	}
 }

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -1,29 +1,162 @@
 package upgrade
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
 	"fmt"
-	"os/exec"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 )
 
-func Run() error {
-	ghPath, err := exec.LookPath("gh")
+const (
+	repoOwner      = "CircleCI-Public"
+	repoName       = "chunk-cli"
+	maxArchiveSize = 100 << 20 // 100 MB
+)
+
+type ghRelease struct {
+	TagName string    `json:"tag_name"`
+	Assets  []ghAsset `json:"assets"`
+}
+
+type ghAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+func isBrewManaged(path string) bool {
+	return strings.Contains(path, "/opt/homebrew/bin/")
+}
+
+func Run(out io.Writer, client *http.Client, apiBase, installPath string) error {
+	if isBrewManaged(installPath) {
+		return fmt.Errorf("chunk is managed by Homebrew — upgrade with: brew upgrade chunk-cli")
+	}
+
+	rel, err := fetchLatestRelease(client, apiBase)
 	if err != nil {
-		return fmt.Errorf("gh CLI not found. Install it from https://cli.github.com")
+		return fmt.Errorf("fetch latest release: %w", err)
 	}
 
-	// Check gh auth status
-	cmd := exec.Command(ghPath, "auth", "status")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("gh is not authenticated. Run: gh auth login")
+	assetName := PlatformAssetName()
+	var downloadURL string
+	for _, a := range rel.Assets {
+		if a.Name == assetName {
+			downloadURL = a.BrowserDownloadURL
+			break
+		}
+	}
+	if downloadURL == "" {
+		return fmt.Errorf("no release asset found for platform (%s)", assetName)
 	}
 
-	// Run the upgrade
-	upgradeCmd := exec.Command(ghPath, "extension", "upgrade", "circleci-public/chunk-cli")
-	upgradeCmd.Stdout = nil
-	upgradeCmd.Stderr = nil
-	if err := upgradeCmd.Run(); err != nil {
-		return fmt.Errorf("upgrade failed: %w", err)
+	_, _ = fmt.Fprintf(out, "Downloading chunk %s...\n", rel.TagName)
+	if err := downloadAndReplace(client, downloadURL, installPath); err != nil {
+		return fmt.Errorf("install update: %w", err)
 	}
 
+	_, _ = fmt.Fprintf(out, "Updated to %s\n", rel.TagName)
 	return nil
+}
+
+func fetchLatestRelease(client *http.Client, apiBase string) (*ghRelease, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/latest", apiBase, repoOwner, repoName)
+	req, err := http.NewRequest(http.MethodGet, url, nil) //nolint:gosec // URL comes from trusted config (GITHUB_API_URL env var)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := client.Do(req) //nolint:gosec // same as above
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	}
+
+	var rel ghRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &rel, nil
+}
+
+func PlatformAssetName() string {
+	osName := runtime.GOOS
+	if len(osName) > 0 {
+		osName = strings.ToUpper(osName[:1]) + osName[1:]
+	}
+	archName := runtime.GOARCH
+	if archName == "amd64" {
+		archName = "x86_64"
+	}
+	return fmt.Sprintf("chunk_%s_%s.tar.gz", osName, archName)
+}
+
+func downloadAndReplace(client *http.Client, url, installPath string) error {
+	resp, err := client.Get(url) //nolint:gosec // URL comes from GitHub release API response for a known repo
+	if err != nil {
+		return fmt.Errorf("download: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download returned %d", resp.StatusCode)
+	}
+
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return fmt.Errorf("gzip: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read tar: %w", err)
+		}
+		if filepath.Base(hdr.Name) != "chunk" {
+			continue
+		}
+
+		dir := filepath.Dir(installPath)
+		tmp, err := os.CreateTemp(dir, "chunk-*.tmp")
+		if err != nil {
+			return fmt.Errorf("create temp file: %w", err)
+		}
+		tmpPath := tmp.Name()
+
+		if _, err := io.Copy(tmp, io.LimitReader(tr, maxArchiveSize)); err != nil { //nolint:gosec // size limited above
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+			return fmt.Errorf("write binary: %w", err)
+		}
+		_ = tmp.Close()
+
+		if err := os.Chmod(tmpPath, 0o755); err != nil {
+			_ = os.Remove(tmpPath)
+			return fmt.Errorf("chmod: %w", err)
+		}
+
+		if err := os.Rename(tmpPath, installPath); err != nil {
+			_ = os.Remove(tmpPath)
+			return fmt.Errorf("replace binary: %w", err)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("chunk binary not found in archive")
 }

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -99,7 +99,7 @@ func PlatformAssetName() string {
 	if archName == "amd64" {
 		archName = "x86_64"
 	}
-	return fmt.Sprintf("chunk_%s_%s.tar.gz", osName, archName)
+	return fmt.Sprintf("chunk-cli_%s_%s.tar.gz", osName, archName)
 }
 
 func downloadAndReplace(client *http.Client, url, installPath string) error {

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -1,7 +1,13 @@
 package upgrade
 
 import (
-	"fmt"
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,81 +15,117 @@ import (
 	"testing"
 )
 
-// writeFakeGh creates a fake "gh" script in a temp directory that
-// records its arguments and returns the given exit code.
-// It returns the directory containing the fake.
-func writeFakeGh(t *testing.T, authExit, upgradeExit int) string {
+// makeTarGz returns a .tar.gz containing a single file named "chunk" with the given content.
+func makeTarGz(t *testing.T, content []byte) []byte {
 	t.Helper()
-	dir := t.TempDir()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
 
-	if runtime.GOOS == "windows" {
-		t.Skip("fake gh script not supported on Windows")
+	hdr := &tar.Header{
+		Name: "chunk",
+		Mode: 0o755,
+		Size: int64(len(content)),
 	}
-
-	// The fake gh script inspects its arguments to decide behavior.
-	// "auth status" → authExit
-	// "extension upgrade ..." → upgradeExit
-	script := fmt.Sprintf(`#!/bin/sh
-if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
-  exit %d
-fi
-if [ "$1" = "extension" ] && [ "$2" = "upgrade" ]; then
-  exit %d
-fi
-exit 0
-`, authExit, upgradeExit)
-	ghPath := filepath.Join(dir, "gh")
-	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+	if err := tw.WriteHeader(hdr); err != nil {
 		t.Fatal(err)
 	}
-	return dir
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// fakeServer sets up an httptest server that serves a GitHub-like release API
+// and a download endpoint. Returns the server and the install target path.
+func fakeServer(t *testing.T, apiStatus int, assetContent []byte) (*httptest.Server, string) {
+	t.Helper()
+
+	installDir := t.TempDir()
+	installPath := filepath.Join(installDir, "chunk")
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/releases/latest") {
+			if apiStatus != http.StatusOK {
+				w.WriteHeader(apiStatus)
+				return
+			}
+			assetName := PlatformAssetName()
+			rel := ghRelease{
+				TagName: "v9.9.9",
+				Assets: []ghAsset{
+					{
+						Name:               assetName,
+						BrowserDownloadURL: srv.URL + "/download/" + assetName,
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(rel)
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/download/") {
+			if assetContent == nil {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(assetContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv, installPath
 }
 
 func TestRun(t *testing.T) {
+	fakeBinary := []byte("#!/bin/sh\necho chunk v9.9.9\n")
+	archiveData := makeTarGz(t, fakeBinary)
+
 	tests := []struct {
 		name        string
-		path        string // override PATH; empty means use writeFakeGh
-		authExit    int
-		upgradeExit int
+		apiStatus   int
+		archive     []byte
 		wantErr     bool
 		errContains string
 	}{
 		{
-			name:        "gh not found",
-			path:        "/nonexistent",
-			wantErr:     true,
-			errContains: "gh CLI not found",
+			name:      "success",
+			apiStatus: http.StatusOK,
+			archive:   archiveData,
 		},
 		{
-			name:        "not authenticated",
-			authExit:    1,
+			name:        "API error",
+			apiStatus:   http.StatusInternalServerError,
 			wantErr:     true,
-			errContains: "not authenticated",
+			errContains: "fetch latest release",
 		},
 		{
-			name: "success",
-		},
-		{
-			name:        "upgrade fails",
-			upgradeExit: 1,
+			name:        "download fails",
+			apiStatus:   http.StatusOK,
+			archive:     nil, // server returns 404 for download
 			wantErr:     true,
-			errContains: "upgrade failed",
+			errContains: "install update",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.path != "" {
-				t.Setenv("PATH", tt.path)
-			} else {
-				dir := writeFakeGh(t, tt.authExit, tt.upgradeExit)
-				t.Setenv("PATH", dir)
-			}
+			srv, installPath := fakeServer(t, tt.apiStatus, tt.archive)
 
-			err := Run()
+			err := Run(io.Discard, srv.Client(), srv.URL, installPath)
 			if tt.wantErr {
 				if err == nil {
-					t.Fatal("expected error")
+					t.Fatal("expected error, got nil")
 				}
 				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
 					t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
@@ -93,6 +135,54 @@ func TestRun(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
+
+			got, err := os.ReadFile(installPath)
+			if err != nil {
+				t.Fatalf("read installed binary: %v", err)
+			}
+			if !bytes.Equal(got, fakeBinary) {
+				t.Fatalf("installed binary content mismatch: got %q, want %q", got, fakeBinary)
+			}
 		})
+	}
+}
+
+func TestIsBrewManaged(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/opt/homebrew/bin/chunk", true},
+		{"/opt/homebrew/bin/something-else", true},
+		{"/usr/local/bin/chunk", false},
+		{"/home/user/.local/bin/chunk", false},
+		{"/tmp/chunk", false},
+	}
+	for _, tt := range tests {
+		got := isBrewManaged(tt.path)
+		if got != tt.want {
+			t.Errorf("isBrewManaged(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestPlatformAssetName(t *testing.T) {
+	name := PlatformAssetName()
+	if !strings.HasPrefix(name, "chunk_") {
+		t.Errorf("expected name to start with chunk_, got %q", name)
+	}
+	if !strings.HasSuffix(name, ".tar.gz") {
+		t.Errorf("expected name to end with .tar.gz, got %q", name)
+	}
+
+	switch runtime.GOARCH {
+	case "amd64":
+		if !strings.Contains(name, "x86_64") {
+			t.Errorf("expected x86_64 for amd64, got %q", name)
+		}
+	case "arm64":
+		if !strings.Contains(name, "arm64") {
+			t.Errorf("expected arm64, got %q", name)
+		}
 	}
 }

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -168,8 +168,8 @@ func TestIsBrewManaged(t *testing.T) {
 
 func TestPlatformAssetName(t *testing.T) {
 	name := PlatformAssetName()
-	if !strings.HasPrefix(name, "chunk_") {
-		t.Errorf("expected name to start with chunk_, got %q", name)
+	if !strings.HasPrefix(name, "chunk-cli_") {
+		t.Errorf("expected name to start with chunk-cli_, got %q", name)
 	}
 	if !strings.HasSuffix(name, ".tar.gz") {
 		t.Errorf("expected name to end with .tar.gz, got %q", name)


### PR DESCRIPTION
## Summary

- Replaces the `gh` CLI dependency for upgrades with direct GitHub API calls
- Downloads the platform-specific release tarball, extracts the binary, and atomically replaces the running executable via temp file + rename
- Handles Homebrew-managed installs with a clear error directing users to `brew upgrade`
- Env var reads (`GITHUB_API_URL`, `CHUNK_INSTALL_PATH`) hoisted to the `cmd/` layer per architectural rules
- Progress output routed through `iostream` instead of `fmt.Printf` in business logic
- `PlatformAssetName` exported so acceptance tests call the real implementation rather than a duplicate copy

## Test plan

- [x] `TestUpgradeHappyPath` — fake HTTP server serves a real tar.gz; verifies binary is replaced on disk
- [x] `TestUpgradeBrewManaged` — verifies Homebrew-path installs exit with a helpful error
- [x] `TestUpgradeAPIError` — verifies non-200 from GitHub API produces a clear error
- [x] Unit tests cover `isBrewManaged`, `PlatformAssetName`, and the full `Run` happy/error paths
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)