### PR TITLE
Retry sidecar API 429s honouring Retry-After (30s budget)

### DIFF
--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 	"github.com/CircleCI-Public/chunk-cli/internal/version"
@@ -33,10 +34,11 @@ func NewClient(cfg Config) (*Client, error) {
 		return nil, ErrTokenNotFound
 	}
 	cl := hc.New(hc.Config{
-		BaseURL:    cfg.BaseURL,
-		AuthToken:  cfg.Token,
-		AuthHeader: "Circle-Token",
-		UserAgent:  version.UserAgent(),
+		BaseURL:          cfg.BaseURL,
+		AuthToken:        cfg.Token,
+		AuthHeader:       "Circle-Token",
+		UserAgent:        version.UserAgent(),
+		RetryOn429Budget: 30 * time.Second,
 	})
 	return &Client{cl: cl}, nil
 }

--- a/internal/httpcl/client.go
+++ b/internal/httpcl/client.go
@@ -11,10 +11,21 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 )
+
+// retryCtxKey is the context key for the per-call retry state.
+type retryCtxKey struct{}
+
+// retryState tracks per-call retry counters stored in the request context.
+// Using a pointer allows mutation across CheckRetry invocations for the same call.
+type retryState struct {
+	start                time.Time
+	nonRateLimitAttempts int
+}
 
 const jsonContentType = "application/json; charset=utf-8"
 
@@ -34,18 +45,24 @@ type Config struct {
 	// DisableRetries disables automatic retries. By default requests are
 	// retried up to 3 times with exponential backoff.
 	DisableRetries bool
+	// RetryOn429Budget, when non-zero, enables retrying HTTP 429 responses by
+	// honouring the Retry-After response header. Retries stop when the
+	// cumulative wait time would exceed this budget, or when a single
+	// Retry-After value exceeds it, and a RateLimitError is returned.
+	RetryOn429Budget time.Duration
 	// Transport overrides the HTTP transport (useful for testing).
 	Transport http.RoundTripper
 }
 
 // Client is a simple HTTP client with JSON defaults and automatic retries.
 type Client struct {
-	baseURL    string
-	authToken  string
-	authHeader string
-	userAgent  string
-	timeout    time.Duration
-	http       *retryablehttp.Client
+	baseURL          string
+	authToken        string
+	authHeader       string
+	userAgent        string
+	timeout          time.Duration
+	retryOn429Budget time.Duration
+	http             *retryablehttp.Client
 }
 
 // New creates a Client from the given config.
@@ -64,18 +81,73 @@ func New(cfg Config) *Client {
 	rc.RetryWaitMax = 2 * time.Second
 	rc.Logger = nil // suppress default log output
 
+	if cfg.RetryOn429Budget > 0 {
+		// Raise RetryMax to accommodate 429 retries. The CheckRetry below caps
+		// non-429 retries at the original limit so 5xx behaviour is unchanged.
+		rc.RetryMax = 30
+		budget := cfg.RetryOn429Budget
+		origMax := 3
+		if cfg.DisableRetries {
+			origMax = 0
+		}
+		rc.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+			state, _ := ctx.Value(retryCtxKey{}).(*retryState)
+			if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+				retryAfter := parseRetryAfter(resp)
+				elapsed := time.Duration(0)
+				if state != nil {
+					elapsed = time.Since(state.start)
+				}
+				if elapsed+retryAfter > budget {
+					return false, &RateLimitError{RetryAfter: retryAfter, Budget: budget}
+				}
+				return true, nil
+			}
+			// Cap non-429 retries at the original limit.
+			if state != nil {
+				state.nonRateLimitAttempts++
+				if state.nonRateLimitAttempts > origMax {
+					return false, nil
+				}
+			}
+			return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+		}
+		// DefaultBackoff already honours Retry-After; keep it.
+	}
+
 	if cfg.Transport != nil {
 		rc.HTTPClient.Transport = cfg.Transport
 	}
 
 	return &Client{
-		baseURL:    cfg.BaseURL,
-		authToken:  cfg.AuthToken,
-		authHeader: cfg.AuthHeader,
-		userAgent:  cfg.UserAgent,
-		timeout:    timeout,
-		http:       rc,
+		baseURL:          cfg.BaseURL,
+		authToken:        cfg.AuthToken,
+		authHeader:       cfg.AuthHeader,
+		userAgent:        cfg.UserAgent,
+		timeout:          timeout,
+		retryOn429Budget: cfg.RetryOn429Budget,
+		http:             rc,
 	}
+}
+
+// parseRetryAfter parses the Retry-After header as seconds or an HTTP date.
+func parseRetryAfter(resp *http.Response) time.Duration {
+	ra := resp.Header.Get("Retry-After")
+	if ra == "" {
+		return 0
+	}
+	if secs, err := strconv.ParseInt(ra, 10, 64); err == nil {
+		if secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+		return 0
+	}
+	if t, err := http.ParseTime(ra); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
 }
 
 // Call executes the request and returns the HTTP status code.
@@ -99,7 +171,15 @@ func (c *Client) Call(ctx context.Context, r Request) (int, error) {
 		bodyReader = bytes.NewReader(b)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	if c.retryOn429Budget > 0 {
+		ctx = context.WithValue(ctx, retryCtxKey{}, &retryState{start: time.Now()})
+	}
+	// When 429 retry is enabled, extend the deadline to accommodate retry waits.
+	ctxTimeout := c.timeout
+	if c.retryOn429Budget > 0 {
+		ctxTimeout = c.retryOn429Budget + c.timeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, ctxTimeout)
 	defer cancel()
 
 	req, err := retryablehttp.NewRequestWithContext(ctx, r.method, u.String(), bodyReader)
@@ -131,13 +211,15 @@ func (c *Client) Call(ctx context.Context, r Request) (int, error) {
 	}
 
 	resp, err := c.http.Do(req)
+	if resp != nil {
+		defer func() {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}()
+	}
 	if err != nil {
 		return 0, err
 	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-	}()
 
 	status := resp.StatusCode
 

--- a/internal/httpcl/client.go
+++ b/internal/httpcl/client.go
@@ -82,14 +82,14 @@ func New(cfg Config) *Client {
 	rc.Logger = nil // suppress default log output
 
 	if cfg.RetryOn429Budget > 0 {
-		// Raise RetryMax to accommodate 429 retries. The CheckRetry below caps
-		// non-429 retries at the original limit so 5xx behaviour is unchanged.
-		rc.RetryMax = 30
 		budget := cfg.RetryOn429Budget
 		origMax := 3
 		if cfg.DisableRetries {
 			origMax = 0
 		}
+		// Raise RetryMax so it never binds before the budget does.
+		// Each 429 retry consumes ≥1s (Retry-After floor), so budget/s + origMax is sufficient.
+		rc.RetryMax = int(budget/time.Second) + origMax
 		rc.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 			state, _ := ctx.Value(retryCtxKey{}).(*retryState)
 			if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
@@ -171,13 +171,10 @@ func (c *Client) Call(ctx context.Context, r Request) (int, error) {
 		bodyReader = bytes.NewReader(b)
 	}
 
-	if c.retryOn429Budget > 0 {
-		ctx = context.WithValue(ctx, retryCtxKey{}, &retryState{start: time.Now()})
-	}
-	// When 429 retry is enabled, extend the deadline to accommodate retry waits.
 	ctxTimeout := c.timeout
 	if c.retryOn429Budget > 0 {
-		ctxTimeout = c.retryOn429Budget + c.timeout
+		ctx = context.WithValue(ctx, retryCtxKey{}, &retryState{start: time.Now()})
+		ctxTimeout = c.retryOn429Budget + c.timeout // extend deadline to cover retry waits
 	}
 	ctx, cancel := context.WithTimeout(ctx, ctxTimeout)
 	defer cancel()

--- a/internal/httpcl/client_internal_test.go
+++ b/internal/httpcl/client_internal_test.go
@@ -1,0 +1,56 @@
+package httpcl
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestParseRetryAfter_Seconds(t *testing.T) {
+	resp := &http.Response{Header: http.Header{"Retry-After": []string{"30"}}}
+	if d := parseRetryAfter(resp); d != 30*time.Second {
+		t.Fatalf("expected 30s, got %v", d)
+	}
+}
+
+func TestParseRetryAfter_ZeroSeconds(t *testing.T) {
+	resp := &http.Response{Header: http.Header{"Retry-After": []string{"0"}}}
+	if d := parseRetryAfter(resp); d != 0 {
+		t.Fatalf("expected 0, got %v", d)
+	}
+}
+
+func TestParseRetryAfter_HTTPDate_Future(t *testing.T) {
+	future := time.Now().Add(5 * time.Second)
+	resp := &http.Response{
+		Header: http.Header{"Retry-After": []string{future.UTC().Format(http.TimeFormat)}},
+	}
+	d := parseRetryAfter(resp)
+	if d < 3*time.Second || d > 6*time.Second {
+		t.Fatalf("expected ~5s from HTTP-date, got %v", d)
+	}
+}
+
+func TestParseRetryAfter_HTTPDate_Past(t *testing.T) {
+	past := time.Now().Add(-5 * time.Second)
+	resp := &http.Response{
+		Header: http.Header{"Retry-After": []string{past.UTC().Format(http.TimeFormat)}},
+	}
+	if d := parseRetryAfter(resp); d != 0 {
+		t.Fatalf("expected 0 for past date, got %v", d)
+	}
+}
+
+func TestParseRetryAfter_Missing(t *testing.T) {
+	resp := &http.Response{Header: http.Header{}}
+	if d := parseRetryAfter(resp); d != 0 {
+		t.Fatalf("expected 0 for missing header, got %v", d)
+	}
+}
+
+func TestParseRetryAfter_Invalid(t *testing.T) {
+	resp := &http.Response{Header: http.Header{"Retry-After": []string{"garbage"}}}
+	if d := parseRetryAfter(resp); d != 0 {
+		t.Fatalf("expected 0 for invalid value, got %v", d)
+	}
+}

--- a/internal/httpcl/client_test.go
+++ b/internal/httpcl/client_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
 )
@@ -143,6 +145,112 @@ func TestRouteParams(t *testing.T) {
 	}
 	if status != 200 {
 		t.Fatalf("expected 200, got %d", status)
+	}
+}
+
+func TestRetryOn429_RetriesWithinBudget(t *testing.T) {
+	var attempts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := hc.New(hc.Config{
+		BaseURL:          srv.URL,
+		RetryOn429Budget: 10 * time.Second,
+	})
+
+	status, err := c.Call(context.Background(), hc.NewRequest("GET", "/"))
+	if err != nil {
+		t.Fatalf("expected success after retry, got: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if n := attempts.Load(); n != 2 {
+		t.Fatalf("expected 2 attempts, got %d", n)
+	}
+}
+
+func TestRetryOn429_BailsWhenRetryAfterExceedsBudget(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := hc.New(hc.Config{
+		BaseURL:          srv.URL,
+		RetryOn429Budget: 30 * time.Second,
+	})
+
+	_, err := c.Call(context.Background(), hc.NewRequest("GET", "/"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !hc.IsRateLimitError(err) {
+		t.Fatalf("expected RateLimitError, got: %v", err)
+	}
+}
+
+func TestRetryOn429_MessageContainsBackoffHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "45")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := hc.New(hc.Config{
+		BaseURL:          srv.URL,
+		RetryOn429Budget: 30 * time.Second,
+	})
+
+	_, err := c.Call(context.Background(), hc.NewRequest("GET", "/"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "rate limited") {
+		t.Errorf("error message should mention rate limiting: %q", msg)
+	}
+	if !strings.Contains(msg, "try again later") {
+		t.Errorf("error message should hint to retry later: %q", msg)
+	}
+}
+
+func TestRetryOn429_DisabledByDefault(t *testing.T) {
+	var attempts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	// No RetryOn429Budget — falls through to DefaultRetryPolicy which
+	// retries 429 up to RetryMax times with normal backoff (not a budget error).
+	c := hc.New(hc.Config{
+		BaseURL:        srv.URL,
+		DisableRetries: true,
+	})
+
+	_, err := c.Call(context.Background(), hc.NewRequest("GET", "/"))
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+	if hc.IsRateLimitError(err) {
+		t.Fatal("expected plain HTTPError (no budget configured), got RateLimitError")
+	}
+	if n := attempts.Load(); n != 1 {
+		t.Fatalf("expected 1 attempt with retries disabled, got %d", n)
 	}
 }
 

--- a/internal/httpcl/client_test.go
+++ b/internal/httpcl/client_test.go
@@ -254,6 +254,32 @@ func TestRetryOn429_DisabledByDefault(t *testing.T) {
 	}
 }
 
+func TestRetryOn429_5xxStillCapsAtThreeWithBudgetSet(t *testing.T) {
+	var attempts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := hc.New(hc.Config{
+		BaseURL:          srv.URL,
+		RetryOn429Budget: 30 * time.Second,
+	})
+
+	_, err := c.Call(context.Background(), hc.NewRequest("GET", "/"))
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+	if hc.IsRateLimitError(err) {
+		t.Fatalf("expected plain HTTPError for 500, got RateLimitError")
+	}
+	if n := attempts.Load(); n != 4 {
+		t.Fatalf("expected 4 attempts (1 + 3 retries), got %d", n)
+	}
+}
+
 func TestRouteParamsMultiple(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v2/agents/org/org-1/project/proj-2/runs" {

--- a/internal/httpcl/error.go
+++ b/internal/httpcl/error.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 // HTTPError represents a non-2xx HTTP response.
@@ -44,4 +45,27 @@ func HasStatusCode(err error, codes ...int) bool {
 		}
 	}
 	return false
+}
+
+// RateLimitError is returned when the server sends a 429 with a Retry-After
+// value that, combined with elapsed retry time, exceeds the configured budget.
+type RateLimitError struct {
+	RetryAfter time.Duration
+	Budget     time.Duration
+}
+
+func (e *RateLimitError) Error() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf(
+			"rate limited: server requests %s back-off, retry budget of %s exhausted — try again later",
+			e.RetryAfter.Round(time.Second), e.Budget.Round(time.Second),
+		)
+	}
+	return fmt.Sprintf("rate limited: retry budget of %s exhausted — try again later", e.Budget.Round(time.Second))
+}
+
+// IsRateLimitError reports whether err is a *RateLimitError.
+func IsRateLimitError(err error) bool {
+	var rle *RateLimitError
+	return errors.As(err, &rle)
 }


### PR DESCRIPTION
## Summary

- Adds `RetryOn429Budget` to `httpcl.Config`: retries HTTP 429 responses by honouring the `Retry-After` response header (integer seconds or HTTP date)
- Retries stop and a `RateLimitError` is returned when elapsed + pending wait would exceed the budget, or when a single `Retry-After` value exceeds it — error message is agent-readable: _"rate limited: server requests 45s back-off, retry budget of 30s exhausted — try again later"_
- Non-429 retry behaviour (5xx, network errors) is unchanged — a per-call counter caps those at the original 3-retry limit even though `RetryMax` is raised to 30 for 429 headroom
- Fixes a `resp.Body` leak when `retryablehttp` returns both a response and a `CheckRetry` error
- `IsRateLimitError` helper added for callers that need to distinguish rate-limit failures
- CircleCI API client wired with a 30s budget, covering all sidecar API calls