### PR TITLE
Add required trigger_type field to task run request

### DIFF
--- a/internal/circleci/circleci_test.go
+++ b/internal/circleci/circleci_test.go
@@ -306,6 +306,7 @@ func TestTriggerRun(t *testing.T) {
 			DefinitionID:   "def-1",
 			CheckoutBranch: "main",
 			TriggerSource:  "cli",
+			TriggerType:    "api",
 			Parameters:     map[string]interface{}{"key": "val"},
 		})
 		if err != nil {

--- a/internal/circleci/types.go
+++ b/internal/circleci/types.go
@@ -33,7 +33,8 @@ type TriggerRunRequest struct {
 	DefinitionID       string                 `json:"definition_id"`
 	CheckoutBranch     string                 `json:"checkout_branch"`
 	TriggerSource      string                 `json:"trigger_source"`
-	ChunkEnvironmentID *string                `json:"chunk_environment_id"`
+	TriggerType        string                 `json:"trigger_type"`
+	ChunkEnvironmentID *string                `json:"chunk_environment_id,omitempty"`
 	Parameters         map[string]interface{} `json:"parameters"`
 	Stats              *TriggerRunStats       `json:"stats,omitempty"`
 }

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -31,6 +31,7 @@ func TriggerRun(ctx context.Context, client *circleci.Client, cfg *RunConfig, pa
 		DefinitionID:       defID,
 		CheckoutBranch:     branch,
 		TriggerSource:      "chunk-cli",
+		TriggerType:        "api",
 		ChunkEnvironmentID: envID,
 		Parameters: map[string]interface{}{
 			"agent-type":             "prompt",


### PR DESCRIPTION
## Summary

- The `llmops-service` backend added `trigger_type` as a `binding:"required"` field to `StartAgentRunRequest`, causing every `chunk task run` to return a 400
- Add `TriggerType: "api"` to the request body in `TriggerRun`
- Also adds `omitempty` to `ChunkEnvironmentID` so a nil value omits the field rather than serializing as `null`

## Test plan

- [x] All 975 existing tests pass
- [x] Verified with a live trigger against a real definition — run `bcffd912-394c-487d-accf-27d68e2fa58b` triggered successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)