### PR TITLE
[FACT-146] Double sandbox provisioner API request timeout to 60s

### DIFF
--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 	"github.com/CircleCI-Public/chunk-cli/internal/version"
@@ -37,6 +38,7 @@ func NewClient(cfg Config) (*Client, error) {
 		AuthToken:  cfg.Token,
 		AuthHeader: "Circle-Token",
 		UserAgent:  version.UserAgent(),
+		Timeout:    60 * time.Second,
 	})
 	return &Client{cl: cl}, nil
 }


### PR DESCRIPTION
## Summary

- Doubles the per-request timeout on the CircleCI sandbox provisioner API client from 30s (httpcl default) to 60s
- The provisioner API has internal retry loops that can exceed 30s, causing spurious client-side timeouts

## Test plan

- [ ] Verify `go build ./...` passes
- [ ] Manual sidecar creation to confirm no regression on fast paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)