### PR TITLE
Route validate to active sidecar when sidecarImage is configured

### DIFF
--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -397,17 +397,16 @@ func TestValidateRunRemoteUsesSSH(t *testing.T) {
 	assert.Equal(t, len(execReqs), 0, "expected 0 HTTP exec requests (SSH should be used)")
 }
 
-func TestValidateAutoCreatesSidecar(t *testing.T) {
-	// Verify that chunk validate (no --remote) auto-creates a sidecar using the
-	// image stored in validation.sidecarImage when no active sidecar exists.
+func TestValidateSidecarImageNoActiveSidecarRunsLocally(t *testing.T) {
+	// Plain chunk validate with sidecarImage configured but no active sidecar must
+	// NOT auto-create a sandbox — it runs commands locally instead. Auto-create is
+	// reserved for the Stop hook path (TestValidateHookAutoCreatesSidecarFromSidecarImage).
 	cci := fakes.NewFakeCircleCI()
-	cci.AddKeyURL = "127.0.0.1" // SSH will fail — no real server at port 2222
 	srv := httptest.NewServer(cci)
 	defer srv.Close()
 
 	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
 
-	// Write a config with a remote command and a snapshot image reference.
 	chunkDir := filepath.Join(workDir, ".chunk")
 	assert.NilError(t, os.MkdirAll(chunkDir, 0o755))
 	cfg := map[string]interface{}{
@@ -422,37 +421,19 @@ func TestValidateAutoCreatesSidecar(t *testing.T) {
 	assert.NilError(t, err)
 	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), data, 0o644))
 
-	sshDir := filepath.Join(t.TempDir(), ".ssh")
-	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
-	identityFile := filepath.Join(sshDir, "chunk_ai")
-	assert.NilError(t, generateTestSSHKey(t, identityFile))
-
 	env := testenv.NewTestEnv(t)
 	env.CircleCIURL = srv.URL
 	env.Extra["CIRCLECI_ORG_ID"] = "org-aaa"
 
-	result := binary.RunCLI(t, []string{
-		"validate",
-		"--identity-file", identityFile,
-	}, env, workDir)
+	result := binary.RunCLI(t, []string{"validate"}, env, workDir)
 
-	// SSH to 127.0.0.1:2222 fails — expected, but a sidecar must have been created first.
-	assert.Assert(t, result.ExitCode != 0, "expected failure because no SSH server is running")
+	// Command runs locally (echo test-output) — must succeed.
+	assert.Equal(t, result.ExitCode, 0, "expected local fallback to succeed, stderr: %s", result.Stderr)
 
+	// No sidecar must have been created.
 	reqs := cci.Recorder.AllRequests()
-
-	// A sidecar must have been created with the configured image.
 	createReqs := filterByPath(reqs, "/api/v2/sidecar/instances")
-	assert.Equal(t, len(createReqs), 1, "expected 1 create-sidecar request; got: %v", reqs)
-
-	var body map[string]interface{}
-	assert.NilError(t, json.Unmarshal(createReqs[0].Body, &body))
-	assert.Equal(t, body["image"], "my-snapshot-abc123", "expected sidecar image from config")
-	assert.Equal(t, body["org_id"], "org-aaa", "expected org from CIRCLECI_ORG_ID")
-
-	// AddSSHKey must be called on the newly created sidecar — proves it was used.
-	addKeyReqs := filterByPath(reqs, "/api/v2/sidecar/instances/sidecar-new-123/ssh/add-key")
-	assert.Equal(t, len(addKeyReqs), 1, "expected 1 add-key request for newly created sidecar; got: %v", reqs)
+	assert.Equal(t, len(createReqs), 0, "expected no create-sidecar request when no active sidecar exists; got: %v", reqs)
 }
 
 func TestValidateHookAutoCreatesSidecarFromSidecarImage(t *testing.T) {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -150,11 +150,11 @@ func initHook(ctx context.Context, hook *hookContext, workDir string, streams io
 	return ctx, streams, false, nil
 }
 
-func validateNeedsSidecar(explicitRemote bool, cfg *config.ProjectConfig, hook *hookContext) bool {
+func validateNeedsSidecar(explicitRemote bool, cfg *config.ProjectConfig, hook *hookContext, hasActiveSidecar bool) bool {
 	if explicitRemote || cfg.HasRemoteCommands() {
 		return true
 	}
-	return hook != nil && cfg.HasSidecarImage()
+	return cfg.HasSidecarImage() && (hook != nil || hasActiveSidecar)
 }
 
 func maybeEnsureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc config.ResolvedConfig, needsSidecar bool, streams iostream.Streams) (*circleci.Client, error) {
@@ -230,7 +230,8 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	rc, _ := config.Resolve("", "", insecureStorage)
 
 	explicitRemote := opts.remote || opts.sidecarID != ""
-	needsSidecar := validateNeedsSidecar(explicitRemote, cfg, hook)
+	activeSidecar, _ := sidecar.LoadActive(ctx)
+	needsSidecar := validateNeedsSidecar(explicitRemote, cfg, hook, activeSidecar != nil)
 	if hook != nil && needsSidecar && rc.CircleCIToken == "" {
 		streams.ErrPrintln("CircleCI auth is not configured.")
 		streams.ErrPrintln("Suggestion: " + suggestionCircleCIAuth)
@@ -242,7 +243,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	// (--remote or --sidecar-id), meaning every command runs there.
 	// Per-command routing only applies when the sidecar is resolved implicitly.
 	allRemote := explicitRemote
-	if hook != nil && cfg.HasSidecarImage() {
+	if cfg.HasSidecarImage() {
 		allRemote = true
 	}
 
@@ -253,7 +254,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return err
 	}
 
-	freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, hook, statusFn, workDir, streams)
+	freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, hook, activeSidecar != nil, statusFn, workDir, streams)
 	if err != nil {
 		return err
 	}
@@ -399,8 +400,8 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 
 // setupRemote resolves (or creates) the sidecar ID based on the validate flags
 // and config, then returns whether a new sidecar was provisioned.
-func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpts, image string, cfg *config.ProjectConfig, hook *hookContext, statusFn iostream.StatusFunc, workDir string, streams iostream.Streams) (bool, error) {
-	if validateNeedsSidecar(opts.remote || opts.sidecarID != "", cfg, hook) {
+func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpts, image string, cfg *config.ProjectConfig, hook *hookContext, hasActiveSidecar bool, statusFn iostream.StatusFunc, workDir string, streams iostream.Streams) (bool, error) {
+	if validateNeedsSidecar(opts.remote || opts.sidecarID != "", cfg, hook, hasActiveSidecar) {
 		if opts.remote {
 			created, err := resolveOrCreateSidecarID(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, streams)
 			if err != nil {
@@ -583,9 +584,9 @@ func resolveSidecar(ctx context.Context, client *circleci.Client, sidecarID *str
 		statusFn(iostream.LevelInfo, fmt.Sprintf("using sidecar %s for remote commands", *sidecarID))
 		return false
 	}
-	if hook != nil || image != "" {
-		// In Stop hook context, or when a sidecar image is configured: auto-create
-		// from the stored snapshot so remote commands get the prepared environment.
+	if hook != nil {
+		// In Stop hook context: auto-create from the stored snapshot so remote
+		// commands get the prepared environment.
 		created, err := resolveOrCreateSidecarID(ctx, client, sidecarID, orgID, image, workDir, streams)
 		if err != nil {
 			streams.ErrPrintf("warning: no sandbox available (%v); run 'chunk config set orgID <id>' to enable remote validation, running locally instead\n", err)

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -254,7 +254,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return err
 	}
 
-	freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, hook, activeSidecar != nil, statusFn, workDir, streams)
+	freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, hook, activeSidecar, statusFn, workDir, streams)
 	if err != nil {
 		return err
 	}
@@ -400,8 +400,8 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 
 // setupRemote resolves (or creates) the sidecar ID based on the validate flags
 // and config, then returns whether a new sidecar was provisioned.
-func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpts, image string, cfg *config.ProjectConfig, hook *hookContext, hasActiveSidecar bool, statusFn iostream.StatusFunc, workDir string, streams iostream.Streams) (bool, error) {
-	if validateNeedsSidecar(opts.remote || opts.sidecarID != "", cfg, hook, hasActiveSidecar) {
+func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpts, image string, cfg *config.ProjectConfig, hook *hookContext, activeSidecar *sidecar.ActiveSidecar, statusFn iostream.StatusFunc, workDir string, streams iostream.Streams) (bool, error) {
+	if validateNeedsSidecar(opts.remote || opts.sidecarID != "", cfg, hook, activeSidecar != nil) {
 		if opts.remote {
 			created, err := resolveOrCreateSidecarID(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, streams)
 			if err != nil {
@@ -410,7 +410,7 @@ func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpt
 			statusFn(iostream.LevelInfo, fmt.Sprintf("running all commands on sidecar %s", opts.sidecarID))
 			return created, nil
 		}
-		return resolveSidecar(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, hook, streams), nil
+		return resolveSidecar(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, hook, activeSidecar, streams), nil
 	}
 	return false, nil
 }
@@ -574,12 +574,12 @@ func resolveImage(name string, cfg *config.ProjectConfig) string {
 
 // resolveSidecar fills sidecarID for per-command remote routing
 // (i.e. when --remote is not set but some commands have Remote:true).
-// It uses the active sidecar when available, auto-creates one when a sidecar
-// image is configured or the caller is a Stop hook, and warns otherwise.
+// It uses the active sidecar when available, auto-creates one when the
+// caller is a Stop hook, and warns otherwise.
 // Returns true when a brand-new sidecar was provisioned in this call.
-func resolveSidecar(ctx context.Context, client *circleci.Client, sidecarID *string, orgID, image, workDir string, hook *hookContext, streams iostream.Streams) bool {
+func resolveSidecar(ctx context.Context, client *circleci.Client, sidecarID *string, orgID, image, workDir string, hook *hookContext, active *sidecar.ActiveSidecar, streams iostream.Streams) bool {
 	statusFn := newStatusFunc(streams)
-	if active, err := sidecar.LoadActive(ctx); err == nil && active != nil {
+	if active != nil {
 		*sidecarID = active.SidecarID
 		statusFn(iostream.LevelInfo, fmt.Sprintf("using sidecar %s for remote commands", *sidecarID))
 		return false

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -111,6 +111,24 @@ func TestValidateHookSkipsAuthCheckWhenNoRemoteCommands(t *testing.T) {
 	_ = err
 }
 
+func TestValidateNeedsSidecarSidecarImageWithActiveSidecar(t *testing.T) {
+	cfg := &config.ProjectConfig{
+		Validation: &config.ValidationConfig{SidecarImage: "my-snapshot-abc123"},
+	}
+	// sidecarImage + active sidecar, no hook → should use sidecar
+	got := validateNeedsSidecar(false, cfg, nil, true)
+	assert.Assert(t, got, "expected validateNeedsSidecar=true with sidecarImage and active sidecar")
+}
+
+func TestValidateNeedsSidecarSidecarImageNoActiveSidecar(t *testing.T) {
+	cfg := &config.ProjectConfig{
+		Validation: &config.ValidationConfig{SidecarImage: "my-snapshot-abc123"},
+	}
+	// sidecarImage but no active sidecar, no hook → must not use sidecar (avoids auto-create)
+	got := validateNeedsSidecar(false, cfg, nil, false)
+	assert.Assert(t, !got, "expected validateNeedsSidecar=false with sidecarImage but no active sidecar")
+}
+
 func TestHostForwardEnv(t *testing.T) {
 	t.Run("returns nil when token is empty", func(t *testing.T) {
 		assert.Assert(t, hostForwardEnv("") == nil)


### PR DESCRIPTION
## Problem

From the friction log: after running `chunk sidecar snapshot create` and `chunk config set validation.sidecarImage`, users expected `chunk validate` to route to the sidecar. It didn't -`sidecarImage` alone only activated sidecar routing in Stop hook context, not for plain invocations.

## What changed

`validateNeedsSidecar` now returns true when `sidecarImage` is set **and** an active sidecar already exists, regardless of whether we're in a Stop hook. allRemote is set to true on `sidecarImage alone (hook guard removed).

Auto-create remains hook-only - `resolveSidecar` no longer auto-provisions a sandbox just because `image != ""`. Plain `chunk validate` with no active sidecar falls back to local with a warning.

<img width="579" height="314" alt="Screenshot 2026-06-17 at 2 16 56 PM" src="https://github.com/user-attachments/assets/497ddef3-2c77-456c-924f-f4a7b0de0834" />


<img width="572" height="368" alt="Screenshot 2026-06-17 at 2 20 09 PM" src="https://github.com/user-attachments/assets/398a25ba-ff5e-43b7-8da5-6801a3e99e78" />
