### PR TITLE
Enforce orgID preflight in chunk-sidecar skill (fixes #385)

### DIFF
--- a/skills/chunk-sidecar/SKILL.md
+++ b/skills/chunk-sidecar/SKILL.md
@@ -46,9 +46,7 @@ Do **not** run `echo $CIRCLE_TOKEN`, `env`, `printenv`, or any other command tha
       > No CircleCI orgID found in `.chunk/config.json`. Sidecar cannot select an org in a non-interactive session. Please provide your CircleCI org ID. To persist it for future sessions, I will run: `chunk config set orgID <id>`
 
       After the user provides the ID, run `chunk config set orgID <id>`, then continue to Step 2.
-   4. If only `CIRCLECI_ORG_ID` is set (config still lacks `orgID`), you may pass that value as `--org-id` on sidecar commands. Persisting with `chunk config set orgID <id>` is recommended but not required before Step 2.
-
-   Record the resolved org ID for Step 2: from `.chunk/config.json` after step 3, or from `CIRCLECI_ORG_ID` per step 4.
+   4. If only `CIRCLECI_ORG_ID` is set (config still lacks `orgID`), `chunk sidecar create` will detect it automatically. Persisting with `chunk config set orgID <id>` is recommended but not required before Step 2.
 
 ## Step 2: Find or create the active sidecar
 
@@ -57,16 +55,16 @@ Run `chunk sidecar current`. Three cases:
 - **It prints a sidecar** — use it; go to Step 4.
 - **No active sidecar, and `validation.sidecarImage` is set in `.chunk/config.json`** — create a new sidecar from the snapshot, sync, and go straight to Step 4:
   ```
-  chunk sidecar create --org-id <orgID> --image <sidecarImage>
+  chunk sidecar create --image <sidecarImage>
   chunk sidecar sync
   ```
-  Read `orgID` and `validation.sidecarImage` from `.chunk/config.json` (orgID was resolved in Step 1).
-- **No active sidecar, no `sidecarImage` configured** — full environment setup is needed. Inform the user, create a sidecar with the org ID from Step 1, then go to Step 3:
+  Read `validation.sidecarImage` from `.chunk/config.json`; orgID is resolved automatically from config or `CIRCLECI_ORG_ID`.
+- **No active sidecar, no `sidecarImage` configured** — full environment setup is needed. Inform the user, then go to Step 3:
   ```
-  chunk sidecar create --org-id <orgID>
+  chunk sidecar create
   ```
 
-Always pass `--org-id` to `chunk sidecar create` and `chunk sidecar snapshot list` — use the org ID resolved in Step 1. Interactive org selection does not work in agent sessions. `--name` is optional; a random adjective-adverb-noun name (e.g. `happy-quickly-tesla`) is generated automatically if omitted.
+`chunk sidecar create` resolves orgID automatically: first from `.chunk/config.json`, then from `CIRCLECI_ORG_ID`. The Step 1 preflight guarantees one of those is set before this point. `--name` is optional; a random adjective-adverb-noun name (e.g. `happy-quickly-tesla`) is generated automatically if omitted.
 
 ## Step 3: One-time setup
 
@@ -74,11 +72,11 @@ This step produces a reusable snapshot so future sessions boot fast. Follow it w
 
 1. `chunk sidecar setup --dir .` — detects the stack, syncs files, and runs install steps on the sidecar. Pass `--name <name>` if you want a specific name; otherwise one is generated automatically.
 2. Verify the sidecar is working correctly: `chunk validate`. This uses per-command routing — commands marked `remote: true` run on the sidecar, the rest run locally. If any command fails with a missing binary or dependency, see Troubleshooting below, then re-run `chunk validate` until it passes.
-3. Snapshot the working sidecar: `chunk sidecar snapshot create --name <snapshot-name>`. This captures the configured state and returns a snapshot ID. **Always snapshot after confirming the sidecar is working — do not skip this step.** Snapshot names are limited to 255 characters; the CLI will reject longer names before making the API call. **The source sidecar is deleted after a successful snapshot** to avoid leaking the build instance, and local active-sidecar state is cleared — expect `chunk sidecar current` to return empty until you launch a new one in step 5. To look up snapshot IDs later, run `chunk sidecar snapshot list --org-id <orgID>`.
+3. Snapshot the working sidecar: `chunk sidecar snapshot create --name <snapshot-name>`. This captures the configured state and returns a snapshot ID. **Always snapshot after confirming the sidecar is working — do not skip this step.** Snapshot names are limited to 255 characters; the CLI will reject longer names before making the API call. **The source sidecar is deleted after a successful snapshot** to avoid leaking the build instance, and local active-sidecar state is cleared — expect `chunk sidecar current` to return empty until you launch a new one in step 5. To look up snapshot IDs later, run `chunk sidecar snapshot list`.
 4. Record the snapshot ID in `.chunk/config.json`: `chunk config set validation.sidecarImage <snapshot-id>`.
 5. Create a **new** sidecar from the snapshot and set it as active — this is the clean environment you will use going forward:
    ```
-   chunk sidecar create --org-id <orgID> --image <snapshot-id>
+   chunk sidecar create --image <snapshot-id>
    chunk sidecar sync
    ```
 6. Re-verify with `chunk validate` to confirm the snapshot-booted sidecar is healthy before entering the loop.
@@ -177,7 +175,7 @@ When `CLAUDE_SESSION_ID` is set, `chunk` auto-scopes the active-sidecar file to 
 - **SSH key registration or API calls time out (`context deadline exceeded`)** — the sidecar is unhealthy. If `validation.sidecarImage` is set in `.chunk/config.json`, create a fresh sidecar from the snapshot (Step 2 case 2). If not, run `chunk sidecar forget` and repeat Step 3 with a new sidecar.
 - **Missing dependency or binary not on `$PATH` on the sidecar** — the environment setup steps may not have installed everything needed, or a runtime was installed to a non-standard path. Use `chunk validate --remote --cmd "<install-or-symlink-command>"` to install the missing tool or make it accessible. Once `chunk validate` passes, re-snapshot so future sidecars include it — note this deletes the current sidecar, so launch a new one from the snapshot to keep working.
 - **`sync` errors about merge base or upstream** — the local branch has no remote upstream. Ask the user to push the branch (`git push -u origin <branch>`) or rebase onto a tracked ref.
-- **Snapshot `--image` will not boot a new sidecar** — snapshot IDs are org-scoped. Confirm the new sidecar is being created in the same org as the snapshot. Run `chunk sidecar snapshot list --org-id <id>` to verify available snapshot IDs.
+- **Snapshot `--image` will not boot a new sidecar** — snapshot IDs are org-scoped. Confirm the new sidecar is being created in the same org as the snapshot. Run `chunk sidecar snapshot list` to verify available snapshot IDs.
 
 ## Out of scope
 

--- a/skills/chunk-sidecar/SKILL.md
+++ b/skills/chunk-sidecar/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: chunk-sidecar
 description: Use when the user says "validate on the sidecar", "run tests on the sidecar", "sync to sidecar", "sidecar dev loop", "check this on the sidecar", "validate remotely", "scaffold test-suites.yml", "set up smarter testing", or "write .circleci/test-suites.yml", or when you have made edits and want to verify them on a remote `chunk` sidecar instead of running locally. Also covers creating sidecars, snapshotting a configured environment, customizing the sidecar image via `chunk sidecar`, and scaffolding `.circleci/test-suites.yml` for CircleCI Smarter Testing.
-version: 1.4.0
+version: 1.5.0
 allowed-tools:
   - Bash(chunk --version)
   - Bash(chunk auth status)
+  - Bash(chunk config set:*)
   - Bash(chunk sidecar:*)
   - Bash(chunk validate:*)
   - Bash(cat .chunk/config.json)
   - Bash(cat .chunk/sidecar.json)
+  - Bash(test -n*)
   - Read
   - Write
   - Edit
@@ -35,6 +37,19 @@ Run these checks in order. Stop and report to the user if anything fails.
 
 Do **not** run `echo $CIRCLE_TOKEN`, `env`, `printenv`, or any other command that reads credential environment variables. That leaks secrets into conversation context. If `chunk auth status` reports a failure or shows a required credential as "Not set", surface its printed remediation (e.g. "Run `chunk auth set circleci`") and stop.
 
+3. **CircleCI orgID preflight** — run **before any** `chunk sidecar` subcommand. Interactive org selection does not work in agent sessions.
+
+   1. `cat .chunk/config.json` and confirm `orgID` is set to a non-empty value.
+   2. If `orgID` is absent from the config, check whether `CIRCLECI_ORG_ID` is set **without printing its value** (e.g. `test -n "${CIRCLECI_ORG_ID:-}"`). Do not run `printenv`, `env`, or `echo` on credential variables.
+   3. If **both** are unset, **stop** — do not call `chunk sidecar create`, `chunk sidecar list`, or any other `chunk sidecar` command. Ask the user for their org ID **exactly once** using this message:
+
+      > No CircleCI orgID found in `.chunk/config.json`. Sidecar cannot select an org in a non-interactive session. Please provide your CircleCI org ID. To persist it for future sessions, I will run: `chunk config set orgID <id>`
+
+      After the user provides the ID, run `chunk config set orgID <id>`, then continue to Step 2.
+   4. If only `CIRCLECI_ORG_ID` is set (config still lacks `orgID`), you may pass that value as `--org-id` on sidecar commands. Persisting with `chunk config set orgID <id>` is recommended but not required before Step 2.
+
+   Record the resolved org ID for Step 2: from `.chunk/config.json` after step 3, or from `CIRCLECI_ORG_ID` per step 4.
+
 ## Step 2: Find or create the active sidecar
 
 Run `chunk sidecar current`. Three cases:
@@ -45,13 +60,13 @@ Run `chunk sidecar current`. Three cases:
   chunk sidecar create --org-id <orgID> --image <sidecarImage>
   chunk sidecar sync
   ```
-  Read `orgID` and `validation.sidecarImage` from `.chunk/config.json`. Ask the user for the org ID if it is not present in the config.
-- **No active sidecar, no `sidecarImage` configured** — full environment setup is needed. Inform the user, confirm the org ID (read from `.chunk/config.json` or ask), create a sidecar, then go to Step 3:
+  Read `orgID` and `validation.sidecarImage` from `.chunk/config.json` (orgID was resolved in Step 1).
+- **No active sidecar, no `sidecarImage` configured** — full environment setup is needed. Inform the user, create a sidecar with the org ID from Step 1, then go to Step 3:
   ```
   chunk sidecar create --org-id <orgID>
   ```
 
-Always pass `--org-id` to `chunk sidecar create` — interactive org selection does not work in Claude sessions. `--name` is optional; a random adjective-adverb-noun name (e.g. `happy-quickly-tesla`) is generated automatically if omitted.
+Always pass `--org-id` to `chunk sidecar create` and `chunk sidecar snapshot list` — use the org ID resolved in Step 1. Interactive org selection does not work in agent sessions. `--name` is optional; a random adjective-adverb-noun name (e.g. `happy-quickly-tesla`) is generated automatically if omitted.
 
 ## Step 3: One-time setup
 
@@ -154,7 +169,8 @@ When `CLAUDE_SESSION_ID` is set, `chunk` auto-scopes the active-sidecar file to 
 
 ## Troubleshooting
 
-- **`no organization configured`** — pass `--org-id <id>` explicitly to the failing command. Read it from `.chunk/config.json` (`orgID` field) or ask the user.
+- **`Could not select an organization`**, **`no interactive terminal available`**, or **`Pass --org-id instead`** — orgID was missing when a sidecar command ran. Return to Step 1 orgID preflight: ask the user exactly once, then `chunk config set orgID <id>`. Do not explore peripheral commands (`chunk config show`, `chunk --help | grep -i org`, etc.).
+- **Anti-pattern: orgID absent** — if `orgID` is not in `.chunk/config.json` and `CIRCLECI_ORG_ID` is unset, do not call `chunk sidecar create` or probe the CLI for org discovery. Ask the user once and persist with `chunk config set orgID <id>`.
 - **Auth errors (401/403, "token invalid", "unauthorized")** — run `chunk auth status` and follow its printed remediation (`chunk auth set circleci` / `github` / `anthropic`). Never dump env vars.
 - **Sidecar 404 on `current`, `sync`, or `validate`** — the sidecar was deleted externally. Run `chunk sidecar forget`, then return to Step 2.
 - **`permission denied (publickey)` on sync, ssh, or exec** — the sidecar does not have your SSH key registered. Run `chunk sidecar add-ssh-key --public-key-file ~/.ssh/chunk_ai.pub` (or pass `--public-key "<ssh-ed25519 ...>"` directly). The command requires one of those flags; invoking it bare returns "A public key is required." If the issue persists, tell the user they can remove `~/.ssh/chunk_ai*` to regenerate the keypair on next use.
@@ -167,7 +183,7 @@ When `CLAUDE_SESSION_ID` is set, `chunk` auto-scopes the active-sidecar file to 
 
 This skill does **not**:
 
-- Modify `.chunk/config.json` (that is `chunk init`'s job; user-owned).
+- Hand-edit `.chunk/config.json` or run `chunk init` for bulk project setup (user-owned). The skill **may** run `chunk config set` for `orgID` (Step 1 bootstrap) and `validation.sidecarImage` (Step 3 snapshot).
 - Install or change pre-commit hooks (that is `chunk init`).
 - Run `chunk init`.
 - Edit files on the sidecar over SSH — they will be wiped by the next `sync`.


### PR DESCRIPTION
## Summary

- Add a mandatory **orgID preflight** in Step 1 (after CircleCI auth) so agents never call `chunk sidecar create` before an org is configured.
- When `orgID` is missing from `.chunk/config.json` and `CIRCLECI_ORG_ID` is unset, stop once, prompt the user, and persist with `chunk config set orgID <id>`.
- Extend `allowed-tools` with `chunk config set:*` and `test -n*` for env presence checks.
- Align Troubleshooting with actual CLI errors (`Could not select an organization`, `no interactive terminal available`, `Pass --org-id instead`) and document the anti-pattern of probing peripheral commands.
- Clarify Out of scope: hand-editing config is out of scope; skill-driven `chunk config set` for `orgID` and `validation.sidecarImage` is allowed.
- Bump skill version to `1.5.0`.

Fixes #385.

## Test plan

- [x] `go test -race -count=1 ./...` (local)
- [ ] CI: lint, test, acceptance-test, build-smoke-test
- [ ] Manual: repo without `orgID` in `.chunk/config.json`, valid `chunk auth status`, invoke `/chunk-sidecar` in a non-interactive agent session — verify no `chunk sidecar create` until user provides org ID and `chunk config set orgID` runs

Made with [Cursor](https://cursor.com)