### PR TITLE
docs: fix chunk-sidecar skill invocation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ chunk validate --list       # list configured commands
 
 ### Agent Onboarding for Sidecars (Preferred method)
 
-Chunk init will install skills for working with Chunk sidecars. After the init, start a claude session and run `/chunk-sidecars` and your agent will create a sidecar and configure it for use running tests and creating snapshots of good Chunk sidecars.
+Chunk init will install skills for working with Chunk sidecars. After the init, start a claude session and run `/chunk-sidecar` and your agent will create a sidecar and configure it for use running tests and creating snapshots of good Chunk sidecars.
 
 ### Manual setup
 


### PR DESCRIPTION
## Summary

- Corrects the Claude Code skill invocation in README from `/chunk-sidecars` to `/chunk-sidecar`
- Aligns the README with the actual installed skill name (`chunk-sidecar`) used elsewhere in the repo

## Test plan

- [x] Verified skill name in `skills/chunk-sidecar/SKILL.md` and `internal/skills/install.go`
- [ ] N/A — documentation-only change


Made with [Cursor](https://cursor.com)