### PR TITLE
Auto-resolve orgID from .chunk/config.json in sidecar commands

### DIFF
--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -72,13 +72,20 @@ func resolveSidecarID(ctx context.Context, sidecarID *string) error {
 }
 
 // resolveOrgID returns orgID from the flag, the CIRCLECI_ORG_ID env var,
-// or by calling pickOrg as a last resort (e.g. to present a TUI picker).
-func resolveOrgID(orgID string, pickOrg func() (string, error)) (string, error) {
+// the orgID field in workDir/.chunk/config.json, or by calling pickOrg as a
+// last resort (e.g. to present a TUI picker). workDir may be empty to skip
+// the project-config lookup.
+func resolveOrgID(orgID, workDir string, pickOrg func() (string, error)) (string, error) {
 	if orgID != "" {
 		return orgID, nil
 	}
 	if envID := os.Getenv(config.EnvCircleCIOrgID); envID != "" {
 		return envID, nil
+	}
+	if workDir != "" {
+		if cfg, err := config.LoadProjectConfig(workDir); err == nil && cfg.OrgID != "" {
+			return cfg.OrgID, nil
+		}
 	}
 	return pickOrg()
 }
@@ -109,7 +116,11 @@ func orgPicker(ctx context.Context, client *circleci.Client) func() (string, err
 		}
 		idx, err := tui.SelectFromList("Select an organization:", labels)
 		if err != nil {
-			return "", &userError{msg: "Could not select an organization.", suggestion: "Pass --org-id instead.", err: err}
+			return "", &userError{
+				msg:        "Could not select an organization.",
+				suggestion: "Pass --org-id, set CIRCLECI_ORG_ID, or run 'chunk config set orgID <id>' so the project config carries it.",
+				err:        err,
+			}
 		}
 		return collabs[idx].ID, nil
 	}
@@ -129,7 +140,7 @@ func newSidecarListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			resolvedOrgID, err := resolveOrgID(orgID, orgPicker(cmd.Context(), client))
+			resolvedOrgID, err := resolveOrgID(orgID, ".", orgPicker(cmd.Context(), client))
 			if err != nil {
 				return err
 			}
@@ -192,7 +203,7 @@ func newSidecarCreateCmd() *cobra.Command {
 			if name == "" {
 				name = randomSidecarName()
 			}
-			resolvedOrgID, err := resolveOrgID(orgID, orgPicker(cmd.Context(), client))
+			resolvedOrgID, err := resolveOrgID(orgID, ".", orgPicker(cmd.Context(), client))
 			if err != nil {
 				return err
 			}
@@ -794,7 +805,7 @@ Example:
 			// Step 2: Resolve or create sidecar.
 			if sidecarID == "" {
 				var resolveErr error
-				sidecarID, _, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, name, status, streams)
+				sidecarID, _, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, dir, name, status, streams)
 				if resolveErr != nil {
 					return resolveErr
 				}
@@ -856,7 +867,7 @@ Example:
 func sidecarSetupResolveSidecar(
 	ctx context.Context,
 	client *circleci.Client,
-	orgID, name string,
+	orgID, workDir, name string,
 	status iostream.StatusFunc,
 	streams iostream.Streams,
 ) (id, displayName string, err error) {
@@ -871,7 +882,7 @@ func sidecarSetupResolveSidecar(
 	if name == "" {
 		name = randomSidecarName()
 	}
-	resolvedOrgID, err := resolveOrgID(orgID, orgPicker(ctx, client))
+	resolvedOrgID, err := resolveOrgID(orgID, workDir, orgPicker(ctx, client))
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/cmd/sidecar_test.go
+++ b/internal/cmd/sidecar_test.go
@@ -1,10 +1,15 @@
 package cmd
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
 )
 
 func TestSnapshotCreateNameTooLong(t *testing.T) {
@@ -33,4 +38,77 @@ func TestSnapshotCreateNameAtLimit(t *testing.T) {
 		assert.Assert(t, !strings.Contains(err.Error(), "255 characters or fewer"),
 			"unexpected length validation error for 255-char name: %v", err)
 	}
+}
+
+func TestResolveOrgID(t *testing.T) {
+	pickerErr := errors.New("picker should not be called")
+	failPicker := func() (string, error) { return "", pickerErr }
+	okPicker := func() (string, error) { return "picked-org", nil }
+
+	writeConfig := func(t *testing.T, dir, orgID string) {
+		t.Helper()
+		assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".chunk"), 0o755))
+		body := `{"orgID": "` + orgID + `"}`
+		assert.NilError(t, os.WriteFile(filepath.Join(dir, ".chunk", "config.json"), []byte(body), 0o644))
+	}
+
+	t.Run("flag wins over everything", func(t *testing.T) {
+		dir := t.TempDir()
+		writeConfig(t, dir, "config-org")
+		t.Setenv(config.EnvCircleCIOrgID, "env-org")
+		got, err := resolveOrgID("flag-org", dir, failPicker)
+		assert.NilError(t, err)
+		assert.Equal(t, got, "flag-org")
+	})
+
+	t.Run("env wins over config and picker", func(t *testing.T) {
+		dir := t.TempDir()
+		writeConfig(t, dir, "config-org")
+		t.Setenv(config.EnvCircleCIOrgID, "env-org")
+		got, err := resolveOrgID("", dir, failPicker)
+		assert.NilError(t, err)
+		assert.Equal(t, got, "env-org")
+	})
+
+	t.Run("config wins over picker", func(t *testing.T) {
+		dir := t.TempDir()
+		writeConfig(t, dir, "config-org")
+		t.Setenv(config.EnvCircleCIOrgID, "")
+		got, err := resolveOrgID("", dir, failPicker)
+		assert.NilError(t, err)
+		assert.Equal(t, got, "config-org")
+	})
+
+	t.Run("picker called when no other source", func(t *testing.T) {
+		dir := t.TempDir() // no config written
+		t.Setenv(config.EnvCircleCIOrgID, "")
+		got, err := resolveOrgID("", dir, okPicker)
+		assert.NilError(t, err)
+		assert.Equal(t, got, "picked-org")
+	})
+
+	t.Run("empty workDir skips config lookup", func(t *testing.T) {
+		t.Setenv(config.EnvCircleCIOrgID, "")
+		got, err := resolveOrgID("", "", okPicker)
+		assert.NilError(t, err)
+		assert.Equal(t, got, "picked-org")
+	})
+
+	t.Run("missing config falls through to picker", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv(config.EnvCircleCIOrgID, "")
+		got, err := resolveOrgID("", dir, okPicker)
+		assert.NilError(t, err)
+		assert.Equal(t, got, "picked-org")
+	})
+
+	t.Run("config without orgID falls through to picker", func(t *testing.T) {
+		dir := t.TempDir()
+		assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".chunk"), 0o755))
+		assert.NilError(t, os.WriteFile(filepath.Join(dir, ".chunk", "config.json"), []byte(`{}`), 0o644))
+		t.Setenv(config.EnvCircleCIOrgID, "")
+		got, err := resolveOrgID("", dir, okPicker)
+		assert.NilError(t, err)
+		assert.Equal(t, got, "picked-org")
+	})
 }

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -548,13 +548,7 @@ func resolveOrCreateSidecarID(ctx context.Context, sidecarID *string, orgID, ima
 	if err != nil {
 		return false, err
 	}
-	// Fallback: read org ID from project config if not provided via flag or env.
-	if orgID == "" {
-		if projCfg, cfgErr := config.LoadProjectConfig(workDir); cfgErr == nil && projCfg.OrgID != "" {
-			orgID = projCfg.OrgID
-		}
-	}
-	resolvedOrgID, err := resolveOrgID(orgID, orgPicker(ctx, client))
+	resolvedOrgID, err := resolveOrgID(orgID, workDir, orgPicker(ctx, client))
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
- `resolveOrgID` now reads the project configs orgID field between the -`-org-id` flag, `CIRCLECI_ORG_ID` env var, and the tui org picker. This removes the 'Could not select an organization prompt on `chunk sidecar list/create/setup` in non-tty sessions when the project has already run `chunk config set orgID <id>
`- plumbs the working directory through sidecarSetupResolvesSidecar so `chunk sidecar setup --dir <dir>` honors the project config it just detected. 
- expanded the picker's failure suggestion too point at all three escape places (-`-org-id`, `CIRCLECI_ORG_ID`, `chunk config set orgID`.