### PR TITLE
Document Smarter Testing on sidecars

### DIFF
--- a/.circleci/test-suites.yml
+++ b/.circleci/test-suites.yml
@@ -1,6 +1,6 @@
 ---
 name: ci tests
 discover: go list -f '{{ if or (len .TestGoFiles) (len .XTestGoFiles) }} {{ .ImportPath }} {{end}}' ./...
-run: go tool gotestsum --junitfile="<< outputs.junit >>" -- -race -coverprofile=coverage.out << test.atoms >>
+run: go tool gotestsum --junitfile="<< outputs.junit >>" -- -race << test.atoms >>
 outputs:
   junit: test-reports/tests.xml

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -31,6 +31,8 @@ chunk
 │   --skip-hooks                    # Skip hook file generation
 │   --skip-validate                 # Skip validate command detection
 │   --skip-completions               # Skip shell completion installation
+│   --skip-test-suites              # Skip .circleci/test-suites.yml scaffolding (default: true; pass =false to generate)
+│   --skip-skills                   # Skip agent skill installation
 │   --project-dir <path>            # Project directory (defaults to cwd)
 │
 ├── task

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -236,6 +236,95 @@ chunk sidecar create --image <snapshot-id>           # name auto-generated
 
 ---
 
+## Smarter Testing on a sidecar
+
+CircleCI Smarter Testing splits your test suite into independent **atoms** and distributes them across parallel shards so CI runs finish faster. The split is driven by `.circleci/test-suites.yml`, a file that declares how to **discover** atoms and how to **run** them. Sidecars are an ideal place to validate this file before pushing — they run Linux (matching CI), have the `circleci-testsuite` plugin and `circleci` CLI pre-installed, and automatically receive your `CIRCLE_TOKEN` over SSH.
+
+### Scaffold `.circleci/test-suites.yml`
+
+**Built-in templates (Go and pytest):**
+
+```bash
+chunk init --skip-test-suites=false
+```
+
+> `--skip-test-suites` defaults to `true`, so you must pass `=false` explicitly. The `=` is required — `--skip-test-suites false` does not work with boolean cobra flags.
+
+This detects `go.mod` or `pyproject.toml` and writes a matching template. If the file already exists it is left as-is.
+
+**Other stacks (Jest, RSpec, etc.):** write the file manually or ask your AI agent to `"scaffold test-suites.yml"` (the `chunk-sidecar` skill covers per-language patterns). The file schema:
+
+```yaml
+---
+name: <suite-name>
+discover: <shell command that prints one test atom per line>
+run: <shell command that runs atoms in << test.atoms >>, writing junit XML to << outputs.junit >>>
+outputs:
+  junit: <path/to/junit.xml>
+```
+
+CircleCI substitutes `<< test.atoms >>` and `<< outputs.junit >>` at run time. Example for Jest:
+
+```yaml
+---
+name: ci tests
+discover: npx jest --listTests
+run: JEST_JUNIT_OUTPUT_FILE=<< outputs.junit >> npx jest --reporters=default --reporters=jest-junit << test.atoms >>
+outputs:
+  junit: test-reports/tests.xml
+```
+
+### Validate on the sidecar
+
+After writing `.circleci/test-suites.yml`, use the sidecar to verify it works in a CI-like environment:
+
+```bash
+# 1. Push your local tree (including the new file) to the sidecar
+chunk sidecar sync
+
+# 2. Test discover — should print one atom per line and exit zero
+chunk validate --remote --cmd "go list -f '{{ if or (len .TestGoFiles) (len .XTestGoFiles) }} {{ .ImportPath }} {{end}}' ./..."
+
+# 3. Test run with a sample atom — should produce junit XML at the declared path
+chunk validate --remote --cmd "go tool gotestsum --junitfile=test-reports/tests.xml -- -race ./internal/config/..."
+
+# 4. Validate your CircleCI config references the suite correctly
+chunk validate --remote --cmd "circleci config validate"
+```
+
+Replace the Go commands above with your stack's `discover` and `run` commands. For the run step, substitute `<< test.atoms >>` with one or two atoms from discover's output and `<< outputs.junit >>` with the `outputs.junit` path from your YAML.
+
+### Why use a sidecar for this
+
+- **Pre-installed tooling** — `circleci-testsuite` and `circleci` CLI are available on every sidecar without any install step.
+- **Automatic auth** — `CIRCLE_TOKEN` is forwarded over SSH to the sidecar session, so authenticated `circleci` commands work out of the box. You do not need to set the token manually on the sidecar.
+- **CI parity** — the sidecar runs Linux, catching path separator issues, case sensitivity, and missing system dependencies that pass on macOS but fail in CI.
+
+### Wire up `.circleci/config.yml`
+
+After validating the suite, reference it from your CircleCI config using the `circleci-testsuite` plugin in your test job:
+
+```yaml
+jobs:
+  test:
+    docker:
+      - image: cimg/go:1.26
+    steps:
+      - checkout
+      - run:
+          name: Run tests
+          command: |
+            circleci-testsuite exec \
+              --suite "ci tests" \
+              --results-dir test-reports
+      - store_test_results:
+          path: test-reports
+```
+
+The `--suite` value must match the `name` field in `.circleci/test-suites.yml`. The plugin handles discovery, atom assignment, and result collection.
+
+---
+
 ## Hook behavior
 
 After `chunk init`, two hooks run automatically in Claude Code and Cursor:

--- a/skills/chunk-sidecar/SKILL.md
+++ b/skills/chunk-sidecar/SKILL.md
@@ -135,13 +135,16 @@ An atom is the smallest independent unit the runner accepts. Match the runner's 
 - `discover` must be deterministic and exit non-zero on error — the platform calls it once per pipeline.
 - `run` must accept any subset of `discover`'s output, including a single atom and the full set. Verify locally with a hand-picked subset before committing.
 - `outputs.junit` must be a junit XML file the runner actually writes. The platform reads it to report pass/fail and timing.
-- `.circleci/test-suites.yml` is referenced from `.circleci/config.yml` via the Smarter Testing orb. After writing the suite, confirm the orb usage references the suite `name` you chose.
+- `.circleci/test-suites.yml` is referenced from `.circleci/config.yml` via the `circleci-testsuite` plugin invoked directly in a test job (not via the Smarter Testing orb). After writing the suite, confirm the `circleci-testsuite exec --suite <name>` call uses the suite `name` you chose.
 
 ### After writing
 
-1. Run `discover` locally — confirm it prints one atom per line on stdout and exits zero.
-2. Run `run` locally with `<< test.atoms >>` substituted by one or two atoms — confirm a junit XML file appears at the `outputs.junit` path.
-3. Read `.circleci/config.yml` and verify the Smarter Testing orb references the suite name.
+Validate on the sidecar — the `circleci-testsuite` plugin and `circleci` CLI are pre-installed there, matching the CI environment.
+
+1. `chunk sidecar sync` — push the new file to the active sidecar.
+2. `chunk validate --remote --cmd "<discover-command>"` — confirm it prints one atom per line and exits zero.
+3. `chunk validate --remote --cmd "<run-command with one or two atoms>"` — confirm a junit XML file appears at the `outputs.junit` path.
+4. `chunk validate --remote --cmd "circleci config validate"` — confirm `.circleci/config.yml` parses and the `circleci-testsuite exec --suite <name>` call uses the suite `name` you chose.
 
 ## Parallel sessions
 


### PR DESCRIPTION
## Summary
- Sidecar templates now ship with the `circleci-testsuite` plugin and `circleci` CLI pre-installed; update GETTING_STARTED with a Smarter Testing walkthrough that scaffolds `.circleci/test-suites.yml` and validates it on the sidecar (no install step).
- Replace stale "Smarter Testing orb" references in `skills/chunk-sidecar/SKILL.md` with the `circleci-testsuite` plugin invocation, and switch the post-write validation steps to use `chunk validate --remote` so they match the new sidecar capabilities.
- Document the new `chunk init` flags (`--skip-test-suites`, `--skip-skills`) in `docs/CLI.md`, and drop the unused `-coverprofile` flag from this repo's own `.circleci/test-suites.yml`.

## Test plan
- [ ] `task lint` passes
- [ ] Skim rendered `docs/GETTING_STARTED.md` — Smarter Testing section reads cleanly
- [ ] Confirm `skills/chunk-sidecar/SKILL.md` no longer mentions the Smarter Testing orb
- [ ] On a fresh sidecar from the rebuilt template, verify `circleci-testsuite --help` and `circleci --version` work without setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)