### PR TITLE
Trust circleci-public/circleci tap before brew install on Linux

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -64,6 +64,7 @@ jobs:
             echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> "$BASH_ENV"
             source "$BASH_ENV"
             brew update
+            brew trust circleci-public/circleci
             brew install CircleCI-Public/circleci/chunk
       - run:
           name: Verify installation of correct version


### PR DESCRIPTION
## Summary

- The `test-linux-install` CI job was hanging until its 10-minute timeout because `brew install` prompted interactively `"Do you want to proceed with the installation? [y/n]"` when the `circleci-public/circleci` tap was untrusted on a fresh Linux environment
- Adding `brew trust circleci-public/circleci` before the install suppresses the prompt — this is exactly what Homebrew's own warning message instructs
- The `test-homebrew-install` (macOS) job was unaffected; this is Linux-specific tap trust behaviour

## Test plan

- [ ] Verify `test-linux-install` job completes without hanging on the next release pipeline run
- [ ] Confirm `test-homebrew-install` (macOS) still passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)