### PR TITLE
Align better with CircleCI CLI guidelines

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -25,8 +25,10 @@ const configFilePermHint = "Check file permissions on the chunk config file."
 
 func newAuthCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "auth",
-		Short: "Manage authentication",
+		Use:                "auth",
+		Short:              "Manage authentication",
+		RunE:               groupRunE,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
 	cmd.AddCommand(newAuthSetCmd())
 	cmd.AddCommand(newAuthStatusCmd())

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -13,8 +13,10 @@ import (
 
 func newConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "config",
-		Short: "Manage configuration",
+		Use:                "config",
+		Short:              "Manage configuration",
+		RunE:               groupRunE,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
 	cmd.AddCommand(newConfigShowCmd())
 	cmd.AddCommand(newConfigSetCmd())

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -26,6 +26,24 @@ Getting started:
   chunk task config             Set up CircleCI task configuration
   chunk task run --definition <name> --prompt "<task>"
                                 Trigger an AI coding task
+
+Environment Variables:
+  CIRCLECI_TOKEN                  CircleCI API token (also: CIRCLE_TOKEN)
+  ANTHROPIC_API_KEY               Anthropic API key
+  GITHUB_TOKEN                    GitHub personal access token
+  CIRCLECI_ORG_ID                 CircleCI organization ID
+  CODE_REVIEW_CLI_MODEL           Claude model override
+  CIRCLECI_BASE_URL               CircleCI API URL [default: https://circleci.com]
+  ANTHROPIC_BASE_URL              Anthropic API URL [default: https://api.anthropic.com]
+  GITHUB_API_URL                  GitHub API URL [default: https://api.github.com]
+  SSH_AUTH_SOCK                   SSH agent socket for sidecar key auth
+  NO_COLOR                        Disable colored output
+  CI                              Disable interactive prompts (set by most CI systems)
+
+Configuration:
+  ~/.config/chunk/config.json     User credentials and settings ($XDG_CONFIG_HOME/chunk/config.json)
+  .chunk/config.json              Project settings (per repository)
+  .chunk/run.json                 Task run configuration (chunk task config)
 `)
 
 	rootCmd.AddCommand(newInitCmd())

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -30,8 +30,10 @@ func randomSidecarName() string {
 
 func newSidecarCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "sidecar",
-		Short: "Manage sidecars",
+		Use:                "sidecar",
+		Short:              "Manage sidecars",
+		RunE:               groupRunE,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
 
 	cmd.AddCommand(newSidecarListCmd())
@@ -641,8 +643,10 @@ Example:
 
 func newSidecarSnapshotCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "snapshot",
-		Short: "Manage sidecar snapshots",
+		Use:                "snapshot",
+		Short:              "Manage sidecar snapshots",
+		RunE:               groupRunE,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
 	cmd.AddCommand(newSidecarSnapshotCreateCmd())
 	cmd.AddCommand(newSidecarSnapshotGetCmd())

--- a/internal/cmd/skills.go
+++ b/internal/cmd/skills.go
@@ -13,8 +13,10 @@ import (
 
 func newSkillCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "skill",
-		Short: "Install and manage AI agent skills",
+		Use:                "skill",
+		Short:              "Install and manage AI agent skills",
+		RunE:               groupRunE,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
 
 	cmd.AddCommand(newSkillInstallCmd())

--- a/internal/cmd/task.go
+++ b/internal/cmd/task.go
@@ -20,8 +20,10 @@ import (
 
 func newTaskCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "task",
-		Short: "Manage task runs",
+		Use:                "task",
+		Short:              "Manage task runs",
+		RunE:               groupRunE,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
 
 	cmd.AddCommand(newTaskRunCmd())

--- a/internal/cmd/usererr.go
+++ b/internal/cmd/usererr.go
@@ -128,7 +128,10 @@ func (e *userError) UserExitCode() int {
 // structured error for unknown subcommands.
 func groupRunE(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return cmd.Help()
+		if err := cmd.Help(); err != nil {
+			return fmt.Errorf("show help: %w", err)
+		}
+		return nil
 	}
 	return newUserError(fmt.Sprintf("%q is not a %s command. Run '%s --help' for available commands.", args[0], cmd.Name(), cmd.CommandPath())).
 		withCode("command.unknown").

--- a/internal/cmd/usererr.go
+++ b/internal/cmd/usererr.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
@@ -119,6 +121,18 @@ func (e *userError) UserExitCode() int {
 		return e.exitCode
 	}
 	return ExitGeneral
+}
+
+// groupRunE is the RunE for group (parent) commands that have no action of
+// their own. It shows help when invoked with no arguments and returns a
+// structured error for unknown subcommands.
+func groupRunE(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return cmd.Help()
+	}
+	return newUserError(fmt.Sprintf("%q is not a %s command. Run '%s --help' for available commands.", args[0], cmd.Name(), cmd.CommandPath())).
+		withCode("command.unknown").
+		withExitCode(ExitBadArgs)
 }
 
 // errNoForce returns a structured error for when a confirmation prompt cannot

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -27,13 +27,13 @@ func newStatusFunc(streams iostream.Streams) iostream.StatusFunc {
 	return func(level iostream.Level, msg string) {
 		switch level {
 		case iostream.LevelStep:
-			streams.ErrPrintln(ui.Bold(msg))
+			streams.ErrPrintln(ui.ErrBold(msg))
 		case iostream.LevelInfo:
-			streams.ErrPrintf("  %s\n", ui.Dim(msg))
+			streams.ErrPrintf("  %s\n", ui.ErrDim(msg))
 		case iostream.LevelWarn:
-			streams.ErrPrintf("  %s\n", ui.Warning(msg))
+			streams.ErrPrintf("  %s\n", ui.ErrWarning(msg))
 		case iostream.LevelDone:
-			streams.ErrPrintf("  %s\n", ui.Success(msg))
+			streams.ErrPrintf("  %s\n", ui.ErrSuccess(msg))
 		}
 	}
 }

--- a/internal/ui/colors.go
+++ b/internal/ui/colors.go
@@ -9,22 +9,36 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 )
 
-var colorEnabled = detectColor()
+var (
+	stdoutColorEnabled = detectColorFor(os.Stdout)
+	stderrColorEnabled = detectColorFor(os.Stderr)
+)
 
-func detectColor() bool {
+func detectColorFor(f *os.File) bool {
 	if os.Getenv(config.EnvNoColor) != "" {
 		return false
 	}
-	return term.IsTerminal(int(os.Stderr.Fd()))
+	if os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd()))
 }
 
-// SetColorEnabled overrides automatic color detection.
+// SetColorEnabled overrides automatic color detection for both stdout and stderr.
 func SetColorEnabled(enabled bool) {
-	colorEnabled = enabled
+	stdoutColorEnabled = enabled
+	stderrColorEnabled = enabled
 }
 
 func wrap(code, text string) string {
-	if !colorEnabled {
+	if !stdoutColorEnabled {
+		return text
+	}
+	return fmt.Sprintf("\x1b[%sm%s\x1b[0m", code, text)
+}
+
+func wrapErr(code, text string) string {
+	if !stderrColorEnabled {
 		return text
 	}
 	return fmt.Sprintf("\x1b[%sm%s\x1b[0m", code, text)
@@ -37,3 +51,15 @@ func Cyan(text string) string   { return wrap("36", text) }
 func Gray(text string) string   { return wrap("90", text) }
 func Bold(text string) string   { return wrap("1", text) }
 func Dim(text string) string    { return wrap("2", text) }
+
+// ErrGreen applies green color using stderr color detection.
+func ErrGreen(text string) string { return wrapErr("32", text) }
+
+// ErrYellow applies yellow color using stderr color detection.
+func ErrYellow(text string) string { return wrapErr("33", text) }
+
+// ErrBold applies bold using stderr color detection.
+func ErrBold(text string) string { return wrapErr("1", text) }
+
+// ErrDim applies dim using stderr color detection.
+func ErrDim(text string) string { return wrapErr("2", text) }

--- a/internal/ui/format.go
+++ b/internal/ui/format.go
@@ -15,6 +15,16 @@ func Warning(msg string) string {
 	return Yellow("⚠ " + msg)
 }
 
+// ErrSuccess formats a success message using stderr color detection.
+func ErrSuccess(msg string) string {
+	return ErrGreen("✓ " + msg)
+}
+
+// ErrWarning formats a warning message using stderr color detection.
+func ErrWarning(msg string) string {
+	return ErrYellow("⚠ " + msg)
+}
+
 // FormatError formats a red error with optional detail and suggestion.
 func FormatError(brief string, detail string, suggestion string) string {
 	var b strings.Builder

--- a/internal/ui/spinner.go
+++ b/internal/ui/spinner.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"golang.org/x/term"
 )
 
 var frames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
@@ -32,7 +34,7 @@ type Spinner struct {
 func NewSpinner() *Spinner {
 	return &Spinner{
 		w:     os.Stderr,
-		isTTY: stderrColorEnabled,
+		isTTY: term.IsTerminal(int(os.Stderr.Fd())),
 	}
 }
 

--- a/internal/ui/spinner.go
+++ b/internal/ui/spinner.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"sync"
 	"time"
-
-	"golang.org/x/term"
 )
 
 var frames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
@@ -34,7 +32,7 @@ type Spinner struct {
 func NewSpinner() *Spinner {
 	return &Spinner{
 		w:     os.Stderr,
-		isTTY: term.IsTerminal(int(os.Stderr.Fd())),
+		isTTY: stderrColorEnabled,
 	}
 }
 
@@ -119,7 +117,7 @@ func (s *Spinner) render() {
 
 	line := fmt.Sprintf("%s %s", frame, msg)
 	if elapsed := time.Since(start); elapsed >= elapsedThreshold {
-		line += Dim(fmt.Sprintf(" (%ds)", int(elapsed.Seconds())))
+		line += ErrDim(fmt.Sprintf(" (%ds)", int(elapsed.Seconds())))
 	}
 	_, _ = fmt.Fprintf(s.w, "\r\x1b[2K%s", line)
 }


### PR DESCRIPTION
Fix three gaps between the current implementation and the circleci-cli engineering guidelines:

  1. Group commands now return structured errors for unknown subcommands (auth, config, sidecar, snapshot, skill, task). Previously these silently showed help and exited 0. Now they return a command.unknown error with exit code 2, making them scriptable and consistent with leaf commands.

  2. TTY/color detection checks stdout and stderr independently. The original code used os.Stderr.Fd() for everything — so piping stdout (chunk validate | jq) would still emit ANSI codes on stdout. Stdout and stderr are now detected separately, TERM=dumb is respected, and progress output that goes to stderr uses Err* color variants. Spinner TTY detection (cursor control) is kept independent of color detection so NO_COLOR=1 doesn't break the animation.

  3. chunk --help now lists all environment variables and config file locations — credentials, URL overrides, NO_COLOR, CI, SSH_AUTH_SOCK, and the three config file paths (~/.config/chunk/config.json, .chunk/config.json, .chunk/run.json).