### PR TITLE
Fix intermittent broken pipe in test-linux-install nightly job

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -58,12 +58,16 @@ jobs:
       - attach_workspace:
           at: /tmp
       - run:
-          name: Install chunk via Homebrew
+          name: Install Homebrew
           command: |
             export NONINTERACTIVE=1
-            export HOMEBREW_NO_ASK=1
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
             echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> "$BASH_ENV"
+      - run:
+          name: Install chunk via Homebrew
+          command: |
+            export HOMEBREW_NO_ASK=1
+            export HOMEBREW_NO_AUTO_UPDATE=1
             source "$BASH_ENV"
             brew update
             brew trust circleci-public/circleci


### PR DESCRIPTION
## Summary

Fixes an intermittent `Error: Broken pipe` in the `test-linux-install` nightly job (~30% failure rate, same revision across all runs).

## Root cause

The failure always occurred at exactly the same point — immediately after `brew trust` finished tapping the repo, before `brew install` produced any output:

**Failing run:**
```
Tapped 27 casks and 1 formula (47 files, 422.2KB).
Error: Broken pipe
```

**Successful run:**
```
Tapped 27 casks and 1 formula (47 files, 417.8KB).
==> Trusted formula circleci-public/circleci/chunk   <- from brew install's trust check
==> Fetching downloads for: chunk
```

Reading the Homebrew source (`Library/Homebrew/cmd/trust.rb` and `trust.rb`) confirmed that `brew trust` itself is not the cause — it just writes to `~/.homebrew/trust.json` and triggers a tap install as a side effect. The pipe break happens at the start of the **subsequent** `brew install` command.

Without `HOMEBREW_NO_AUTO_UPDATE=1`, `brew install` spawns a background update subprocess via an internal pipe before doing anything else (including the `==> Trusted formula` trust check). When that subprocess races or fails intermittently, Homebrew catches `EPIPE` and exits with `Error: Broken pipe` — before the install even starts. Since we already call `brew update` explicitly, the internal auto-update is redundant and skipping it with `HOMEBREW_NO_AUTO_UPDATE=1` eliminates the race.

The Homebrew bootstrap is also split into its own `run` step for clearer failure attribution if issues recur.

## Test plan

- [ ] Nightly release run passes `test-linux-install` on next trigger
- [ ] `test-homebrew-install` (macOS) unaffected — no changes to that job