### PR TITLE
Add smarter testing doctor validation

### DIFF
--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -73,7 +73,7 @@ If no issues survive filtering, the skill reports "No significant issues identif
 
 ### chunk-sidecar
 
-**Trigger phrases**: "validate on the sidecar", "run tests on the sidecar", "sync to sidecar", "sidecar dev loop", "validate remotely"
+**Trigger phrases**: "validate on the sidecar", "run tests on the sidecar", "sync to sidecar", "sidecar dev loop", "validate remotely", "run smarter testing doctor", "diagnose smarter testing"
 
 Runs the sync → validate loop on a remote CircleCI sidecar. Also handles one-time sidecar creation, environment setup, and snapshotting.
 

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -39,7 +39,7 @@ var All = []Skill{
 	},
 	{
 		Name:        "chunk-sidecar",
-		Description: `Run build/test/validate on a remote chunk sidecar instead of locally. Use when asked to "validate on the sidecar", "run tests on the sidecar", "sync to sidecar", "check this on the sidecar", or when edits need remote verification. Also covers creating sidecars, snapshots, and env customization.`,
+		Description: `Run build/test/validate on a remote chunk sidecar instead of locally. Use when asked to "validate on the sidecar", "run tests on the sidecar", "sync to sidecar", "check this on the sidecar", "run smarter testing doctor", "diagnose smarter testing", or when edits need remote verification. Also covers creating sidecars, snapshots, and env customization.`,
 	},
 }
 

--- a/skills/chunk-sidecar/SKILL.md
+++ b/skills/chunk-sidecar/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: chunk-sidecar
-description: Use when the user says "validate on the sidecar", "run tests on the sidecar", "sync to sidecar", "sidecar dev loop", "check this on the sidecar", "validate remotely", "scaffold test-suites.yml", "set up smarter testing", or "write .circleci/test-suites.yml", or when you have made edits and want to verify them on a remote `chunk` sidecar instead of running locally. Also covers creating sidecars, snapshotting a configured environment, customizing the sidecar image via `chunk sidecar`, and scaffolding `.circleci/test-suites.yml` for CircleCI Smarter Testing.
-version: 1.5.0
+description: Use when the user says "validate on the sidecar", "run tests on the sidecar", "sync to sidecar", "sidecar dev loop", "check this on the sidecar", "validate remotely", "scaffold test-suites.yml", "set up smarter testing", "write .circleci/test-suites.yml", "run smarter testing doctor", or "diagnose smarter testing", or when you have made edits and want to verify them on a remote `chunk` sidecar instead of running locally. Also covers creating sidecars, snapshotting a configured environment, customizing the sidecar image via `chunk sidecar`, and scaffolding `.circleci/test-suites.yml` for CircleCI Smarter Testing.
+version: 1.6.0
 allowed-tools:
   - Bash(chunk --version)
   - Bash(chunk auth status)
@@ -157,9 +157,21 @@ An atom is the smallest independent unit the runner accepts. Match the runner's 
 Validate on the sidecar — the `circleci-testsuite` plugin and `circleci` CLI are pre-installed there, matching the CI environment.
 
 1. `chunk sidecar sync` — push the new file to the active sidecar.
-2. `chunk validate --remote --cmd "<discover-command>"` — confirm it prints one atom per line and exits zero.
-3. `chunk validate --remote --cmd "<run-command with one or two atoms>"` — confirm a junit XML file appears at the `outputs.junit` path.
-4. `chunk validate --remote --cmd "circleci config validate"` — confirm `.circleci/config.yml` parses and the `circleci-testsuite exec --suite <name>` call uses the suite `name` you chose.
+2. Run the doctor diagnostic on the sidecar:
+   ```
+   chunk validate --remote --cmd 'script -q /dev/null circleci run testsuite "<suite-name>" --doctor'
+   ```
+   Doctor validates YAML structure, the discover command, the run command with sample atoms, JUnit output, and config wiring in a single pass. Read its output and fix any reported issues locally, then sync and re-run doctor. Repeat until all checks pass.
+
+If `circleci-testsuite` is not installed on the sidecar (see Step 3 for installing it), fall back to manual validation:
+
+1. `chunk validate --remote --cmd "<discover-command>"` — confirm it prints one atom per line and exits zero.
+2. `chunk validate --remote --cmd "<run-command with one or two atoms>"` — confirm a junit XML file appears at the `outputs.junit` path.
+3. `chunk validate --remote --cmd "circleci config validate"` — confirm `.circleci/config.yml` parses and the `circleci-testsuite exec --suite <name>` call uses the suite `name` you chose.
+
+### Beyond scaffolding
+
+This skill covers writing `test-suites.yml` and validating it with doctor on the sidecar. For deeper Smarter Testing configuration — test impact analysis, dynamic test splitting, auto-rerun, CI job wiring, or troubleshooting doctor failures beyond YAML/command issues — see the **`circleci-smarter-testing`** skill (available as a CircleCI plugin skill via `CircleCI-Public/skills`). It provides runner-specific templates, reference docs, and a full onboarding workflow.
 
 ## Parallel sessions
 


### PR DESCRIPTION
## Summary
- Integrates `circleci run testsuite --doctor` into the sidecar skill's smarter testing scaffolding section, replacing manual validation steps with a doctor-first workflow
- Keeps manual validation steps as a fallback when `circleci-testsuite` isn't installed on the sidecar
- Adds a "Beyond scaffolding" hand-off note pointing to the external `circleci-smarter-testing` skill for advanced config (TIA, dynamic splitting, auto-rerun)
- Adds trigger phrases: "run smarter testing doctor", "diagnose smarter testing"

## Test plan
- [x] `task build` passes
- [x] `task test` passes (905 tests)
- [x] `task lint` passes
- [ ] Install updated skill via `chunk skill install` and verify doctor workflow triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)