### PR TITLE
docs: document orgID and --org-id; show orgID in config show

### DIFF
--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -1,6 +1,7 @@
 package acceptance
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/chunk-cli/internal/testing/env"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/gitrepo"
 )
 
 func TestConfigSetAndShow(t *testing.T) {
@@ -311,4 +313,52 @@ func TestConfigSetMissingKeyAndValue(t *testing.T) {
 	result := binary.RunCLI(t, []string{"config", "set"}, env, env.HomeDir)
 	assert.Assert(t, result.ExitCode != 0,
 		"expected non-zero exit for missing args\nstdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+}
+
+func TestConfigSetOrgID(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	env := testenv.NewTestEnv(t)
+
+	setResult := binary.RunCLI(t, []string{"config", "set", "orgID", "org-xyz"}, env, workDir)
+	assert.Equal(t, setResult.ExitCode, 0, "config set orgID failed\nstdout: %s\nstderr: %s", setResult.Stdout, setResult.Stderr)
+
+	data, err := os.ReadFile(filepath.Join(workDir, ".chunk", "config.json"))
+	assert.NilError(t, err)
+	var cfg map[string]string
+	err = json.Unmarshal(data, &cfg)
+	assert.NilError(t, err)
+	assert.Equal(t, cfg["orgID"], "org-xyz")
+}
+
+func TestConfigShowOrgIDFromProjectConfig(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	env := testenv.NewTestEnv(t)
+
+	setResult := binary.RunCLI(t, []string{"config", "set", "orgID", "org-show-test"}, env, workDir)
+	assert.Equal(t, setResult.ExitCode, 0, "config set orgID failed")
+
+	showResult := binary.RunCLI(t, []string{"config", "show"}, env, workDir)
+	assert.Equal(t, showResult.ExitCode, 0, "config show failed\nstdout: %s\nstderr: %s", showResult.Stdout, showResult.Stderr)
+
+	combined := showResult.Stdout + showResult.Stderr
+	assert.Check(t, cmp.Contains(combined, "org-show-test"))
+	assert.Check(t, cmp.Contains(combined, "Project config"))
+}
+
+func TestConfigShowOrgIDEnvPrecedence(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	env := testenv.NewTestEnv(t)
+
+	err := config.SaveProjectConfig(workDir, &config.ProjectConfig{OrgID: "org-from-file"})
+	assert.NilError(t, err)
+
+	env.Extra["CIRCLECI_ORG_ID"] = "org-from-env"
+	result := binary.RunCLI(t, []string{"config", "show"}, env, workDir)
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	combined := result.Stdout + result.Stderr
+	assert.Check(t, cmp.Contains(combined, "org-from-env"))
+	assert.Check(t, !strings.Contains(combined, "org-from-file"),
+		"project orgID should not appear when env var is set, got: %s", combined)
+	assert.Check(t, cmp.Contains(combined, "CIRCLECI_ORG_ID"))
 }

--- a/acceptance/sidecar_gaps_test.go
+++ b/acceptance/sidecar_gaps_test.go
@@ -8,6 +8,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/chunk-cli/internal/testing/env"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
@@ -195,7 +196,7 @@ func TestSidecarEnvNonexistentDir(t *testing.T) {
 
 // --- create error paths ---
 
-func TestSidecarCreateOrgIDFromConfig(t *testing.T) {
+func TestSidecarCreateOrgIDFromEnv(t *testing.T) {
 	cci := fakes.NewFakeCircleCI()
 	srv := httptest.NewServer(cci)
 	defer srv.Close()
@@ -204,17 +205,16 @@ func TestSidecarCreateOrgIDFromConfig(t *testing.T) {
 
 	env := testenv.NewTestEnv(t)
 	env.CircleCIURL = srv.URL
-	env.Extra["CIRCLECI_ORG_ID"] = "org-from-config"
+	env.Extra["CIRCLECI_ORG_ID"] = "org-from-env"
 
 	// No --org-id flag; should read from CIRCLECI_ORG_ID
 	result := binary.RunCLI(t, []string{
 		"sidecar", "create",
-		"--name", "config-sidecar",
+		"--name", "env-sidecar",
 	}, env, workDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 
-	// Verify org_id in request body came from config
 	reqs := cci.Recorder.AllRequests()
 	createReqs := filterByMethod(reqs, "POST", "/api/v2/sidecar/instances")
 	assert.Equal(t, len(createReqs), 1)
@@ -222,7 +222,36 @@ func TestSidecarCreateOrgIDFromConfig(t *testing.T) {
 	var body map[string]interface{}
 	err := json.Unmarshal(createReqs[0].Body, &body)
 	assert.NilError(t, err)
-	assert.Equal(t, body["org_id"], "org-from-config")
+	assert.Equal(t, body["org_id"], "org-from-env")
+}
+
+func TestSidecarCreateOrgIDFromProjectConfig(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	err := config.SaveProjectConfig(workDir, &config.ProjectConfig{OrgID: "org-from-project"})
+	assert.NilError(t, err)
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, []string{
+		"sidecar", "create",
+		"--name", "project-sidecar",
+	}, env, workDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	reqs := cci.Recorder.AllRequests()
+	createReqs := filterByMethod(reqs, "POST", "/api/v2/sidecar/instances")
+	assert.Equal(t, len(createReqs), 1)
+
+	var body map[string]interface{}
+	err = json.Unmarshal(createReqs[0].Body, &body)
+	assert.NilError(t, err)
+	assert.Equal(t, body["org_id"], "org-from-project")
 }
 
 func TestSidecarCreateNoOrgIDNoConfig(t *testing.T) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,8 +158,17 @@ User config lives at `$XDG_CONFIG_HOME/chunk/config.json` (default: `~/.config/c
 
 ```json
 {
-  "apiKey": "sk-...",
+  "anthropicAPIKey": "sk-...",
   "model": "claude-sonnet-4-6"
+}
+```
+
+Project config lives in `.chunk/config.json` (per repository):
+
+```json
+{
+  "orgID": "f22b6566-597d-46d5-ba74-99ef5bb3d85c",
+  "commands": []
 }
 ```
 
@@ -178,6 +187,7 @@ in `config.Resolve` and makes clients testable.
 | `GITHUB_TOKEN` | github | GitHub authentication |
 | `GITHUB_API_URL` | github | GitHub API endpoint override |
 | `CIRCLE_TOKEN` / `CIRCLECI_TOKEN` | circleci | CircleCI authentication |
+| `CIRCLECI_ORG_ID` | sidecar | CircleCI organization ID (overrides `orgID` in `.chunk/config.json`) |
 | `CIRCLECI_BASE_URL` | circleci | CircleCI endpoint override |
 | `CLAUDE_PROJECT_DIR` | init | IDE-provided project directory |
 | `XDG_CONFIG_HOME` | config | User config directory (default: `~/.config`) |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -24,7 +24,7 @@ chunk
 │
 ├── config
 │   ├── show                        # Display resolved configuration
-│   └── set <key> <value>           # Set a config value (keys: model, apiKey)
+│   └── set <key> <value>           # Set a config value (see Config keys below)
 │
 ├── init                            # Initialize project configuration
 │   --force                         # Overwrite existing config
@@ -64,8 +64,8 @@ chunk
 ├── sidecar
 │   ├── list --org-id <id>          # List sidecars
 │   ├── create                      # Create a sidecar
-│   │   --org-id <id>               # Organization ID (required)
-│   │   --name <name>               # Sidecar name (required)
+│   │   --org-id <id>               # Organization ID (see Org ID resolution)
+│   │   --name <name>               # Sidecar name (auto-generated if omitted)
 │   │   --image <image>             # E2B template ID or container image
 │   ├── use <id>                    # Set the active sidecar for this project
 │   ├── current                     # Show the active sidecar
@@ -127,7 +127,13 @@ chunk
 - `build-prompt --since` defaults to 3 months before the current date.
 - `task run` defaults to pipeline-as-tool mode; use `--no-pipeline-as-tool`
   to disable.
-- `config set` accepts only `model` and `apiKey` as keys.
+- `config set` user keys: `model`. Project keys (`.chunk/config.json`): `orgID`,
+  `validation.sidecarImage`. Credentials use `chunk auth set`, not `config set`.
+- **Org ID resolution** for `sidecar create`, `sidecar list`, and other sidecar
+  subcommands that need an org (in order): `--org-id` flag → `CIRCLECI_ORG_ID`
+  env var → `orgID` in `.chunk/config.json` → interactive org picker (TTY only).
+  Non-interactive sessions (agents, CI) should set `orgID` in project config or
+  pass `--org-id` / `CIRCLECI_ORG_ID`.
 - `chunk init` uses Claude to auto-detect the test command for the project.
   It generates `.claude/settings.json` with pre-commit hooks. It never touches
   CircleCI — tokens are prompted inline only when a command actually needs them.
@@ -136,6 +142,18 @@ chunk
   failing with an error.
 - `chunk auth set github` stores a GitHub token in the config file; previously
   only the `GITHUB_TOKEN` environment variable was supported.
+
+## Config keys
+
+| Key | Scope | Description |
+|-----|-------|-------------|
+| `model` | user config (`~/.config/chunk/config.json`) | Claude model override |
+| `orgID` | `.chunk/config.json` | CircleCI organization ID for sidecar subcommands |
+| `validation.sidecarImage` | `.chunk/config.json` | Snapshot or image ID for sidecar bootstrap and validate |
+
+`chunk config show` displays resolved user credentials and, when run from a
+project directory, the resolved `orgID` (env var takes precedence over project
+config).
 
 ## Flag Conventions
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -70,6 +70,7 @@ Credentials are stored in `~/.config/chunk/config.json` (respects `XDG_CONFIG_HO
 | `ANTHROPIC_API_KEY` | `build-prompt`, `init` |
 | `GITHUB_TOKEN` | `build-prompt` |
 | `CIRCLE_TOKEN` | `sidecar`, `task` |
+| `CIRCLECI_ORG_ID` | `sidecar` (optional; overrides `orgID` in `.chunk/config.json`) |
 
 ---
 
@@ -169,10 +170,28 @@ The agent loads your team's prompt, diffs the changes, and returns filtered find
 
 ## Sidecar workflow (preview)
 
+### First-time sidecar setup
+
+Before creating a sidecar in a non-interactive session (AI agents, scripts), set
+your CircleCI org ID once per project:
+
+```bash
+chunk auth set circleci
+chunk config set orgID <your-org-id>
+chunk sidecar create
+```
+
+`chunk config show` displays the resolved `orgID` when set. One-off overrides:
+`chunk sidecar create --org-id <id>` or `CIRCLECI_ORG_ID=<id> chunk sidecar create`.
+See [docs/CLI.md](CLI.md) for the full resolution order (`--org-id` → env →
+project config → interactive picker).
+
+### Dev loop
+
 Sidecars let you run validations in a clean cloud environment. The typical loop:
 
 ```bash
-# One-time: create a sidecar (--name is optional; a random name is generated if omitted)
+# Create a sidecar (--name is optional; a random name is generated if omitted)
 chunk sidecar create
 chunk sidecar create --name my-sidecar
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -37,6 +37,12 @@ func newConfigShowCmd() *cobra.Command {
 				io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", resolveErr)))
 			}
 
+			workDir, wdErr := os.Getwd()
+			if wdErr != nil {
+				return wdErr
+			}
+			orgID, orgIDSource := config.ResolveOrgID(workDir)
+
 			if jsonOut {
 				type configEntry struct {
 					Value  string `json:"value"`
@@ -47,6 +53,7 @@ func newConfigShowCmd() *cobra.Command {
 					AnthropicAPIKey configEntry `json:"anthropicAPIKey"`
 					CircleCIToken   configEntry `json:"circleCIToken"`
 					GitHubToken     configEntry `json:"gitHubToken"`
+					OrgID           configEntry `json:"orgID"`
 				}
 				maskOrEmpty := func(key string) string {
 					if key == "" {
@@ -59,6 +66,7 @@ func newConfigShowCmd() *cobra.Command {
 					AnthropicAPIKey: configEntry{Value: maskOrEmpty(rc.AnthropicAPIKey), Source: rc.AnthropicAPIKeySource},
 					CircleCIToken:   configEntry{Value: maskOrEmpty(rc.CircleCIToken), Source: rc.CircleCITokenSource},
 					GitHubToken:     configEntry{Value: maskOrEmpty(rc.GitHubToken), Source: rc.GitHubTokenSource},
+					OrgID:           configEntry{Value: orgID, Source: orgIDSource},
 				})
 			}
 
@@ -81,6 +89,12 @@ func newConfigShowCmd() *cobra.Command {
 				io.Printf("%s %s %s\n", ui.Label("gitHubToken:", w), config.MaskKey(rc.GitHubToken), ui.Dim("("+rc.GitHubTokenSource+")"))
 			} else {
 				io.Printf("%s %s\n", ui.Label("gitHubToken:", w), ui.Dim("(not set)"))
+			}
+
+			if orgID != "" {
+				io.Printf("%s %s %s\n", ui.Label("orgID:", w), orgID, ui.Dim("("+orgIDSource+")"))
+			} else {
+				io.Printf("%s %s\n", ui.Label("orgID:", w), ui.Dim("(not set)"))
 			}
 
 			return nil

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -73,30 +73,17 @@ func resolveSidecarID(ctx context.Context, sidecarID *string) error {
 	return nil
 }
 
-// resolveOrgID returns orgID from the flag, the CIRCLECI_ORG_ID env var,
-// the project config, or by calling pickOrg as a last resort (e.g. to present
-// a TUI picker).
-func resolveOrgID(orgID, projOrgID string, pickOrg func() (string, error)) (string, error) {
+// resolveOrgID returns orgID from the flag, then delegates to
+// config.ResolveOrgID for the env-vs-project-config precedence, and finally
+// calls pickOrg as a last resort (e.g. to present a TUI picker).
+func resolveOrgID(orgID, workDir string, pickOrg func() (string, error)) (string, error) {
 	if orgID != "" {
 		return orgID, nil
 	}
-	if envID := os.Getenv(config.EnvCircleCIOrgID); envID != "" {
-		return envID, nil
-	}
-	if projOrgID != "" {
-		return projOrgID, nil
+	if v, _ := config.ResolveOrgID(workDir); v != "" {
+		return v, nil
 	}
 	return pickOrg()
-}
-
-// configOrgID returns the orgID stored in .chunk/config.json for dir, or ""
-// if the config cannot be loaded or has no orgID set.
-func configOrgID(dir string) string {
-	cfg, err := config.LoadProjectConfig(dir)
-	if err != nil {
-		return ""
-	}
-	return cfg.OrgID
 }
 
 func orgPicker(ctx context.Context, client *circleci.Client) func() (string, error) {
@@ -151,7 +138,7 @@ func newSidecarListCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get working directory: %w", err)
 			}
-			resolvedOrgID, err := resolveOrgID(orgID, configOrgID(cwd), orgPicker(cmd.Context(), client))
+			resolvedOrgID, err := resolveOrgID(orgID, cwd, orgPicker(cmd.Context(), client))
 			if err != nil {
 				return err
 			}
@@ -220,7 +207,7 @@ func newSidecarCreateCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get working directory: %w", err)
 			}
-			resolvedOrgID, err := resolveOrgID(orgID, configOrgID(cwd), orgPicker(cmd.Context(), client))
+			resolvedOrgID, err := resolveOrgID(orgID, cwd, orgPicker(cmd.Context(), client))
 			if err != nil {
 				return err
 			}
@@ -791,7 +778,7 @@ func newSidecarSnapshotListCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get working directory: %w", err)
 			}
-			resolvedOrgID, err := resolveOrgID(orgID, configOrgID(cwd), orgPicker(cmd.Context(), client))
+			resolvedOrgID, err := resolveOrgID(orgID, cwd, orgPicker(cmd.Context(), client))
 			if err != nil {
 				return err
 			}
@@ -966,7 +953,7 @@ func sidecarSetupResolveSidecar(
 	if name == "" {
 		name = randomSidecarName()
 	}
-	resolvedOrgID, err := resolveOrgID(orgID, configOrgID(workDir), orgPicker(ctx, client))
+	resolvedOrgID, err := resolveOrgID(orgID, workDir, orgPicker(ctx, client))
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -583,7 +583,7 @@ func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, side
 		return false, nil
 	}
 	streams.ErrPrintf("No active sidecar found, creating a new sandbox...\n")
-	resolvedOrgID, err := resolveOrgID(orgID, configOrgID(workDir), orgPicker(ctx, client))
+	resolvedOrgID, err := resolveOrgID(orgID, workDir, orgPicker(ctx, client))
 	if err != nil {
 		return false, err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,9 @@ const (
 
 	// SourceConfigFile is the source label used when a value comes from the user config file.
 	SourceConfigFile = "Config file (user config)"
+
+	// SourceProjectConfig is the source label for values from .chunk/config.json.
+	SourceProjectConfig = "Project config (.chunk/config.json)"
 )
 
 // Chunk-specific environment variable names.
@@ -294,6 +297,20 @@ func MaskKey(key string) string {
 		return "****"
 	}
 	return strings.Repeat("*", len(key)-4) + key[len(key)-4:]
+}
+
+// ResolveOrgID returns the CircleCI org ID for display in config show.
+// Priority: CIRCLECI_ORG_ID env var > orgID in .chunk/config.json for workDir.
+func ResolveOrgID(workDir string) (value, source string) {
+	env, err := LoadEnv(context.Background())
+	if err == nil && env.CircleCIOrgID != "" {
+		return env.CircleCIOrgID, "Environment variable (" + EnvCircleCIOrgID + ")"
+	}
+	projCfg, err := LoadProjectConfig(workDir)
+	if err == nil && projCfg.OrgID != "" {
+		return projCfg.OrgID, SourceProjectConfig
+	}
+	return "", ""
 }
 
 // ValidConfigKeys are the keys accepted by "config set" that write to the user config.


### PR DESCRIPTION
## Summary

- Document `orgID`, `--org-id`, and `CIRCLECI_ORG_ID` with the org ID resolution order used by sidecar subcommands
- Add a **First-time sidecar setup** section to Getting Started (`chunk auth set circleci` + `chunk config set orgID`)
- Show resolved org ID in `chunk config show` (text and `--json`; env var takes precedence over project config)
- Fix outdated CLI.md references that listed only `model` and `apiKey` as config keys

## Test plan

- [x] `go test -race ./...`
- [x] `go test -race ./acceptance/...`
- [x] `go tool golangci-lint run ./...`
- [x] New acceptance: `TestConfigSetOrgID`, `TestConfigShowOrgID*`, `TestSidecarCreateOrgIDFromProjectConfig`; renamed env test to `TestSidecarCreateOrgIDFromEnv`
- [x] Manual: `chunk config show` displays `orgID` from `.chunk/config.json`
- [x] Manual: `chunk sidecar create` from project `orgID` + snapshot image (sidecar provisioned successfully)
- [ ] `chunk sidecar sync` + `chunk validate` on sidecar (sync failed locally due to git object parse error unrelated to this change)

Closes #386


Made with [Cursor](https://cursor.com)