### PR TITLE
Set HOMEBREW_NO_ASK=1 to fix nightly hang in test-linux-install

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -61,6 +61,7 @@ jobs:
           name: Install chunk via Homebrew
           command: |
             export NONINTERACTIVE=1
+            export HOMEBREW_NO_ASK=1
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
             echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> "$BASH_ENV"
             source "$BASH_ENV"


### PR DESCRIPTION
## Summary

- Homebrew 6.0.0 (released June 11) introduced **ask mode** as the default — `brew install` now shows a dependency summary and prompts "Do you want to proceed with the installation? [y/n]" before making changes
- The nightly release pipeline (`test-linux-install` job) has been hanging on this prompt and timing out after 10 minutes
- `NONINTERACTIVE=1` (added in #409) only suppresses the install.sh bootstrapper prompt — it has no effect on `brew install`'s ask mode
- `HOMEBREW_NO_ASK=1` is the correct env var to disable ask mode per the Homebrew manpage

## Test plan

- [ ] Trigger the nightly release pipeline manually and confirm `test-linux-install` no longer hangs on the `brew install` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)