### PR TITLE
Read org ID from project config in sidecar list and create commands

### DIFF
--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -72,15 +72,29 @@ func resolveSidecarID(ctx context.Context, sidecarID *string) error {
 }
 
 // resolveOrgID returns orgID from the flag, the CIRCLECI_ORG_ID env var,
-// or by calling pickOrg as a last resort (e.g. to present a TUI picker).
-func resolveOrgID(orgID string, pickOrg func() (string, error)) (string, error) {
+// the project config, or by calling pickOrg as a last resort (e.g. to present
+// a TUI picker).
+func resolveOrgID(orgID, projOrgID string, pickOrg func() (string, error)) (string, error) {
 	if orgID != "" {
 		return orgID, nil
 	}
 	if envID := os.Getenv(config.EnvCircleCIOrgID); envID != "" {
 		return envID, nil
 	}
+	if projOrgID != "" {
+		return projOrgID, nil
+	}
 	return pickOrg()
+}
+
+// configOrgID returns the orgID stored in .chunk/config.json for dir, or ""
+// if the config cannot be loaded or has no orgID set.
+func configOrgID(dir string) string {
+	cfg, err := config.LoadProjectConfig(dir)
+	if err != nil {
+		return ""
+	}
+	return cfg.OrgID
 }
 
 func orgPicker(ctx context.Context, client *circleci.Client) func() (string, error) {
@@ -131,7 +145,11 @@ func newSidecarListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			resolvedOrgID, err := resolveOrgID(orgID, orgPicker(cmd.Context(), client))
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("get working directory: %w", err)
+			}
+			resolvedOrgID, err := resolveOrgID(orgID, configOrgID(cwd), orgPicker(cmd.Context(), client))
 			if err != nil {
 				return err
 			}
@@ -196,7 +214,11 @@ func newSidecarCreateCmd() *cobra.Command {
 			if name == "" {
 				name = randomSidecarName()
 			}
-			resolvedOrgID, err := resolveOrgID(orgID, orgPicker(cmd.Context(), client))
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("get working directory: %w", err)
+			}
+			resolvedOrgID, err := resolveOrgID(orgID, configOrgID(cwd), orgPicker(cmd.Context(), client))
 			if err != nil {
 				return err
 			}
@@ -812,7 +834,7 @@ Example:
 			// Step 2: Resolve or create sidecar.
 			if sidecarID == "" {
 				var resolveErr error
-				sidecarID, _, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, name, status, streams)
+				sidecarID, _, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, name, dir, status, streams)
 				if resolveErr != nil {
 					return resolveErr
 				}
@@ -874,7 +896,7 @@ Example:
 func sidecarSetupResolveSidecar(
 	ctx context.Context,
 	client *circleci.Client,
-	orgID, name string,
+	orgID, name, workDir string,
 	status iostream.StatusFunc,
 	streams iostream.Streams,
 ) (id, displayName string, err error) {
@@ -889,7 +911,7 @@ func sidecarSetupResolveSidecar(
 	if name == "" {
 		name = randomSidecarName()
 	}
-	resolvedOrgID, err := resolveOrgID(orgID, orgPicker(ctx, client))
+	resolvedOrgID, err := resolveOrgID(orgID, configOrgID(workDir), orgPicker(ctx, client))
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -550,13 +550,7 @@ func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, side
 		return false, nil
 	}
 	streams.ErrPrintf("No active sidecar found, creating a new sandbox...\n")
-	// Fallback: read org ID from project config if not provided via flag or env.
-	if orgID == "" {
-		if projCfg, cfgErr := config.LoadProjectConfig(workDir); cfgErr == nil && projCfg.OrgID != "" {
-			orgID = projCfg.OrgID
-		}
-	}
-	resolvedOrgID, err := resolveOrgID(orgID, orgPicker(ctx, client))
+	resolvedOrgID, err := resolveOrgID(orgID, configOrgID(workDir), orgPicker(ctx, client))
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## Summary

- Adds a `configOrgID(dir string)` helper that reads the org ID from `.chunk/config.json`, keeping that logic in one place
- Threads the project config org ID into `resolveOrgID` as a new middle-priority fallback (flag → env var → project config → TUI picker), covering the `sidecar list` and `sidecar create` commands which previously skipped it
- Propagates `os.Getwd()` errors in both `RunE` closures instead of silently discarding them — a deleted working directory would otherwise cause the config lookup to be silently skipped with no diagnostic
- Consolidates the inline org-ID-from-config fallback in `validate.go` to use the shared helper

## Test plan

- [ ] `chunk sidecar list` resolves org ID from `.chunk/config.json` when no flag or `CIRCLECI_ORG_ID` env var is set
- [ ] `chunk sidecar create` resolves org ID from `.chunk/config.json` under the same conditions
- [ ] Both commands return a clear error if the working directory cannot be determined

🤖 Generated with [Claude Code](https://claude.com/claude-code)