### PR TITLE
Add telemetry opt-out controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,36 @@ See [docs/CLI.md](docs/CLI.md) for the full command and flag reference.
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the complete environment variable reference.
 
+## Telemetry
+
+chunk collects anonymous usage statistics to help improve the tool.
+
+**What we collect:**
+- Which commands and subcommands are used
+- Whether commands succeed or fail (no error messages or details)
+- chunk version, OS, and architecture
+
+**What we do NOT collect:**
+- Command arguments or flag values
+- File or directory names
+- IP addresses or hostnames
+- Any personally identifiable information
+
+**To disable telemetry:**
+
+```bash
+# Permanently via the telemetry command
+chunk telemetry disable
+
+# Environment variable (persists for the session or CI run)
+CHUNK_NO_TELEMETRY=1 chunk <command>
+
+# Per-invocation flag
+chunk --no-telemetry <command>
+```
+
+The standard `NO_ANALYTICS=1`, `DO_NOT_TRACK=1`, and `CI=true` environment variables are also respected.
+
 ## Platform Support
 
 | Platform | Status |

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/segmentio/analytics-go/v3 v3.3.0
 	github.com/sethvargo/go-envconfig v1.3.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.51.0
 	golang.org/x/term v0.43.0
@@ -224,7 +225,6 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.12.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.3.1 // indirect

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -96,7 +97,7 @@ func newConfigSetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "set <key> <value>",
 		Short: "Set a config value",
-		Long:  "Set a config value. Use 'chunk auth set <provider>' to store credentials with validation.\n\nUser keys: model\nProject keys: orgID, validation.sidecarImage",
+		Long:  "Set a config value. Use 'chunk auth set <provider>' to store credentials with validation.\n\nUser keys: model, telemetry\nProject keys: orgID, validation.sidecarImage",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
@@ -132,7 +133,7 @@ func newConfigSetCmd() *cobra.Command {
 			if !config.ValidConfigKeys[key] {
 				return &userError{
 					msg:    fmt.Sprintf("Unknown config key: %q.", key),
-					detail: "Supported keys: model, orgID, validation.sidecarImage.",
+					detail: "Supported keys: model, telemetry, orgID, validation.sidecarImage.",
 					errMsg: fmt.Sprintf("unknown config key %q", key),
 				}
 			}
@@ -142,12 +143,22 @@ func newConfigSetCmd() *cobra.Command {
 				return &userError{msg: msgCouldNotLoadConfig, suggestion: configFilePermHint, err: err}
 			}
 
-			if key == "model" {
+			switch key {
+			case "model":
 				cfg.Model = value
+			case "telemetry":
+				enabled, parseErr := strconv.ParseBool(value)
+				if parseErr != nil {
+					return &userError{
+						msg:    fmt.Sprintf("Invalid value for telemetry: %q. Use true or false.", value),
+						errMsg: fmt.Sprintf("invalid telemetry value %q", value),
+					}
+				}
+				cfg.NoTelemetry = !enabled
 			}
 
 			if err := config.Save(cfg); err != nil {
-				return &userError{msg: "Could not save configuration.", suggestion: configFilePermHint, err: err}
+				return &userError{msg: msgCouldNotSaveConfig, suggestion: configFilePermHint, err: err}
 			}
 
 			io.Printf("%s\n", ui.Success(fmt.Sprintf("Set %s to %s", key, value)))

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -81,6 +81,7 @@ Telemetry:
 
   To disable telemetry:
     Set CHUNK_NO_TELEMETRY=1 in your environment
+    Run: chunk telemetry disable
     Pass --no-telemetry to disable for a single invocation
 
 Configuration:
@@ -101,6 +102,7 @@ Configuration:
 	rootCmd.AddCommand(newHookCmd())
 	rootCmd.AddCommand(newUpgradeCmd())
 	rootCmd.AddCommand(newCommandsCmd())
+	rootCmd.AddCommand(newTelemetryCmd())
 
 	recordTelemetryForSubcommands(rootCmd, telem)
 

--- a/internal/cmd/telemetry.go
+++ b/internal/cmd/telemetry.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+)
+
+func newTelemetryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "telemetry",
+		Short: "Manage telemetry settings",
+		RunE:  groupRunE,
+	}
+
+	enableCmd := newTelemetryEnableCmd()
+	disableCmd := newTelemetryDisableCmd()
+
+	disableTelemetry(enableCmd)
+	disableTelemetry(disableCmd)
+
+	cmd.AddCommand(enableCmd)
+	cmd.AddCommand(disableCmd)
+
+	return cmd
+}
+
+func newTelemetryEnableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "enable",
+		Short: "Enable anonymous usage telemetry",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			io := iostream.FromCmd(cmd)
+			cfg, err := config.Load()
+			if err != nil {
+				return &userError{msg: msgCouldNotLoadConfig, suggestion: configFilePermHint, err: err}
+			}
+			cfg.NoTelemetry = false
+			if err := config.Save(cfg); err != nil {
+				return &userError{msg: msgCouldNotSaveConfig, suggestion: configFilePermHint, err: err}
+			}
+			io.Printf("%s\n", ui.Success("Telemetry enabled."))
+			return nil
+		},
+	}
+}
+
+func newTelemetryDisableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "disable",
+		Short: "Disable anonymous usage telemetry",
+		Long: fmt.Sprintf(`Disable anonymous usage telemetry.
+
+You can also set %s=1 in your environment, or pass --no-telemetry
+to disable telemetry for a single invocation.
+
+Run 'chunk telemetry enable' to re-enable.`, config.EnvChunkNoTelemetry),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			io := iostream.FromCmd(cmd)
+			cfg, err := config.Load()
+			if err != nil {
+				return &userError{msg: msgCouldNotLoadConfig, suggestion: configFilePermHint, err: err}
+			}
+			cfg.NoTelemetry = true
+			if err := config.Save(cfg); err != nil {
+				return &userError{msg: msgCouldNotSaveConfig, suggestion: configFilePermHint, err: err}
+			}
+			io.Printf("%s\n", ui.Success("Telemetry disabled."))
+			return nil
+		},
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -308,7 +308,8 @@ func MaskKey(key string) string {
 // Credentials (anthropicAPIKey, circleCIToken) are intentionally excluded —
 // users should use "auth set" which validates before storing.
 var ValidConfigKeys = map[string]bool{
-	"model": true,
+	"model":     true,
+	"telemetry": true,
 }
 
 // ValidProjectConfigKeys are the keys accepted by "config set" that write to


### PR DESCRIPTION
## Summary

Adds user-facing opt-out controls for the anonymous telemetry introduced in the base branch.

- `chunk telemetry disable` / `chunk telemetry enable` — persists preference to config
- `--no-telemetry` flag — disables telemetry for a single invocation
- `CHUNK_NO_TELEMETRY=1`, `NO_ANALYTICS=1`, `DO_NOT_TRACK=1`, `CI=true` env vars — all respected
- `chunk config set telemetry false/true` — alternative config-key path
- README telemetry section documenting what is and isn't collected, and how to opt out

## Test plan

- [ ] `chunk telemetry disable` sets `noTelemetry: true` in config; subsequent commands emit no events
- [ ] `chunk telemetry enable` clears the flag
- [ ] `CHUNK_NO_TELEMETRY=1 chunk build-prompt` emits no events
- [ ] `--no-telemetry` suppresses telemetry for a single invocation
- [ ] `CI=true` suppresses telemetry
- [ ] `chunk config set telemetry false` / `true` toggles the setting correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)