### PR TITLE
Switch release job to use devex-release context

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -76,7 +76,7 @@ workflows:
     jobs:
       - release:
           context:
-            - chunk-cli-deploy
+            - devex-release
       - test-homebrew-install:
           requires:
             - release


### PR DESCRIPTION
## Summary
- Updates the release job in `.circleci/release.yml` to use the `devex-release` context instead of `chunk-cli-deploy`

## Test plan
- [ ] Verify the release workflow picks up the correct context on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)