### PR TITLE
Store credentials in system keychain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/sethvargo/go-envconfig v1.3.0
 	github.com/spf13/cobra v1.10.2
+	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.51.0
 	golang.org/x/term v0.43.0
 	gotest.tools/v3 v3.5.2
@@ -242,7 +243,6 @@ require (
 	github.com/yagipy/maintidx v1.0.0 // indirect
 	github.com/yeya24/promlinter v0.3.0 // indirect
 	github.com/ykadowak/zerologlint v0.1.5 // indirect
-	github.com/zalando/go-keyring v0.2.8 // indirect
 	gitlab.com/bosi/decorder v0.4.2 // indirect
 	go-simpler.org/musttag v0.14.0 // indirect
 	go-simpler.org/sloglint v0.12.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/curioswitch/go-reassign v0.3.0 // indirect
 	github.com/daixiang0/gci v0.13.7 // indirect
+	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/dave/dst v0.27.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
@@ -113,6 +114,7 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/godoc-lint/godoc-lint v0.11.2 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
@@ -240,6 +242,7 @@ require (
 	github.com/yagipy/maintidx v1.0.0 // indirect
 	github.com/yeya24/promlinter v0.3.0 // indirect
 	github.com/ykadowak/zerologlint v0.1.5 // indirect
+	github.com/zalando/go-keyring v0.2.8 // indirect
 	gitlab.com/bosi/decorder v0.4.2 // indirect
 	go-simpler.org/musttag v0.14.0 // indirect
 	go-simpler.org/sloglint v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ github.com/curioswitch/go-reassign v0.3.0 h1:dh3kpQHuADL3cobV/sSGETA8DOv457dwl+f
 github.com/curioswitch/go-reassign v0.3.0/go.mod h1:nApPCCTtqLJN/s8HfItCcKV0jIPwluBOvZP+dsJGA88=
 github.com/daixiang0/gci v0.13.7 h1:+0bG5eK9vlI08J+J/NWGbWPTNiXPG4WhNLJOkSxWITQ=
 github.com/daixiang0/gci v0.13.7/go.mod h1:812WVN6JLFY9S6Tv76twqmNqevN0pa3SX3nih0brVzQ=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/dave/dst v0.27.3 h1:P1HPoMza3cMEquVf9kKy8yXsFirry4zEnWOdYPOoIzY=
 github.com/dave/dst v0.27.3/go.mod h1:jHh6EOibnHgcUW3WjKHisiooEkYwqpHLBSX1iOBhEyc=
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=
@@ -277,6 +279,8 @@ github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
 github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/godoc-lint/godoc-lint v0.11.2 h1:Bp0FkJWoSdNsBikdNgIcgtaoo+xz6I/Y9s5WSBQUeeM=
 github.com/godoc-lint/godoc-lint v0.11.2/go.mod h1:iVpGdL1JCikNH2gGeAn3Hh+AgN5Gx/I/cxV+91L41jo=
 github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
@@ -689,6 +693,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 gitlab.com/bosi/decorder v0.4.2 h1:qbQaV3zgwnBZ4zPMhGLW4KZe7A7NwxEhJx39R3shffo=
 gitlab.com/bosi/decorder v0.4.2/go.mod h1:muuhHoaJkA9QLcYHq4Mj8FJUwDZ+EirSHRiaTcTf6T8=
 go-simpler.org/assert v0.9.0 h1:PfpmcSvL7yAnWyChSjOz6Sp6m9j5lyK8Ok9pEL31YkQ=

--- a/internal/authprompt/authprompt.go
+++ b/internal/authprompt/authprompt.go
@@ -11,6 +11,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/github"
 	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	"github.com/CircleCI-Public/chunk-cli/internal/keyring"
 	"github.com/CircleCI-Public/chunk-cli/internal/version"
 )
 
@@ -114,8 +115,12 @@ func ResolveGitHubClient(rc config.ResolvedConfig, logStatus func(string)) (*git
 	})
 }
 
-// SaveCircleCIToken persists a CircleCI token to the config file.
-func SaveCircleCIToken(token string) error {
+// SaveCircleCIToken persists a CircleCI token. When secureStorage is true it uses
+// the system keychain; when false it falls back to the config file.
+func SaveCircleCIToken(token, baseURL string, secureStorage bool) error {
+	if secureStorage {
+		return keyring.Set(keyring.ServiceCircleCI(baseURL), token)
+	}
 	cfg, err := config.Load()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
@@ -127,8 +132,12 @@ func SaveCircleCIToken(token string) error {
 	return nil
 }
 
-// SaveAnthropicKey persists an Anthropic API key to the config file.
-func SaveAnthropicKey(key string) error {
+// SaveAnthropicKey persists an Anthropic API key. When secureStorage is true it uses
+// the system keychain; when false it falls back to the config file.
+func SaveAnthropicKey(key, baseURL string, secureStorage bool) error {
+	if secureStorage {
+		return keyring.Set(keyring.ServiceAnthropic(baseURL), key)
+	}
 	cfg, err := config.Load()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
@@ -140,8 +149,12 @@ func SaveAnthropicKey(key string) error {
 	return nil
 }
 
-// SaveGitHubToken persists a GitHub token to the config file.
-func SaveGitHubToken(token string) error {
+// SaveGitHubToken persists a GitHub token. When secureStorage is true it uses
+// the system keychain; when false it falls back to the config file.
+func SaveGitHubToken(token, baseURL string, secureStorage bool) error {
+	if secureStorage {
+		return keyring.Set(keyring.ServiceGitHub(baseURL), token)
+	}
 	cfg, err := config.Load()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)

--- a/internal/authprompt/authprompt.go
+++ b/internal/authprompt/authprompt.go
@@ -115,10 +115,10 @@ func ResolveGitHubClient(rc config.ResolvedConfig, logStatus func(string)) (*git
 	})
 }
 
-// SaveCircleCIToken persists a CircleCI token. When secureStorage is true it uses
-// the system keychain; when false it falls back to the config file.
-func SaveCircleCIToken(token, baseURL string, secureStorage bool) error {
-	if secureStorage {
+// SaveCircleCIToken persists a CircleCI token. When insecureStorage is false it uses
+// the system keychain; when true it falls back to the config file.
+func SaveCircleCIToken(token, baseURL string, insecureStorage bool) error {
+	if !insecureStorage {
 		return keyring.Set(keyring.ServiceCircleCI(baseURL), token)
 	}
 	cfg, err := config.Load()
@@ -132,10 +132,10 @@ func SaveCircleCIToken(token, baseURL string, secureStorage bool) error {
 	return nil
 }
 
-// SaveAnthropicKey persists an Anthropic API key. When secureStorage is true it uses
-// the system keychain; when false it falls back to the config file.
-func SaveAnthropicKey(key, baseURL string, secureStorage bool) error {
-	if secureStorage {
+// SaveAnthropicKey persists an Anthropic API key. When insecureStorage is false it uses
+// the system keychain; when true it falls back to the config file.
+func SaveAnthropicKey(key, baseURL string, insecureStorage bool) error {
+	if !insecureStorage {
 		return keyring.Set(keyring.ServiceAnthropic(baseURL), key)
 	}
 	cfg, err := config.Load()
@@ -149,10 +149,10 @@ func SaveAnthropicKey(key, baseURL string, secureStorage bool) error {
 	return nil
 }
 
-// SaveGitHubToken persists a GitHub token. When secureStorage is true it uses
-// the system keychain; when false it falls back to the config file.
-func SaveGitHubToken(token, baseURL string, secureStorage bool) error {
-	if secureStorage {
+// SaveGitHubToken persists a GitHub token. When insecureStorage is false it uses
+// the system keychain; when true it falls back to the config file.
+func SaveGitHubToken(token, baseURL string, insecureStorage bool) error {
+	if !insecureStorage {
 		return keyring.Set(keyring.ServiceGitHub(baseURL), token)
 	}
 	cfg, err := config.Load()

--- a/internal/authprompt/authprompt_test.go
+++ b/internal/authprompt/authprompt_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 )
 
+const insecureStorage = true // skip keychain in unit tests; use config file only
+
 func isolateConfig(t *testing.T) {
 	t.Helper()
 	home := t.TempDir()
@@ -66,7 +68,7 @@ func TestResolveCircleCIClient_TokenInEnv(t *testing.T) {
 	t.Setenv(config.EnvCircleToken, randToken("cci-"))
 	t.Setenv(config.EnvCircleCIBaseURL, srv.URL)
 
-	rc, _ := config.Resolve("", "", false)
+	rc, _ := config.Resolve("", "", insecureStorage)
 	client, err := authprompt.ResolveCircleCIClient(rc)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
@@ -88,7 +90,7 @@ func TestResolveCircleCIClient_TokenInConfig(t *testing.T) {
 	cfg.CircleCIToken = randToken("cci-")
 	assert.NilError(t, config.Save(cfg))
 
-	rc, _ := config.Resolve("", "", false)
+	rc, _ := config.Resolve("", "", insecureStorage)
 	client, err := authprompt.ResolveCircleCIClient(rc)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
@@ -99,7 +101,7 @@ func TestResolveCircleCIClient_NeedsAuth(t *testing.T) {
 	t.Setenv(config.EnvCircleToken, "")
 	t.Setenv(config.EnvCircleCIToken, "")
 
-	rc, _ := config.Resolve("", "", false)
+	rc, _ := config.Resolve("", "", insecureStorage)
 	_, err := authprompt.ResolveCircleCIClient(rc)
 	assert.Assert(t, errors.Is(err, authprompt.ErrNeedsAuth))
 }
@@ -114,7 +116,7 @@ func TestResolveAnthropicClient_KeyInEnv(t *testing.T) {
 	t.Setenv(config.EnvAnthropicAPIKey, randToken("sk-ant-"))
 	t.Setenv(config.EnvAnthropicBaseURL, srv.URL)
 
-	rc, _ := config.Resolve("", "", false)
+	rc, _ := config.Resolve("", "", insecureStorage)
 	client, err := authprompt.ResolveAnthropicClient(rc)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
@@ -135,7 +137,7 @@ func TestResolveAnthropicClient_KeyInConfig(t *testing.T) {
 	cfg.AnthropicAPIKey = randToken("sk-ant-")
 	assert.NilError(t, config.Save(cfg))
 
-	rc, _ := config.Resolve("", "", false)
+	rc, _ := config.Resolve("", "", insecureStorage)
 	client, err := authprompt.ResolveAnthropicClient(rc)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
@@ -145,7 +147,7 @@ func TestResolveAnthropicClient_NeedsAuth(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv(config.EnvAnthropicAPIKey, "")
 
-	rc, _ := config.Resolve("", "", false)
+	rc, _ := config.Resolve("", "", insecureStorage)
 	_, err := authprompt.ResolveAnthropicClient(rc)
 	assert.Assert(t, errors.Is(err, authprompt.ErrNeedsAuth))
 }
@@ -160,7 +162,7 @@ func TestResolveGitHubClient_TokenInEnv(t *testing.T) {
 	t.Setenv(config.EnvGitHubToken, randToken("ghp_"))
 	t.Setenv(config.EnvGitHubAPIURL, srv.URL)
 
-	rc, _ := config.Resolve("", "", false)
+	rc, _ := config.Resolve("", "", insecureStorage)
 	client, err := authprompt.ResolveGitHubClient(rc, nil)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
@@ -181,7 +183,7 @@ func TestResolveGitHubClient_TokenInConfig(t *testing.T) {
 	cfg.GitHubToken = randToken("ghp_")
 	assert.NilError(t, config.Save(cfg))
 
-	rc, _ := config.Resolve("", "", false)
+	rc, _ := config.Resolve("", "", insecureStorage)
 	client, err := authprompt.ResolveGitHubClient(rc, nil)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
@@ -191,7 +193,7 @@ func TestResolveGitHubClient_NeedsAuth(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv(config.EnvGitHubToken, "")
 
-	rc, _ := config.Resolve("", "", false)
+	rc, _ := config.Resolve("", "", insecureStorage)
 	_, err := authprompt.ResolveGitHubClient(rc, nil)
 	assert.Assert(t, errors.Is(err, authprompt.ErrNeedsAuth))
 }
@@ -200,7 +202,7 @@ func TestSaveCircleCIToken(t *testing.T) {
 	isolateConfig(t)
 
 	token := randToken("cci-")
-	err := authprompt.SaveCircleCIToken(token, "https://circleci.com", false)
+	err := authprompt.SaveCircleCIToken(token, "https://circleci.com", true)
 	assert.NilError(t, err)
 
 	cfg, err := config.Load()
@@ -212,7 +214,7 @@ func TestSaveAnthropicKey(t *testing.T) {
 	isolateConfig(t)
 
 	key := randToken("sk-ant-")
-	err := authprompt.SaveAnthropicKey(key, "https://api.anthropic.com", false)
+	err := authprompt.SaveAnthropicKey(key, "https://api.anthropic.com", true)
 	assert.NilError(t, err)
 
 	cfg, err := config.Load()
@@ -224,7 +226,7 @@ func TestSaveGitHubToken(t *testing.T) {
 	isolateConfig(t)
 
 	token := randToken("ghp_")
-	err := authprompt.SaveGitHubToken(token, "https://api.github.com", false)
+	err := authprompt.SaveGitHubToken(token, "https://api.github.com", true)
 	assert.NilError(t, err)
 
 	cfg, err := config.Load()

--- a/internal/authprompt/authprompt_test.go
+++ b/internal/authprompt/authprompt_test.go
@@ -66,7 +66,7 @@ func TestResolveCircleCIClient_TokenInEnv(t *testing.T) {
 	t.Setenv(config.EnvCircleToken, randToken("cci-"))
 	t.Setenv(config.EnvCircleCIBaseURL, srv.URL)
 
-	rc, _ := config.Resolve("", "")
+	rc, _ := config.Resolve("", "", false)
 	client, err := authprompt.ResolveCircleCIClient(rc)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
@@ -88,7 +88,7 @@ func TestResolveCircleCIClient_TokenInConfig(t *testing.T) {
 	cfg.CircleCIToken = randToken("cci-")
 	assert.NilError(t, config.Save(cfg))
 
-	rc, _ := config.Resolve("", "")
+	rc, _ := config.Resolve("", "", false)
 	client, err := authprompt.ResolveCircleCIClient(rc)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
@@ -99,7 +99,7 @@ func TestResolveCircleCIClient_NeedsAuth(t *testing.T) {
 	t.Setenv(config.EnvCircleToken, "")
 	t.Setenv(config.EnvCircleCIToken, "")
 
-	rc, _ := config.Resolve("", "")
+	rc, _ := config.Resolve("", "", false)
 	_, err := authprompt.ResolveCircleCIClient(rc)
 	assert.Assert(t, errors.Is(err, authprompt.ErrNeedsAuth))
 }
@@ -114,7 +114,7 @@ func TestResolveAnthropicClient_KeyInEnv(t *testing.T) {
 	t.Setenv(config.EnvAnthropicAPIKey, randToken("sk-ant-"))
 	t.Setenv(config.EnvAnthropicBaseURL, srv.URL)
 
-	rc, _ := config.Resolve("", "")
+	rc, _ := config.Resolve("", "", false)
 	client, err := authprompt.ResolveAnthropicClient(rc)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
@@ -135,7 +135,7 @@ func TestResolveAnthropicClient_KeyInConfig(t *testing.T) {
 	cfg.AnthropicAPIKey = randToken("sk-ant-")
 	assert.NilError(t, config.Save(cfg))
 
-	rc, _ := config.Resolve("", "")
+	rc, _ := config.Resolve("", "", false)
 	client, err := authprompt.ResolveAnthropicClient(rc)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
@@ -145,7 +145,7 @@ func TestResolveAnthropicClient_NeedsAuth(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv(config.EnvAnthropicAPIKey, "")
 
-	rc, _ := config.Resolve("", "")
+	rc, _ := config.Resolve("", "", false)
 	_, err := authprompt.ResolveAnthropicClient(rc)
 	assert.Assert(t, errors.Is(err, authprompt.ErrNeedsAuth))
 }
@@ -160,7 +160,7 @@ func TestResolveGitHubClient_TokenInEnv(t *testing.T) {
 	t.Setenv(config.EnvGitHubToken, randToken("ghp_"))
 	t.Setenv(config.EnvGitHubAPIURL, srv.URL)
 
-	rc, _ := config.Resolve("", "")
+	rc, _ := config.Resolve("", "", false)
 	client, err := authprompt.ResolveGitHubClient(rc, nil)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
@@ -181,7 +181,7 @@ func TestResolveGitHubClient_TokenInConfig(t *testing.T) {
 	cfg.GitHubToken = randToken("ghp_")
 	assert.NilError(t, config.Save(cfg))
 
-	rc, _ := config.Resolve("", "")
+	rc, _ := config.Resolve("", "", false)
 	client, err := authprompt.ResolveGitHubClient(rc, nil)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
@@ -191,7 +191,7 @@ func TestResolveGitHubClient_NeedsAuth(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv(config.EnvGitHubToken, "")
 
-	rc, _ := config.Resolve("", "")
+	rc, _ := config.Resolve("", "", false)
 	_, err := authprompt.ResolveGitHubClient(rc, nil)
 	assert.Assert(t, errors.Is(err, authprompt.ErrNeedsAuth))
 }
@@ -200,7 +200,7 @@ func TestSaveCircleCIToken(t *testing.T) {
 	isolateConfig(t)
 
 	token := randToken("cci-")
-	err := authprompt.SaveCircleCIToken(token)
+	err := authprompt.SaveCircleCIToken(token, "https://circleci.com", false)
 	assert.NilError(t, err)
 
 	cfg, err := config.Load()
@@ -212,7 +212,7 @@ func TestSaveAnthropicKey(t *testing.T) {
 	isolateConfig(t)
 
 	key := randToken("sk-ant-")
-	err := authprompt.SaveAnthropicKey(key)
+	err := authprompt.SaveAnthropicKey(key, "https://api.anthropic.com", false)
 	assert.NilError(t, err)
 
 	cfg, err := config.Load()
@@ -224,7 +224,7 @@ func TestSaveGitHubToken(t *testing.T) {
 	isolateConfig(t)
 
 	token := randToken("ghp_")
-	err := authprompt.SaveGitHubToken(token)
+	err := authprompt.SaveGitHubToken(token, "https://api.github.com", false)
 	assert.NilError(t, err)
 
 	cfg, err := config.Load()

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -11,6 +11,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/authprompt"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/keyring"
 	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
@@ -42,19 +43,20 @@ func newAuthSetCmd() *cobra.Command {
 		Args:      cobra.ExactArgs(1),
 		ValidArgs: []string{"circleci", "anthropic", "github"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			rc, _ := config.Resolve("", "")
+			insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
+			rc, _ := config.Resolve("", "", !insecureStorage)
 			provider := args[0]
 			io := iostream.FromCmd(cmd)
 			switch provider {
 			case providerCircleCI:
 				envSet := strings.HasPrefix(rc.CircleCITokenSource, "Environment")
-				return authSetCircleCI(cmd.Context(), io, rc.CircleCIBaseURL, envSet, force)
+				return authSetCircleCI(cmd.Context(), io, rc.CircleCIBaseURL, envSet, force, insecureStorage)
 			case providerAnthropic:
 				envSet := strings.HasPrefix(rc.AnthropicAPIKeySource, "Environment")
-				return authSetAnthropic(cmd.Context(), io, rc.AnthropicBaseURL, envSet, force)
+				return authSetAnthropic(cmd.Context(), io, rc.AnthropicBaseURL, envSet, force, insecureStorage)
 			case providerGitHub:
 				envSet := strings.HasPrefix(rc.GitHubTokenSource, "Environment")
-				return authSetGitHub(cmd.Context(), io, rc.GitHubAPIURL, envSet, force)
+				return authSetGitHub(cmd.Context(), io, rc.GitHubAPIURL, envSet, force, insecureStorage)
 			default:
 				return &userError{
 					msg:    fmt.Sprintf("Unknown provider %q.", provider),
@@ -68,12 +70,12 @@ func newAuthSetCmd() *cobra.Command {
 	return cmd
 }
 
-func authSetCircleCI(ctx context.Context, io iostream.Streams, baseURL string, envSet, force bool) error {
+func authSetCircleCI(ctx context.Context, io iostream.Streams, baseURL string, envSet, force, insecureStorage bool) error {
 	io.Println("")
 	io.Println(ui.Bold("Chunk CLI - CircleCI Token Setup"))
 	io.Println("")
 	io.Println("Create a CircleCI token at https://app.circleci.com/settings/user/tokens")
-	printSaveHint(io, "Token")
+	printSaveHint(io, "Token", insecureStorage)
 	io.Println("")
 
 	if envSet {
@@ -124,15 +126,15 @@ func authSetCircleCI(ctx context.Context, io iostream.Streams, baseURL string, e
 		}
 	}
 
-	return saveCircleCIToken(ctx, token, io, baseURL)
+	return saveCircleCIToken(ctx, token, io, baseURL, insecureStorage)
 }
 
-func authSetAnthropic(ctx context.Context, io iostream.Streams, baseURL string, envSet, force bool) error {
+func authSetAnthropic(ctx context.Context, io iostream.Streams, baseURL string, envSet, force, insecureStorage bool) error {
 	io.Println("")
 	io.Println(ui.Bold("Chunk CLI - Anthropic API Key Setup"))
 	io.Println("")
 	io.Println("Enter your Anthropic API key (starts with sk-ant-).")
-	printSaveHint(io, "Key")
+	printSaveHint(io, "Key", insecureStorage)
 	io.Println("")
 	if envSet {
 		io.Println(ui.Warning("An Anthropic API key is set in environment variables (" + config.EnvAnthropicAPIKey + ")."))
@@ -200,22 +202,17 @@ func authSetAnthropic(ctx context.Context, io iostream.Streams, baseURL string, 
 		}
 	}
 
-	cfg, err = config.Load()
-	if err != nil {
-		return &userError{msg: msgCouldNotLoadConfig, suggestion: configFilePermHint, err: err}
-	}
-	cfg.AnthropicAPIKey = key
-	if err := config.Save(cfg); err != nil {
+	if err := authprompt.SaveAnthropicKey(key, baseURL, !insecureStorage); err != nil {
 		return &userError{msg: "Could not save credentials.", suggestion: configFilePermHint, err: err}
 	}
 
 	io.Println("")
-	printSaved(io, "Anthropic API key")
+	printSaved(io, "Anthropic API key", insecureStorage)
 	io.Println(ui.Dim("You can now run code reviews with: chunk build-prompt"))
 	return nil
 }
 
-func saveCircleCIToken(ctx context.Context, token string, streams iostream.Streams, circleCIBaseURL string) error {
+func saveCircleCIToken(ctx context.Context, token string, streams iostream.Streams, circleCIBaseURL string, insecureStorage bool) error {
 	streams.ErrPrintln(ui.Dim("Validating CircleCI token..."))
 	if err := authprompt.ValidateCircleCIToken(ctx, token, circleCIBaseURL); err != nil {
 		return &userError{
@@ -225,12 +222,7 @@ func saveCircleCIToken(ctx context.Context, token string, streams iostream.Strea
 		}
 	}
 
-	cfg, err := config.Load()
-	if err != nil {
-		return &userError{msg: msgCouldNotLoadConfig, suggestion: configFilePermHint, err: err}
-	}
-	cfg.CircleCIToken = token
-	if err := config.Save(cfg); err != nil {
+	if err := authprompt.SaveCircleCIToken(token, circleCIBaseURL, !insecureStorage); err != nil {
 		return &userError{
 			msg:        "Failed to save CircleCI token.",
 			suggestion: "Check that your config file is writable.",
@@ -239,7 +231,7 @@ func saveCircleCIToken(ctx context.Context, token string, streams iostream.Strea
 	}
 
 	streams.ErrPrintln("")
-	printSaved(streams, "CircleCI token")
+	printSaved(streams, "CircleCI token", insecureStorage)
 	return nil
 }
 
@@ -254,7 +246,8 @@ func newAuthStatusCmd() *cobra.Command {
 			io.Println(ui.Bold("Chunk CLI - Authentication Status"))
 			io.Println("")
 
-			rc, resolveErr := config.Resolve("", "")
+			insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
+			rc, resolveErr := config.Resolve("", "", !insecureStorage)
 			if resolveErr != nil {
 				io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", resolveErr)))
 			}
@@ -341,19 +334,20 @@ func newAuthRemoveCmd() *cobra.Command {
 		Args:      cobra.ExactArgs(1),
 		ValidArgs: []string{"circleci", "anthropic", "github"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			rc, _ := config.Resolve("", "")
+			insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
+			rc, _ := config.Resolve("", "", !insecureStorage)
 			provider := args[0]
 			io := iostream.FromCmd(cmd)
 			switch provider {
 			case providerCircleCI:
 				envSet := strings.HasPrefix(rc.CircleCITokenSource, "Environment")
-				return authRemoveCircleCI(io, envSet, force)
+				return authRemoveCircleCI(io, envSet, force, insecureStorage)
 			case providerAnthropic:
 				envSet := strings.HasPrefix(rc.AnthropicAPIKeySource, "Environment")
-				return authRemoveAnthropic(io, envSet, force)
+				return authRemoveAnthropic(io, envSet, force, insecureStorage)
 			case providerGitHub:
 				envSet := strings.HasPrefix(rc.GitHubTokenSource, "Environment")
-				return authRemoveGitHub(io, envSet, force)
+				return authRemoveGitHub(io, envSet, force, insecureStorage)
 			default:
 				return &userError{
 					msg:    fmt.Sprintf("Unknown provider %q.", provider),
@@ -367,13 +361,39 @@ func newAuthRemoveCmd() *cobra.Command {
 	return cmd
 }
 
-func authRemoveCircleCI(io iostream.Streams, envSet, force bool) error {
-	cfg, err := config.Load()
-	if err != nil {
-		return &userError{msg: msgCouldNotLoadConfig, suggestion: configFilePermHint, err: err}
+func hasStoredCircleCIToken(secureStorage bool, baseURL string) bool {
+	if secureStorage {
+		_, err := keyring.Get(keyring.ServiceCircleCI(baseURL))
+		return err == nil
 	}
-	if cfg.CircleCIToken == "" {
-		io.Println(ui.Warning("No CircleCI token stored in config file."))
+	cfg, _ := config.Load()
+	return cfg.CircleCIToken != ""
+}
+
+func hasStoredAnthropicKey(secureStorage bool, baseURL string) bool {
+	if secureStorage {
+		_, err := keyring.Get(keyring.ServiceAnthropic(baseURL))
+		return err == nil
+	}
+	cfg, _ := config.Load()
+	return cfg.AnthropicAPIKey != ""
+}
+
+func hasStoredGitHubToken(secureStorage bool, baseURL string) bool {
+	if secureStorage {
+		_, err := keyring.Get(keyring.ServiceGitHub(baseURL))
+		return err == nil
+	}
+	cfg, _ := config.Load()
+	return cfg.GitHubToken != ""
+}
+
+func authRemoveCircleCI(io iostream.Streams, envSet, force, insecureStorage bool) error {
+	secureStorage := !insecureStorage
+	rc, _ := config.Resolve("", "", secureStorage)
+	hasStored := hasStoredCircleCIToken(secureStorage, rc.CircleCIBaseURL)
+	if !hasStored {
+		io.Println(ui.Warning("No CircleCI token stored."))
 		if envSet {
 			io.Println("Note: A CircleCI token is set in environment variables.")
 			io.Println("To remove it, unset the environment variable.")
@@ -383,11 +403,15 @@ func authRemoveCircleCI(io iostream.Streams, envSet, force bool) error {
 	}
 
 	io.Println("")
-	cfgPath, err := config.Path()
-	if err != nil {
-		return &userError{msg: msgCouldNotAccessConfig, err: err}
+	if secureStorage {
+		io.Println("This will remove your stored CircleCI token from the system keychain.")
+	} else {
+		cfgPath, err := config.Path()
+		if err != nil {
+			return &userError{msg: msgCouldNotAccessConfig, err: err}
+		}
+		io.Printf("This will remove your stored CircleCI token from %s\n", cfgPath)
 	}
-	io.Printf("This will remove your stored CircleCI token from %s\n", cfgPath)
 	if !force {
 		if nonInteractive() {
 			return errNoForce("remove CircleCI token")
@@ -404,16 +428,13 @@ func authRemoveCircleCI(io iostream.Streams, envSet, force bool) error {
 		}
 	}
 
-	if err := config.Clear("circleCIToken"); err != nil {
-		hint := configFilePermHint
-		if errPath, pathErr := config.Path(); pathErr == nil {
-			hint = fmt.Sprintf("Check file permissions on %s.", errPath)
+	if secureStorage {
+		if err := keyring.Delete(keyring.ServiceCircleCI(rc.CircleCIBaseURL)); err != nil {
+			return &userError{msg: "Failed to remove CircleCI token from keychain.", err: err}
 		}
-		return &userError{
-			msg:        "Failed to remove CircleCI token.",
-			detail:     "An error occurred while trying to remove the token from the config file.",
-			suggestion: hint,
-			err:        err,
+	} else {
+		if err := config.Clear("circleCIToken"); err != nil {
+			return &userError{msg: "Failed to remove CircleCI token.", err: err}
 		}
 	}
 
@@ -424,13 +445,12 @@ func authRemoveCircleCI(io iostream.Streams, envSet, force bool) error {
 	return nil
 }
 
-func authRemoveAnthropic(io iostream.Streams, envSet, force bool) error {
-	cfg, err := config.Load()
-	if err != nil {
-		return &userError{msg: msgCouldNotLoadConfig, suggestion: configFilePermHint, err: err}
-	}
-	if cfg.AnthropicAPIKey == "" {
-		io.Println(ui.Warning("No API key stored in config file."))
+func authRemoveAnthropic(io iostream.Streams, envSet, force, insecureStorage bool) error {
+	secureStorage := !insecureStorage
+	rc, _ := config.Resolve("", "", secureStorage)
+	hasStored := hasStoredAnthropicKey(secureStorage, rc.AnthropicBaseURL)
+	if !hasStored {
+		io.Println(ui.Warning("No API key stored."))
 		if envSet {
 			io.Println("Note: " + config.EnvAnthropicAPIKey + " is set in your environment variables.")
 			io.Println("To remove it, unset the environment variable.")
@@ -440,11 +460,15 @@ func authRemoveAnthropic(io iostream.Streams, envSet, force bool) error {
 	}
 
 	io.Println("")
-	cfgPath, err := config.Path()
-	if err != nil {
-		return &userError{msg: msgCouldNotAccessConfig, err: err}
+	if secureStorage {
+		io.Println("This will remove your stored Anthropic API key from the system keychain.")
+	} else {
+		cfgPath, err := config.Path()
+		if err != nil {
+			return &userError{msg: msgCouldNotAccessConfig, err: err}
+		}
+		io.Printf("This will remove your stored API key from %s\n", cfgPath)
 	}
-	io.Printf("This will remove your stored API key from %s\n", cfgPath)
 	if !force {
 		if nonInteractive() {
 			return errNoForce("remove Anthropic API key")
@@ -461,16 +485,13 @@ func authRemoveAnthropic(io iostream.Streams, envSet, force bool) error {
 		}
 	}
 
-	if err := config.Clear("anthropicAPIKey"); err != nil {
-		hint := configFilePermHint
-		if errPath, pathErr := config.Path(); pathErr == nil {
-			hint = fmt.Sprintf("Check file permissions on %s.", errPath)
+	if secureStorage {
+		if err := keyring.Delete(keyring.ServiceAnthropic(rc.AnthropicBaseURL)); err != nil {
+			return &userError{msg: "Failed to remove Anthropic API key from keychain.", err: err}
 		}
-		return &userError{
-			msg:        "Failed to remove API key.",
-			detail:     "An error occurred while trying to remove the API key from the config file.",
-			suggestion: hint,
-			err:        err,
+	} else {
+		if err := config.Clear("anthropicAPIKey"); err != nil {
+			return &userError{msg: "Failed to remove Anthropic API key.", err: err}
 		}
 	}
 
@@ -481,12 +502,12 @@ func authRemoveAnthropic(io iostream.Streams, envSet, force bool) error {
 	return nil
 }
 
-func authSetGitHub(ctx context.Context, io iostream.Streams, baseURL string, envSet, force bool) error {
+func authSetGitHub(ctx context.Context, io iostream.Streams, baseURL string, envSet, force, insecureStorage bool) error {
 	io.Println("")
 	io.Println(ui.Bold("Chunk CLI - GitHub Token Setup"))
 	io.Println("")
 	io.Println("Create a token at https://github.com/settings/tokens")
-	printSaveHint(io, "Token")
+	printSaveHint(io, "Token", insecureStorage)
 	io.Println("")
 
 	if envSet {
@@ -546,27 +567,21 @@ func authSetGitHub(ctx context.Context, io iostream.Streams, baseURL string, env
 		}
 	}
 
-	cfg, err = config.Load()
-	if err != nil {
-		return &userError{msg: msgCouldNotLoadConfig, suggestion: configFilePermHint, err: err}
-	}
-	cfg.GitHubToken = token
-	if err := config.Save(cfg); err != nil {
+	if err := authprompt.SaveGitHubToken(token, baseURL, !insecureStorage); err != nil {
 		return &userError{msg: "Could not save credentials.", suggestion: configFilePermHint, err: err}
 	}
 
 	io.Println("")
-	printSaved(io, "GitHub token")
+	printSaved(io, "GitHub token", insecureStorage)
 	return nil
 }
 
-func authRemoveGitHub(io iostream.Streams, envSet, force bool) error {
-	cfg, err := config.Load()
-	if err != nil {
-		return &userError{msg: msgCouldNotLoadConfig, suggestion: configFilePermHint, err: err}
-	}
-	if cfg.GitHubToken == "" {
-		io.Println(ui.Warning("No GitHub token stored in config file."))
+func authRemoveGitHub(io iostream.Streams, envSet, force, insecureStorage bool) error {
+	secureStorage := !insecureStorage
+	rc, _ := config.Resolve("", "", secureStorage)
+	hasStored := hasStoredGitHubToken(secureStorage, rc.GitHubAPIURL)
+	if !hasStored {
+		io.Println(ui.Warning("No GitHub token stored."))
 		if envSet {
 			io.Println("Note: A GitHub token is set in environment variables.")
 			io.Println("To remove it, unset the environment variable.")
@@ -576,11 +591,15 @@ func authRemoveGitHub(io iostream.Streams, envSet, force bool) error {
 	}
 
 	io.Println("")
-	cfgPath, err := config.Path()
-	if err != nil {
-		return &userError{msg: msgCouldNotAccessConfig, err: err}
+	if secureStorage {
+		io.Println("This will remove your stored GitHub token from the system keychain.")
+	} else {
+		cfgPath, err := config.Path()
+		if err != nil {
+			return &userError{msg: msgCouldNotAccessConfig, err: err}
+		}
+		io.Printf("This will remove your stored GitHub token from %s\n", cfgPath)
 	}
-	io.Printf("This will remove your stored GitHub token from %s\n", cfgPath)
 	if !force {
 		if nonInteractive() {
 			return errNoForce("remove GitHub token")
@@ -597,16 +616,13 @@ func authRemoveGitHub(io iostream.Streams, envSet, force bool) error {
 		}
 	}
 
-	if err := config.Clear("gitHubToken"); err != nil {
-		hint := configFilePermHint
-		if errPath, pathErr := config.Path(); pathErr == nil {
-			hint = fmt.Sprintf("Check file permissions on %s.", errPath)
+	if secureStorage {
+		if err := keyring.Delete(keyring.ServiceGitHub(rc.GitHubAPIURL)); err != nil {
+			return &userError{msg: "Failed to remove GitHub token from keychain.", err: err}
 		}
-		return &userError{
-			msg:        "Failed to remove GitHub token.",
-			detail:     "An error occurred while trying to remove the token from the config file.",
-			suggestion: hint,
-			err:        err,
+	} else {
+		if err := config.Clear("gitHubToken"); err != nil {
+			return &userError{msg: "Failed to remove GitHub token.", err: err}
 		}
 	}
 

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -44,7 +44,7 @@ func newAuthSetCmd() *cobra.Command {
 		ValidArgs: []string{"circleci", "anthropic", "github"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
-			rc, _ := config.Resolve("", "", !insecureStorage)
+			rc, _ := config.Resolve("", "", insecureStorage)
 			provider := args[0]
 			io := iostream.FromCmd(cmd)
 			switch provider {
@@ -202,7 +202,7 @@ func authSetAnthropic(ctx context.Context, io iostream.Streams, baseURL string, 
 		}
 	}
 
-	if err := authprompt.SaveAnthropicKey(key, baseURL, !insecureStorage); err != nil {
+	if err := authprompt.SaveAnthropicKey(key, baseURL, insecureStorage); err != nil {
 		return &userError{msg: "Could not save credentials.", suggestion: configFilePermHint, err: err}
 	}
 
@@ -222,7 +222,7 @@ func saveCircleCIToken(ctx context.Context, token string, streams iostream.Strea
 		}
 	}
 
-	if err := authprompt.SaveCircleCIToken(token, circleCIBaseURL, !insecureStorage); err != nil {
+	if err := authprompt.SaveCircleCIToken(token, circleCIBaseURL, insecureStorage); err != nil {
 		return &userError{
 			msg:        "Failed to save CircleCI token.",
 			suggestion: "Check that your config file is writable.",
@@ -247,7 +247,7 @@ func newAuthStatusCmd() *cobra.Command {
 			io.Println("")
 
 			insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
-			rc, resolveErr := config.Resolve("", "", !insecureStorage)
+			rc, resolveErr := config.Resolve("", "", insecureStorage)
 			if resolveErr != nil {
 				io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", resolveErr)))
 			}
@@ -335,7 +335,7 @@ func newAuthRemoveCmd() *cobra.Command {
 		ValidArgs: []string{"circleci", "anthropic", "github"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
-			rc, _ := config.Resolve("", "", !insecureStorage)
+			rc, _ := config.Resolve("", "", insecureStorage)
 			provider := args[0]
 			io := iostream.FromCmd(cmd)
 			switch provider {
@@ -361,8 +361,8 @@ func newAuthRemoveCmd() *cobra.Command {
 	return cmd
 }
 
-func hasStoredCircleCIToken(secureStorage bool, baseURL string) bool {
-	if secureStorage {
+func hasStoredCircleCIToken(insecureStorage bool, baseURL string) bool {
+	if !insecureStorage {
 		_, err := keyring.Get(keyring.ServiceCircleCI(baseURL))
 		return err == nil
 	}
@@ -370,8 +370,8 @@ func hasStoredCircleCIToken(secureStorage bool, baseURL string) bool {
 	return cfg.CircleCIToken != ""
 }
 
-func hasStoredAnthropicKey(secureStorage bool, baseURL string) bool {
-	if secureStorage {
+func hasStoredAnthropicKey(insecureStorage bool, baseURL string) bool {
+	if !insecureStorage {
 		_, err := keyring.Get(keyring.ServiceAnthropic(baseURL))
 		return err == nil
 	}
@@ -379,8 +379,8 @@ func hasStoredAnthropicKey(secureStorage bool, baseURL string) bool {
 	return cfg.AnthropicAPIKey != ""
 }
 
-func hasStoredGitHubToken(secureStorage bool, baseURL string) bool {
-	if secureStorage {
+func hasStoredGitHubToken(insecureStorage bool, baseURL string) bool {
+	if !insecureStorage {
 		_, err := keyring.Get(keyring.ServiceGitHub(baseURL))
 		return err == nil
 	}
@@ -389,9 +389,8 @@ func hasStoredGitHubToken(secureStorage bool, baseURL string) bool {
 }
 
 func authRemoveCircleCI(io iostream.Streams, envSet, force, insecureStorage bool) error {
-	secureStorage := !insecureStorage
-	rc, _ := config.Resolve("", "", secureStorage)
-	hasStored := hasStoredCircleCIToken(secureStorage, rc.CircleCIBaseURL)
+	rc, _ := config.Resolve("", "", insecureStorage)
+	hasStored := hasStoredCircleCIToken(insecureStorage, rc.CircleCIBaseURL)
 	if !hasStored {
 		io.Println(ui.Warning("No CircleCI token stored."))
 		if envSet {
@@ -403,7 +402,7 @@ func authRemoveCircleCI(io iostream.Streams, envSet, force, insecureStorage bool
 	}
 
 	io.Println("")
-	if secureStorage {
+	if !insecureStorage {
 		io.Println("This will remove your stored CircleCI token from the system keychain.")
 	} else {
 		cfgPath, err := config.Path()
@@ -428,7 +427,7 @@ func authRemoveCircleCI(io iostream.Streams, envSet, force, insecureStorage bool
 		}
 	}
 
-	if secureStorage {
+	if !insecureStorage {
 		if err := keyring.Delete(keyring.ServiceCircleCI(rc.CircleCIBaseURL)); err != nil {
 			return &userError{msg: "Failed to remove CircleCI token from keychain.", err: err}
 		}
@@ -446,9 +445,8 @@ func authRemoveCircleCI(io iostream.Streams, envSet, force, insecureStorage bool
 }
 
 func authRemoveAnthropic(io iostream.Streams, envSet, force, insecureStorage bool) error {
-	secureStorage := !insecureStorage
-	rc, _ := config.Resolve("", "", secureStorage)
-	hasStored := hasStoredAnthropicKey(secureStorage, rc.AnthropicBaseURL)
+	rc, _ := config.Resolve("", "", insecureStorage)
+	hasStored := hasStoredAnthropicKey(insecureStorage, rc.AnthropicBaseURL)
 	if !hasStored {
 		io.Println(ui.Warning("No API key stored."))
 		if envSet {
@@ -460,7 +458,7 @@ func authRemoveAnthropic(io iostream.Streams, envSet, force, insecureStorage boo
 	}
 
 	io.Println("")
-	if secureStorage {
+	if !insecureStorage {
 		io.Println("This will remove your stored Anthropic API key from the system keychain.")
 	} else {
 		cfgPath, err := config.Path()
@@ -485,7 +483,7 @@ func authRemoveAnthropic(io iostream.Streams, envSet, force, insecureStorage boo
 		}
 	}
 
-	if secureStorage {
+	if !insecureStorage {
 		if err := keyring.Delete(keyring.ServiceAnthropic(rc.AnthropicBaseURL)); err != nil {
 			return &userError{msg: "Failed to remove Anthropic API key from keychain.", err: err}
 		}
@@ -567,7 +565,7 @@ func authSetGitHub(ctx context.Context, io iostream.Streams, baseURL string, env
 		}
 	}
 
-	if err := authprompt.SaveGitHubToken(token, baseURL, !insecureStorage); err != nil {
+	if err := authprompt.SaveGitHubToken(token, baseURL, insecureStorage); err != nil {
 		return &userError{msg: "Could not save credentials.", suggestion: configFilePermHint, err: err}
 	}
 
@@ -577,9 +575,8 @@ func authSetGitHub(ctx context.Context, io iostream.Streams, baseURL string, env
 }
 
 func authRemoveGitHub(io iostream.Streams, envSet, force, insecureStorage bool) error {
-	secureStorage := !insecureStorage
-	rc, _ := config.Resolve("", "", secureStorage)
-	hasStored := hasStoredGitHubToken(secureStorage, rc.GitHubAPIURL)
+	rc, _ := config.Resolve("", "", insecureStorage)
+	hasStored := hasStoredGitHubToken(insecureStorage, rc.GitHubAPIURL)
 	if !hasStored {
 		io.Println(ui.Warning("No GitHub token stored."))
 		if envSet {
@@ -591,7 +588,7 @@ func authRemoveGitHub(io iostream.Streams, envSet, force, insecureStorage bool) 
 	}
 
 	io.Println("")
-	if secureStorage {
+	if !insecureStorage {
 		io.Println("This will remove your stored GitHub token from the system keychain.")
 	} else {
 		cfgPath, err := config.Path()
@@ -616,7 +613,7 @@ func authRemoveGitHub(io iostream.Streams, envSet, force, insecureStorage bool) 
 		}
 	}
 
-	if secureStorage {
+	if !insecureStorage {
 		if err := keyring.Delete(keyring.ServiceGitHub(rc.GitHubAPIURL)); err != nil {
 			return &userError{msg: "Failed to remove GitHub token from keychain.", err: err}
 		}

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -438,6 +438,13 @@ func authRemoveCircleCI(io iostream.Streams, envSet, force, insecureStorage bool
 	}
 
 	io.Println(ui.Success("CircleCI token removed successfully."))
+	if !insecureStorage {
+		if cfg, err := config.Load(); err == nil && cfg.CircleCIToken != "" {
+			cfgPath, _ := config.Path()
+			io.Println(ui.Warning("A CircleCI token is still stored in the config file: " + cfgPath))
+			io.Println(ui.Dim("Run `chunk auth remove --insecure-storage circleci` to remove it, or edit the file directly."))
+		}
+	}
 	if envSet {
 		io.Println(ui.Warning("Note: " + config.EnvCircleToken + "/" + config.EnvCircleCIToken + " is still set in your environment variables."))
 	}
@@ -494,6 +501,13 @@ func authRemoveAnthropic(io iostream.Streams, envSet, force, insecureStorage boo
 	}
 
 	io.Println(ui.Success("API key removed successfully."))
+	if !insecureStorage {
+		if cfg, err := config.Load(); err == nil && cfg.AnthropicAPIKey != "" {
+			cfgPath, _ := config.Path()
+			io.Println(ui.Warning("An Anthropic API key is still stored in the config file: " + cfgPath))
+			io.Println(ui.Dim("Run `chunk auth remove --insecure-storage anthropic` to remove it, or edit the file directly."))
+		}
+	}
 	if envSet {
 		io.Println(ui.Warning("Note: " + config.EnvAnthropicAPIKey + " is still set in your environment variables."))
 	}
@@ -624,6 +638,13 @@ func authRemoveGitHub(io iostream.Streams, envSet, force, insecureStorage bool) 
 	}
 
 	io.Println(ui.Success("GitHub token removed successfully."))
+	if !insecureStorage {
+		if cfg, err := config.Load(); err == nil && cfg.GitHubToken != "" {
+			cfgPath, _ := config.Path()
+			io.Println(ui.Warning("A GitHub token is still stored in the config file: " + cfgPath))
+			io.Println(ui.Dim("Run `chunk auth remove --insecure-storage github` to remove it, or edit the file directly."))
+		}
+	}
 	if envSet {
 		io.Println(ui.Warning("Note: " + config.EnvGitHubToken + " is still set in your environment variables."))
 	}

--- a/internal/cmd/authhelper.go
+++ b/internal/cmd/authhelper.go
@@ -53,9 +53,8 @@ func printSaved(streams iostream.Streams, label string, insecureStorage bool) {
 	streams.ErrPrintln(ui.Success(msg))
 }
 
-func ensureCircleCIClient(ctx context.Context, cmd *cobra.Command, streams iostream.Streams, prompter func(string) (string, error)) (*circleci.Client, error) {
+func ensureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc config.ResolvedConfig, streams iostream.Streams, prompter func(string) (string, error)) (*circleci.Client, error) {
 	insecureStorage := insecureStorageFlag(cmd)
-	rc, _ := config.Resolve("", "", insecureStorage)
 	client, err := authprompt.ResolveCircleCIClient(rc)
 	if err == nil {
 		return client, nil
@@ -108,9 +107,8 @@ func ensureCircleCIClient(ctx context.Context, cmd *cobra.Command, streams iostr
 	})
 }
 
-func ensureAnthropicClient(ctx context.Context, cmd *cobra.Command, streams iostream.Streams, prompter func(string) (string, error)) (*anthropic.Client, error) {
+func ensureAnthropicClient(ctx context.Context, cmd *cobra.Command, rc config.ResolvedConfig, streams iostream.Streams, prompter func(string) (string, error)) (*anthropic.Client, error) {
 	insecureStorage := insecureStorageFlag(cmd)
-	rc, _ := config.Resolve("", "", insecureStorage)
 	client, err := authprompt.ResolveAnthropicClient(rc)
 	if err == nil {
 		return client, nil
@@ -171,9 +169,8 @@ func ensureAnthropicClient(ctx context.Context, cmd *cobra.Command, streams iost
 	})
 }
 
-func ensureGitHubClient(ctx context.Context, cmd *cobra.Command, streams iostream.Streams, prompter func(string) (string, error)) (*github.Client, error) {
+func ensureGitHubClient(ctx context.Context, cmd *cobra.Command, rc config.ResolvedConfig, streams iostream.Streams, prompter func(string) (string, error)) (*github.Client, error) {
 	insecureStorage := insecureStorageFlag(cmd)
-	rc, _ := config.Resolve("", "", insecureStorage)
 	logStatus := func(msg string) { streams.ErrPrintln("  " + msg) }
 	client, err := authprompt.ResolveGitHubClient(rc, logStatus)
 	if err == nil {

--- a/internal/cmd/authhelper.go
+++ b/internal/cmd/authhelper.go
@@ -26,9 +26,9 @@ const (
 	suggestionGitHubAuth    = "Set " + config.EnvGitHubToken + " or run 'chunk auth set github'."
 )
 
-func isSecureStorage(cmd *cobra.Command) bool {
-	insecure, _ := cmd.Flags().GetBool("insecure-storage")
-	return !insecure
+func insecureStorageFlag(cmd *cobra.Command) bool {
+	v, _ := cmd.Flags().GetBool("insecure-storage")
+	return v
 }
 
 func printSaveHint(streams iostream.Streams, label string, insecureStorage bool) {
@@ -54,8 +54,8 @@ func printSaved(streams iostream.Streams, label string, insecureStorage bool) {
 }
 
 func ensureCircleCIClient(ctx context.Context, cmd *cobra.Command, streams iostream.Streams, prompter func(string) (string, error)) (*circleci.Client, error) {
-	secureStorage := isSecureStorage(cmd)
-	rc, _ := config.Resolve("", "", secureStorage)
+	insecureStorage := insecureStorageFlag(cmd)
+	rc, _ := config.Resolve("", "", insecureStorage)
 	client, err := authprompt.ResolveCircleCIClient(rc)
 	if err == nil {
 		return client, nil
@@ -67,7 +67,7 @@ func ensureCircleCIClient(ctx context.Context, cmd *cobra.Command, streams iostr
 	streams.ErrPrintln("")
 	streams.ErrPrintln(ui.Bold("CircleCI token required"))
 	streams.ErrPrintln("Create a token at https://app.circleci.com/settings/user/tokens")
-	printSaveHint(streams, "Token", !secureStorage)
+	printSaveHint(streams, "Token", insecureStorage)
 	streams.ErrPrintln("")
 
 	token, err := prompter("CircleCI Token")
@@ -98,10 +98,10 @@ func ensureCircleCIClient(ctx context.Context, cmd *cobra.Command, streams iostr
 		return nil, fmt.Errorf("could not validate CircleCI token: %w", err)
 	}
 
-	if err := authprompt.SaveCircleCIToken(token, rc.CircleCIBaseURL, secureStorage); err != nil {
+	if err := authprompt.SaveCircleCIToken(token, rc.CircleCIBaseURL, insecureStorage); err != nil {
 		return nil, err
 	}
-	printSaved(streams, "CircleCI token", !secureStorage)
+	printSaved(streams, "CircleCI token", insecureStorage)
 	return circleci.NewClient(circleci.Config{
 		Token:   token,
 		BaseURL: rc.CircleCIBaseURL,
@@ -109,8 +109,8 @@ func ensureCircleCIClient(ctx context.Context, cmd *cobra.Command, streams iostr
 }
 
 func ensureAnthropicClient(ctx context.Context, cmd *cobra.Command, streams iostream.Streams, prompter func(string) (string, error)) (*anthropic.Client, error) {
-	secureStorage := isSecureStorage(cmd)
-	rc, _ := config.Resolve("", "", secureStorage)
+	insecureStorage := insecureStorageFlag(cmd)
+	rc, _ := config.Resolve("", "", insecureStorage)
 	client, err := authprompt.ResolveAnthropicClient(rc)
 	if err == nil {
 		return client, nil
@@ -122,7 +122,7 @@ func ensureAnthropicClient(ctx context.Context, cmd *cobra.Command, streams iost
 	streams.ErrPrintln("")
 	streams.ErrPrintln(ui.Bold("Anthropic API key required"))
 	streams.ErrPrintln("Get a key at https://console.anthropic.com/")
-	printSaveHint(streams, "Key", !secureStorage)
+	printSaveHint(streams, "Key", insecureStorage)
 	streams.ErrPrintln("")
 
 	key, err := prompter("API Key")
@@ -161,10 +161,10 @@ func ensureAnthropicClient(ctx context.Context, cmd *cobra.Command, streams iost
 		return nil, fmt.Errorf("could not validate Anthropic API key: %w", err)
 	}
 
-	if err := authprompt.SaveAnthropicKey(key, rc.AnthropicBaseURL, secureStorage); err != nil {
+	if err := authprompt.SaveAnthropicKey(key, rc.AnthropicBaseURL, insecureStorage); err != nil {
 		return nil, err
 	}
-	printSaved(streams, "Anthropic API key", !secureStorage)
+	printSaved(streams, "Anthropic API key", insecureStorage)
 	return anthropic.New(anthropic.Config{
 		APIKey:  key,
 		BaseURL: rc.AnthropicBaseURL,
@@ -172,8 +172,8 @@ func ensureAnthropicClient(ctx context.Context, cmd *cobra.Command, streams iost
 }
 
 func ensureGitHubClient(ctx context.Context, cmd *cobra.Command, streams iostream.Streams, prompter func(string) (string, error)) (*github.Client, error) {
-	secureStorage := isSecureStorage(cmd)
-	rc, _ := config.Resolve("", "", secureStorage)
+	insecureStorage := insecureStorageFlag(cmd)
+	rc, _ := config.Resolve("", "", insecureStorage)
 	logStatus := func(msg string) { streams.ErrPrintln("  " + msg) }
 	client, err := authprompt.ResolveGitHubClient(rc, logStatus)
 	if err == nil {
@@ -186,7 +186,7 @@ func ensureGitHubClient(ctx context.Context, cmd *cobra.Command, streams iostrea
 	streams.ErrPrintln("")
 	streams.ErrPrintln(ui.Bold("GitHub token required"))
 	streams.ErrPrintln("Create a token at https://github.com/settings/tokens")
-	printSaveHint(streams, "Token", !secureStorage)
+	printSaveHint(streams, "Token", insecureStorage)
 	streams.ErrPrintln("")
 
 	token, err := prompter("GitHub Token")
@@ -217,10 +217,10 @@ func ensureGitHubClient(ctx context.Context, cmd *cobra.Command, streams iostrea
 		return nil, fmt.Errorf("could not validate GitHub token: %w", err)
 	}
 
-	if err := authprompt.SaveGitHubToken(token, rc.GitHubAPIURL, secureStorage); err != nil {
+	if err := authprompt.SaveGitHubToken(token, rc.GitHubAPIURL, insecureStorage); err != nil {
 		return nil, err
 	}
-	printSaved(streams, "GitHub token", !secureStorage)
+	printSaved(streams, "GitHub token", insecureStorage)
 	return github.New(github.Config{
 		Token:     token,
 		BaseURL:   rc.GitHubAPIURL,

--- a/internal/cmd/authhelper.go
+++ b/internal/cmd/authhelper.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/CircleCI-Public/chunk-cli/internal/anthropic"
 	"github.com/CircleCI-Public/chunk-cli/internal/authprompt"
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
@@ -24,13 +26,26 @@ const (
 	suggestionGitHubAuth    = "Set " + config.EnvGitHubToken + " or run 'chunk auth set github'."
 )
 
-func printSaveHint(streams iostream.Streams, label string) {
+func isSecureStorage(cmd *cobra.Command) bool {
+	insecure, _ := cmd.Flags().GetBool("insecure-storage")
+	return !insecure
+}
+
+func printSaveHint(streams iostream.Streams, label string, insecureStorage bool) {
+	if !insecureStorage {
+		streams.ErrPrintln(ui.Dim(label + " will be saved to system keychain"))
+		return
+	}
 	if cfgPath, err := config.Path(); err == nil {
 		streams.ErrPrintln(ui.Dim(fmt.Sprintf("%s will be saved to user config (%s, mode 0600)", label, cfgPath)))
 	}
 }
 
-func printSaved(streams iostream.Streams, label string) {
+func printSaved(streams iostream.Streams, label string, insecureStorage bool) {
+	if !insecureStorage {
+		streams.ErrPrintln(ui.Success(label + " saved to system keychain"))
+		return
+	}
 	msg := label + " saved"
 	if cfgPath, err := config.Path(); err == nil {
 		msg = fmt.Sprintf("%s saved to user config (%s)", label, cfgPath)
@@ -38,8 +53,9 @@ func printSaved(streams iostream.Streams, label string) {
 	streams.ErrPrintln(ui.Success(msg))
 }
 
-func ensureCircleCIClient(ctx context.Context, streams iostream.Streams, prompter func(string) (string, error)) (*circleci.Client, error) {
-	rc, _ := config.Resolve("", "")
+func ensureCircleCIClient(ctx context.Context, cmd *cobra.Command, streams iostream.Streams, prompter func(string) (string, error)) (*circleci.Client, error) {
+	secureStorage := isSecureStorage(cmd)
+	rc, _ := config.Resolve("", "", secureStorage)
 	client, err := authprompt.ResolveCircleCIClient(rc)
 	if err == nil {
 		return client, nil
@@ -51,7 +67,7 @@ func ensureCircleCIClient(ctx context.Context, streams iostream.Streams, prompte
 	streams.ErrPrintln("")
 	streams.ErrPrintln(ui.Bold("CircleCI token required"))
 	streams.ErrPrintln("Create a token at https://app.circleci.com/settings/user/tokens")
-	printSaveHint(streams, "Token")
+	printSaveHint(streams, "Token", !secureStorage)
 	streams.ErrPrintln("")
 
 	token, err := prompter("CircleCI Token")
@@ -82,18 +98,19 @@ func ensureCircleCIClient(ctx context.Context, streams iostream.Streams, prompte
 		return nil, fmt.Errorf("could not validate CircleCI token: %w", err)
 	}
 
-	if err := authprompt.SaveCircleCIToken(token); err != nil {
+	if err := authprompt.SaveCircleCIToken(token, rc.CircleCIBaseURL, secureStorage); err != nil {
 		return nil, err
 	}
-	printSaved(streams, "CircleCI token")
+	printSaved(streams, "CircleCI token", !secureStorage)
 	return circleci.NewClient(circleci.Config{
 		Token:   token,
 		BaseURL: rc.CircleCIBaseURL,
 	})
 }
 
-func ensureAnthropicClient(ctx context.Context, streams iostream.Streams, prompter func(string) (string, error)) (*anthropic.Client, error) {
-	rc, _ := config.Resolve("", "")
+func ensureAnthropicClient(ctx context.Context, cmd *cobra.Command, streams iostream.Streams, prompter func(string) (string, error)) (*anthropic.Client, error) {
+	secureStorage := isSecureStorage(cmd)
+	rc, _ := config.Resolve("", "", secureStorage)
 	client, err := authprompt.ResolveAnthropicClient(rc)
 	if err == nil {
 		return client, nil
@@ -105,7 +122,7 @@ func ensureAnthropicClient(ctx context.Context, streams iostream.Streams, prompt
 	streams.ErrPrintln("")
 	streams.ErrPrintln(ui.Bold("Anthropic API key required"))
 	streams.ErrPrintln("Get a key at https://console.anthropic.com/")
-	printSaveHint(streams, "Key")
+	printSaveHint(streams, "Key", !secureStorage)
 	streams.ErrPrintln("")
 
 	key, err := prompter("API Key")
@@ -144,18 +161,19 @@ func ensureAnthropicClient(ctx context.Context, streams iostream.Streams, prompt
 		return nil, fmt.Errorf("could not validate Anthropic API key: %w", err)
 	}
 
-	if err := authprompt.SaveAnthropicKey(key); err != nil {
+	if err := authprompt.SaveAnthropicKey(key, rc.AnthropicBaseURL, secureStorage); err != nil {
 		return nil, err
 	}
-	printSaved(streams, "Anthropic API key")
+	printSaved(streams, "Anthropic API key", !secureStorage)
 	return anthropic.New(anthropic.Config{
 		APIKey:  key,
 		BaseURL: rc.AnthropicBaseURL,
 	})
 }
 
-func ensureGitHubClient(ctx context.Context, streams iostream.Streams, prompter func(string) (string, error)) (*github.Client, error) {
-	rc, _ := config.Resolve("", "")
+func ensureGitHubClient(ctx context.Context, cmd *cobra.Command, streams iostream.Streams, prompter func(string) (string, error)) (*github.Client, error) {
+	secureStorage := isSecureStorage(cmd)
+	rc, _ := config.Resolve("", "", secureStorage)
 	logStatus := func(msg string) { streams.ErrPrintln("  " + msg) }
 	client, err := authprompt.ResolveGitHubClient(rc, logStatus)
 	if err == nil {
@@ -168,7 +186,7 @@ func ensureGitHubClient(ctx context.Context, streams iostream.Streams, prompter 
 	streams.ErrPrintln("")
 	streams.ErrPrintln(ui.Bold("GitHub token required"))
 	streams.ErrPrintln("Create a token at https://github.com/settings/tokens")
-	printSaveHint(streams, "Token")
+	printSaveHint(streams, "Token", !secureStorage)
 	streams.ErrPrintln("")
 
 	token, err := prompter("GitHub Token")
@@ -199,10 +217,10 @@ func ensureGitHubClient(ctx context.Context, streams iostream.Streams, prompter 
 		return nil, fmt.Errorf("could not validate GitHub token: %w", err)
 	}
 
-	if err := authprompt.SaveGitHubToken(token); err != nil {
+	if err := authprompt.SaveGitHubToken(token, rc.GitHubAPIURL, secureStorage); err != nil {
 		return nil, err
 	}
-	printSaved(streams, "GitHub token")
+	printSaved(streams, "GitHub token", !secureStorage)
 	return github.New(github.Config{
 		Token:     token,
 		BaseURL:   rc.GitHubAPIURL,

--- a/internal/cmd/authhelper_test.go
+++ b/internal/cmd/authhelper_test.go
@@ -54,7 +54,8 @@ func TestEnsureCircleCIClient_NoTTY(t *testing.T) {
 	t.Setenv(config.EnvCircleToken, "")
 	t.Setenv(config.EnvCircleCIToken, "")
 
-	_, err := ensureCircleCIClient(context.Background(), testCmd(), discardStreams(), noTTYPrompter)
+	rc, _ := config.Resolve("", "", true)
+	_, err := ensureCircleCIClient(context.Background(), testCmd(), rc, discardStreams(), noTTYPrompter)
 	assert.Assert(t, err != nil)
 	assert.Assert(t, errors.Is(err, tui.ErrNoTTY))
 
@@ -67,7 +68,8 @@ func TestEnsureAnthropicClient_NoTTY(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv(config.EnvAnthropicAPIKey, "")
 
-	_, err := ensureAnthropicClient(context.Background(), testCmd(), discardStreams(), noTTYPrompter)
+	rc, _ := config.Resolve("", "", true)
+	_, err := ensureAnthropicClient(context.Background(), testCmd(), rc, discardStreams(), noTTYPrompter)
 	assert.Assert(t, err != nil)
 	assert.Assert(t, errors.Is(err, tui.ErrNoTTY))
 
@@ -80,7 +82,8 @@ func TestEnsureGitHubClient_NoTTY(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv(config.EnvGitHubToken, "")
 
-	_, err := ensureGitHubClient(context.Background(), testCmd(), discardStreams(), noTTYPrompter)
+	rc, _ := config.Resolve("", "", true)
+	_, err := ensureGitHubClient(context.Background(), testCmd(), rc, discardStreams(), noTTYPrompter)
 	assert.Assert(t, err != nil)
 	assert.Assert(t, errors.Is(err, tui.ErrNoTTY))
 
@@ -102,7 +105,8 @@ func TestEnsureGitHubClient_PromptAndSave(t *testing.T) {
 	token := randToken("ghp_")
 	prompter := func(_ string) (string, error) { return token, nil }
 
-	client, err := ensureGitHubClient(context.Background(), testCmd(), discardStreams(), prompter)
+	rc, _ := config.Resolve("", "", true)
+	client, err := ensureGitHubClient(context.Background(), testCmd(), rc, discardStreams(), prompter)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
 
@@ -124,7 +128,8 @@ func TestEnsureAnthropicClient_PromptAndSave(t *testing.T) {
 	key := randToken("sk-ant-")
 	prompter := func(_ string) (string, error) { return key, nil }
 
-	client, err := ensureAnthropicClient(context.Background(), testCmd(), discardStreams(), prompter)
+	rc, _ := config.Resolve("", "", true)
+	client, err := ensureAnthropicClient(context.Background(), testCmd(), rc, discardStreams(), prompter)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
 
@@ -139,7 +144,8 @@ func TestEnsureAnthropicClient_InvalidPrefix(t *testing.T) {
 
 	prompter := func(_ string) (string, error) { return "bad-key", nil }
 
-	_, err := ensureAnthropicClient(context.Background(), testCmd(), discardStreams(), prompter)
+	rc, _ := config.Resolve("", "", true)
+	_, err := ensureAnthropicClient(context.Background(), testCmd(), rc, discardStreams(), prompter)
 	assert.Assert(t, err != nil)
 
 	var ue *userError
@@ -154,7 +160,8 @@ func TestEnsureCircleCIClient_EmptyToken(t *testing.T) {
 
 	prompter := func(_ string) (string, error) { return "", nil }
 
-	_, err := ensureCircleCIClient(context.Background(), testCmd(), discardStreams(), prompter)
+	rc, _ := config.Resolve("", "", true)
+	_, err := ensureCircleCIClient(context.Background(), testCmd(), rc, discardStreams(), prompter)
 	assert.Assert(t, err != nil)
 
 	var ue *userError

--- a/internal/cmd/authhelper_test.go
+++ b/internal/cmd/authhelper_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"gotest.tools/v3/assert"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
@@ -40,12 +41,20 @@ func noTTYPrompter(_ string) (string, error) {
 	return "", tui.ErrNoTTY
 }
 
+func testCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("insecure-storage", false, "")
+	// Use insecure (config file) storage in tests to avoid hitting the system keychain.
+	_ = cmd.Flags().Set("insecure-storage", "true")
+	return cmd
+}
+
 func TestEnsureCircleCIClient_NoTTY(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv(config.EnvCircleToken, "")
 	t.Setenv(config.EnvCircleCIToken, "")
 
-	_, err := ensureCircleCIClient(context.Background(), discardStreams(), noTTYPrompter)
+	_, err := ensureCircleCIClient(context.Background(), testCmd(), discardStreams(), noTTYPrompter)
 	assert.Assert(t, err != nil)
 	assert.Assert(t, errors.Is(err, tui.ErrNoTTY))
 
@@ -58,7 +67,7 @@ func TestEnsureAnthropicClient_NoTTY(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv(config.EnvAnthropicAPIKey, "")
 
-	_, err := ensureAnthropicClient(context.Background(), discardStreams(), noTTYPrompter)
+	_, err := ensureAnthropicClient(context.Background(), testCmd(), discardStreams(), noTTYPrompter)
 	assert.Assert(t, err != nil)
 	assert.Assert(t, errors.Is(err, tui.ErrNoTTY))
 
@@ -71,7 +80,7 @@ func TestEnsureGitHubClient_NoTTY(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv(config.EnvGitHubToken, "")
 
-	_, err := ensureGitHubClient(context.Background(), discardStreams(), noTTYPrompter)
+	_, err := ensureGitHubClient(context.Background(), testCmd(), discardStreams(), noTTYPrompter)
 	assert.Assert(t, err != nil)
 	assert.Assert(t, errors.Is(err, tui.ErrNoTTY))
 
@@ -93,7 +102,7 @@ func TestEnsureGitHubClient_PromptAndSave(t *testing.T) {
 	token := randToken("ghp_")
 	prompter := func(_ string) (string, error) { return token, nil }
 
-	client, err := ensureGitHubClient(context.Background(), discardStreams(), prompter)
+	client, err := ensureGitHubClient(context.Background(), testCmd(), discardStreams(), prompter)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
 
@@ -115,7 +124,7 @@ func TestEnsureAnthropicClient_PromptAndSave(t *testing.T) {
 	key := randToken("sk-ant-")
 	prompter := func(_ string) (string, error) { return key, nil }
 
-	client, err := ensureAnthropicClient(context.Background(), discardStreams(), prompter)
+	client, err := ensureAnthropicClient(context.Background(), testCmd(), discardStreams(), prompter)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
 
@@ -130,7 +139,7 @@ func TestEnsureAnthropicClient_InvalidPrefix(t *testing.T) {
 
 	prompter := func(_ string) (string, error) { return "bad-key", nil }
 
-	_, err := ensureAnthropicClient(context.Background(), discardStreams(), prompter)
+	_, err := ensureAnthropicClient(context.Background(), testCmd(), discardStreams(), prompter)
 	assert.Assert(t, err != nil)
 
 	var ue *userError
@@ -145,7 +154,7 @@ func TestEnsureCircleCIClient_EmptyToken(t *testing.T) {
 
 	prompter := func(_ string) (string, error) { return "", nil }
 
-	_, err := ensureCircleCIClient(context.Background(), discardStreams(), prompter)
+	_, err := ensureCircleCIClient(context.Background(), testCmd(), discardStreams(), prompter)
 	assert.Assert(t, err != nil)
 
 	var ue *userError

--- a/internal/cmd/buildprompt.go
+++ b/internal/cmd/buildprompt.go
@@ -73,12 +73,12 @@ func newBuildPromptCmd() *cobra.Command {
 				}
 			}
 
-			ghClient, err := ensureGitHubClient(cmd.Context(), streams, tui.PromptHidden)
+			ghClient, err := ensureGitHubClient(cmd.Context(), cmd, streams, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
 
-			anthropicClient, err := ensureAnthropicClient(cmd.Context(), streams, tui.PromptHidden)
+			anthropicClient, err := ensureAnthropicClient(cmd.Context(), cmd, streams, tui.PromptHidden)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/buildprompt.go
+++ b/internal/cmd/buildprompt.go
@@ -73,12 +73,14 @@ func newBuildPromptCmd() *cobra.Command {
 				}
 			}
 
-			ghClient, err := ensureGitHubClient(cmd.Context(), cmd, streams, tui.PromptHidden)
+			insecureStorage := insecureStorageFlag(cmd)
+			rc, _ := config.Resolve("", "", insecureStorage)
+			ghClient, err := ensureGitHubClient(cmd.Context(), cmd, rc, streams, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
 
-			anthropicClient, err := ensureAnthropicClient(cmd.Context(), cmd, streams, tui.PromptHidden)
+			anthropicClient, err := ensureAnthropicClient(cmd.Context(), cmd, rc, streams, tui.PromptHidden)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -31,7 +31,8 @@ func newConfigShowCmd() *cobra.Command {
 		Short: "Display resolved configuration",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			rc, resolveErr := config.Resolve("", "")
+			insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
+			rc, resolveErr := config.Resolve("", "", !insecureStorage)
 			if resolveErr != nil {
 				io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", resolveErr)))
 			}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -32,7 +32,7 @@ func newConfigShowCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 			insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
-			rc, resolveErr := config.Resolve("", "", !insecureStorage)
+			rc, resolveErr := config.Resolve("", "", insecureStorage)
 			if resolveErr != nil {
 				io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", resolveErr)))
 			}

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -311,7 +311,7 @@ hook config files.`,
 
 			// Step 2: Validate command detection
 			if !skipValidate {
-				rc, _ := config.Resolve("", "", !insecureStorage)
+				rc, _ := config.Resolve("", "", insecureStorage)
 				claude, _ := anthropic.New(anthropic.Config{APIKey: rc.AnthropicAPIKey, BaseURL: rc.AnthropicBaseURL})
 				commands, detectErr := validate.DetectCommands(ctx, claude, workDir)
 				if detectErr != nil {

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -266,6 +266,7 @@ hook config files.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			streams := iostream.FromCmd(cmd)
 			ctx := cmd.Context()
+			insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
 
 			workDir := projectDir
 			if workDir == "" {
@@ -310,7 +311,7 @@ hook config files.`,
 
 			// Step 2: Validate command detection
 			if !skipValidate {
-				rc, _ := config.Resolve("", "")
+				rc, _ := config.Resolve("", "", !insecureStorage)
 				claude, _ := anthropic.New(anthropic.Config{APIKey: rc.AnthropicAPIKey, BaseURL: rc.AnthropicBaseURL})
 				commands, detectErr := validate.DetectCommands(ctx, claude, workDir)
 				if detectErr != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -60,5 +60,8 @@ Configuration:
 
 	rootCmd.AddCommand(newCommandsCmd())
 
+	rootCmd.PersistentFlags().Bool("insecure-storage", false, "do not use the system's secure storage for storing tokens")
+	_ = rootCmd.PersistentFlags().MarkHidden("insecure-storage")
+
 	return rootCmd
 }

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -125,7 +125,7 @@ func newSidecarListCmd() *cobra.Command {
 		Short: "List sidecars",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -185,7 +185,7 @@ func newSidecarCreateCmd() *cobra.Command {
 		Long:  "Create a sidecar.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -237,7 +237,7 @@ func newSidecarExecCmd() *cobra.Command {
 			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
 				return err
 			}
-			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -281,7 +281,7 @@ func newSidecarAddSSHKeyCmd() *cobra.Command {
 			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
 				return err
 			}
-			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -337,7 +337,7 @@ func newSidecarSSHCmd() *cobra.Command {
 				return err
 			}
 			authSock := os.Getenv(config.EnvSSHAuthSock)
-			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -383,7 +383,7 @@ func newSidecarSyncCmd() *cobra.Command {
 				return err
 			}
 			authSock := os.Getenv(config.EnvSSHAuthSock)
-			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -664,7 +664,7 @@ snapshot with 'chunk sidecar create --image <snapshot-id>'.`,
 			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
 				return err
 			}
-			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -706,7 +706,7 @@ func newSidecarSnapshotGetCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
-			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -758,7 +758,7 @@ Example:
 			status := newStatusFunc(streams)
 			authSock := os.Getenv("SSH_AUTH_SOCK")
 
-			client, err := ensureCircleCIClient(cmd.Context(), streams, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, streams, tui.PromptHidden)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -125,7 +125,9 @@ func newSidecarListCmd() *cobra.Command {
 		Short: "List sidecars",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
+			insecureStorage := insecureStorageFlag(cmd)
+			rc, _ := config.Resolve("", "", insecureStorage)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -185,7 +187,9 @@ func newSidecarCreateCmd() *cobra.Command {
 		Long:  "Create a sidecar.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
+			insecureStorage := insecureStorageFlag(cmd)
+			rc, _ := config.Resolve("", "", insecureStorage)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -237,7 +241,9 @@ func newSidecarExecCmd() *cobra.Command {
 			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
 				return err
 			}
-			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
+			insecureStorage := insecureStorageFlag(cmd)
+			rc, _ := config.Resolve("", "", insecureStorage)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -281,7 +287,9 @@ func newSidecarAddSSHKeyCmd() *cobra.Command {
 			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
 				return err
 			}
-			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
+			insecureStorage := insecureStorageFlag(cmd)
+			rc, _ := config.Resolve("", "", insecureStorage)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -337,7 +345,9 @@ func newSidecarSSHCmd() *cobra.Command {
 				return err
 			}
 			authSock := os.Getenv(config.EnvSSHAuthSock)
-			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
+			insecureStorage := insecureStorageFlag(cmd)
+			rc, _ := config.Resolve("", "", insecureStorage)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -383,7 +393,9 @@ func newSidecarSyncCmd() *cobra.Command {
 				return err
 			}
 			authSock := os.Getenv(config.EnvSSHAuthSock)
-			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
+			insecureStorage := insecureStorageFlag(cmd)
+			rc, _ := config.Resolve("", "", insecureStorage)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -664,7 +676,9 @@ snapshot with 'chunk sidecar create --image <snapshot-id>'.`,
 			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
 				return err
 			}
-			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
+			insecureStorage := insecureStorageFlag(cmd)
+			rc, _ := config.Resolve("", "", insecureStorage)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -706,7 +720,9 @@ func newSidecarSnapshotGetCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
-			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
+			insecureStorage := insecureStorageFlag(cmd)
+			rc, _ := config.Resolve("", "", insecureStorage)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -758,7 +774,9 @@ Example:
 			status := newStatusFunc(streams)
 			authSock := os.Getenv("SSH_AUTH_SOCK")
 
-			client, err := ensureCircleCIClient(cmd.Context(), cmd, streams, tui.PromptHidden)
+			insecureStorage := insecureStorageFlag(cmd)
+			rc, _ := config.Resolve("", "", insecureStorage)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, streams, tui.PromptHidden)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/task.go
+++ b/internal/cmd/task.go
@@ -59,7 +59,7 @@ func newTaskRunCmd() *cobra.Command {
 			}
 
 			io := iostream.FromCmd(cmd)
-			client, err := ensureCircleCIClient(cmd.Context(), io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -143,7 +143,7 @@ func newTaskConfigCmd() *cobra.Command {
 			io.Println(ui.Bold("Chunk Run Setup"))
 			io.Println("")
 
-			client, err := ensureCircleCIClient(ctx, io, tui.PromptHidden)
+			client, err := ensureCircleCIClient(ctx, cmd, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/task.go
+++ b/internal/cmd/task.go
@@ -59,7 +59,9 @@ func newTaskRunCmd() *cobra.Command {
 			}
 
 			io := iostream.FromCmd(cmd)
-			client, err := ensureCircleCIClient(cmd.Context(), cmd, io, tui.PromptHidden)
+			insecureStorage := insecureStorageFlag(cmd)
+			rc, _ := config.Resolve("", "", insecureStorage)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}
@@ -143,7 +145,9 @@ func newTaskConfigCmd() *cobra.Command {
 			io.Println(ui.Bold("Chunk Run Setup"))
 			io.Println("")
 
-			client, err := ensureCircleCIClient(ctx, cmd, io, tui.PromptHidden)
+			insecureStorage := insecureStorageFlag(cmd)
+			rc, _ := config.Resolve("", "", insecureStorage)
+			client, err := ensureCircleCIClient(ctx, cmd, rc, io, tui.PromptHidden)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -229,7 +229,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 
 	image := resolveImage(name, cfg)
 
-	circleCIClient, err := maybeEnsureCircleCIClient(cmd, opts, cfg, streams)
+	circleCIClient, err := ensureCircleCIClient(cmd.Context(), cmd, rc, streams, tui.PromptHidden)
 	if err != nil {
 		return err
 	}
@@ -257,7 +257,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		}
 	}
 
-	execErr := runValidate(ctx, circleCIClient, insecureStorage, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.identityFile, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
+	execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.identityFile, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
 
 	if hook != nil {
 		maxAttempts := cfg.StopHookMaxAttempts
@@ -285,7 +285,7 @@ func runValidateDryRun(name, inlineCmd string, cfg *config.ProjectConfig, status
 // provided options. It is shared by both direct and hook invocations.
 // allRemote is true when --remote is passed explicitly (all commands run on the
 // sidecar); false means only commands with Remote:true are routed to the sidecar.
-func runValidate(ctx context.Context, client *circleci.Client, insecureStorage bool, workDir, name, inlineCmd string, save bool, sidecarID string, freshlyCreated bool, identityFile, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, freshlyCreated bool, identityFile, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	// --cmd: inline command (always local in per-command mode)
 	if inlineCmd != "" {
 		cmdName := name
@@ -299,7 +299,7 @@ func runValidate(ctx context.Context, client *circleci.Client, insecureStorage b
 			streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", cmdName)))
 		}
 		if sidecarID != "" && allRemote {
-			execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, insecureStorage)
+			execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc)
 			if err != nil {
 				return err
 			}
@@ -310,7 +310,7 @@ func runValidate(ctx context.Context, client *circleci.Client, insecureStorage b
 
 	// All-remote execution (--remote flag): send everything to the sidecar.
 	if sidecarID != "" && allRemote {
-		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, insecureStorage)
+		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc)
 		if err != nil {
 			return err
 		}
@@ -323,7 +323,7 @@ func runValidate(ctx context.Context, client *circleci.Client, insecureStorage b
 		if name != "" {
 			if cmd := cfg.FindCommand(name); cmd != nil && cmd.Remote {
 				statusFn(iostream.LevelInfo, fmt.Sprintf("running %s on sidecar %s", name, sidecarID))
-				execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, insecureStorage)
+				execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc)
 				if err != nil {
 					return err
 				}
@@ -332,7 +332,7 @@ func runValidate(ctx context.Context, client *circleci.Client, insecureStorage b
 			statusFn(iostream.LevelInfo, fmt.Sprintf("running %s locally (not marked remote)", name))
 			// Named command is not marked remote; fall through to local execution.
 		} else {
-			return runSplitCommands(ctx, client, sidecarID, freshlyCreated, identityFile, workdir, workDir, envVars, insecureStorage, cfg, statusFn, streams)
+			return runSplitCommands(ctx, client, sidecarID, freshlyCreated, identityFile, workdir, workDir, envVars, rc, cfg, statusFn, streams)
 		}
 	}
 
@@ -375,18 +375,9 @@ func runValidate(ctx context.Context, client *circleci.Client, insecureStorage b
 	return mapValidateError(validate.RunAll(ctx, workDir, cfg, statusFn, streams))
 }
 
-// maybeEnsureCircleCIClient pre-resolves the CircleCI client when any remote
-// operation may be needed. Returns nil, nil when no remote ops are expected.
-func maybeEnsureCircleCIClient(cmd *cobra.Command, opts *validateOpts, cfg *config.ProjectConfig, streams iostream.Streams) (*circleci.Client, error) {
-	if !opts.remote && opts.sidecarID == "" && (cfg == nil || !cfg.HasRemoteCommands()) {
-		return nil, nil
-	}
-	return ensureCircleCIClient(cmd.Context(), cmd, streams, tui.PromptHidden)
-}
-
 // openSSHSession establishes an SSH session to the sidecar and returns an
 // exec function and the resolved remote working directory.
-func openSSHSession(ctx context.Context, client *circleci.Client, sidecarID, identityFile, workdir string, envVars map[string]string, insecureStorage bool) (func(context.Context, string) (string, string, int, error), string, error) {
+func openSSHSession(ctx context.Context, client *circleci.Client, sidecarID, identityFile, workdir string, envVars map[string]string, rc config.ResolvedConfig) (func(context.Context, string) (string, string, int, error), string, error) {
 	authSock := os.Getenv(config.EnvSSHAuthSock)
 	session, err := sidecar.OpenSession(ctx, client, sidecarID, identityFile, authSock)
 	if err != nil {
@@ -395,10 +386,6 @@ func openSSHSession(ctx context.Context, client *circleci.Client, sidecarID, ide
 	cwd, _ := os.Getwd()
 	_, repo, _ := gitremote.DetectOrgAndRepo(cwd)
 	dest := sidecar.ResolveWorkspace(ctx, workdir, repo)
-	rc, err := config.Resolve("", "", insecureStorage)
-	if err != nil {
-		return nil, "", &userError{msg: "Could not resolve config.", err: err}
-	}
 	merged := hostForwardEnv(rc.CircleCIToken)
 	if merged == nil {
 		merged = make(map[string]string, len(envVars))
@@ -434,7 +421,7 @@ func hostForwardEnv(token string) map[string]string {
 // When freshlyCreated is true, SSH failures are hard errors rather than
 // silent local fallbacks (a newly provisioned sidecar that can't be reached
 // indicates a real problem, not temporary unavailability).
-func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, identityFile, workdir, workDir string, envVars map[string]string, insecureStorage bool, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, identityFile, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	remoteCfg, localCfg := splitByRemote(cfg)
 	if len(remoteCfg.Commands) > 0 {
 		statusFn(iostream.LevelInfo, fmt.Sprintf("running on sidecar %s: %s", sidecarID, commandNames(remoteCfg.Commands)))
@@ -444,7 +431,7 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 	}
 	var runErr error
 	if len(remoteCfg.Commands) > 0 {
-		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, insecureStorage)
+		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc)
 		if err != nil {
 			if freshlyCreated {
 				return newUserError(fmt.Sprintf("Could not reach newly created sidecar %s.", sidecarID)).

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
@@ -172,6 +173,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return nil
 	}
 	statusFn := newStatusFunc(streams)
+	secureStorage := isSecureStorage(cmd)
 
 	var name string
 	if len(args) == 1 {
@@ -213,7 +215,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	// Hook: fail early when CircleCI auth is missing and remote commands need it.
 	// In non-hook context ensureCircleCIClient prompts interactively; hooks have
 	// no TTY so we surface a clear message here instead of a confusing fallback.
-	rc, _ := config.Resolve("", "")
+	rc, _ := config.Resolve("", "", secureStorage)
 	if hook != nil && cfg.HasRemoteCommands() && rc.CircleCIToken == "" {
 		streams.ErrPrintln("CircleCI auth is not configured.")
 		streams.ErrPrintln("Suggestion: " + suggestionCircleCIAuth)
@@ -227,16 +229,21 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 
 	image := resolveImage(name, cfg)
 
+	circleCIClient, err := maybeEnsureCircleCIClient(cmd, opts, cfg, streams)
+	if err != nil {
+		return err
+	}
+
 	freshlyCreated := false
 	if opts.remote {
 		// --remote: force all commands to sidecar, creating one if needed.
-		freshlyCreated, err = resolveOrCreateSidecarID(ctx, &opts.sidecarID, opts.orgID, image, workDir, streams)
+		freshlyCreated, err = resolveOrCreateSidecarID(ctx, circleCIClient, &opts.sidecarID, opts.orgID, image, workDir, streams)
 		if err != nil {
 			return err
 		}
 		statusFn(iostream.LevelInfo, fmt.Sprintf("running all commands on sidecar %s", opts.sidecarID))
 	} else if cfg.HasRemoteCommands() {
-		freshlyCreated = resolveSidecar(ctx, &opts.sidecarID, opts.orgID, image, workDir, hook, streams)
+		freshlyCreated = resolveSidecar(ctx, circleCIClient, &opts.sidecarID, opts.orgID, image, workDir, hook, streams)
 	}
 
 	// Only load env vars and resolve secrets when a sidecar is actually
@@ -250,7 +257,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		}
 	}
 
-	execErr := runValidate(ctx, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.identityFile, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
+	execErr := runValidate(ctx, circleCIClient, secureStorage, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.identityFile, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
 
 	if hook != nil {
 		maxAttempts := cfg.StopHookMaxAttempts
@@ -278,7 +285,7 @@ func runValidateDryRun(name, inlineCmd string, cfg *config.ProjectConfig, status
 // provided options. It is shared by both direct and hook invocations.
 // allRemote is true when --remote is passed explicitly (all commands run on the
 // sidecar); false means only commands with Remote:true are routed to the sidecar.
-func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool, sidecarID string, freshlyCreated bool, identityFile, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func runValidate(ctx context.Context, client *circleci.Client, secureStorage bool, workDir, name, inlineCmd string, save bool, sidecarID string, freshlyCreated bool, identityFile, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	// --cmd: inline command (always local in per-command mode)
 	if inlineCmd != "" {
 		cmdName := name
@@ -292,7 +299,7 @@ func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool
 			streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", cmdName)))
 		}
 		if sidecarID != "" && allRemote {
-			execFn, dest, err := openSSHSession(ctx, sidecarID, identityFile, workdir, envVars, streams)
+			execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, secureStorage)
 			if err != nil {
 				return err
 			}
@@ -303,7 +310,7 @@ func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool
 
 	// All-remote execution (--remote flag): send everything to the sidecar.
 	if sidecarID != "" && allRemote {
-		execFn, dest, err := openSSHSession(ctx, sidecarID, identityFile, workdir, envVars, streams)
+		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, secureStorage)
 		if err != nil {
 			return err
 		}
@@ -316,7 +323,7 @@ func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool
 		if name != "" {
 			if cmd := cfg.FindCommand(name); cmd != nil && cmd.Remote {
 				statusFn(iostream.LevelInfo, fmt.Sprintf("running %s on sidecar %s", name, sidecarID))
-				execFn, dest, err := openSSHSession(ctx, sidecarID, identityFile, workdir, envVars, streams)
+				execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, secureStorage)
 				if err != nil {
 					return err
 				}
@@ -325,7 +332,7 @@ func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool
 			statusFn(iostream.LevelInfo, fmt.Sprintf("running %s locally (not marked remote)", name))
 			// Named command is not marked remote; fall through to local execution.
 		} else {
-			return runSplitCommands(ctx, sidecarID, freshlyCreated, identityFile, workdir, workDir, envVars, cfg, statusFn, streams)
+			return runSplitCommands(ctx, client, sidecarID, freshlyCreated, identityFile, workdir, workDir, envVars, secureStorage, cfg, statusFn, streams)
 		}
 	}
 
@@ -368,13 +375,18 @@ func runValidate(ctx context.Context, workDir, name, inlineCmd string, save bool
 	return mapValidateError(validate.RunAll(ctx, workDir, cfg, statusFn, streams))
 }
 
+// maybeEnsureCircleCIClient pre-resolves the CircleCI client when any remote
+// operation may be needed. Returns nil, nil when no remote ops are expected.
+func maybeEnsureCircleCIClient(cmd *cobra.Command, opts *validateOpts, cfg *config.ProjectConfig, streams iostream.Streams) (*circleci.Client, error) {
+	if !opts.remote && opts.sidecarID == "" && (cfg == nil || !cfg.HasRemoteCommands()) {
+		return nil, nil
+	}
+	return ensureCircleCIClient(cmd.Context(), cmd, streams, tui.PromptHidden)
+}
+
 // openSSHSession establishes an SSH session to the sidecar and returns an
 // exec function and the resolved remote working directory.
-func openSSHSession(ctx context.Context, sidecarID, identityFile, workdir string, envVars map[string]string, streams iostream.Streams) (func(context.Context, string) (string, string, int, error), string, error) {
-	client, err := ensureCircleCIClient(ctx, streams, tui.PromptHidden)
-	if err != nil {
-		return nil, "", err
-	}
+func openSSHSession(ctx context.Context, client *circleci.Client, sidecarID, identityFile, workdir string, envVars map[string]string, secureStorage bool) (func(context.Context, string) (string, string, int, error), string, error) {
 	authSock := os.Getenv(config.EnvSSHAuthSock)
 	session, err := sidecar.OpenSession(ctx, client, sidecarID, identityFile, authSock)
 	if err != nil {
@@ -383,7 +395,7 @@ func openSSHSession(ctx context.Context, sidecarID, identityFile, workdir string
 	cwd, _ := os.Getwd()
 	_, repo, _ := gitremote.DetectOrgAndRepo(cwd)
 	dest := sidecar.ResolveWorkspace(ctx, workdir, repo)
-	rc, err := config.Resolve("", "")
+	rc, err := config.Resolve("", "", secureStorage)
 	if err != nil {
 		return nil, "", &userError{msg: "Could not resolve config.", err: err}
 	}
@@ -422,7 +434,7 @@ func hostForwardEnv(token string) map[string]string {
 // When freshlyCreated is true, SSH failures are hard errors rather than
 // silent local fallbacks (a newly provisioned sidecar that can't be reached
 // indicates a real problem, not temporary unavailability).
-func runSplitCommands(ctx context.Context, sidecarID string, freshlyCreated bool, identityFile, workdir, workDir string, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, identityFile, workdir, workDir string, envVars map[string]string, secureStorage bool, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	remoteCfg, localCfg := splitByRemote(cfg)
 	if len(remoteCfg.Commands) > 0 {
 		statusFn(iostream.LevelInfo, fmt.Sprintf("running on sidecar %s: %s", sidecarID, commandNames(remoteCfg.Commands)))
@@ -432,7 +444,7 @@ func runSplitCommands(ctx context.Context, sidecarID string, freshlyCreated bool
 	}
 	var runErr error
 	if len(remoteCfg.Commands) > 0 {
-		execFn, dest, err := openSSHSession(ctx, sidecarID, identityFile, workdir, envVars, streams)
+		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, secureStorage)
 		if err != nil {
 			if freshlyCreated {
 				return newUserError(fmt.Sprintf("Could not reach newly created sidecar %s.", sidecarID)).
@@ -508,7 +520,7 @@ func resolveImage(name string, cfg *config.ProjectConfig) string {
 // It uses the active sidecar when available, auto-creates one when a sidecar
 // image is configured or the caller is a Stop hook, and warns otherwise.
 // Returns true when a brand-new sidecar was provisioned in this call.
-func resolveSidecar(ctx context.Context, sidecarID *string, orgID, image, workDir string, hook *hookContext, streams iostream.Streams) bool {
+func resolveSidecar(ctx context.Context, client *circleci.Client, sidecarID *string, orgID, image, workDir string, hook *hookContext, streams iostream.Streams) bool {
 	statusFn := newStatusFunc(streams)
 	if active, err := sidecar.LoadActive(ctx); err == nil && active != nil {
 		*sidecarID = active.SidecarID
@@ -518,7 +530,7 @@ func resolveSidecar(ctx context.Context, sidecarID *string, orgID, image, workDi
 	if hook != nil || image != "" {
 		// In Stop hook context, or when a sidecar image is configured: auto-create
 		// from the stored snapshot so remote commands get the prepared environment.
-		created, err := resolveOrCreateSidecarID(ctx, sidecarID, orgID, image, workDir, streams)
+		created, err := resolveOrCreateSidecarID(ctx, client, sidecarID, orgID, image, workDir, streams)
 		if err != nil {
 			streams.ErrPrintf("warning: no sandbox available (%v); run 'chunk config set orgID <id>' to enable remote validation, running locally instead\n", err)
 		}
@@ -531,7 +543,7 @@ func resolveSidecar(ctx context.Context, sidecarID *string, orgID, image, workDi
 // resolveOrCreateSidecarID fills sidecarID from the active sidecar, or creates
 // a new sandbox when none is configured. Returns true when a new sidecar was
 // provisioned (as opposed to loaded from the active state file).
-func resolveOrCreateSidecarID(ctx context.Context, sidecarID *string, orgID, image, workDir string, streams iostream.Streams) (created bool, err error) {
+func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, sidecarID *string, orgID, image, workDir string, streams iostream.Streams) (created bool, err error) {
 	if *sidecarID != "" {
 		return false, nil
 	}
@@ -544,10 +556,6 @@ func resolveOrCreateSidecarID(ctx context.Context, sidecarID *string, orgID, ima
 		return false, nil
 	}
 	streams.ErrPrintf("No active sidecar found, creating a new sandbox...\n")
-	client, err := ensureCircleCIClient(ctx, streams, tui.PromptHidden)
-	if err != nil {
-		return false, err
-	}
 	// Fallback: read org ID from project config if not provided via flag or env.
 	if orgID == "" {
 		if projCfg, cfgErr := config.LoadProjectConfig(workDir); cfgErr == nil && projCfg.OrgID != "" {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -173,7 +173,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return nil
 	}
 	statusFn := newStatusFunc(streams)
-	secureStorage := isSecureStorage(cmd)
+	insecureStorage := insecureStorageFlag(cmd)
 
 	var name string
 	if len(args) == 1 {
@@ -215,7 +215,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	// Hook: fail early when CircleCI auth is missing and remote commands need it.
 	// In non-hook context ensureCircleCIClient prompts interactively; hooks have
 	// no TTY so we surface a clear message here instead of a confusing fallback.
-	rc, _ := config.Resolve("", "", secureStorage)
+	rc, _ := config.Resolve("", "", insecureStorage)
 	if hook != nil && cfg.HasRemoteCommands() && rc.CircleCIToken == "" {
 		streams.ErrPrintln("CircleCI auth is not configured.")
 		streams.ErrPrintln("Suggestion: " + suggestionCircleCIAuth)
@@ -257,7 +257,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		}
 	}
 
-	execErr := runValidate(ctx, circleCIClient, secureStorage, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.identityFile, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
+	execErr := runValidate(ctx, circleCIClient, insecureStorage, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.identityFile, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
 
 	if hook != nil {
 		maxAttempts := cfg.StopHookMaxAttempts
@@ -285,7 +285,7 @@ func runValidateDryRun(name, inlineCmd string, cfg *config.ProjectConfig, status
 // provided options. It is shared by both direct and hook invocations.
 // allRemote is true when --remote is passed explicitly (all commands run on the
 // sidecar); false means only commands with Remote:true are routed to the sidecar.
-func runValidate(ctx context.Context, client *circleci.Client, secureStorage bool, workDir, name, inlineCmd string, save bool, sidecarID string, freshlyCreated bool, identityFile, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func runValidate(ctx context.Context, client *circleci.Client, insecureStorage bool, workDir, name, inlineCmd string, save bool, sidecarID string, freshlyCreated bool, identityFile, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	// --cmd: inline command (always local in per-command mode)
 	if inlineCmd != "" {
 		cmdName := name
@@ -299,7 +299,7 @@ func runValidate(ctx context.Context, client *circleci.Client, secureStorage boo
 			streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", cmdName)))
 		}
 		if sidecarID != "" && allRemote {
-			execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, secureStorage)
+			execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, insecureStorage)
 			if err != nil {
 				return err
 			}
@@ -310,7 +310,7 @@ func runValidate(ctx context.Context, client *circleci.Client, secureStorage boo
 
 	// All-remote execution (--remote flag): send everything to the sidecar.
 	if sidecarID != "" && allRemote {
-		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, secureStorage)
+		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, insecureStorage)
 		if err != nil {
 			return err
 		}
@@ -323,7 +323,7 @@ func runValidate(ctx context.Context, client *circleci.Client, secureStorage boo
 		if name != "" {
 			if cmd := cfg.FindCommand(name); cmd != nil && cmd.Remote {
 				statusFn(iostream.LevelInfo, fmt.Sprintf("running %s on sidecar %s", name, sidecarID))
-				execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, secureStorage)
+				execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, insecureStorage)
 				if err != nil {
 					return err
 				}
@@ -332,7 +332,7 @@ func runValidate(ctx context.Context, client *circleci.Client, secureStorage boo
 			statusFn(iostream.LevelInfo, fmt.Sprintf("running %s locally (not marked remote)", name))
 			// Named command is not marked remote; fall through to local execution.
 		} else {
-			return runSplitCommands(ctx, client, sidecarID, freshlyCreated, identityFile, workdir, workDir, envVars, secureStorage, cfg, statusFn, streams)
+			return runSplitCommands(ctx, client, sidecarID, freshlyCreated, identityFile, workdir, workDir, envVars, insecureStorage, cfg, statusFn, streams)
 		}
 	}
 
@@ -386,7 +386,7 @@ func maybeEnsureCircleCIClient(cmd *cobra.Command, opts *validateOpts, cfg *conf
 
 // openSSHSession establishes an SSH session to the sidecar and returns an
 // exec function and the resolved remote working directory.
-func openSSHSession(ctx context.Context, client *circleci.Client, sidecarID, identityFile, workdir string, envVars map[string]string, secureStorage bool) (func(context.Context, string) (string, string, int, error), string, error) {
+func openSSHSession(ctx context.Context, client *circleci.Client, sidecarID, identityFile, workdir string, envVars map[string]string, insecureStorage bool) (func(context.Context, string) (string, string, int, error), string, error) {
 	authSock := os.Getenv(config.EnvSSHAuthSock)
 	session, err := sidecar.OpenSession(ctx, client, sidecarID, identityFile, authSock)
 	if err != nil {
@@ -395,7 +395,7 @@ func openSSHSession(ctx context.Context, client *circleci.Client, sidecarID, ide
 	cwd, _ := os.Getwd()
 	_, repo, _ := gitremote.DetectOrgAndRepo(cwd)
 	dest := sidecar.ResolveWorkspace(ctx, workdir, repo)
-	rc, err := config.Resolve("", "", secureStorage)
+	rc, err := config.Resolve("", "", insecureStorage)
 	if err != nil {
 		return nil, "", &userError{msg: "Could not resolve config.", err: err}
 	}
@@ -434,7 +434,7 @@ func hostForwardEnv(token string) map[string]string {
 // When freshlyCreated is true, SSH failures are hard errors rather than
 // silent local fallbacks (a newly provisioned sidecar that can't be reached
 // indicates a real problem, not temporary unavailability).
-func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, identityFile, workdir, workDir string, envVars map[string]string, secureStorage bool, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, identityFile, workdir, workDir string, envVars map[string]string, insecureStorage bool, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	remoteCfg, localCfg := splitByRemote(cfg)
 	if len(remoteCfg.Commands) > 0 {
 		statusFn(iostream.LevelInfo, fmt.Sprintf("running on sidecar %s: %s", sidecarID, commandNames(remoteCfg.Commands)))
@@ -444,7 +444,7 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 	}
 	var runErr error
 	if len(remoteCfg.Commands) > 0 {
-		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, secureStorage)
+		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, insecureStorage)
 		if err != nil {
 			if freshlyCreated {
 				return newUserError(fmt.Sprintf("Could not reach newly created sidecar %s.", sidecarID)).

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -148,6 +148,13 @@ func initHook(ctx context.Context, hook *hookContext, workDir string, streams io
 	return ctx, streams, false, nil
 }
 
+func maybeEnsureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc config.ResolvedConfig, allRemote bool, cfg *config.ProjectConfig, streams iostream.Streams) (*circleci.Client, error) {
+	if !allRemote && !cfg.HasRemoteCommands() {
+		return nil, nil
+	}
+	return ensureCircleCIClient(ctx, cmd, rc, streams, tui.PromptHidden)
+}
+
 func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) error {
 	streams := iostream.FromCmd(cmd)
 
@@ -229,7 +236,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 
 	image := resolveImage(name, cfg)
 
-	circleCIClient, err := ensureCircleCIClient(cmd.Context(), cmd, rc, streams, tui.PromptHidden)
+	circleCIClient, err := maybeEnsureCircleCIClient(cmd.Context(), cmd, rc, allRemote, cfg, streams)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -12,6 +12,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 )
@@ -118,8 +119,14 @@ func setupSSHSession(t *testing.T) (*fakes.SSHServer, string) {
 func TestOpenSSHSessionPassesEnvVars(t *testing.T) {
 	sshSrv, keyFile := setupSSHSession(t)
 
+	client, err := circleci.NewClient(circleci.Config{
+		Token:   "test-token",
+		BaseURL: os.Getenv(config.EnvCircleCIBaseURL),
+	})
+	assert.NilError(t, err)
+
 	envVars := map[string]string{"FOO": "bar", "BAZ": "qux"}
-	execFn, _, err := openSSHSession(context.Background(), "sidecar-123", keyFile, "", envVars, discardStreams())
+	execFn, _, err := openSSHSession(context.Background(), client, "sidecar-123", keyFile, "", envVars, false)
 	assert.NilError(t, err)
 
 	_, _, _, err = execFn(context.Background(), "echo hello")

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -126,7 +126,7 @@ func TestOpenSSHSessionPassesEnvVars(t *testing.T) {
 	assert.NilError(t, err)
 
 	envVars := map[string]string{"FOO": "bar", "BAZ": "qux"}
-	execFn, _, err := openSSHSession(context.Background(), client, "sidecar-123", keyFile, "", envVars, false)
+	execFn, _, err := openSSHSession(context.Background(), client, "sidecar-123", keyFile, "", envVars, config.ResolvedConfig{})
 	assert.NilError(t, err)
 
 	_, _, _, err = execFn(context.Background(), "echo hello")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -193,10 +193,10 @@ func Clear(key string) error {
 }
 
 // Resolve computes the final config from flags, env, and file.
-// Priority for API key: flag > env > keychain (when secureStorage) > config file > (none).
+// Priority for API key: flag > env > keychain (when !insecureStorage) > config file > (none).
 // Priority for model: flag > env > config file > default.
-// When secureStorage is false, keychain reads are skipped entirely.
-func Resolve(flagAPIKey, flagModel string, secureStorage bool) (ResolvedConfig, error) {
+// When insecureStorage is true, keychain reads are skipped entirely.
+func Resolve(flagAPIKey, flagModel string, insecureStorage bool) (ResolvedConfig, error) {
 	cfg, err := Load()
 
 	env, envErr := LoadEnv(context.Background())
@@ -217,7 +217,7 @@ func Resolve(flagAPIKey, flagModel string, secureStorage bool) (ResolvedConfig, 
 		rc.CircleCIToken = env.CircleCIToken
 		rc.CircleCITokenSource = "Environment variable (" + EnvCircleCIToken + ")"
 	default:
-		if secureStorage {
+		if !insecureStorage {
 			if token, krErr := keyring.Get(keyring.ServiceCircleCI(env.CircleCIBaseURL)); krErr == nil {
 				rc.CircleCIToken = token
 				rc.CircleCITokenSource = keyring.SourceKeychain
@@ -237,7 +237,7 @@ func Resolve(flagAPIKey, flagModel string, secureStorage bool) (ResolvedConfig, 
 		rc.AnthropicAPIKey = env.AnthropicAPIKey
 		rc.AnthropicAPIKeySource = "Environment variable"
 	default:
-		if secureStorage {
+		if !insecureStorage {
 			if apiKey, krErr := keyring.Get(keyring.ServiceAnthropic(env.AnthropicBaseURL)); krErr == nil {
 				rc.AnthropicAPIKey = apiKey
 				rc.AnthropicAPIKeySource = keyring.SourceKeychain
@@ -254,7 +254,7 @@ func Resolve(flagAPIKey, flagModel string, secureStorage bool) (ResolvedConfig, 
 		rc.GitHubToken = env.GitHubToken
 		rc.GitHubTokenSource = "Environment variable (" + EnvGitHubToken + ")"
 	default:
-		if secureStorage {
+		if !insecureStorage {
 			if token, krErr := keyring.Get(keyring.ServiceGitHub(env.GitHubAPIURL)); krErr == nil {
 				rc.GitHubToken = token
 				rc.GitHubTokenSource = keyring.SourceKeychain

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/sethvargo/go-envconfig"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/keyring"
 )
 
 // marshalIndent encodes v as indented JSON without HTML-escaping special characters
@@ -191,9 +193,10 @@ func Clear(key string) error {
 }
 
 // Resolve computes the final config from flags, env, and file.
-// Priority for API key: flag > env > config file > (none).
+// Priority for API key: flag > env > keychain (when secureStorage) > config file > (none).
 // Priority for model: flag > env > config file > default.
-func Resolve(flagAPIKey, flagModel string) (ResolvedConfig, error) {
+// When secureStorage is false, keychain reads are skipped entirely.
+func Resolve(flagAPIKey, flagModel string, secureStorage bool) (ResolvedConfig, error) {
 	cfg, err := Load()
 
 	env, envErr := LoadEnv(context.Background())
@@ -213,9 +216,17 @@ func Resolve(flagAPIKey, flagModel string) (ResolvedConfig, error) {
 	case env.CircleCIToken != "":
 		rc.CircleCIToken = env.CircleCIToken
 		rc.CircleCITokenSource = "Environment variable (" + EnvCircleCIToken + ")"
-	case cfg.CircleCIToken != "":
-		rc.CircleCIToken = cfg.CircleCIToken
-		rc.CircleCITokenSource = SourceConfigFile
+	default:
+		if secureStorage {
+			if token, krErr := keyring.Get(keyring.ServiceCircleCI(env.CircleCIBaseURL)); krErr == nil {
+				rc.CircleCIToken = token
+				rc.CircleCITokenSource = keyring.SourceKeychain
+			}
+		}
+		if rc.CircleCIToken == "" && cfg.CircleCIToken != "" {
+			rc.CircleCIToken = cfg.CircleCIToken
+			rc.CircleCITokenSource = SourceConfigFile
+		}
 	}
 
 	switch {
@@ -225,18 +236,34 @@ func Resolve(flagAPIKey, flagModel string) (ResolvedConfig, error) {
 	case env.AnthropicAPIKey != "":
 		rc.AnthropicAPIKey = env.AnthropicAPIKey
 		rc.AnthropicAPIKeySource = "Environment variable"
-	case cfg.AnthropicAPIKey != "":
-		rc.AnthropicAPIKey = cfg.AnthropicAPIKey
-		rc.AnthropicAPIKeySource = SourceConfigFile
+	default:
+		if secureStorage {
+			if apiKey, krErr := keyring.Get(keyring.ServiceAnthropic(env.AnthropicBaseURL)); krErr == nil {
+				rc.AnthropicAPIKey = apiKey
+				rc.AnthropicAPIKeySource = keyring.SourceKeychain
+			}
+		}
+		if rc.AnthropicAPIKey == "" && cfg.AnthropicAPIKey != "" {
+			rc.AnthropicAPIKey = cfg.AnthropicAPIKey
+			rc.AnthropicAPIKeySource = SourceConfigFile
+		}
 	}
 
 	switch {
 	case env.GitHubToken != "":
 		rc.GitHubToken = env.GitHubToken
 		rc.GitHubTokenSource = "Environment variable (" + EnvGitHubToken + ")"
-	case cfg.GitHubToken != "":
-		rc.GitHubToken = cfg.GitHubToken
-		rc.GitHubTokenSource = SourceConfigFile
+	default:
+		if secureStorage {
+			if token, krErr := keyring.Get(keyring.ServiceGitHub(env.GitHubAPIURL)); krErr == nil {
+				rc.GitHubToken = token
+				rc.GitHubTokenSource = keyring.SourceKeychain
+			}
+		}
+		if rc.GitHubToken == "" && cfg.GitHubToken != "" {
+			rc.GitHubToken = cfg.GitHubToken
+			rc.GitHubTokenSource = SourceConfigFile
+		}
 	}
 
 	switch {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -288,7 +288,7 @@ func TestResolve_Defaults(t *testing.T) {
 	setupTempConfig(t)
 	t.Setenv(EnvAnthropicAPIKey, "")
 
-	rc, _ := Resolve("", "")
+	rc, _ := Resolve("", "", false)
 
 	assert.Equal(t, rc.AnthropicAPIKey, "")
 	assert.Equal(t, rc.Model, DefaultModel)
@@ -301,7 +301,7 @@ func TestResolve_EnvKey(t *testing.T) {
 	setupTempConfig(t)
 	t.Setenv(EnvAnthropicAPIKey, "sk-from-env")
 
-	rc, _ := Resolve("", "")
+	rc, _ := Resolve("", "", false)
 	assert.Equal(t, rc.AnthropicAPIKey, "sk-from-env")
 	assert.Equal(t, rc.AnthropicAPIKeySource, "Environment variable")
 }
@@ -312,7 +312,7 @@ func TestResolve_EnvOverridesConfigFile(t *testing.T) {
 
 	assert.NilError(t, Save(UserConfig{AnthropicAPIKey: "sk-from-file"}))
 
-	rc, _ := Resolve("", "")
+	rc, _ := Resolve("", "", false)
 	assert.Equal(t, rc.AnthropicAPIKey, "sk-from-env")
 	assert.Equal(t, rc.AnthropicAPIKeySource, "Environment variable")
 }
@@ -322,7 +322,7 @@ func TestResolve_FlagOverridesAll(t *testing.T) {
 	t.Setenv(EnvAnthropicAPIKey, "sk-from-env")
 	assert.NilError(t, Save(UserConfig{AnthropicAPIKey: "sk-from-file", Model: "file-model"}))
 
-	rc, _ := Resolve("sk-from-flag", "flag-model")
+	rc, _ := Resolve("sk-from-flag", "flag-model", false)
 	assert.Equal(t, rc.AnthropicAPIKey, "sk-from-flag")
 	assert.Equal(t, rc.AnthropicAPIKeySource, "Flag")
 	assert.Equal(t, rc.Model, "flag-model")
@@ -333,7 +333,7 @@ func TestResolve_ModelFromConfig(t *testing.T) {
 	setupTempConfig(t)
 	assert.NilError(t, Save(UserConfig{Model: "config-model"}))
 
-	rc, _ := Resolve("", "")
+	rc, _ := Resolve("", "", false)
 	assert.Equal(t, rc.Model, "config-model")
 	assert.Equal(t, rc.ModelSource, SourceConfigFile)
 }

--- a/internal/keyring/keyring.go
+++ b/internal/keyring/keyring.go
@@ -1,0 +1,99 @@
+package keyring
+
+import (
+	"errors"
+	"os/user"
+	"strings"
+	"time"
+
+	"github.com/zalando/go-keyring"
+)
+
+const (
+	servicePrefix = "com.circleci.chunk:"
+
+	// SourceKeychain is the source label used when a value comes from the system keychain.
+	SourceKeychain = "System keychain"
+
+	opTimeout = 3 * time.Second
+)
+
+// ServiceCircleCI returns the keychain service key for the given CircleCI base URL.
+func ServiceCircleCI(baseURL string) string {
+	return servicePrefix + "circleci:" + strings.TrimRight(baseURL, "/")
+}
+
+// ServiceAnthropic returns the keychain service key for the given Anthropic base URL.
+func ServiceAnthropic(baseURL string) string {
+	return servicePrefix + "anthropic:" + strings.TrimRight(baseURL, "/")
+}
+
+// ServiceGitHub returns the keychain service key for the given GitHub API URL.
+func ServiceGitHub(baseURL string) string {
+	return servicePrefix + "github:" + strings.TrimRight(baseURL, "/")
+}
+
+// ErrNotFound is returned by Get when no credential is stored or the keyring is unavailable.
+var ErrNotFound = errors.New("credential not found in keychain")
+
+func username() string {
+	u, err := user.Current()
+	if err != nil {
+		return "chunk"
+	}
+	return u.Username
+}
+
+// Get retrieves a credential. Returns ErrNotFound if absent or keyring unavailable.
+func Get(service string) (string, error) {
+	type result struct {
+		val string
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		val, err := keyring.Get(service, username())
+		ch <- result{val, err}
+	}()
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			return "", ErrNotFound
+		}
+		return r.val, nil
+	case <-time.After(opTimeout):
+		return "", ErrNotFound
+	}
+}
+
+// Set stores a credential in the system keychain.
+func Set(service, secret string) error {
+	ch := make(chan error, 1)
+	go func() {
+		ch <- keyring.Set(service, username(), secret)
+	}()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(opTimeout):
+		return errors.New("keyring Set timed out")
+	}
+}
+
+// Delete removes a credential. Returns nil if not present.
+func Delete(service string) error {
+	ch := make(chan error, 1)
+	go func() {
+		err := keyring.Delete(service, username())
+		if errors.Is(err, keyring.ErrNotFound) {
+			err = nil
+		}
+		ch <- err
+	}()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(opTimeout):
+		return errors.New("keyring Delete timed out")
+	}
+}

--- a/internal/keyring/keyring_test.go
+++ b/internal/keyring/keyring_test.go
@@ -1,0 +1,37 @@
+package keyring_test
+
+import (
+	"testing"
+
+	gokeyring "github.com/zalando/go-keyring"
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/keyring"
+)
+
+func TestGetReturnsNotFoundWhenEmpty(t *testing.T) {
+	gokeyring.MockInit()
+	_, err := keyring.Get(keyring.ServiceAnthropic("https://api.anthropic.com"))
+	assert.ErrorIs(t, err, keyring.ErrNotFound)
+}
+
+func TestSetAndGetRoundTrip(t *testing.T) {
+	gokeyring.MockInit()
+	assert.NilError(t, keyring.Set(keyring.ServiceCircleCI("https://circleci.com"), "token123"))
+	val, err := keyring.Get(keyring.ServiceCircleCI("https://circleci.com"))
+	assert.NilError(t, err)
+	assert.Equal(t, val, "token123")
+}
+
+func TestDeleteNonExistentSucceeds(t *testing.T) {
+	gokeyring.MockInit()
+	assert.NilError(t, keyring.Delete(keyring.ServiceGitHub("https://api.github.com")))
+}
+
+func TestDeleteRemovesStoredCredential(t *testing.T) {
+	gokeyring.MockInit()
+	assert.NilError(t, keyring.Set(keyring.ServiceGitHub("https://api.github.com"), "gh-token"))
+	assert.NilError(t, keyring.Delete(keyring.ServiceGitHub("https://api.github.com")))
+	_, err := keyring.Get(keyring.ServiceGitHub("https://api.github.com"))
+	assert.ErrorIs(t, err, keyring.ErrNotFound)
+}

--- a/internal/keyring/keyring_test.go
+++ b/internal/keyring/keyring_test.go
@@ -1,6 +1,7 @@
 package keyring_test
 
 import (
+	"os"
 	"testing"
 
 	gokeyring "github.com/zalando/go-keyring"
@@ -9,14 +10,17 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/keyring"
 )
 
-func TestGetReturnsNotFoundWhenEmpty(t *testing.T) {
+func TestMain(m *testing.M) {
 	gokeyring.MockInit()
+	os.Exit(m.Run())
+}
+
+func TestGetReturnsNotFoundWhenEmpty(t *testing.T) {
 	_, err := keyring.Get(keyring.ServiceAnthropic("https://api.anthropic.com"))
 	assert.ErrorIs(t, err, keyring.ErrNotFound)
 }
 
 func TestSetAndGetRoundTrip(t *testing.T) {
-	gokeyring.MockInit()
 	assert.NilError(t, keyring.Set(keyring.ServiceCircleCI("https://circleci.com"), "token123"))
 	val, err := keyring.Get(keyring.ServiceCircleCI("https://circleci.com"))
 	assert.NilError(t, err)
@@ -24,12 +28,10 @@ func TestSetAndGetRoundTrip(t *testing.T) {
 }
 
 func TestDeleteNonExistentSucceeds(t *testing.T) {
-	gokeyring.MockInit()
 	assert.NilError(t, keyring.Delete(keyring.ServiceGitHub("https://api.github.com")))
 }
 
 func TestDeleteRemovesStoredCredential(t *testing.T) {
-	gokeyring.MockInit()
 	assert.NilError(t, keyring.Set(keyring.ServiceGitHub("https://api.github.com"), "gh-token"))
 	assert.NilError(t, keyring.Delete(keyring.ServiceGitHub("https://api.github.com")))
 	_, err := keyring.Get(keyring.ServiceGitHub("https://api.github.com"))

--- a/internal/testing/binary/binary.go
+++ b/internal/testing/binary/binary.go
@@ -78,7 +78,9 @@ func RunCLIWithStdin(t *testing.T, args []string, e *env.TestEnv, workDir string
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binaryPath, args...)
+	// Prepend --insecure-storage so acceptance tests never touch the system keychain.
+	allArgs := append([]string{"--insecure-storage"}, args...)
+	cmd := exec.CommandContext(ctx, binaryPath, allArgs...)
 	cmd.Dir = workDir
 	cmd.Env = e.Environ()
 


### PR DESCRIPTION
## Summary

- Adds a `internal/keyring` package wrapping `go-keyring` with a 3-second timeout and service keys namespaced by provider + base URL (supporting multiple server instances)
- `config.Resolve` now reads from the system keychain between env-vars and config-file layers when `--insecure-storage` is not set
- `auth set/remove/status` commands read and write from the keychain by default; `--insecure-storage` falls back to the config file
- All `ensure*Client` helpers now receive the `*cobra.Command` so they can read `--insecure-storage` without it being threaded as a separate parameter
- Acceptance tests prepend `--insecure-storage` automatically so they never trigger a keychain prompt

## Review notes

The four commits are intended to be reviewed in order — each builds cleanly on the previous one:

1. **`internal/keyring` package** — pure library, no command changes
2. **`--insecure-storage` + `config.Resolve`** — flag wiring and priority order, no UI changes
3. **`auth` commands** — the user-facing keychain behaviour
4. **`cmd` threading + test bypass** — mechanical call-site updates

## Test plan

- [x] `task test` passes (all packages including acceptance)
- [x] `chunk auth set circleci` stores token in keychain; `security find-generic-password -s "com.circleci.chunk:circleci:https://circleci.com"` confirms entry
- [x] `chunk auth remove circleci` removes it; subsequent lookup returns not-found
- [x] `chunk auth set circleci --insecure-storage` writes to config file instead; keychain entry absent
- [x] With `CIRCLE_TOKEN` set, `chunk auth remove circleci` reports "No CircleCI token stored" (nothing to remove from storage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)