### PR TITLE
sidecar sync: restore git fetch before reset to handle stale clones

### DIFF
--- a/internal/sidecar/sync.go
+++ b/internal/sidecar/sync.go
@@ -155,6 +155,16 @@ func syncWorkspace(ctx context.Context, status iostream.StatusFunc, org, repo, r
 
 	status(iostream.LevelInfo, fmt.Sprintf("Synchronising local %s/%s to remote: %s...", org, repo, repoPath))
 
+	status(iostream.LevelInfo, "Fetching remote refs on sidecar...")
+	fetchCmd := fmt.Sprintf("git -C %s fetch origin", ShellEscape(repoPath))
+	fetchResult, err := ExecOverSSH(ctx, session, fetchCmd, nil, nil)
+	if err != nil {
+		return fmt.Errorf("sync: fetch: %w", err)
+	}
+	if fetchResult.ExitCode != 0 {
+		return fmt.Errorf("sync: fetch failed (exit code: %d): %s", fetchResult.ExitCode, fetchResult.Stderr)
+	}
+
 	base, err := gitutil.MergeBase()
 	if err != nil {
 		return &RemoteBaseError{Err: err}

--- a/internal/sidecar/sync_test.go
+++ b/internal/sidecar/sync_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -15,6 +18,34 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/gitrepo"
 )
+
+// setupRepoWithOriginHEAD creates a git repo whose remote URL looks like
+// github.com/org/repo and whose refs/remotes/origin/HEAD points to the current
+// HEAD SHA, so that gitutil.MergeBase can resolve a base commit.
+func setupRepoWithOriginHEAD(t *testing.T, org, repo string) string {
+	t.Helper()
+	dir := gitrepo.SetupGitRepo(t, org, repo)
+	env := gitrepo.GitEnv(dir)
+
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	head := strings.TrimSpace(string(out))
+
+	for _, args := range [][]string{
+		{"update-ref", "refs/remotes/origin/main", head},
+		{"symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = env
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	return dir
+}
 
 // TestSync_NonApplyFailureReturnsImmediately verifies that Sync does not send a
 // "rm -rf" cleanup command when syncWorkspace fails for a reason other than a
@@ -63,4 +94,56 @@ func TestSync_NonApplyFailureReturnsImmediately(t *testing.T) {
 		assert.Assert(t, !strings.Contains(cmd, "rm -rf"),
 			"Sync must not send rm -rf for non-apply failures; got command: %q", cmd)
 	}
+}
+
+// TestSync_FetchBeforeReset verifies that Sync issues a git fetch origin on the
+// sidecar before git reset --hard. This ensures the sidecar can recover when
+// its clone is stale — i.e. the merge-base commit exists on GitHub but is
+// absent from the sidecar's local object store (e.g. when booted from an older
+// snapshot).
+func TestSync_FetchBeforeReset(t *testing.T) {
+	keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+
+	// SSH server: all commands succeed, so the full sync path runs through to
+	// git apply without triggering the rm-rf retry.
+	sshSrv := fakes.NewSSHServer(t, pubKey)
+	sshSrv.SetResult("", 0)
+
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = sshSrv.Addr()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	t.Setenv(config.EnvHome, t.TempDir())
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
+
+	// Repo with origin/HEAD set so MergeBase resolves successfully.
+	repoDir := setupRepoWithOriginHEAD(t, "my-org", "my-repo")
+	// Write an untracked file so GeneratePatch produces a non-empty patch and
+	// Sync reaches the reset+apply steps rather than returning early.
+	assert.NilError(t, os.WriteFile(filepath.Join(repoDir, "change.txt"), []byte("change"), 0o644))
+	t.Chdir(repoDir)
+
+	cl := newClient(t, srv.URL)
+	noopStatus := iostream.StatusFunc(func(_ iostream.Level, _ string) {})
+
+	err := sidecar.Sync(context.Background(), cl, "sb-1", keyFile, "", "", noopStatus)
+	assert.NilError(t, err)
+
+	// Find the positions of the fetch and reset commands in the recorded sequence.
+	cmds := sshSrv.Commands()
+	fetchIdx, resetIdx := -1, -1
+	for i, cmd := range cmds {
+		if strings.Contains(cmd, "fetch origin") {
+			fetchIdx = i
+		}
+		if strings.Contains(cmd, "reset --hard") {
+			resetIdx = i
+		}
+	}
+
+	assert.Assert(t, fetchIdx >= 0, "expected a fetch origin command; got: %v", cmds)
+	assert.Assert(t, resetIdx >= 0, "expected a reset --hard command; got: %v", cmds)
+	assert.Assert(t, fetchIdx < resetIdx,
+		"fetch (index %d) must come before reset (index %d); commands: %v", fetchIdx, resetIdx, cmds)
 }

--- a/internal/testing/fakes/ssh.go
+++ b/internal/testing/fakes/ssh.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/binary"
 	"encoding/pem"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -168,7 +169,6 @@ func (s *SSHServer) handleConn(conn net.Conn, cfg *ssh.ServerConfig) {
 }
 
 func (s *SSHServer) handleSession(ch ssh.Channel, requests <-chan *ssh.Request) {
-	defer func() { _ = ch.Close() }()
 
 	for req := range requests {
 		switch req.Type {
@@ -225,6 +225,12 @@ func (s *SSHServer) handleSession(ch ssh.Channel, requests <-chan *ssh.Request) 
 		exitPayload := make([]byte, 4)
 		binary.BigEndian.PutUint32(exitPayload, uint32(exitCode)) //nolint:gosec // exit codes are 0-255
 		_, _ = ch.SendRequest("exit-status", false, exitPayload)
+		// Signal EOF on stdout/stderr, then drain stdin before closing the
+		// channel. Without the drain, the client's stdin write (e.g. a patch
+		// piped to git apply) races with channel close and returns io.EOF.
+		_ = ch.CloseWrite()
+		_, _ = io.Copy(io.Discard, ch)
+		_ = ch.Close()
 		return // one exec per session
 	}
 }


### PR DESCRIPTION
## Summary

- Re-adds `git fetch origin` before `git reset --hard` in `syncWorkspace`, restoring behaviour removed in bacb751
- Without the fetch, `git reset --hard <merge-base>` fails when the sidecar's clone is missing that commit — e.g. when booted from a snapshot taken before the most recent push to origin
- Adds `TestSync_FetchBeforeReset` to verify fetch is issued before reset in the SSH command sequence
- Fixes a latent race in the fake SSH server (`fakes.SSHServer`) where closing the channel before draining stdin caused intermittent `io.EOF` errors on commands that pipe stdin (e.g. `git apply`)

## Test plan

- [x] `task test` passes (888 tests)
- [x] `TestSync_FetchBeforeReset` reproduces the contract: fetch command recorded before reset command in the SSH sequence
- [x] Run `scripts/test-fetch-on-stale-sidecar.sh` against a real sidecar to verify end-to-end recovery from a purged object store

🤖 Generated with [Claude Code](https://claude.com/claude-code)