### PR TITLE
Fix npm not found on bare Ubuntu by adding Node.js system step

### DIFF
--- a/envbuilder/envbuilder.go
+++ b/envbuilder/envbuilder.go
@@ -390,9 +390,6 @@ func compareVersions(a, b string) int {
 func nodeInstallCmd(major string) string {
 	// Require a purely numeric major version so we never produce an invalid
 	// NodeSource URL (e.g. "unknown" from a failed version detection).
-	if major == "" || major == stackUnknown {
-		major = "22"
-	}
 	if _, err := strconv.Atoi(major); err != nil {
 		major = "22"
 	}

--- a/envbuilder/envbuilder.go
+++ b/envbuilder/envbuilder.go
@@ -388,7 +388,12 @@ func compareVersions(a, b string) int {
 }
 
 func nodeInstallCmd(major string) string {
+	// Require a purely numeric major version so we never produce an invalid
+	// NodeSource URL (e.g. "unknown" from a failed version detection).
 	if major == "" || major == stackUnknown {
+		major = "22"
+	}
+	if _, err := strconv.Atoi(major); err != nil {
 		major = "22"
 	}
 	return fmt.Sprintf(
@@ -1939,9 +1944,6 @@ func DetectEnvironment(ctx context.Context, dir string) (*Environment, error) {
 	for _, dep := range systemDeps {
 		var cmd string
 		if dep == "node" {
-			// Use the detected major version to pick the right NodeSource stream.
-			// sudo is already explicit in nodeInstallCmd, so we skip the cimg
-			// substitution below to avoid double-sudo on apt-get.
 			major := strings.SplitN(imageVersion, ".", 2)[0]
 			cmd = nodeInstallCmd(major)
 		} else if c, ok := extraDepInstalls[dep]; ok {

--- a/envbuilder/envbuilder.go
+++ b/envbuilder/envbuilder.go
@@ -387,6 +387,16 @@ func compareVersions(a, b string) int {
 	return 0
 }
 
+func nodeInstallCmd(major string) string {
+	if major == "" || major == stackUnknown {
+		major = "22"
+	}
+	return fmt.Sprintf(
+		"curl -fsSL https://deb.nodesource.com/setup_%s.x | sudo -E bash - && sudo apt-get install -y nodejs --no-install-recommends && sudo rm -rf /var/lib/apt/lists/*",
+		major,
+	)
+}
+
 var extraDepInstalls = map[string]string{
 	"uv":          "pip install uv",
 	"pipenv":      "pip install pipenv",
@@ -1927,13 +1937,23 @@ func DetectEnvironment(ctx context.Context, dir string) (*Environment, error) {
 
 	var sysCmds []string
 	for _, dep := range systemDeps {
-		if cmd, ok := extraDepInstalls[dep]; ok {
+		var cmd string
+		if dep == "node" {
+			// Use the detected major version to pick the right NodeSource stream.
+			// sudo is already explicit in nodeInstallCmd, so we skip the cimg
+			// substitution below to avoid double-sudo on apt-get.
+			major := strings.SplitN(imageVersion, ".", 2)[0]
+			cmd = nodeInstallCmd(major)
+		} else if c, ok := extraDepInstalls[dep]; ok {
+			cmd = c
 			if strings.HasPrefix(image, cimgPrefix) {
 				cmd = strings.ReplaceAll(cmd, "apt-get", "sudo apt-get")
 				cmd = strings.ReplaceAll(cmd, "rm -rf /var/lib/apt/lists/*", "sudo rm -rf /var/lib/apt/lists/*")
 				cmd = strings.ReplaceAll(cmd, "locale-gen", "sudo locale-gen")
 				cmd = strings.ReplaceAll(cmd, "update-locale", "sudo update-locale")
 			}
+		}
+		if cmd != "" {
 			sysCmds = append(sysCmds, cmd)
 		}
 	}

--- a/envbuilder/envbuilder_test.go
+++ b/envbuilder/envbuilder_test.go
@@ -448,6 +448,29 @@ func TestDetectGoDartSassDep(t *testing.T) {
 	})
 }
 
+func TestNodeInstallCmd(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses detected major version", func(t *testing.T) {
+		t.Parallel()
+		cmd := nodeInstallCmd("22")
+		assert.Assert(t, strings.Contains(cmd, "setup_22.x"), "expected setup_22.x in command, got: %s", cmd)
+		assert.Assert(t, strings.Contains(cmd, "nodejs"), "expected nodejs in command, got: %s", cmd)
+	})
+
+	t.Run("empty version falls back to 22", func(t *testing.T) {
+		t.Parallel()
+		cmd := nodeInstallCmd("")
+		assert.Assert(t, strings.Contains(cmd, "setup_22.x"), "expected setup_22.x fallback, got: %s", cmd)
+	})
+
+	t.Run("unknown version falls back to 22", func(t *testing.T) {
+		t.Parallel()
+		cmd := nodeInstallCmd(stackUnknown)
+		assert.Assert(t, strings.Contains(cmd, "setup_22.x"), "expected setup_22.x fallback for unknown, got: %s", cmd)
+	})
+}
+
 func TestDetectNodeTestCommand(t *testing.T) {
 	t.Parallel()
 

--- a/envbuilder/envbuilder_test.go
+++ b/envbuilder/envbuilder_test.go
@@ -469,6 +469,12 @@ func TestNodeInstallCmd(t *testing.T) {
 		cmd := nodeInstallCmd(stackUnknown)
 		assert.Assert(t, strings.Contains(cmd, "setup_22.x"), "expected setup_22.x fallback for unknown, got: %s", cmd)
 	})
+
+	t.Run("non-numeric version falls back to 22", func(t *testing.T) {
+		t.Parallel()
+		cmd := nodeInstallCmd("unknown") // e.g. from splitting "unknown.0"
+		assert.Assert(t, strings.Contains(cmd, "setup_22.x"), "expected setup_22.x fallback for non-numeric, got: %s", cmd)
+	})
 }
 
 func TestDetectNodeTestCommand(t *testing.T) {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -216,12 +216,12 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		}
 	}
 
-	if opts.dryRun {
-		return runValidateDryRun(name, opts.inlineCmd, cfg, statusFn)
-	}
-
 	if err := validateEnvFlag(opts.envVarsFlag); err != nil {
 		return err
+	}
+
+	if opts.dryRun {
+		return runValidateDryRun(name, opts.inlineCmd, cfg, statusFn)
 	}
 
 	// Hook: fail early when CircleCI auth is missing and remote commands need it.

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -216,12 +216,6 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		}
 	}
 
-	// Validate --env flag syntax before any remote resolution so bad
-	// values are caught immediately regardless of execution mode.
-	if err := validateEnvFlag(opts.envVarsFlag); err != nil {
-		return err
-	}
-
 	if opts.dryRun {
 		return runValidateDryRun(name, opts.inlineCmd, cfg, statusFn)
 	}
@@ -284,16 +278,6 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
 	}
 	return execErr
-}
-
-func validateEnvFlag(envVarsFlag []string) error {
-	if len(envVarsFlag) == 0 {
-		return nil
-	}
-	if _, vErr := sidecar.ParseEnvPairs(envVarsFlag); vErr != nil {
-		return &userError{msg: fmt.Sprintf("invalid --env value: %s", vErr), err: vErr}
-	}
-	return nil
 }
 
 func runValidateDryRun(name, inlineCmd string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc) error {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -220,6 +220,10 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return runValidateDryRun(name, opts.inlineCmd, cfg, statusFn)
 	}
 
+	if err := validateEnvFlag(opts.envVarsFlag); err != nil {
+		return err
+	}
+
 	// Hook: fail early when CircleCI auth is missing and remote commands need it.
 	// In non-hook context ensureCircleCIClient prompts interactively; hooks have
 	// no TTY so we surface a clear message here instead of a confusing fallback.
@@ -278,6 +282,13 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
 	}
 	return execErr
+}
+
+func validateEnvFlag(envVarsFlag []string) error {
+	if _, err := sidecar.ParseEnvPairs(envVarsFlag); err != nil {
+		return &userError{msg: fmt.Sprintf("invalid --env value: %s", err), err: err}
+	}
+	return nil
 }
 
 func runValidateDryRun(name, inlineCmd string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc) error {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -157,7 +157,7 @@ func validateNeedsSidecar(explicitRemote bool, cfg *config.ProjectConfig, hook *
 	return hook != nil && cfg.HasSidecarImage()
 }
 
-func maybeEnsureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc config.ResolvedConfig, needsSidecar bool, cfg *config.ProjectConfig, streams iostream.Streams) (*circleci.Client, error) {
+func maybeEnsureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc config.ResolvedConfig, needsSidecar bool, streams iostream.Streams) (*circleci.Client, error) {
 	if !needsSidecar {
 		return nil, nil
 	}
@@ -218,10 +218,8 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 
 	// Validate --env flag syntax before any remote resolution so bad
 	// values are caught immediately regardless of execution mode.
-	if len(opts.envVarsFlag) > 0 {
-		if _, vErr := sidecar.ParseEnvPairs(opts.envVarsFlag); vErr != nil {
-			return &userError{msg: fmt.Sprintf("invalid --env value: %s", vErr), err: vErr}
-		}
+	if err := validateEnvFlag(opts.envVarsFlag); err != nil {
+		return err
 	}
 
 	if opts.dryRun {
@@ -252,7 +250,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 
 	image := resolveImage(name, cfg)
 
-	circleCIClient, err := maybeEnsureCircleCIClient(cmd.Context(), cmd, rc, needsSidecar, cfg, streams)
+	circleCIClient, err := maybeEnsureCircleCIClient(cmd.Context(), cmd, rc, needsSidecar, streams)
 	if err != nil {
 		return err
 	}
@@ -286,6 +284,16 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
 	}
 	return execErr
+}
+
+func validateEnvFlag(envVarsFlag []string) error {
+	if len(envVarsFlag) == 0 {
+		return nil
+	}
+	if _, vErr := sidecar.ParseEnvPairs(envVarsFlag); vErr != nil {
+		return &userError{msg: fmt.Sprintf("invalid --env value: %s", vErr), err: vErr}
+	}
+	return nil
 }
 
 func runValidateDryRun(name, inlineCmd string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc) error {


### PR DESCRIPTION
## Summary

- Node/JS/TS projects now get a `system` setup step that installs Node.js via NodeSource before `npm install` / `yarn install` runs
- Uses the detected major version (e.g. `setup_22.x`) so it matches the project's Node version
- Fixes `npm: command not found` on bare Ubuntu sidecars during `chunk sidecar setup`

## Changes

- `envbuilder/envbuilder.go`: add `nodeInstallCmd(major)` helper and handle `"node"` inline in the system step loop using the already-detected `imageVersion`
- `envbuilder/envbuilder_test.go`: add `TestNodeInstallCmd` covering the version-aware path and fallback

## Test plan

- [x] `go test -race ./envbuilder/... -run 'TestNodeInstallCmd|TestDetectCommands'`
- [x] `chunk sidecar env` on a real TypeScript project shows a `system` step with the NodeSource install command
<img width="567" height="353" alt="Screenshot 2026-06-16 at 11 58 14 AM" src="https://github.com/user-attachments/assets/8dcf7e10-eccf-44f8-a07f-87c700640c74" />
