### PR TITLE
Fix onboarding settings decline and remote CHANGED_PACKAGES expansion

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -110,10 +110,10 @@ func writeSettings(workDir string, commands []config.Command, streams iostream.S
 	apply, confirmErr := confirm("Apply changes to .claude/settings.json?", false)
 	if confirmErr != nil {
 		streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not confirm: %v", confirmErr)))
-	}
-	if confirmErr != nil || !apply {
-		// Decline, cancel, or non-TTY — fall back to example file.
 		return writeSettingsExample(dir, generated, streams)
+	}
+	if !apply {
+		return nil
 	}
 
 	if err := os.WriteFile(path, withTrailingNewline(result.Merged), 0o644); err != nil {

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -107,7 +107,7 @@ func TestWriteSettingsExistingMergeDeclined(t *testing.T) {
 	existing := []byte(`{"permissions": {"allow": ["Read"]}}`)
 	assert.NilError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), existing, 0o644))
 
-	streams, _, errOut := testStreams()
+	streams, _, _ := testStreams()
 	commands := []config.Command{
 		{Name: "test", Run: "go test ./...", Timeout: 60},
 	}
@@ -120,11 +120,9 @@ func TestWriteSettingsExistingMergeDeclined(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, string(data), string(existing))
 
-	// Example file written.
+	// No example file written on explicit decline.
 	_, statErr := os.Stat(filepath.Join(claudeDir, "settings.example.json"))
-	assert.NilError(t, statErr)
-
-	assert.Assert(t, bytes.Contains(errOut.Bytes(), []byte("settings.example.json")))
+	assert.Assert(t, errors.Is(statErr, fs.ErrNotExist))
 }
 
 func TestWriteSettingsExistingNoTTYFallback(t *testing.T) {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -345,7 +345,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 		if err != nil {
 			return err
 		}
-		return validate.RunRemote(ctx, execFn, cfg, name, dest, statusFn, streams)
+		return validate.RunRemote(ctx, execFn, cfg, name, dest, workDir, statusFn, streams)
 	}
 
 	// Per-command remote routing: commands with Remote:true go to the sidecar,
@@ -358,7 +358,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 				if err != nil {
 					return err
 				}
-				return validate.RunRemote(ctx, execFn, cfg, name, dest, statusFn, streams)
+				return validate.RunRemote(ctx, execFn, cfg, name, dest, workDir, statusFn, streams)
 			}
 			statusFn(iostream.LevelInfo, fmt.Sprintf("running %s locally (not marked remote)", name))
 			// Named command is not marked remote; fall through to local execution.
@@ -531,7 +531,7 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 			streams.ErrPrintf("warning: %v (%q); run 'chunk sidecar env build' to set up the workspace; running %s locally instead\n", wsErr, dest, commandNames(remoteCfg.Commands))
 			localCfg.Commands = append(remoteCfg.Commands, localCfg.Commands...)
 		} else {
-			runErr = validate.RunRemote(ctx, execFn, remoteCfg, "", dest, statusFn, streams)
+			runErr = validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, statusFn, streams)
 		}
 	}
 	if len(localCfg.Commands) > 0 {

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -108,7 +108,8 @@ func RunDryRun(cfg *config.ProjectConfig, name string, status iostream.StatusFun
 
 // RunRemote runs commands on a remote sidecar via SSH.
 // If name is non-empty, only the named command is run.
-func RunRemote(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), cfg *config.ProjectConfig, name, dest string, status iostream.StatusFunc, streams iostream.Streams) error {
+// workDir is the local repository root used to expand {{CHANGED_PACKAGES}}.
+func RunRemote(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), cfg *config.ProjectConfig, name, dest, workDir string, status iostream.StatusFunc, streams iostream.Streams) error {
 	commands := cfg.Commands
 	if name != "" {
 		c := cfg.FindCommand(name)
@@ -118,7 +119,8 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 		commands = []config.Command{*c}
 	}
 	for _, c := range commands {
-		script := "cd " + shellEscape(dest) + " && " + c.Run
+		run := expandCommand(workDir, c.Run)
+		script := "cd " + shellEscape(dest) + " && " + run
 		status(iostream.LevelInfo, fmt.Sprintf("Running %s (remote): %s", c.Name, c.Run))
 		stdout, stderr, exitCode, err := execFn(ctx, script)
 		if err != nil {

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -281,7 +281,7 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, out, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", func(iostream.Level, string) {}, streams))
+		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams))
 		assert.Assert(t, strings.Contains(out.String(), "remote output"), "got: %s", out.String())
 		assert.Equal(t, execCount, 2)
 	})
@@ -296,7 +296,7 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		err := RunRemote(context.Background(), execFn, cfg, "", "/workspace", func(iostream.Level, string) {}, streams)
+		err := RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, "remote test failed")
 	})
 
@@ -310,7 +310,7 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, out, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", func(iostream.Level, string) {}, streams))
+		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams))
 		assert.Equal(t, out.Len(), 0)
 	})
 
@@ -327,7 +327,7 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "test", "/workspace", func(iostream.Level, string) {}, streams))
+		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "test", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams))
 		assert.Equal(t, len(capturedScripts), 1)
 		assert.Assert(t, strings.Contains(capturedScripts[0], "echo test"), "got: %s", capturedScripts[0])
 	})
@@ -342,7 +342,7 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		err := RunRemote(context.Background(), execFn, cfg, "lint", "/workspace", func(iostream.Level, string) {}, streams)
+		err := RunRemote(context.Background(), execFn, cfg, "lint", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, `"lint" not configured`)
 	})
 
@@ -358,7 +358,7 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/custom/path", func(iostream.Level, string) {}, streams))
+		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/custom/path", t.TempDir(), func(iostream.Level, string) {}, streams))
 		assert.Assert(t, strings.HasPrefix(capturedScript, "cd '/custom/path' &&"), "got: %s", capturedScript)
 	})
 }
@@ -404,7 +404,7 @@ func TestRunRemoteSSH(t *testing.T) {
 		}}
 		streams, out, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", func(iostream.Level, string) {}, streams))
+		assert.NilError(t, RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), func(iostream.Level, string) {}, streams))
 		assert.Assert(t, strings.Contains(out.String(), "hello from remote"), "got: %s", out.String())
 		assert.Equal(t, len(sshSrv.Commands()), 1)
 	})
@@ -429,7 +429,7 @@ func TestRunRemoteSSH(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		err = RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", func(iostream.Level, string) {}, streams)
+		err = RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, "remote test failed")
 	})
 
@@ -454,7 +454,7 @@ func TestRunRemoteSSH(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		err = RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", func(iostream.Level, string) {}, streams)
+		err = RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, "remote install failed")
 		assert.Equal(t, len(sshSrv.Commands()), 1)
 	})


### PR DESCRIPTION
## Summary
- When a user explicitly declines applying settings changes during `chunk init`, leave `.claude/settings.json` untouched and do not write `settings.example.json` (example file is still written on confirm errors or non-TTY fallback)
- Expand `{{CHANGED_PACKAGES}}` in remote validation commands by passing the local repo root into `RunRemote`, so sidecar runs use the same command substitution as local runs

## Test plan
- [x] `TestWriteSettingsExistingMergeDeclined` updated to assert no example file is written on decline
- [x] `RunRemote` tests updated for new `workDir` parameter
- [ ] Run `task test` locally
- [ ] Run `chunk init` in a repo with existing `.claude/settings.json`, decline the merge prompt, and confirm settings are unchanged and no example file is created
- [ ] Run `chunk validate` with a remote command using `{{CHANGED_PACKAGES}}` and confirm packages are expanded in the sidecar script


Made with [Cursor](https://cursor.com)