### PR TITLE
feat(validate): wire sidecar setup and Stop hook to remote validation

### DIFF
--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -455,6 +455,59 @@ func TestValidateAutoCreatesSidecar(t *testing.T) {
 	assert.Equal(t, len(addKeyReqs), 1, "expected 1 add-key request for newly created sidecar; got: %v", reqs)
 }
 
+func TestValidateHookAutoCreatesSidecarFromSidecarImage(t *testing.T) {
+	// Stop hook + validation.sidecarImage (no remote: true) should still resolve
+	// a sidecar from the configured snapshot and attempt remote validation.
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = "127.0.0.1"
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	chunkDir := filepath.Join(workDir, ".chunk")
+	assert.NilError(t, os.MkdirAll(chunkDir, 0o755))
+	cfg := map[string]interface{}{
+		"commands": []map[string]interface{}{
+			{"name": "install", "run": "echo install"},
+			{"name": "test", "run": "echo test", "role": "gate"},
+		},
+		"validation": map[string]interface{}{
+			"sidecarImage": "my-snapshot-abc123",
+		},
+	}
+	data, err := json.Marshal(cfg)
+	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), data, 0o644))
+
+	sshDir := filepath.Join(t.TempDir(), ".ssh")
+	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
+	identityFile := filepath.Join(sshDir, "chunk_ai")
+	assert.NilError(t, generateTestSSHKey(t, identityFile))
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	env.Extra["CIRCLECI_ORG_ID"] = "org-aaa"
+
+	result := binary.RunCLIWithStdin(t, []string{
+		"validate",
+		"--identity-file", identityFile,
+	}, env, workDir, hookStdin(t, "test-session-sidecar-image", false))
+
+	assert.Assert(t, result.ExitCode != 0, "expected failure because no SSH server is running")
+
+	reqs := cci.Recorder.AllRequests()
+	createReqs := filterByPath(reqs, "/api/v2/sidecar/instances")
+	assert.Equal(t, len(createReqs), 1, "expected 1 create-sidecar request; got: %v", reqs)
+
+	var body map[string]interface{}
+	assert.NilError(t, json.Unmarshal(createReqs[0].Body, &body))
+	assert.Equal(t, body["image"], "my-snapshot-abc123")
+	assert.Equal(t, body["org_id"], "org-aaa")
+
+	addKeyReqs := filterByPath(reqs, "/api/v2/sidecar/instances/sidecar-new-123/ssh/add-key")
+	assert.Equal(t, len(addKeyReqs), 1, "expected 1 add-key request for newly created sidecar; got: %v", reqs)
+}
+
 // writeRemoteProjectConfig writes a config with a single remote command.
 func writeRemoteProjectConfig(t *testing.T, workDir string) {
 	t.Helper()

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -932,6 +932,14 @@ Example:
 				return err
 			}
 
+			if cfg.MarkRemoteCommandsForSidecarSetup() {
+				if saveErr := config.SaveProjectConfig(dir, cfg); saveErr != nil {
+					streams.ErrPrintf("Warning: could not save config: %v\n", saveErr)
+				} else {
+					streams.ErrPrintf("Marked install and gate commands as remote in .chunk/config.json\n")
+				}
+			}
+
 			streams.ErrPrintf("\nSetup complete. Verify the sidecar is working correctly, then snapshot it:\n")
 			streams.ErrPrintf("  chunk sidecar snapshot create --name <snapshot-name>\n")
 			streams.ErrPrintf("  chunk sidecar snapshot list              # list snapshot IDs for your org\n\n")

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -150,8 +150,15 @@ func initHook(ctx context.Context, hook *hookContext, workDir string, streams io
 	return ctx, streams, false, nil
 }
 
-func maybeEnsureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc config.ResolvedConfig, allRemote bool, cfg *config.ProjectConfig, streams iostream.Streams) (*circleci.Client, error) {
-	if !allRemote && !cfg.HasRemoteCommands() {
+func validateNeedsSidecar(explicitRemote bool, cfg *config.ProjectConfig, hook *hookContext) bool {
+	if explicitRemote || cfg.HasRemoteCommands() {
+		return true
+	}
+	return hook != nil && cfg.HasSidecarImage()
+}
+
+func maybeEnsureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc config.ResolvedConfig, needsSidecar bool, cfg *config.ProjectConfig, streams iostream.Streams) (*circleci.Client, error) {
+	if !needsSidecar {
 		return nil, nil
 	}
 	return ensureCircleCIClient(ctx, cmd, rc, streams, tui.PromptHidden)
@@ -225,7 +232,10 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	// In non-hook context ensureCircleCIClient prompts interactively; hooks have
 	// no TTY so we surface a clear message here instead of a confusing fallback.
 	rc, _ := config.Resolve("", "", insecureStorage)
-	if hook != nil && cfg.HasRemoteCommands() && rc.CircleCIToken == "" {
+
+	explicitRemote := opts.remote || opts.sidecarID != ""
+	needsSidecar := validateNeedsSidecar(explicitRemote, cfg, hook)
+	if hook != nil && needsSidecar && rc.CircleCIToken == "" {
 		streams.ErrPrintln("CircleCI auth is not configured.")
 		streams.ErrPrintln("Suggestion: " + suggestionCircleCIAuth)
 		streams.ErrPrintln("Don't have an account? Sign up at https://app.circleci.com/signup")
@@ -235,11 +245,14 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	// allRemote is true when the caller explicitly targets the sidecar
 	// (--remote or --sidecar-id), meaning every command runs there.
 	// Per-command routing only applies when the sidecar is resolved implicitly.
-	allRemote := opts.remote || opts.sidecarID != ""
+	allRemote := explicitRemote
+	if hook != nil && cfg.HasSidecarImage() {
+		allRemote = true
+	}
 
 	image := resolveImage(name, cfg)
 
-	circleCIClient, err := maybeEnsureCircleCIClient(cmd.Context(), cmd, rc, allRemote, cfg, streams)
+	circleCIClient, err := maybeEnsureCircleCIClient(cmd.Context(), cmd, rc, needsSidecar, cfg, streams)
 	if err != nil {
 		return err
 	}
@@ -384,7 +397,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 // setupRemote resolves (or creates) the sidecar ID based on the validate flags
 // and config, then returns whether a new sidecar was provisioned.
 func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpts, image string, cfg *config.ProjectConfig, hook *hookContext, statusFn iostream.StatusFunc, workDir string, streams iostream.Streams) (bool, error) {
-	if opts.remote || cfg.HasRemoteCommands() {
+	if validateNeedsSidecar(opts.remote || opts.sidecarID != "", cfg, hook) {
 		if opts.remote {
 			created, err := resolveOrCreateSidecarID(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, streams)
 			if err != nil {

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -63,6 +63,32 @@ func TestValidateHookExitsOneWhenCircleCITokenMissingAndRemoteCommands(t *testin
 		"expected auth hint in stderr, got: %q", stderr)
 }
 
+func TestValidateHookExitsOneWhenCircleCITokenMissingAndSidecarImage(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv(config.EnvCircleToken, "")
+	t.Setenv(config.EnvCircleCIToken, "")
+
+	dir := t.TempDir()
+	projCfg := &config.ProjectConfig{
+		Commands: []config.Command{
+			{Name: "test", Run: "npm test", Role: config.RoleGate},
+		},
+		Validation: &config.ValidationConfig{
+			SidecarImage: "my-snapshot-abc123",
+		},
+	}
+	assert.NilError(t, config.SaveProjectConfig(dir, projCfg))
+
+	_, stderr, err := runValidateHook(t, dir)
+
+	assert.Assert(t, err != nil)
+	var ec interface{ ExitCode() int }
+	assert.Assert(t, errors.As(err, &ec), "expected ExitCode error, got %T: %v", err, err)
+	assert.Equal(t, ec.ExitCode(), 1)
+	assert.Assert(t, strings.Contains(stderr, "CircleCI auth is not configured"),
+		"expected auth message in stderr, got: %q", stderr)
+}
+
 func TestValidateHookSkipsAuthCheckWhenNoRemoteCommands(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv(config.EnvCircleToken, "")

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -94,6 +94,38 @@ func (c *ProjectConfig) HasRemoteCommands() bool {
 	return false
 }
 
+// HasSidecarImage reports whether a project-level sidecar snapshot image is configured.
+func (c *ProjectConfig) HasSidecarImage() bool {
+	return c != nil && c.Validation != nil && c.Validation.SidecarImage != ""
+}
+
+func commandEligibleForSidecarRemote(cmd Command) bool {
+	if cmd.Remote {
+		return false
+	}
+	if cmd.Name == "install" {
+		return true
+	}
+	return cmd.Role == RoleGate
+}
+
+// MarkRemoteCommandsForSidecarSetup marks install and gate commands for remote
+// execution after a successful sidecar setup. Returns true when any command
+// was updated.
+func (c *ProjectConfig) MarkRemoteCommandsForSidecarSetup() bool {
+	if c == nil {
+		return false
+	}
+	changed := false
+	for i := range c.Commands {
+		if commandEligibleForSidecarRemote(c.Commands[i]) {
+			c.Commands[i].Remote = true
+			changed = true
+		}
+	}
+	return changed
+}
+
 // FindCommand returns the command with the given name, or nil if not found.
 func (c *ProjectConfig) FindCommand(name string) *Command {
 	for i := range c.Commands {

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestHasSidecarImage(t *testing.T) {
+	assert.Assert(t, !(*ProjectConfig)(nil).HasSidecarImage())
+
+	cfg := &ProjectConfig{}
+	assert.Assert(t, !cfg.HasSidecarImage())
+
+	cfg.Validation = &ValidationConfig{}
+	assert.Assert(t, !cfg.HasSidecarImage())
+
+	cfg.Validation.SidecarImage = "snap-123"
+	assert.Assert(t, cfg.HasSidecarImage())
+}
+
+func TestMarkRemoteCommandsForSidecarSetup(t *testing.T) {
+	cfg := &ProjectConfig{
+		Commands: []Command{
+			{Name: "install", Run: "npm ci"},
+			{Name: "test", Run: "npm test", Role: RoleGate},
+			{Name: "format", Run: "npm run format", Role: RoleAutofix},
+			{Name: "lint", Run: "npm run lint", Role: RolePrecheck},
+			{Name: "test-changed", Run: "npm test --changed", Role: RoleGate, Remote: true},
+		},
+	}
+
+	changed := cfg.MarkRemoteCommandsForSidecarSetup()
+	assert.Assert(t, changed)
+	assert.Assert(t, cfg.FindCommand("install").Remote)
+	assert.Assert(t, cfg.FindCommand("test").Remote)
+	assert.Assert(t, !cfg.FindCommand("format").Remote)
+	assert.Assert(t, !cfg.FindCommand("lint").Remote)
+	assert.Assert(t, cfg.FindCommand("test-changed").Remote)
+
+	assert.Assert(t, !cfg.MarkRemoteCommandsForSidecarSetup())
+}


### PR DESCRIPTION
## Summary

- After a successful `chunk sidecar setup`, automatically mark `install` and `role: gate` commands as `remote: true` in `.chunk/config.json`
- When Stop hook runs `chunk validate` and `validation.sidecarImage` is configured, resolve a sidecar from the snapshot and run all validate commands remotely
- Unify sidecar resolution behind `validateNeedsSidecar()` so `sidecarImage` is no longer ignored when no command has `remote: true`

## Problem

The sidecar workflow had three disconnected paths:

1. `chunk init` generates local-only validate commands (no `remote: true`)
2. `chunk sidecar setup` + snapshot stores `validation.sidecarImage`, but does not wire commands to the sidecar
3. Stop hook runs plain `chunk validate`, which stayed local unless commands were manually marked remote

This caused friction where sidecar validation could pass while Stop hook / CI still failed on the local environment (e.g. macOS lock file vs Linux `npm ci`).

## Changes

### `internal/config/project.go`
- Add `HasSidecarImage()`
- Add `MarkRemoteCommandsForSidecarSetup()` — marks `install` and `role: gate` commands only; skips `autofix` / `precheck`

### `internal/cmd/sidecar.go`
- On successful setup, persist remote flags and print:
  `Marked install and gate commands as remote in .chunk/config.json`

### `internal/cmd/validate.go`
- Add `validateNeedsSidecar()` shared by auth check, CircleCI client setup, and `setupRemote`
- Stop hook + `validation.sidecarImage`: treat as `allRemote` and auto-create sidecar from snapshot
- Fix dead path where `resolveSidecar()` had hook/image auto-create logic but `setupRemote` never reached it

## Out of scope

- `chunk init` still does not default commands to remote
- PreToolUse hooks still run shell commands locally
- Node/npm base image improvements for bare Ubuntu sidecars
- Lock file pull-from-sidecar sync

## Test plan

- [x] `go test -race ./internal/config/... ./internal/cmd/... -run 'TestHasSidecarImage|TestMarkRemoteCommandsForSidecarSetup|TestValidateHook'`
- [x] `go test -race ./acceptance/... -run 'TestValidateHookAutoCreatesSidecarFromSidecarImage|TestValidateAutoCreatesSidecar'`
- [x] `go test -race ./acceptance/... -run 'Validate'`
- [ ] Full `task test` (unrelated `TestBuildPrompt*` failures observed locally)


Made with [Cursor](https://cursor.com)