### PR TITLE
Write .circleci/test-suites.yml during chunk init

### DIFF
--- a/.circleci/test-suites.yml
+++ b/.circleci/test-suites.yml
@@ -1,0 +1,6 @@
+---
+name: ci tests
+discover: go list -f '{{ if or (len .TestGoFiles) (len .XTestGoFiles) }} {{ .ImportPath }} {{end}}' ./...
+run: go tool gotestsum --junitfile="<< outputs.junit >>" -- -race -coverprofile=coverage.out << test.atoms >>
+outputs:
+  junit: test-reports/tests.xml

--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -555,7 +555,7 @@ func TestInitWritesTestSuitesForGoWhenCircleDirExists(t *testing.T) {
 	env.AnthropicKey = ""
 
 	result := binary.RunCLI(t, []string{
-		"init", "--skip-hooks",
+		"init", "--skip-hooks", "--skip-test-suites=false",
 	}, env, workDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
@@ -575,7 +575,7 @@ func TestInitCreatesCircleDirAndWritesTestSuites(t *testing.T) {
 	env.AnthropicKey = ""
 
 	result := binary.RunCLI(t, []string{
-		"init", "--skip-hooks",
+		"init", "--skip-hooks", "--skip-test-suites=false",
 	}, env, workDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
@@ -598,7 +598,7 @@ func TestInitDoesNotOverwriteExistingTestSuites(t *testing.T) {
 	env.AnthropicKey = ""
 
 	result := binary.RunCLI(t, []string{
-		"init", "--skip-hooks",
+		"init", "--skip-hooks", "--skip-test-suites=false",
 	}, env, workDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
@@ -608,7 +608,7 @@ func TestInitDoesNotOverwriteExistingTestSuites(t *testing.T) {
 	assert.Equal(t, string(data), string(existing), "existing test-suites.yml should be preserved")
 }
 
-func TestInitSkipTestSuitesFlag(t *testing.T) {
+func TestInitSkipsTestSuitesByDefault(t *testing.T) {
 	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
 	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module example.com/m\n"), 0o644))
 	assert.NilError(t, os.MkdirAll(filepath.Join(workDir, ".circleci"), 0o755))
@@ -617,13 +617,18 @@ func TestInitSkipTestSuitesFlag(t *testing.T) {
 	env.AnthropicKey = ""
 
 	result := binary.RunCLI(t, []string{
-		"init", "--skip-hooks", "--skip-test-suites",
+		"init", "--skip-hooks",
 	}, env, workDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 
 	_, err := os.Stat(filepath.Join(workDir, ".circleci", "test-suites.yml"))
-	assert.Assert(t, os.IsNotExist(err), "expected --skip-test-suites to suppress write, err=%v", err)
+	assert.Assert(t, os.IsNotExist(err), "expected default to skip write, err=%v", err)
+
+	assert.Assert(t, strings.Contains(result.Stderr, "Smarter Testing"),
+		"expected hint in stderr, got: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "test-suites.yml"),
+		"expected hint to mention test-suites.yml, got: %s", result.Stderr)
 }
 
 func TestInitProjectDirNotGitRepo(t *testing.T) {

--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -544,6 +544,88 @@ func TestInitProjectDir(t *testing.T) {
 	assert.Equal(t, vcs["repo"], "my-repo")
 }
 
+// --- CircleCI Smarter Testing test-suites.yml ---
+
+func TestInitWritesTestSuitesForGoWhenCircleDirExists(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module example.com/m\n"), 0o644))
+	assert.NilError(t, os.MkdirAll(filepath.Join(workDir, ".circleci"), 0o755))
+
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{
+		"init", "--skip-hooks",
+	}, env, workDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	data, err := os.ReadFile(filepath.Join(workDir, ".circleci", "test-suites.yml"))
+	assert.NilError(t, err, "expected .circleci/test-suites.yml to exist")
+	body := string(data)
+	assert.Assert(t, strings.Contains(body, "go list -f"), "got: %s", body)
+	assert.Assert(t, strings.Contains(body, "<< test.atoms >>"), "got: %s", body)
+}
+
+func TestInitCreatesCircleDirAndWritesTestSuites(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module example.com/m\n"), 0o644))
+
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{
+		"init", "--skip-hooks",
+	}, env, workDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	data, err := os.ReadFile(filepath.Join(workDir, ".circleci", "test-suites.yml"))
+	assert.NilError(t, err, "expected init to create .circleci/test-suites.yml even when .circleci/ was missing")
+	body := string(data)
+	assert.Assert(t, strings.Contains(body, "go list -f"), "got: %s", body)
+	assert.Assert(t, strings.Contains(body, "<< test.atoms >>"), "got: %s", body)
+}
+
+func TestInitDoesNotOverwriteExistingTestSuites(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module example.com/m\n"), 0o644))
+	assert.NilError(t, os.MkdirAll(filepath.Join(workDir, ".circleci"), 0o755))
+	existing := []byte("# user customization\nname: custom\n")
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, ".circleci", "test-suites.yml"), existing, 0o644))
+
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{
+		"init", "--skip-hooks",
+	}, env, workDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	data, err := os.ReadFile(filepath.Join(workDir, ".circleci", "test-suites.yml"))
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), string(existing), "existing test-suites.yml should be preserved")
+}
+
+func TestInitSkipTestSuitesFlag(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module example.com/m\n"), 0o644))
+	assert.NilError(t, os.MkdirAll(filepath.Join(workDir, ".circleci"), 0o755))
+
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{
+		"init", "--skip-hooks", "--skip-test-suites",
+	}, env, workDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	_, err := os.Stat(filepath.Join(workDir, ".circleci", "test-suites.yml"))
+	assert.Assert(t, os.IsNotExist(err), "expected --skip-test-suites to suppress write, err=%v", err)
+}
+
 func TestInitProjectDirNotGitRepo(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	notGit := t.TempDir()

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -209,8 +209,36 @@ func installSkillsStep(streams iostream.Streams) {
 	}
 }
 
+// writeTestSuites scaffolds .circleci/test-suites.yml for CircleCI Smarter
+// Testing whenever the toolchain has a known template, creating .circleci/
+// if it does not already exist. It never overwrites an existing
+// test-suites.yml.
+func writeTestSuites(workDir string, streams iostream.Streams) error {
+	template := validate.TestSuitesTemplate(workDir)
+	if template == "" {
+		return nil
+	}
+
+	circleDir := filepath.Join(workDir, ".circleci")
+	path := filepath.Join(circleDir, "test-suites.yml")
+	if _, err := os.Stat(path); err == nil {
+		streams.ErrPrintln(ui.Dim(".circleci/test-suites.yml already exists, leaving as-is"))
+		return nil
+	}
+
+	if err := os.MkdirAll(circleDir, 0o755); err != nil {
+		return fmt.Errorf("create .circleci dir: %w", err)
+	}
+
+	if err := os.WriteFile(path, []byte(template), 0o644); err != nil {
+		return fmt.Errorf("write test-suites.yml: %w", err)
+	}
+	streams.ErrPrintln(ui.Success("Wrote .circleci/test-suites.yml"))
+	return nil
+}
+
 func newInitCmd() *cobra.Command {
-	var force, skipHooks, skipValidate, skipCompletions, skipSkills bool
+	var force, skipHooks, skipValidate, skipCompletions, skipSkills, skipTestSuites bool
 	var projectDir string
 
 	cmd := &cobra.Command{
@@ -325,7 +353,14 @@ hook config files.`,
 				}
 			}
 
-			// Step 5: Agent skills
+			// Step 5: CircleCI Smarter Testing test-suites.yml
+			if !skipTestSuites {
+				if err := writeTestSuites(workDir, streams); err != nil {
+					streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not write .circleci/test-suites.yml: %v", err)))
+				}
+			}
+
+			// Step 6: Agent skills
 			if !skipSkills {
 				installSkillsStep(streams)
 			}
@@ -340,6 +375,7 @@ hook config files.`,
 	cmd.Flags().BoolVar(&skipValidate, "skip-validate", false, "Skip validate command detection")
 	cmd.Flags().BoolVar(&skipCompletions, "skip-completions", false, "Skip shell completion installation")
 	cmd.Flags().BoolVar(&skipSkills, "skip-skills", false, "Skip agent skill installation")
+	cmd.Flags().BoolVar(&skipTestSuites, "skip-test-suites", false, "Skip CircleCI test-suites.yml generation")
 	cmd.Flags().StringVar(&projectDir, "project-dir", "", "Project directory (defaults to current directory)")
 
 	return cmd

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -237,6 +237,21 @@ func writeTestSuites(workDir string, streams iostream.Streams) error {
 	return nil
 }
 
+// printTestSuitesHint prints onboarding guidance for scaffolding
+// .circleci/test-suites.yml. Skipped when the file already exists.
+// The schema description is intentionally agent-actionable: an AI agent
+// reading the init output has enough to draft the file for any language.
+func printTestSuitesHint(workDir string, streams iostream.Streams) {
+	if _, err := os.Stat(filepath.Join(workDir, ".circleci", "test-suites.yml")); err == nil {
+		return
+	}
+	streams.ErrPrintln("")
+	streams.ErrPrintln(ui.Bold("Next step: scaffold .circleci/test-suites.yml for Smarter Testing"))
+	streams.ErrPrintln(ui.Dim("  Ask your AI coding agent to scaffold .circleci/test-suites.yml — the"))
+	streams.ErrPrintln(ui.Dim("  chunk-sidecar skill covers the file shape and per-language patterns."))
+	streams.ErrPrintln(ui.Dim("  Or rerun with --skip-test-suites=false to use built-in Go/pytest templates."))
+}
+
 func newInitCmd() *cobra.Command {
 	var force, skipHooks, skipValidate, skipCompletions, skipSkills, skipTestSuites bool
 	var projectDir string
@@ -354,7 +369,9 @@ hook config files.`,
 			}
 
 			// Step 5: CircleCI Smarter Testing test-suites.yml
-			if !skipTestSuites {
+			if skipTestSuites {
+				printTestSuitesHint(workDir, streams)
+			} else {
 				if err := writeTestSuites(workDir, streams); err != nil {
 					streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not write .circleci/test-suites.yml: %v", err)))
 				}
@@ -375,7 +392,7 @@ hook config files.`,
 	cmd.Flags().BoolVar(&skipValidate, "skip-validate", false, "Skip validate command detection")
 	cmd.Flags().BoolVar(&skipCompletions, "skip-completions", false, "Skip shell completion installation")
 	cmd.Flags().BoolVar(&skipSkills, "skip-skills", false, "Skip agent skill installation")
-	cmd.Flags().BoolVar(&skipTestSuites, "skip-test-suites", false, "Skip CircleCI test-suites.yml generation")
+	cmd.Flags().BoolVar(&skipTestSuites, "skip-test-suites", true, "Skip CircleCI test-suites.yml generation (default: skip; pass =false to use built-in Go/pytest templates)")
 	cmd.Flags().StringVar(&projectDir, "project-dir", "", "Project directory (defaults to current directory)")
 
 	return cmd

--- a/internal/validate/testsuites.go
+++ b/internal/validate/testsuites.go
@@ -1,0 +1,40 @@
+package validate
+
+import "os"
+
+// TestSuitesTemplate returns the contents of .circleci/test-suites.yml for the
+// detected toolchain in workDir, or "" if no toolchain template applies.
+//
+// The returned YAML targets CircleCI Smarter Testing: `<< test.atoms >>` is
+// substituted at run time with the subset of test atoms picked by the platform.
+func TestSuitesTemplate(workDir string) string {
+	entries, _ := os.ReadDir(workDir)
+	has := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		has[e.Name()] = true
+	}
+
+	switch {
+	case has["go.mod"]:
+		return goTestSuitesYAML
+	case has["pyproject.toml"]:
+		return pytestTestSuitesYAML
+	}
+	return ""
+}
+
+const goTestSuitesYAML = `---
+name: ci tests
+discover: go list -f '{{ if or (len .TestGoFiles) (len .XTestGoFiles) }} {{ .ImportPath }} {{end}}' ./...
+run: go tool gotestsum --junitfile="<< outputs.junit >>" -- -race << test.atoms >>
+outputs:
+  junit: test-reports/tests.xml
+`
+
+const pytestTestSuitesYAML = `---
+name: ci tests
+discover: python -m pytest --collect-only -q
+run: python -m pytest --junit-xml=<< outputs.junit >> << test.atoms >>
+outputs:
+  junit: test-reports/tests.xml
+`

--- a/internal/validate/testsuites_test.go
+++ b/internal/validate/testsuites_test.go
@@ -1,0 +1,51 @@
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestTestSuitesTemplate(t *testing.T) {
+	t.Run("go.mod yields gotestsum template", func(t *testing.T) {
+		dir := t.TempDir()
+		assert.NilError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/m\n"), 0o644))
+
+		got := TestSuitesTemplate(dir)
+		assert.Assert(t, strings.Contains(got, "go list -f"), "got: %s", got)
+		assert.Assert(t, strings.Contains(got, "<< test.atoms >>"), "got: %s", got)
+		assert.Assert(t, strings.Contains(got, "junit: test-reports/tests.xml"), "got: %s", got)
+	})
+
+	t.Run("pyproject.toml yields pytest template", func(t *testing.T) {
+		dir := t.TempDir()
+		assert.NilError(t, os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte("[project]\n"), 0o644))
+
+		got := TestSuitesTemplate(dir)
+		assert.Assert(t, strings.Contains(got, "pytest --collect-only"), "got: %s", got)
+		assert.Assert(t, strings.Contains(got, "<< test.atoms >>"), "got: %s", got)
+	})
+
+	t.Run("unknown toolchain returns empty string", func(t *testing.T) {
+		dir := t.TempDir()
+		assert.NilError(t, os.WriteFile(filepath.Join(dir, "Cargo.toml"), []byte(""), 0o644))
+
+		assert.Equal(t, TestSuitesTemplate(dir), "")
+	})
+
+	t.Run("empty directory returns empty string", func(t *testing.T) {
+		assert.Equal(t, TestSuitesTemplate(t.TempDir()), "")
+	})
+
+	t.Run("go.mod takes precedence over pyproject.toml", func(t *testing.T) {
+		dir := t.TempDir()
+		assert.NilError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module x\n"), 0o644))
+		assert.NilError(t, os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte("[project]\n"), 0o644))
+
+		got := TestSuitesTemplate(dir)
+		assert.Assert(t, strings.Contains(got, "go list -f"), "expected Go template, got: %s", got)
+	})
+}

--- a/skills/chunk-sidecar/SKILL.md
+++ b/skills/chunk-sidecar/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: chunk-sidecar
-description: Use when the user says "validate on the sidecar", "run tests on the sidecar", "sync to sidecar", "sidecar dev loop", "check this on the sidecar", "validate remotely", or when you have made edits and want to verify them on a remote `chunk` sidecar instead of running locally. Also covers creating sidecars, snapshotting a configured environment, and customizing the sidecar image via `chunk sidecar`.
-version: 1.2.0
+description: Use when the user says "validate on the sidecar", "run tests on the sidecar", "sync to sidecar", "sidecar dev loop", "check this on the sidecar", "validate remotely", "scaffold test-suites.yml", "set up smarter testing", or "write .circleci/test-suites.yml", or when you have made edits and want to verify them on a remote `chunk` sidecar instead of running locally. Also covers creating sidecars, snapshotting a configured environment, customizing the sidecar image via `chunk sidecar`, and scaffolding `.circleci/test-suites.yml` for CircleCI Smarter Testing.
+version: 1.3.0
 allowed-tools:
   - Bash(chunk --version)
   - Bash(chunk auth status)
@@ -10,6 +10,8 @@ allowed-tools:
   - Bash(cat .chunk/config.json)
   - Bash(cat .chunk/sidecar.json)
   - Read
+  - Write
+  - Edit
   - Grep
   - Glob
 ---
@@ -80,6 +82,64 @@ When validate returns non-zero:
 - Map error paths back to local files: the sidecar mirrors your tree at `/workspace/<repo>` (or the workspace configured in `.chunk/sidecar.json`).
 - Fix locally, then repeat Step 4. Do **not** edit files over SSH — changes will be overwritten on the next sync.
 - If the error looks environmental (missing binary, wrong language version, unreachable service), go to Troubleshooting.
+
+## Scaffolding `.circleci/test-suites.yml`
+
+CircleCI Smarter Testing splits a project's test suite into **atoms** (independent units) and runs only the subset the platform picks for a given shard. The split is driven by `.circleci/test-suites.yml`. `chunk init` skips generating this file by default because the built-in templates only cover Go and pytest — for other stacks, write it directly.
+
+### When to scaffold
+
+- The user asks to "scaffold test-suites.yml", "set up smarter testing", or "write `.circleci/test-suites.yml`".
+- During the validate loop, you notice `.circleci/test-suites.yml` is missing and the project has a recognizable test runner.
+
+### File shape
+
+```yaml
+---
+name: <suite-name>
+discover: <shell command that prints one test atom per line>
+run: <shell command that runs the atoms in `<< test.atoms >>`, writing junit XML to `<< outputs.junit >>`>
+outputs:
+  junit: <path/to/junit.xml>
+```
+
+CircleCI substitutes at run time:
+- `<< test.atoms >>` — space-separated subset of atoms picked for this shard.
+- `<< outputs.junit >>` — the path declared under `outputs.junit`; the platform ingests this file to report results.
+
+### Choosing `discover` and `run`
+
+An atom is the smallest independent unit the runner accepts. Match the runner's natural sharding granularity:
+
+- **Go** — atoms are import paths.
+  ```yaml
+  discover: go list -f '{{ if or (len .TestGoFiles) (len .XTestGoFiles) }} {{ .ImportPath }} {{end}}' ./...
+  run: go tool gotestsum --junitfile="<< outputs.junit >>" -- -race << test.atoms >>
+  ```
+- **Python (pytest)** — atoms are node ids.
+  ```yaml
+  discover: python -m pytest --collect-only -q
+  run: python -m pytest --junit-xml=<< outputs.junit >> << test.atoms >>
+  ```
+- **Node (Jest)** — atoms are test file paths.
+  ```yaml
+  discover: npx jest --listTests
+  run: JEST_JUNIT_OUTPUT_FILE=<< outputs.junit >> npx jest --reporters=default --reporters=jest-junit << test.atoms >>
+  ```
+- **Other stacks** — keep the same pattern: `discover` prints one atom per line; `run` accepts whatever subset `discover` could output. Install a junit reporter if the runner does not emit junit natively.
+
+### Constraints
+
+- `discover` must be deterministic and exit non-zero on error — the platform calls it once per pipeline.
+- `run` must accept any subset of `discover`'s output, including a single atom and the full set. Verify locally with a hand-picked subset before committing.
+- `outputs.junit` must be a junit XML file the runner actually writes. The platform reads it to report pass/fail and timing.
+- `.circleci/test-suites.yml` is referenced from `.circleci/config.yml` via the Smarter Testing orb. After writing the suite, confirm the orb usage references the suite `name` you chose.
+
+### After writing
+
+1. Run `discover` locally — confirm it prints one atom per line on stdout and exits zero.
+2. Run `run` locally with `<< test.atoms >>` substituted by one or two atoms — confirm a junit XML file appears at the `outputs.junit` path.
+3. Read `.circleci/config.yml` and verify the Smarter Testing orb references the suite name.
 
 ## Parallel sessions
 


### PR DESCRIPTION
 - `chunk init` now writes a starter `.circleci/test-suites.yml` for the user, so they don't have to write it from scratch.
  - Picks the right template based on the project: `go.mod` → gotestsum, `pyproject.toml` → pytest. Other toolchains are skipped.
  - Creates the `.circleci/` directory if it doesn't exist. Never overwrites an existing `test-suites.yml`.
  - New `--skip-test-suites` flag to turn this off.
  
  ## Tests
  - [x] `go test -race ./internal/validate/ -run TestTestSuitesTemplate` passes
  - [x] `go test -race ./acceptance/ -run "TestInit.*TestSuites"` passes
  - [x] Manual: in a fresh Go repo with no `.circleci/`, run `chunk init` → `.circleci/test-suites.yml` is created
  - [x] Manual: re-run `chunk init` → existing file is preserved, "already exists" message shown
  - [x] Manual: `chunk init --skip-test-suites` → no file written
  - [ ] Manual: in a repo with neither `go.mod` nor `pyproject.toml` → no file written