### PR TITLE
Add --debug-output flag to build-prompt

### DIFF
--- a/acceptance/build_prompt_test.go
+++ b/acceptance/build_prompt_test.go
@@ -49,6 +49,7 @@ func TestBuildPromptHappyPath(t *testing.T) {
 		"--org", "test-org",
 		"--repos", "test-repo",
 		"--top", "2",
+		"--debug",
 		"--output", filepath.Join(workDir, "review-prompt.md"),
 	}, env, workDir)
 
@@ -138,6 +139,7 @@ func TestBuildPromptAutoDetectOrg(t *testing.T) {
 
 	result := binary.RunCLI(t, []string{
 		"build-prompt",
+		"--debug",
 		"--output", filepath.Join(workDir, "review-prompt.md"),
 	}, env, workDir)
 
@@ -349,6 +351,7 @@ func TestBuildPromptBotFiltering(t *testing.T) {
 		"--org", "test-org",
 		"--repos", "test-repo",
 		"--top", "5",
+		"--debug",
 		"--output", filepath.Join(workDir, "review-prompt.md"),
 	}, env, workDir)
 
@@ -398,6 +401,7 @@ func TestBuildPromptFooter(t *testing.T) {
 		"build-prompt",
 		"--org", "test-org",
 		"--repos", "test-repo",
+		"--debug",
 		"--output", filepath.Join(workDir, "review-prompt.md"),
 	}, env, workDir)
 
@@ -415,7 +419,7 @@ func TestBuildPromptFooter(t *testing.T) {
 	assert.Assert(t, strings.Contains(promptStr, "*Model:"),
 		"expected footer with Model, got: %s", promptStr)
 	assert.Assert(t, strings.Contains(promptStr, "*Source:"),
-		"expected footer with Source path, got: %s", promptStr)
+		"expected footer with Source path when --debug is set, got: %s", promptStr)
 }
 
 func TestBuildPromptSinceDateFormat(t *testing.T) {
@@ -443,6 +447,7 @@ func TestBuildPromptSinceDateFormat(t *testing.T) {
 		"--org", "test-org",
 		"--repos", "test-repo",
 		"--since", "2025-06-15",
+		"--debug",
 		"--output", filepath.Join(workDir, "review-prompt.md"),
 	}, env, workDir)
 
@@ -492,6 +497,7 @@ func TestBuildPromptTopNFiltering(t *testing.T) {
 		"--org", "test-org",
 		"--repos", "test-repo",
 		"--top", "2",
+		"--debug",
 		"--output", filepath.Join(workDir, "review-prompt.md"),
 	}, env, workDir)
 
@@ -575,6 +581,7 @@ func TestBuildPromptDefaultTop(t *testing.T) {
 		"build-prompt",
 		"--org", "test-org",
 		"--repos", "test-repo",
+		"--debug",
 		"--output", filepath.Join(workDir, "review-prompt.md"),
 	}, env, workDir)
 
@@ -721,6 +728,7 @@ func TestBuildPromptDefaultOutputPath(t *testing.T) {
 		"build-prompt",
 		"--org", "test-org",
 		"--repos", "test-repo",
+		"--debug",
 	}, env, workDir)
 
 	if result.ExitCode != 0 {
@@ -761,6 +769,7 @@ func TestBuildPromptDefaultSince(t *testing.T) {
 		"build-prompt",
 		"--org", "test-org",
 		"--repos", "test-repo",
+		"--debug",
 		"--output", filepath.Join(workDir, "review-prompt.md"),
 	}, env, workDir)
 
@@ -849,6 +858,7 @@ func TestBuildPromptTopOne(t *testing.T) {
 		"--org", "test-org",
 		"--repos", "test-repo",
 		"--top", "1",
+		"--debug",
 		"--output", filepath.Join(workDir, "review-prompt.md"),
 	}, env, workDir)
 
@@ -1187,6 +1197,7 @@ func TestBuildPromptCreatesOutputDirectory(t *testing.T) {
 		"build-prompt",
 		"--org", "test-org",
 		"--repos", "test-repo",
+		"--debug",
 		"--output", outputPath,
 	}, env, workDir)
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -21,6 +21,7 @@ chunk
 │   --analyze-model <model>         # Model for analysis step
 │   --prompt-model <model>          # Model for prompt generation step
 │   --include-attribution           # Include reviewer attribution
+│   --debug                  # Write intermediate files (details JSON, analysis, PR rankings CSV) for debugging
 │
 ├── config
 │   ├── show                        # Display resolved configuration
@@ -142,6 +143,7 @@ chunk
   are omitted. If `--org` is provided explicitly, `--repos` is required.
 - `build-prompt --output` creates parent directories automatically.
 - `build-prompt --since` defaults to 3 months before the current date.
+- `build-prompt` does not write intermediate files by default. Pass `--debug` to write the raw details JSON, analysis markdown, and PR rankings CSV alongside the prompt — useful when diagnosing unexpected prompt output.
 - `task run` defaults to pipeline-as-tool mode; use `--no-pipeline-as-tool`
   to disable.
 - `config set` user keys: `model`. Project keys (`.chunk/config.json`): `orgID`,

--- a/internal/buildprompt/buildprompt_test.go
+++ b/internal/buildprompt/buildprompt_test.go
@@ -69,7 +69,64 @@ func TestRunHappyPath(t *testing.T) {
 	}, ghClient, anthropicClient)
 	assert.NilError(t, err)
 
-	// All output files created
+	// Prompt file created with canned response and footer
+	paths := DeriveOutputPaths(outputPath)
+	promptBytes, err := os.ReadFile(paths.PromptPath)
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(string(promptBytes), "Code Review Prompt"))
+	assert.Assert(t, strings.Contains(string(promptBytes), "*Generated:"))
+
+	// Intermediate files not written by default
+	for _, p := range []string{paths.DetailsPath, paths.AnalysisPath, paths.CSVPath} {
+		_, statErr := os.Stat(p)
+		assert.Assert(t, os.IsNotExist(statErr), "expected no intermediate file %s", p)
+	}
+
+	// Status callback has step progress
+	assert.Assert(t, strings.Contains(stderr.String(), "Step 1/3"))
+	assert.Assert(t, strings.Contains(stderr.String(), "Step 2/3"))
+	assert.Assert(t, strings.Contains(stderr.String(), "Step 3/3"))
+}
+
+func TestRunWithDebugOutput(t *testing.T) {
+	gh := fakes.NewFakeGitHub()
+	gh.SetOrgRepos(fixtures.OrgReposResponse("test-repo"))
+	gh.SetReviewActivity("test-repo", fixtures.ReviewActivityResponse())
+
+	fakeAnthropic := fakes.NewFakeAnthropic(
+		fixtures.AnalysisResponse,
+		fixtures.PromptResponse,
+	)
+
+	ghSrv := httptest.NewServer(gh)
+	defer ghSrv.Close()
+	anthropicSrv := httptest.NewServer(fakeAnthropic)
+	defer anthropicSrv.Close()
+
+	ghClient, err := ghpkg.New(ghpkg.Config{Token: "fake-token", BaseURL: ghSrv.URL})
+	assert.NilError(t, err)
+	anthropicClient, err := anthropic.New(anthropic.Config{APIKey: "sk-ant-fake", BaseURL: anthropicSrv.URL})
+	assert.NilError(t, err)
+
+	outDir := t.TempDir()
+	outputPath := filepath.Join(outDir, "prompt.md")
+
+	var stderr bytes.Buffer
+
+	err = Run(context.Background(), Options{
+		Org:          "test-org",
+		Repos:        []string{"test-repo"},
+		Top:          5,
+		Since:        time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		OutputPath:   outputPath,
+		AnalyzeModel: "claude-sonnet-4-6",
+		PromptModel:  "claude-sonnet-4-6",
+		DebugOutput:  true,
+		Status:       testStatus(&stderr),
+	}, ghClient, anthropicClient)
+	assert.NilError(t, err)
+
+	// All four files written when --debug is set
 	paths := DeriveOutputPaths(outputPath)
 	for _, p := range []string{paths.PromptPath, paths.DetailsPath, paths.AnalysisPath, paths.CSVPath} {
 		info, statErr := os.Stat(p)
@@ -85,21 +142,15 @@ func TestRunHappyPath(t *testing.T) {
 	assert.Equal(t, details.Metadata.Organization, "test-org")
 	assert.Assert(t, details.Metadata.TotalComments > 0)
 
-	// Prompt file contains canned response and footer
-	promptBytes, err := os.ReadFile(paths.PromptPath)
-	assert.NilError(t, err)
-	assert.Assert(t, strings.Contains(string(promptBytes), "Code Review Prompt"))
-	assert.Assert(t, strings.Contains(string(promptBytes), "*Generated:"))
-
-	// Analysis file contains canned analysis wrapped in report
+	// Analysis file contains report wrapper
 	analysisBytes, err := os.ReadFile(paths.AnalysisPath)
 	assert.NilError(t, err)
 	assert.Assert(t, strings.Contains(string(analysisBytes), "Review Pattern Analysis"))
 
-	// Status callback has step progress
-	assert.Assert(t, strings.Contains(stderr.String(), "Step 1/3"))
-	assert.Assert(t, strings.Contains(stderr.String(), "Step 2/3"))
-	assert.Assert(t, strings.Contains(stderr.String(), "Step 3/3"))
+	// Prompt footer includes source path
+	promptBytes, err := os.ReadFile(paths.PromptPath)
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(string(promptBytes), "*Source:"))
 }
 
 func TestRunNoReposFound(t *testing.T) {
@@ -251,13 +302,11 @@ func TestRunRetryOnTokenLimit(t *testing.T) {
 	// Verify retry messages appeared via status callback
 	assert.Assert(t, strings.Contains(stderr.String(), "Token limit exceeded"))
 
-	// Verify output files were created
+	// Verify prompt file was created
 	paths := DeriveOutputPaths(outputPath)
-	for _, p := range []string{paths.PromptPath, paths.DetailsPath, paths.AnalysisPath} {
-		info, statErr := os.Stat(p)
-		assert.NilError(t, statErr, "expected file %s", p)
-		assert.Assert(t, info.Size() > 0)
-	}
+	info, statErr := os.Stat(paths.PromptPath)
+	assert.NilError(t, statErr, "expected prompt file %s", paths.PromptPath)
+	assert.Assert(t, info.Size() > 0)
 }
 
 func TestRunMissingGithubToken(t *testing.T) {

--- a/internal/buildprompt/orchestrator.go
+++ b/internal/buildprompt/orchestrator.go
@@ -125,17 +125,17 @@ func Run(ctx context.Context, opts Options, ghClient *github.Client, anthropicCl
 	aggregatedDetails := AggregateDetails(allDetails)
 	filteredDetails := FilterDetailsByReviewers(aggregatedDetails, topReviewers)
 
-	if err := WriteDetailsJSON(filteredDetails, paths.DetailsPath, opts.Org, opts.Since, len(repos)); err != nil {
-		return fmt.Errorf("write details JSON: %w", err)
+	if opts.DebugOutput {
+		if err := WriteDetailsJSON(filteredDetails, paths.DetailsPath, opts.Org, opts.Since, len(repos)); err != nil {
+			return fmt.Errorf("write details JSON: %w", err)
+		}
+		prRankings := AggregatePRRankings(filteredDetails)
+		if err := WritePRRankingsCSV(prRankings, paths.CSVPath); err != nil {
+			return fmt.Errorf("write PR rankings CSV: %w", err)
+		}
+		opts.Status(iostream.LevelDone, fmt.Sprintf("Details written to %s", paths.DetailsPath))
+		opts.Status(iostream.LevelDone, fmt.Sprintf("PR rankings written to %s", paths.CSVPath))
 	}
-
-	prRankings := AggregatePRRankings(filteredDetails)
-	if err := WritePRRankingsCSV(prRankings, paths.CSVPath); err != nil {
-		return fmt.Errorf("write PR rankings CSV: %w", err)
-	}
-
-	opts.Status(iostream.LevelDone, fmt.Sprintf("Details written to %s", paths.DetailsPath))
-	opts.Status(iostream.LevelDone, fmt.Sprintf("PR rankings written to %s", paths.CSVPath))
 
 	// --- Step 2: Analyze review patterns ---
 	opts.Status(iostream.LevelStep, "Step 2/3: Analyzing Review Patterns")
@@ -155,30 +155,34 @@ func Run(ctx context.Context, opts Options, ghClient *github.Client, anthropicCl
 		reviewerNames = append(reviewerNames, g.Reviewer)
 	}
 
-	report := FormatMarkdownReport(analysis, paths.DetailsPath, len(filteredDetails), reviewerNames)
+	detailsPath := ""
+	if opts.DebugOutput {
+		detailsPath = paths.DetailsPath
+	}
+	report := FormatMarkdownReport(analysis, detailsPath, len(filteredDetails), reviewerNames)
 
-	if err := os.MkdirAll(filepath.Dir(paths.AnalysisPath), 0o755); err != nil {
-		return err
+	if opts.DebugOutput {
+		if err := os.MkdirAll(filepath.Dir(paths.AnalysisPath), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(paths.AnalysisPath, []byte(report), 0o644); err != nil {
+			return fmt.Errorf("write analysis: %w", err)
+		}
+		opts.Status(iostream.LevelDone, fmt.Sprintf("Analysis written to %s", paths.AnalysisPath))
 	}
-	if err := os.WriteFile(paths.AnalysisPath, []byte(report), 0o644); err != nil {
-		return fmt.Errorf("write analysis: %w", err)
-	}
-	opts.Status(iostream.LevelDone, fmt.Sprintf("Analysis written to %s", paths.AnalysisPath))
 
 	// --- Step 3: Generate review prompt ---
 	opts.Status(iostream.LevelStep, "Step 3/3: Generating PR Review Prompt")
 
-	analysisContent, err := os.ReadFile(paths.AnalysisPath)
-	if err != nil {
-		return fmt.Errorf("read analysis: %w", err)
-	}
-
-	generatedPrompt, err := anthropicClient.GenerateReviewPrompt(ctx, string(analysisContent), opts.PromptModel, opts.IncludeAttribution)
+	generatedPrompt, err := anthropicClient.GenerateReviewPrompt(ctx, report, opts.PromptModel, opts.IncludeAttribution)
 	if err != nil {
 		return fmt.Errorf("generate prompt: %w", err)
 	}
 
-	footer := fmt.Sprintf("\n\n---\n\n*Generated: %s*\n*Source: %s*\n*Model: %s*", time.Now().Format(time.RFC3339), paths.DetailsPath, opts.PromptModel)
+	footer := fmt.Sprintf("\n\n---\n\n*Generated: %s*\n*Model: %s*", time.Now().Format(time.RFC3339), opts.PromptModel)
+	if opts.DebugOutput {
+		footer = fmt.Sprintf("\n\n---\n\n*Generated: %s*\n*Source: %s*\n*Model: %s*", time.Now().Format(time.RFC3339), paths.DetailsPath, opts.PromptModel)
+	}
 
 	if err := os.MkdirAll(filepath.Dir(paths.PromptPath), 0o755); err != nil {
 		return err

--- a/internal/buildprompt/steps.go
+++ b/internal/buildprompt/steps.go
@@ -422,11 +422,14 @@ func formatReviewerData(groups []ReviewerGroup) string {
 
 // FormatMarkdownReport formats the analysis into a markdown report.
 func FormatMarkdownReport(analysis string, detailsPath string, totalComments int, reviewers []string) string {
+	source := ""
+	if detailsPath != "" {
+		source = fmt.Sprintf("**Source:** %s\n", detailsPath)
+	}
 	return fmt.Sprintf(`# Code Review Pattern Analysis
 
 **Generated:** %s
-**Source:** %s
-**Total Comments:** %d
+%s**Total Comments:** %d
 **Reviewers:** %s
 
 ---
@@ -436,5 +439,5 @@ func FormatMarkdownReport(analysis string, detailsPath string, totalComments int
 ---
 
 *This analysis was generated using Claude AI by analyzing code review patterns.*
-`, time.Now().Format(time.RFC3339), detailsPath, totalComments, strings.Join(reviewers, ", "), analysis)
+`, time.Now().Format(time.RFC3339), source, totalComments, strings.Join(reviewers, ", "), analysis)
 }

--- a/internal/buildprompt/types.go
+++ b/internal/buildprompt/types.go
@@ -18,6 +18,7 @@ type Options struct {
 	AnalyzeModel       string
 	PromptModel        string
 	IncludeAttribution bool
+	DebugOutput        bool
 	Status             iostream.StatusFunc
 }
 

--- a/internal/cmd/buildprompt.go
+++ b/internal/cmd/buildprompt.go
@@ -27,6 +27,7 @@ func newBuildPromptCmd() *cobra.Command {
 		analyzeModel       string
 		promptModel        string
 		includeAttribution bool
+		debugOutput        bool
 	)
 
 	cmd := &cobra.Command{
@@ -95,6 +96,7 @@ func newBuildPromptCmd() *cobra.Command {
 				AnalyzeModel:       analyzeModel,
 				PromptModel:        promptModel,
 				IncludeAttribution: includeAttribution,
+				DebugOutput:        debugOutput,
 				Status:             newStatusFunc(streams),
 			}
 
@@ -128,6 +130,7 @@ func newBuildPromptCmd() *cobra.Command {
 	cmd.Flags().StringVar(&analyzeModel, "analyze-model", "", "Model for analysis step")
 	cmd.Flags().StringVar(&promptModel, "prompt-model", "", "Model for prompt generation step")
 	cmd.Flags().BoolVar(&includeAttribution, "include-attribution", false, "Include reviewer attribution in output")
+	cmd.Flags().BoolVar(&debugOutput, "debug", false, "Write intermediate files (details JSON, analysis, PR rankings CSV) alongside the prompt for debugging")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

- Intermediate files (`-details.json`, `-analysis.md`, `-details-pr-rankings.csv`) are no longer written by default — they were being committed into `.chunk/context/` even though they're only useful for debugging
- New `--debug-output` flag writes all three alongside the prompt when explicitly requested
- Eliminates the unnecessary disk round-trip where `analysis.md` was written then immediately read back — the report string is now passed directly to `GenerateReviewPrompt`

## Test plan

- [ ] `TestRunHappyPath` verifies intermediate files are absent by default
- [ ] `TestRunWithDebugOutput` verifies all four files are written when `--debug-output` is set
- [ ] `TestRunRetryOnTokenLimit` updated to only assert on prompt file
- [ ] `go test -race ./internal/buildprompt/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)