### PR TITLE
Set NONINTERACTIVE=1 to fix brew install prompt in test-linux-install

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -60,6 +60,7 @@ jobs:
       - run:
           name: Install chunk via Homebrew
           command: |
+            export NONINTERACTIVE=1
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
             echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> "$BASH_ENV"
             source "$BASH_ENV"


### PR DESCRIPTION
## Summary

- The `test-linux-install` job was hanging on an interactive `[y/n]` confirmation prompt from `brew install`
- Added `export NONINTERACTIVE=1` at the top of the install step, which tells Homebrew to skip all interactive prompts

## Test plan

- [ ] Trigger a release and confirm the `test-linux-install` job completes without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)