### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,6 @@ Read these when working in the relevant area:
 - **Task** (go-task) is at `/usr/local/bin/task`. All build/test/lint/fmt commands use `task` — see "Common Commands" above.
 - **uv** is at `$HOME/.local/bin/uv`. It's only needed for the `task lint` pylint step (the `harness/` Python sub-project).
 - Go tool dependencies (`gotestsum`, `golangci-lint`, `gosimports`) are declared in `go.mod` under `tool (...)` and invoked via `go tool <name>` — no separate install needed.
-- `chunk validate` requires a `.chunk/config.json` with commands configured; it will hang in a bare repo without one. Use `task test` and `task lint` directly for CI-style checks.
+- `chunk validate` hangs in non-TTY shells (like Cloud Agent) because `detectHook` reads JSON from stdin when it's not a terminal. Always redirect stdin: `./dist/chunk validate < /dev/null`. Alternatively, use `task test` and `task lint` directly.
 - The `build-prompt` and `sidecar` commands require `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, and/or `CIRCLECI_TOKEN` env vars. Tests that need these keys skip gracefully when missing.
 - Acceptance tests that clone external repos are gated by `CHUNK_ENV_BUILDER_ACCEPTANCE=1`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,13 @@ Read these when working in the relevant area:
 - **Test isolation**: Each test creates its own temp directory and cleans up
 - **Race detector**: Always run tests with `-race`
 - Acceptance tests live in `acceptance/`
+
+## Cursor Cloud specific instructions
+
+- **Go 1.26** is installed at `/usr/local/go/bin/go`. Ensure `PATH` includes `/usr/local/go/bin:$HOME/go/bin:$HOME/.local/bin`.
+- **Task** (go-task) is at `/usr/local/bin/task`. All build/test/lint/fmt commands use `task` — see "Common Commands" above.
+- **uv** is at `$HOME/.local/bin/uv`. It's only needed for the `task lint` pylint step (the `harness/` Python sub-project).
+- Go tool dependencies (`gotestsum`, `golangci-lint`, `gosimports`) are declared in `go.mod` under `tool (...)` and invoked via `go tool <name>` — no separate install needed.
+- `chunk validate` requires a `.chunk/config.json` with commands configured; it will hang in a bare repo without one. Use `task test` and `task lint` directly for CI-style checks.
+- The `build-prompt` and `sidecar` commands require `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, and/or `CIRCLECI_TOKEN` env vars. Tests that need these keys skip gracefully when missing.
+- Acceptance tests that clone external repos are gated by `CHUNK_ENV_BUILDER_ACCEPTANCE=1`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,4 +51,3 @@ Read these when working in the relevant area:
 - Go tool dependencies (`gotestsum`, `golangci-lint`, `gosimports`) are declared in `go.mod` under `tool (...)` and invoked via `go tool <name>` — no separate install needed.
 - `chunk validate` hangs in non-TTY shells (like Cloud Agent) because `detectHook` reads JSON from stdin when it's not a terminal. Always redirect stdin: `./dist/chunk validate < /dev/null`. Alternatively, use `task test` and `task lint` directly.
 - The `build-prompt` and `sidecar` commands require `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, and/or `CIRCLECI_TOKEN` env vars. Tests that need these keys skip gracefully when missing.
-- Acceptance tests that clone external repos are gated by `CHUNK_ENV_BUILDER_ACCEPTANCE=1`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` so future Cloud Agents can work in this repo without rediscovering environment gotchas.

### What's added

- **Tool locations and PATH**: Go 1.26, Task, uv, and how Go tool dependencies (`gotestsum`, `golangci-lint`, `gosimports`) are managed via `go.mod` tool directives — no separate install needed.
- **`chunk validate` stdin hang**: `detectHook` in `internal/cmd/validate.go` reads a JSON hook payload from stdin when it's not a terminal. In non-TTY shells (Cloud Agent, CI, piped commands) this blocks forever. Workaround: redirect stdin with `< /dev/null`, or use `task test` / `task lint` directly.
- **API key requirements**: `build-prompt` and `sidecar` commands need `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, and/or `CIRCLECI_TOKEN`. Tests skip gracefully when these are missing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-889eb55c-730c-436b-b4b0-8c2b951a3973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-889eb55c-730c-436b-b4b0-8c2b951a3973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

