### PR TITLE
Add support for disabling hooks in a claude executable way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,8 @@ PLANS.md
 .chunk/sidecar.json
 .chunk/sidecar.*.json
 
+# hook disable sentinel
+.chunk/hooks-disabled
+
 # unikraft
 .unikraft/

--- a/internal/cmd/hooks.go
+++ b/internal/cmd/hooks.go
@@ -10,22 +10,28 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/validate"
 )
 
 func newHooksCmd() *cobra.Command {
+	var projectDir string
 	cmd := &cobra.Command{
 		Use:   "hooks",
 		Short: "Manage chunk hook execution",
 	}
-	cmd.AddCommand(newHooksDisableCmd())
-	cmd.AddCommand(newHooksEnableCmd())
-	cmd.AddCommand(newHooksStatusCmd())
+	cmd.PersistentFlags().StringVar(&projectDir, "project", "", "Override project directory")
+	cmd.AddCommand(newHooksDisableCmd(&projectDir))
+	cmd.AddCommand(newHooksEnableCmd(&projectDir))
+	cmd.AddCommand(newHooksStatusCmd(&projectDir))
 	return cmd
 }
 
-func hooksProjectRoot() string {
+func resolveHooksRoot(override string) string {
+	if override != "" {
+		return override
+	}
 	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
 	if err == nil {
 		if s := strings.TrimSpace(string(out)); s != "" {
@@ -39,17 +45,13 @@ func hooksProjectRoot() string {
 	return cwd
 }
 
-func hooksSentinelPath() string {
-	return filepath.Join(hooksProjectRoot(), ".chunk", "hooks-disabled")
-}
-
-func newHooksDisableCmd() *cobra.Command {
+func newHooksDisableCmd(projectDir *string) *cobra.Command {
 	return &cobra.Command{
 		Use:          "disable",
 		Short:        "Disable chunk validate hooks",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			p := hooksSentinelPath()
+			p := filepath.Join(resolveHooksRoot(*projectDir), ".chunk", "hooks-disabled")
 			if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
 				return fmt.Errorf("create .chunk directory: %w", err)
 			}
@@ -63,13 +65,13 @@ func newHooksDisableCmd() *cobra.Command {
 	}
 }
 
-func newHooksEnableCmd() *cobra.Command {
+func newHooksEnableCmd(projectDir *string) *cobra.Command {
 	return &cobra.Command{
 		Use:          "enable",
 		Short:        "Re-enable chunk validate hooks",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			p := hooksSentinelPath()
+			p := filepath.Join(resolveHooksRoot(*projectDir), ".chunk", "hooks-disabled")
 			if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
 				return fmt.Errorf("remove hooks-disabled sentinel: %w", err)
 			}
@@ -80,18 +82,19 @@ func newHooksEnableCmd() *cobra.Command {
 	}
 }
 
-func newHooksStatusCmd() *cobra.Command {
+func newHooksStatusCmd(projectDir *string) *cobra.Command {
 	return &cobra.Command{
 		Use:          "status",
 		Short:        "Show whether hooks are enabled or disabled",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			streams := iostream.FromCmd(cmd)
-			root := hooksProjectRoot()
-			if validate.HooksDisabled(root) {
-				streams.ErrPrintln("disabled")
+			root := resolveHooksRoot(*projectDir)
+			envDisabled := os.Getenv(config.EnvChunkHooksDisabled) != ""
+			if validate.HooksDisabled(root, envDisabled) {
+				streams.Println("disabled")
 			} else {
-				streams.ErrPrintln("enabled")
+				streams.Println("enabled")
 			}
 			return nil
 		},

--- a/internal/cmd/hooks.go
+++ b/internal/cmd/hooks.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/validate"
+)
+
+func newHooksCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "hooks",
+		Short: "Manage chunk hook execution",
+	}
+	cmd.AddCommand(newHooksDisableCmd())
+	cmd.AddCommand(newHooksEnableCmd())
+	cmd.AddCommand(newHooksStatusCmd())
+	return cmd
+}
+
+func hooksProjectRoot() string {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err == nil {
+		if s := strings.TrimSpace(string(out)); s != "" {
+			return s
+		}
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	return cwd
+}
+
+func hooksSentinelPath() string {
+	return filepath.Join(hooksProjectRoot(), ".chunk", "hooks-disabled")
+}
+
+func newHooksDisableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:          "disable",
+		Short:        "Disable chunk validate hooks",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p := hooksSentinelPath()
+			if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+				return fmt.Errorf("create .chunk directory: %w", err)
+			}
+			if err := os.WriteFile(p, []byte{}, 0o644); err != nil {
+				return fmt.Errorf("create hooks-disabled sentinel: %w", err)
+			}
+			streams := iostream.FromCmd(cmd)
+			streams.ErrPrintln("Hooks disabled. Run 'chunk hooks enable' to re-enable.")
+			return nil
+		},
+	}
+}
+
+func newHooksEnableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:          "enable",
+		Short:        "Re-enable chunk validate hooks",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p := hooksSentinelPath()
+			if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove hooks-disabled sentinel: %w", err)
+			}
+			streams := iostream.FromCmd(cmd)
+			streams.ErrPrintln("Hooks enabled.")
+			return nil
+		},
+	}
+}
+
+func newHooksStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:          "status",
+		Short:        "Show whether hooks are enabled or disabled",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			streams := iostream.FromCmd(cmd)
+			root := hooksProjectRoot()
+			if validate.HooksDisabled(root) {
+				streams.ErrPrintln("disabled")
+			} else {
+				streams.ErrPrintln("enabled")
+			}
+			return nil
+		},
+	}
+}

--- a/internal/cmd/hooks_test.go
+++ b/internal/cmd/hooks_test.go
@@ -18,15 +18,10 @@ func runHooksCmd(t *testing.T, dir string, args ...string) (string, string, erro
 	var out, errOut bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&errOut)
-	root.SetArgs(append([]string{"hooks"}, args...))
-
-	// Override the project root detection by changing the working directory.
-	orig, err := os.Getwd()
-	assert.NilError(t, err)
-	assert.NilError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(orig) })
-
-	err = root.Execute()
+	allArgs := append([]string{"hooks"}, args...)
+	allArgs = append(allArgs, "--project", dir)
+	root.SetArgs(allArgs)
+	err := root.Execute()
 	return out.String(), errOut.String(), err
 }
 
@@ -62,16 +57,16 @@ func TestHooksStatus_Disabled(t *testing.T) {
 	assert.NilError(t, os.MkdirAll(chunkDir, 0o755))
 	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "hooks-disabled"), []byte{}, 0o644))
 
-	_, errOut, err := runHooksCmd(t, dir, "status")
+	out, _, err := runHooksCmd(t, dir, "status")
 	assert.NilError(t, err)
-	assert.Assert(t, strings.Contains(errOut, "disabled"), "got: %s", errOut)
+	assert.Assert(t, strings.Contains(out, "disabled"), "got: %s", out)
 }
 
 func TestHooksStatus_Enabled(t *testing.T) {
 	dir := t.TempDir()
-	_, errOut, err := runHooksCmd(t, dir, "status")
+	out, _, err := runHooksCmd(t, dir, "status")
 	assert.NilError(t, err)
-	assert.Assert(t, strings.Contains(errOut, "enabled"), "got: %s", errOut)
+	assert.Assert(t, strings.Contains(out, "enabled"), "got: %s", out)
 }
 
 // TestValidateHookPath_HooksDisabled verifies that when CHUNK_HOOKS_DISABLED is

--- a/internal/cmd/hooks_test.go
+++ b/internal/cmd/hooks_test.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+)
+
+func runHooksCmd(t *testing.T, dir string, args ...string) (string, string, error) {
+	t.Helper()
+	root := NewRootCmd("test")
+	var out, errOut bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	root.SetArgs(append([]string{"hooks"}, args...))
+
+	// Override the project root detection by changing the working directory.
+	orig, err := os.Getwd()
+	assert.NilError(t, err)
+	assert.NilError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	err = root.Execute()
+	return out.String(), errOut.String(), err
+}
+
+func TestHooksDisable_CreatesSentinel(t *testing.T) {
+	dir := t.TempDir()
+	_, _, err := runHooksCmd(t, dir, "disable")
+	assert.NilError(t, err)
+	_, statErr := os.Stat(filepath.Join(dir, ".chunk", "hooks-disabled"))
+	assert.NilError(t, statErr, "expected sentinel file to exist")
+}
+
+func TestHooksEnable_RemovesSentinel(t *testing.T) {
+	dir := t.TempDir()
+	chunkDir := filepath.Join(dir, ".chunk")
+	assert.NilError(t, os.MkdirAll(chunkDir, 0o755))
+	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "hooks-disabled"), []byte{}, 0o644))
+
+	_, _, err := runHooksCmd(t, dir, "enable")
+	assert.NilError(t, err)
+	_, statErr := os.Stat(filepath.Join(chunkDir, "hooks-disabled"))
+	assert.Assert(t, os.IsNotExist(statErr), "expected sentinel file to be removed")
+}
+
+func TestHooksEnable_NoopWhenAlreadyEnabled(t *testing.T) {
+	dir := t.TempDir()
+	_, _, err := runHooksCmd(t, dir, "enable")
+	assert.NilError(t, err)
+}
+
+func TestHooksStatus_Disabled(t *testing.T) {
+	dir := t.TempDir()
+	chunkDir := filepath.Join(dir, ".chunk")
+	assert.NilError(t, os.MkdirAll(chunkDir, 0o755))
+	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "hooks-disabled"), []byte{}, 0o644))
+
+	_, errOut, err := runHooksCmd(t, dir, "status")
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(errOut, "disabled"), "got: %s", errOut)
+}
+
+func TestHooksStatus_Enabled(t *testing.T) {
+	dir := t.TempDir()
+	_, errOut, err := runHooksCmd(t, dir, "status")
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(errOut, "enabled"), "got: %s", errOut)
+}
+
+// TestValidateHookPath_HooksDisabled verifies that when CHUNK_HOOKS_DISABLED is
+// set the validate hook path exits 1 and prints a clear message to stderr.
+func TestValidateHookPath_HooksDisabled(t *testing.T) {
+	t.Setenv(config.EnvChunkHooksDisabled, "1")
+
+	dir := t.TempDir()
+	root := NewRootCmd("test")
+	var errOut bytes.Buffer
+	root.SetErr(&errOut)
+	root.SetArgs([]string{"validate", "--project", dir})
+
+	// Provide a valid Stop hook JSON payload so detectHook returns non-nil.
+	hookPayload := `{"session_id":"test-hooks-disabled","stop_hook_active":false}`
+	root.SetIn(strings.NewReader(hookPayload))
+
+	err := root.Execute()
+	type exitCoder interface{ ExitCode() int }
+	ec, ok := err.(exitCoder)
+	assert.Assert(t, ok, "expected ExitCode() method on error, got: %v", err)
+	assert.Equal(t, ec.ExitCode(), 1)
+	assert.Assert(t, strings.Contains(errOut.String(), "hooks are disabled"), "got: %s", errOut.String())
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -37,6 +37,7 @@ Getting started:
 	rootCmd.AddCommand(newSidecarCmd())
 	rootCmd.AddCommand(newTaskCmd())
 	rootCmd.AddCommand(newValidateCmd())
+	rootCmd.AddCommand(newHooksCmd())
 	rootCmd.AddCommand(newUpgradeCmd())
 
 	rootCmd.AddCommand(newCommandsCmd())

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -113,7 +113,8 @@ func newValidateCmd() *cobra.Command {
 			statusFn := newStatusFunc(streams)
 
 			// Hook: exit 1 with a message when hooks are disabled.
-			if hook != nil && validate.HooksDisabled(workDir) {
+			envDisabled := os.Getenv(config.EnvChunkHooksDisabled) != ""
+			if hook != nil && validate.HooksDisabled(workDir, envDisabled) {
 				streams.ErrPrintln("chunk validate: hooks are disabled — skipping validation")
 				return validate.NewHookExitError(1)
 			}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -112,6 +112,12 @@ func newValidateCmd() *cobra.Command {
 			}
 			statusFn := newStatusFunc(streams)
 
+			// Hook: exit 1 with a message when hooks are disabled.
+			if hook != nil && validate.HooksDisabled(workDir) {
+				streams.ErrPrintln("chunk validate: hooks are disabled — skipping validation")
+				return validate.NewHookExitError(1)
+			}
+
 			// Hook: skip entirely when the working tree is clean.
 			if hook != nil && !validate.HasGitChanges(workDir) {
 				return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,15 +29,16 @@ const (
 //
 //nolint:gosec // env var names, not credentials
 const (
-	EnvCircleToken      = "CIRCLE_TOKEN"
-	EnvCircleCIToken    = "CIRCLECI_TOKEN"
-	EnvCircleCIBaseURL  = "CIRCLECI_BASE_URL"
-	EnvAnthropicAPIKey  = "ANTHROPIC_API_KEY"
-	EnvAnthropicBaseURL = "ANTHROPIC_BASE_URL"
-	EnvGitHubToken      = "GITHUB_TOKEN"
-	EnvGitHubAPIURL     = "GITHUB_API_URL"
-	EnvModel            = "CODE_REVIEW_CLI_MODEL"
-	EnvCircleCIOrgID    = "CIRCLECI_ORG_ID"
+	EnvCircleToken        = "CIRCLE_TOKEN"
+	EnvCircleCIToken      = "CIRCLECI_TOKEN"
+	EnvCircleCIBaseURL    = "CIRCLECI_BASE_URL"
+	EnvAnthropicAPIKey    = "ANTHROPIC_API_KEY"
+	EnvAnthropicBaseURL   = "ANTHROPIC_BASE_URL"
+	EnvGitHubToken        = "GITHUB_TOKEN"
+	EnvGitHubAPIURL       = "GITHUB_API_URL"
+	EnvModel              = "CODE_REVIEW_CLI_MODEL"
+	EnvCircleCIOrgID      = "CIRCLECI_ORG_ID"
+	EnvChunkHooksDisabled = "CHUNK_HOOKS_DISABLED"
 )
 
 // System/standard environment variable names.

--- a/internal/validate/hook_test.go
+++ b/internal/validate/hook_test.go
@@ -120,19 +120,18 @@ func TestWrapHookResult_CustomMaxAttempts(t *testing.T) {
 // --- HooksDisabled ---
 
 func TestHooksDisabled_EnvVar(t *testing.T) {
-	t.Setenv(config.EnvChunkHooksDisabled, "1")
-	assert.Equal(t, HooksDisabled(t.TempDir()), true)
+	assert.Equal(t, HooksDisabled(t.TempDir(), true), true)
 }
 
 func TestHooksDisabled_SentinelFile(t *testing.T) {
 	dir := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".chunk"), 0o755))
 	assert.NilError(t, os.WriteFile(filepath.Join(dir, ".chunk", "hooks-disabled"), []byte{}, 0o644))
-	assert.Equal(t, HooksDisabled(dir), true)
+	assert.Equal(t, HooksDisabled(dir, false), true)
 }
 
 func TestHooksDisabled_Neither(t *testing.T) {
-	assert.Equal(t, HooksDisabled(t.TempDir()), false)
+	assert.Equal(t, HooksDisabled(t.TempDir(), false), false)
 }
 
 // --- HasGitChanges ---

--- a/internal/validate/hook_test.go
+++ b/internal/validate/hook_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -114,6 +115,24 @@ func TestWrapHookResult_CustomMaxAttempts(t *testing.T) {
 	err := WrapHookResult(sid, errors.New("failed"), 1, &buf)
 	assert.NilError(t, err, "expected give-up after 1 attempt")
 	assert.Assert(t, strings.Contains(buf.String(), "ask the user"), "got: %s", buf.String())
+}
+
+// --- HooksDisabled ---
+
+func TestHooksDisabled_EnvVar(t *testing.T) {
+	t.Setenv(config.EnvChunkHooksDisabled, "1")
+	assert.Equal(t, HooksDisabled(t.TempDir()), true)
+}
+
+func TestHooksDisabled_SentinelFile(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".chunk"), 0o755))
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, ".chunk", "hooks-disabled"), []byte{}, 0o644))
+	assert.Equal(t, HooksDisabled(dir), true)
+}
+
+func TestHooksDisabled_Neither(t *testing.T) {
+	assert.Equal(t, HooksDisabled(t.TempDir()), false)
 }
 
 // --- HasGitChanges ---

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -234,12 +234,12 @@ func (e *HookExitError) ExitCode() int { return e.code }
 func NewHookExitError(code int) error { return &HookExitError{code: code} }
 
 // HooksDisabled reports whether chunk validate hooks are currently suppressed.
-// It returns true when the CHUNK_HOOKS_DISABLED env var is non-empty or the
-// sentinel file .chunk/hooks-disabled exists under workDir.
-// On any error other than ErrNotExist the function fails open (returns false)
-// so hooks continue to run when the check is uncertain.
-func HooksDisabled(workDir string) bool {
-	if os.Getenv(config.EnvChunkHooksDisabled) != "" {
+// envDisabled should be set by the caller from CHUNK_HOOKS_DISABLED; it returns
+// true when that flag is set or the sentinel file .chunk/hooks-disabled exists
+// under workDir. On any error other than ErrNotExist the function fails open
+// (returns false) so hooks continue to run when the check is uncertain.
+func HooksDisabled(workDir string, envDisabled bool) bool {
+	if envDisabled {
 		return true
 	}
 	_, err := os.Stat(filepath.Join(workDir, ".chunk", "hooks-disabled"))

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -228,6 +229,22 @@ type HookExitError struct {
 
 func (e *HookExitError) Error() string { return fmt.Sprintf("exit %d", e.code) }
 func (e *HookExitError) ExitCode() int { return e.code }
+
+// NewHookExitError returns a HookExitError with the given exit code.
+func NewHookExitError(code int) error { return &HookExitError{code: code} }
+
+// HooksDisabled reports whether chunk validate hooks are currently suppressed.
+// It returns true when the CHUNK_HOOKS_DISABLED env var is non-empty or the
+// sentinel file .chunk/hooks-disabled exists under workDir.
+// On any error other than ErrNotExist the function fails open (returns false)
+// so hooks continue to run when the check is uncertain.
+func HooksDisabled(workDir string) bool {
+	if os.Getenv(config.EnvChunkHooksDisabled) != "" {
+		return true
+	}
+	_, err := os.Stat(filepath.Join(workDir, ".chunk", "hooks-disabled"))
+	return err == nil
+}
 
 // HasGitChanges reports whether the working tree at workDir has any
 // uncommitted modifications (staged or unstaged). Returns true when git


### PR DESCRIPTION
We previously only had an env var to disable hooks. This was hard to work with in a given claude session, exposing a way via cli to disable hooks for dev, can be discovered by agents via the CLI interface.