### PR TITLE
Show per-command auth requirements in auth status and task help.

### DIFF
--- a/acceptance/auth_test.go
+++ b/acceptance/auth_test.go
@@ -57,6 +57,12 @@ func TestAuthStatusNoKey(t *testing.T) {
 		"expected GitHub section, got: %s", combined)
 	assert.Assert(t, strings.Contains(combined, "Not set"),
 		"expected Not set in output, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "Command requirements"),
+		"expected command requirements section, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "task run"),
+		"expected task run in requirements, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "CircleCI token"),
+		"expected CircleCI token in requirements, got: %s", combined)
 }
 
 func TestAuthStatusInvalidKey(t *testing.T) {

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -360,6 +360,12 @@ func newAuthStatusCmd() *cobra.Command {
 			}
 			io.Println("")
 
+			io.Println(ui.Bold("Command requirements:"))
+			io.Println("  task run, task config, sidecar  → CircleCI token")
+			io.Println("  build-prompt                    → GitHub + Anthropic tokens")
+			io.Println("  validate --remote               → CircleCI token")
+			io.Println("")
+
 			if hasFailure {
 				return &userError{msg: "One or more credential checks failed.", errMsg: "auth status: validation failures"}
 			}

--- a/internal/cmd/task.go
+++ b/internal/cmd/task.go
@@ -39,6 +39,7 @@ func newTaskRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Trigger a task run",
+		Long:  "Trigger a task run.\n\nRequires: CircleCI token (chunk auth set circleci)",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {
@@ -107,6 +108,7 @@ func newTaskConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Set up .chunk/run.json for this repository",
+		Long:  "Set up .chunk/run.json for this repository.\n\nRequires: CircleCI token (chunk auth set circleci)",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 			ctx := cmd.Context()


### PR DESCRIPTION

- Append a static **Command requirements** section to `chunk auth status` so users can see which credentials each command group needs.
- Add a **Requires:** line to `chunk task run --help` and `chunk task config --help`.
- Extend `TestAuthStatusNoKey` to assert the new section is always printed.

Closes #430

## Motivation

Friction report 2-1 ([auth-status-per-command.md](auth-status-per-command.md)): users with only CircleCI configured see `GitHub: Not set` in `auth status` and cannot tell whether `task run` is blocked. The credential-to-command mapping lived only in markdown docs, not in the CLI self-diagnostic output.

## Example output

**`chunk auth status`** (after provider sections):

```
Command requirements:
  task run, task config, sidecar  → CircleCI token
  build-prompt                    → GitHub + Anthropic tokens
  validate --remote               → CircleCI token
```

**`chunk task run --help`**:

```
Trigger a task run.

Requires: CircleCI token (chunk auth set circleci)
```

## Changes

| Area | Change |
|------|--------|
| `internal/cmd/auth.go` | Print static command requirements after provider validation |
| `internal/cmd/task.go` | Add `Long` with `Requires:` to `task run` and `task config` |
| `acceptance/auth_test.go` | Assert `Command requirements`, `task run`, and `CircleCI token` in output |

## Out of scope

- `Requires:` on `build-prompt`, `sidecar`, or `validate` help text
- Dynamic per-command auth checks or exit-code changes
- Structuring task mid-run 401/403 errors with `notAuthorized()`

## Test plan

- [x] `go test -race ./...`
- [x] `TestAuthStatusNoKey` — requirements section present even when all tokens unset
- [x] Manual: `chunk auth status` shows requirements after provider sections
- [x] Manual: `chunk task run --help` and `chunk task config --help` show `Requires: CircleCI token`
