### PR TITLE
Add chunk sidecar snapshot list command

### DIFF
--- a/acceptance/sidecar_snapshot_test.go
+++ b/acceptance/sidecar_snapshot_test.go
@@ -220,6 +220,7 @@ func TestSidecarSnapshotMissingToken(t *testing.T) {
 	}{
 		{"create", []string{"sidecar", "snapshot", "create", "--sidecar-id", "sb-111", "--name", "snap"}},
 		{"get", []string{"sidecar", "snapshot", "get", "snap-abc"}},
+		{"list", []string{"sidecar", "snapshot", "list", "--org-id", "org-abc"}},
 	}
 
 	for _, tt := range tests {
@@ -231,4 +232,43 @@ func TestSidecarSnapshotMissingToken(t *testing.T) {
 			assert.Assert(t, result.ExitCode != 0, "expected non-zero exit code without token")
 		})
 	}
+}
+
+func TestSidecarSnapshotListHappyPath(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.Snapshots = []fakes.Snapshot{
+		{ID: "snap-1", OrgID: "org-abc", Name: "baseline"},
+		{ID: "snap-2", OrgID: "org-abc", Name: "with-deps"},
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, []string{
+		"sidecar", "snapshot", "list", "--org-id", "org-abc",
+	}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stdout, "baseline"), "expected 'baseline' in output: %s", result.Stdout)
+	assert.Assert(t, strings.Contains(result.Stdout, "snap-1"), "expected 'snap-1' in output: %s", result.Stdout)
+	assert.Assert(t, strings.Contains(result.Stdout, "with-deps"), "expected 'with-deps' in output: %s", result.Stdout)
+	assert.Assert(t, strings.Contains(result.Stdout, "snap-2"), "expected 'snap-2' in output: %s", result.Stdout)
+}
+
+func TestSidecarSnapshotListEmpty(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, []string{
+		"sidecar", "snapshot", "list", "--org-id", "org-abc",
+	}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "No snapshots found"), "expected 'No snapshots found' in stderr: %s", result.Stderr)
 }

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -146,6 +146,18 @@ func (c *Client) GetSnapshot(ctx context.Context, id string) (*Snapshot, error) 
 	return &resp, nil
 }
 
+func (c *Client) ListSnapshots(ctx context.Context, orgID string) ([]Snapshot, error) {
+	var resp listSnapshotsResponse
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v2/sidecar/snapshots",
+		hc.QueryParam("org_id", orgID),
+		hc.JSONDecoder(&resp),
+	))
+	if err != nil {
+		return nil, mapErr("list snapshots", err)
+	}
+	return resp.Items, nil
+}
+
 func (c *Client) TriggerRun(ctx context.Context, orgID, projectID string, body TriggerRunRequest) (*RunResponse, error) {
 	var resp RunResponse
 	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodPost, "/api/v2/agents/org/%s/project/%s/runs",

--- a/internal/circleci/types.go
+++ b/internal/circleci/types.go
@@ -11,6 +11,10 @@ type listSidecarsResponse struct {
 	Items []Sidecar `json:"items"`
 }
 
+type listSnapshotsResponse struct {
+	Items []Snapshot `json:"items"`
+}
+
 type ExecRequest struct {
 	Command string   `json:"command"`
 	Args    []string `json:"args,omitempty"`

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -781,11 +781,17 @@ func newSidecarSnapshotListCmd() *cobra.Command {
 		Short: "List snapshots",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			insecureStorage := insecureStorageFlag(cmd)
+			rc, _ := config.Resolve("", "", insecureStorage)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
-			resolvedOrgID, err := resolveOrgID(orgID, orgPicker(cmd.Context(), client))
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("get working directory: %w", err)
+			}
+			resolvedOrgID, err := resolveOrgID(orgID, configOrgID(cwd), orgPicker(cmd.Context(), client))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -26,6 +26,8 @@ func randomSidecarName() string {
 	return petname.Generate(3, "-")
 }
 
+const cmdList = "list"
+
 func newSidecarCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                "sidecar",
@@ -135,7 +137,7 @@ func newSidecarListCmd() *cobra.Command {
 	var jsonOut bool
 
 	cmd := &cobra.Command{
-		Use:   "list",
+		Use:   cmdList,
 		Short: "List sidecars",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
@@ -675,6 +677,7 @@ func newSidecarSnapshotCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newSidecarSnapshotCreateCmd())
 	cmd.AddCommand(newSidecarSnapshotGetCmd())
+	cmd.AddCommand(newSidecarSnapshotListCmd())
 	return cmd
 }
 
@@ -764,6 +767,51 @@ func newSidecarSnapshotGetCmd() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+
+	return cmd
+}
+
+func newSidecarSnapshotListCmd() *cobra.Command {
+	var orgID string
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   cmdList,
+		Short: "List snapshots",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			io := iostream.FromCmd(cmd)
+			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			if err != nil {
+				return err
+			}
+			resolvedOrgID, err := resolveOrgID(orgID, orgPicker(cmd.Context(), client))
+			if err != nil {
+				return err
+			}
+			snapshots, err := client.ListSnapshots(cmd.Context(), resolvedOrgID)
+			if err != nil {
+				return &userError{
+					msg:        "Could not list snapshots.",
+					suggestion: suggestionNetworkRetry,
+					err:        err,
+				}
+			}
+			if jsonOut {
+				return iostream.PrintJSON(io.Out, snapshots)
+			}
+			if len(snapshots) == 0 {
+				io.ErrPrintln(ui.Dim("No snapshots found"))
+				return nil
+			}
+			for _, s := range snapshots {
+				io.Printf("%s  %s\n", s.Name, s.ID)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&orgID, "org-id", "", "Organization ID")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 
 	return cmd

--- a/internal/cmd/skills.go
+++ b/internal/cmd/skills.go
@@ -69,7 +69,7 @@ func newSkillListCmd() *cobra.Command {
 	var jsonOut bool
 
 	cmd := &cobra.Command{
-		Use:   "list",
+		Use:   cmdList,
 		Short: "List bundled skills and their per-agent installation status",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			home := os.Getenv(config.EnvHome)

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -77,6 +77,7 @@ type FakeCircleCI struct {
 	AddKeyStatusCode         int // override for POST /sidecar/instances/:id/ssh/add-key
 	CreateSnapshotStatusCode int // override for POST /sidecar/snapshots
 	GetSnapshotStatusCode    int // override for GET /sidecar/snapshots/:id
+	ListSnapshotsStatusCode  int // override for GET /sidecar/snapshots
 }
 
 func NewFakeCircleCI() *FakeCircleCI {
@@ -100,6 +101,7 @@ func NewFakeCircleCI() *FakeCircleCI {
 	r.POST("/api/v2/sidecar/instances/:id/exec", f.handleExec)
 
 	// Snapshot endpoints
+	r.GET("/api/v2/sidecar/snapshots", f.handleListSnapshots)
 	r.POST("/api/v2/sidecar/snapshots", f.handleCreateSnapshot)
 	r.GET("/api/v2/sidecar/snapshots/:id", f.handleGetSnapshot)
 
@@ -326,6 +328,29 @@ func (f *FakeCircleCI) handleGetSnapshot(c *gin.Context) {
 		}
 	}
 	c.JSON(http.StatusNotFound, gin.H{"message": "snapshot not found"})
+}
+
+func (f *FakeCircleCI) handleListSnapshots(c *gin.Context) {
+	if !f.requireToken(c) {
+		return
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if f.ListSnapshotsStatusCode != 0 {
+		c.JSON(f.ListSnapshotsStatusCode, gin.H{"message": "API error"})
+		return
+	}
+	orgID := c.Query("org_id")
+	var filtered []Snapshot
+	for _, s := range f.Snapshots {
+		if s.OrgID == orgID {
+			filtered = append(filtered, s)
+		}
+	}
+	if filtered == nil {
+		filtered = []Snapshot{}
+	}
+	c.JSON(http.StatusOK, gin.H{"items": filtered})
 }
 
 func (f *FakeCircleCI) handleTriggerRun(c *gin.Context) {


### PR DESCRIPTION
Adds `chunk sidecar snapshot list --org-id <id>` so users can see existing snapshots before creating new ones, avoiding 409 name-conflict errors.

## Changes
- `ListSnapshots` client method hitting `GET /api/v2/sidecar/snapshots`
- `chunk sidecar snapshot list` subcommand with `--org-id` and `--json` flags
- Fake handler + acceptance tests