### PR TITLE
Suggest signup URL when CircleCI auth is missing on sidecar commands

### DIFF
--- a/internal/cmd/authhelper.go
+++ b/internal/cmd/authhelper.go
@@ -66,6 +66,7 @@ func ensureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc config.Res
 	streams.ErrPrintln("")
 	streams.ErrPrintln(ui.Bold("CircleCI token required"))
 	streams.ErrPrintln("Create a token at https://app.circleci.com/settings/user/tokens")
+	streams.ErrPrintln("Don't have an account? Sign up at https://app.circleci.com/signup")
 	printSaveHint(streams, "Token", insecureStorage)
 	streams.ErrPrintln("")
 

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -226,6 +226,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	if hook != nil && cfg.HasRemoteCommands() && rc.CircleCIToken == "" {
 		streams.ErrPrintln("CircleCI auth is not configured.")
 		streams.ErrPrintln("Suggestion: " + suggestionCircleCIAuth)
+		streams.ErrPrintln("Don't have an account? Sign up at https://app.circleci.com/signup")
 		return errSilentExit
 	}
 


### PR DESCRIPTION
## Summary

- When a user runs a sidecar command without a CircleCI token configured, the interactive prompt now includes a \"Don't have an account? Sign up at https://app.circleci.com/signup\" hint beneath the existing token creation link
- The same hint is added to the non-TTY/hook fast-exit path in `validate.go` for users running in hook context without auth configured

The existing token creation URL and `chunk auth set circleci` suggestion are unchanged.

<img width="570" height="146" alt="Screenshot 2026-05-21 at 12 27 05 PM" src="https://github.com/user-attachments/assets/9ec380e8-6c0c-4a6e-a5c8-b9df0e5c9e60" />

<img width="570" height="146" alt="Screenshot 2026-05-21 at 12 27 20 PM" src="https://github.com/user-attachments/assets/d75ad504-1ba9-4166-8993-18c9c4a873e4" />


## Test plan

- [ ] Run a sidecar command (e.g. `chunk sidecar list`) without a CircleCI token configured and verify the signup URL appears below the token creation link
- [ ] Verify the existing token prompt flow still works correctly after entering a valid token

🤖 Generated with [Claude Code](https://claude.com/claude-code)