### PR TITLE
detect Python, Ruby, Java, Gradle toolchains in chunk init

### DIFF
--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -322,6 +322,160 @@ func TestInitDetectsPyprojectCommands(t *testing.T) {
 	assert.Equal(t, test["run"], "pytest")
 }
 
+func TestInitDetectsRequirementsTxtCommands(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "requirements.txt"), []byte("pytest\n"), 0o644))
+
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{
+		"init", "--skip-hooks",
+	}, env, workDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	cfg := readInitConfig(t, workDir)
+	test := commandByName(cfg, "test")
+	assert.Assert(t, test != nil, "expected test command")
+	assert.Equal(t, test["run"], "pytest")
+}
+
+func TestInitDetectsSetupPyCommands(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "setup.py"), []byte("from setuptools import setup\nsetup(name='test')\n"), 0o644))
+
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{
+		"init", "--skip-hooks",
+	}, env, workDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	cfg := readInitConfig(t, workDir)
+	test := commandByName(cfg, "test")
+	assert.Assert(t, test != nil, "expected test command")
+	assert.Equal(t, test["run"], "pytest")
+}
+
+func TestInitDetectsPipfileCommands(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "Pipfile"), []byte("[packages]\npytest = \"*\"\n"), 0o644))
+
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{
+		"init", "--skip-hooks",
+	}, env, workDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	cfg := readInitConfig(t, workDir)
+	test := commandByName(cfg, "test")
+	assert.Assert(t, test != nil, "expected test command")
+	assert.Equal(t, test["run"], "pytest")
+}
+
+func TestInitDetectsGemfileCommands(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "Gemfile"), []byte("source 'https://rubygems.org'\ngem 'rails'\n"), 0o644))
+
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{
+		"init", "--skip-hooks",
+	}, env, workDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	cfg := readInitConfig(t, workDir)
+	test := commandByName(cfg, "test")
+	assert.Assert(t, test != nil, "expected test command")
+	assert.Equal(t, test["run"], "bundle exec rake test")
+}
+
+func TestInitDetectsPomXmlCommands(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "pom.xml"), []byte("<project><modelVersion>4.0.0</modelVersion></project>\n"), 0o644))
+
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{
+		"init", "--skip-hooks",
+	}, env, workDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	cfg := readInitConfig(t, workDir)
+	test := commandByName(cfg, "test")
+	assert.Assert(t, test != nil, "expected test command")
+	assert.Equal(t, test["run"], "mvn test")
+}
+
+func TestInitDetectsGradleCommands(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "build.gradle"), []byte("apply plugin: 'java'\n"), 0o644))
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "gradlew"), []byte("#!/bin/sh\n"), 0o755))
+
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{
+		"init", "--skip-hooks",
+	}, env, workDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	cfg := readInitConfig(t, workDir)
+	test := commandByName(cfg, "test")
+	assert.Assert(t, test != nil, "expected test command")
+	assert.Equal(t, test["run"], "./gradlew test")
+}
+
+func TestInitDetectsGradleWithoutWrapper(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "build.gradle"), []byte("apply plugin: 'java'\n"), 0o644))
+
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{
+		"init", "--skip-hooks",
+	}, env, workDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	cfg := readInitConfig(t, workDir)
+	test := commandByName(cfg, "test")
+	assert.Assert(t, test != nil, "expected test command")
+	assert.Equal(t, test["run"], "gradle test")
+}
+
+func TestInitDetectsGradleKtsCommands(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "build.gradle.kts"), []byte("plugins { java }\n"), 0o644))
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "gradlew"), []byte("#!/bin/sh\n"), 0o755))
+
+	env := testenv.NewTestEnv(t)
+	env.AnthropicKey = ""
+
+	result := binary.RunCLI(t, []string{
+		"init", "--skip-hooks",
+	}, env, workDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	cfg := readInitConfig(t, workDir)
+	test := commandByName(cfg, "test")
+	assert.Assert(t, test != nil, "expected test command")
+	assert.Equal(t, test["run"], "./gradlew test")
+}
+
 func TestInitDetectsPackageJsonWithYarnLock(t *testing.T) {
 	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
 	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "package.json"), []byte(`{"name":"test"}`), 0o644))

--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -388,8 +388,7 @@ func TestInitDetectsUnknownToolchainNoClaude(t *testing.T) {
 
 	cfg := readInitConfig(t, workDir)
 	test := commandByName(cfg, "test")
-	assert.Assert(t, test != nil, "expected fallback test command")
-	assert.Equal(t, test["run"], "npm test", "expected npm test fallback for unknown toolchain")
+	assert.Assert(t, test == nil, "expected no test command for unknown toolchain without Claude")
 }
 
 // --- Hook setup (Gap 3) ---

--- a/internal/validate/setup.go
+++ b/internal/validate/setup.go
@@ -11,7 +11,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 )
 
-// defaultTestCommand is used when no toolchain is detected and Claude is unavailable.
+// defaultTestCommand is used by the Node.js case when no lock file narrows the package manager.
 const defaultTestCommand = "npm test"
 
 // PackageManager holds the name and CI-safe install command for a detected package manager.
@@ -73,9 +73,24 @@ func DetectCommands(ctx context.Context, claude *anthropic.Client, workDir strin
 			{Name: "test", Run: "cargo test", Role: config.RoleGate, Timeout: 300, Limit: 3},
 		}, nil
 
-	case has["pyproject.toml"]:
+	case has["pyproject.toml"], has["requirements.txt"], has["setup.py"], has["Pipfile"]:
 		return []config.Command{
 			{Name: "test", Run: "pytest", Role: config.RoleGate, Timeout: 300, Limit: 3},
+		}, nil
+
+	case has["Gemfile"]:
+		return []config.Command{
+			{Name: "test", Run: "bundle exec rake test", Role: config.RoleGate, Timeout: 300, Limit: 3},
+		}, nil
+
+	case has["pom.xml"]:
+		return []config.Command{
+			{Name: "test", Run: "mvn test", Role: config.RoleGate, Timeout: 300, Limit: 3},
+		}, nil
+
+	case has["build.gradle"], has["build.gradle.kts"]:
+		return []config.Command{
+			{Name: "test", Run: "./gradlew test", Role: config.RoleGate, Timeout: 300, Limit: 3},
 		}, nil
 
 	case has["package.json"]:
@@ -98,7 +113,7 @@ func DetectCommands(ctx context.Context, claude *anthropic.Client, workDir strin
 
 	// Unknown toolchain — ask Claude
 	if claude == nil {
-		return []config.Command{{Name: "test", Run: defaultTestCommand, Role: config.RoleGate}}, nil
+		return nil, nil
 	}
 
 	pm := DetectPackageManager(workDir)
@@ -123,7 +138,7 @@ func DetectCommands(ctx context.Context, claude *anthropic.Client, workDir strin
 
 	result := strings.TrimSpace(resp)
 	if result == "" {
-		result = defaultTestCommand
+		return nil, nil
 	}
 	return []config.Command{{Name: "test", Run: result, Role: config.RoleGate}}, nil
 }

--- a/internal/validate/setup.go
+++ b/internal/validate/setup.go
@@ -79,6 +79,7 @@ func DetectCommands(ctx context.Context, claude *anthropic.Client, workDir strin
 		}, nil
 
 	case has["Gemfile"]:
+		// Assumes Rake-based test task (Rails default). RSpec/Minitest-only stacks may need manual adjustment.
 		return []config.Command{
 			{Name: "test", Run: "bundle exec rake test", Role: config.RoleGate, Timeout: 300, Limit: 3},
 		}, nil
@@ -89,8 +90,12 @@ func DetectCommands(ctx context.Context, claude *anthropic.Client, workDir strin
 		}, nil
 
 	case has["build.gradle"], has["build.gradle.kts"]:
+		gradleCmd := "gradle test"
+		if has["gradlew"] {
+			gradleCmd = "./gradlew test"
+		}
 		return []config.Command{
-			{Name: "test", Run: "./gradlew test", Role: config.RoleGate, Timeout: 300, Limit: 3},
+			{Name: "test", Run: gradleCmd, Role: config.RoleGate, Timeout: 300, Limit: 3},
 		}, nil
 
 	case has["package.json"]:


### PR DESCRIPTION
Fixes https://github.com/CircleCI-Public/chunk-cli/issues/322

## Summary

`chunk init` was falling back to `npm test` for any toolchain not in its deterministic detection list (e.g. Python with `requirements.txt`, Ruby, Java, Gradle). This meant the generated `.chunk/config.json` and Claude `PreToolUse` hook were broken out of the box for those stacks.

- Add deterministic detection for Python (`requirements.txt`, `setup.py`, `Pipfile`), Ruby (`Gemfile`), Maven (`pom.xml`), and Gradle (`build.gradle`, `build.gradle.kts`) in `DetectCommands`
- Return no commands instead of a broken `npm test` fallback when toolchain is unknown and Claude is unavailable

## Test plan

- [x] All 905 tests pass (`task test`)
- [x] `TestInitDetectsUnknownToolchainNoClaude` updated to verify no commands are returned for unknown toolchains
- [ ] Manual: run `chunk init` in a Python project with only `requirements.txt` — should detect `pytest`
- [ ] Manual: run `chunk init` in an empty project without `ANTHROPIC_API_KEY` — should produce no test command

🤖 Generated with [Claude Code](https://claude.com/claude-code)