### PR TITLE
Default `chunk task run` to create a new branch

### DIFF
--- a/acceptance/task_test.go
+++ b/acceptance/task_test.go
@@ -101,7 +101,7 @@ func TestTaskRunHappyPath(t *testing.T) {
 	params := body["parameters"].(map[string]interface{})
 	assert.Equal(t, params["custom-prompt"], "Fix the flaky test")
 	assert.Equal(t, params["run-pipeline-as-a-tool"], true)
-	assert.Equal(t, params["create-new-branch"], false)
+	assert.Equal(t, params["create-new-branch"], true)
 
 	// Verify auth header
 	assert.Assert(t, runReqs[0].Header.Get("Circle-Token") != "",
@@ -138,7 +138,7 @@ func TestTaskRunBranchOverride(t *testing.T) {
 	assert.Equal(t, body["checkout_branch"], "feature/my-branch")
 }
 
-func TestTaskRunNewBranch(t *testing.T) {
+func TestTaskRunNewBranchFalse(t *testing.T) {
 	cci := fakes.NewFakeCircleCI()
 	srv := httptest.NewServer(cci)
 	defer srv.Close()
@@ -153,7 +153,7 @@ func TestTaskRunNewBranch(t *testing.T) {
 		"task", "run",
 		"--definition", "dev",
 		"--prompt", "Add types",
-		"--new-branch",
+		"--new-branch=false",
 	}, env, workDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
@@ -167,7 +167,7 @@ func TestTaskRunNewBranch(t *testing.T) {
 	assert.NilError(t, err)
 
 	params := body["parameters"].(map[string]interface{})
-	assert.Equal(t, params["create-new-branch"], true)
+	assert.Equal(t, params["create-new-branch"], false)
 }
 
 func TestTaskRunPipelineAsToolDefault(t *testing.T) {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -42,7 +42,7 @@ chunk
 │   │   --definition <name|uuid>    # Definition name or UUID (required)
 │   │   --prompt <text>             # Prompt text (required)
 │   │   --branch <branch>           # Branch override
-│   │   --new-branch                # Create a new branch
+│   │   --new-branch                # Create a new branch (default: true; pass =false to commit on checkout branch)
 │   │   --no-pipeline-as-tool       # Disable pipeline-as-tool mode
 │   │   --json                      # Output as JSON
 │   └── config                      # Set up .chunk/run.json for this repository
@@ -146,6 +146,8 @@ chunk
 - `build-prompt` does not write intermediate files by default. Pass `--debug` to write the raw details JSON, analysis markdown, and PR rankings CSV alongside the prompt — useful when diagnosing unexpected prompt output.
 - `task run` defaults to pipeline-as-tool mode; use `--no-pipeline-as-tool`
   to disable.
+- `task run` creates a new branch by default (`create-new-branch: true`);
+  pass `--new-branch=false` to commit on the checkout branch instead.
 - `config set` user keys: `model`. Project keys (`.chunk/config.json`): `orgID`,
   `validation.sidecarImage`. Credentials use `chunk auth set`, not `config set`.
 - **Org ID resolution** for `sidecar create`, `sidecar list`, and other sidecar

--- a/internal/cmd/task.go
+++ b/internal/cmd/task.go
@@ -92,7 +92,7 @@ func newTaskRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&definition, "definition", "", "Definition name or UUID")
 	cmd.Flags().StringVar(&prompt, "prompt", "", "Prompt text")
 	cmd.Flags().StringVar(&branch, "branch", "", "Checkout branch override")
-	cmd.Flags().BoolVar(&newBranch, "new-branch", false, "Create a new branch")
+	cmd.Flags().BoolVar(&newBranch, "new-branch", true, "Create a new branch (default true; pass =false to commit on the checkout branch)")
 	cmd.Flags().BoolVar(&noPipelineAsTool, "no-pipeline-as-tool", false, "Disable running pipeline as a tool")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -276,6 +276,7 @@ func TestTriggerRunHappyPath(t *testing.T) {
 		Definition:     "dev",
 		Prompt:         "Fix tests",
 		PipelineAsTool: true,
+		NewBranch:      true,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -324,9 +325,38 @@ func TestTriggerRunHappyPath(t *testing.T) {
 	if params["run-pipeline-as-a-tool"] != true {
 		t.Fatalf("run-pipeline-as-a-tool = %v, want true", params["run-pipeline-as-a-tool"])
 	}
-	if params["create-new-branch"] != false {
-		t.Fatalf("create-new-branch = %v, want false", params["create-new-branch"])
+	if params["create-new-branch"] != true {
+		t.Fatalf("create-new-branch = %v, want true", params["create-new-branch"])
 	}
+}
+
+func TestTriggerRunNoNewBranch(t *testing.T) {
+	cci, client := newFakeAndClient(t)
+	cfg := testCfg()
+
+	_, err := TriggerRun(context.Background(), client, cfg, RunParams{
+		Definition: "dev",
+		Prompt:     "Add feature",
+		NewBranch:  false,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, r := range cci.Recorder.AllRequests() {
+		if r.URL.Path == "/api/v2/agents/org/org-111/project/proj-222/runs" {
+			var body map[string]interface{}
+			if err := json.Unmarshal(r.Body, &body); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			params := body["parameters"].(map[string]interface{})
+			if params["create-new-branch"] != false {
+				t.Fatalf("create-new-branch = %v, want false", params["create-new-branch"])
+			}
+			return
+		}
+	}
+	t.Fatal("no request to trigger run endpoint")
 }
 
 func TestTriggerRunBranchOverride(t *testing.T) {


### PR DESCRIPTION


- Default `--new-branch` to `true` so `chunk task run` sends `create-new-branch: true` when the flag is omitted, matching the Web UI.
- Users who want to commit on the checkout branch must pass `--new-branch=false` explicitly.
- Update `docs/CLI.md` and tests for the new default.

Closes #432

## Motivation

`chunk task run` without `--new-branch` could commit agent changes directly to `default_branch` (often `main`) with no confirmation. The Web UI always sets `create-new-branch: true`; chunk-cli defaulted to `false`, which is unsafe for users following `task config` → `task run`.

## Behavior change

| Invocation | Before | After |
|------------|--------|-------|
| `chunk task run ...` (no branch flag) | `create-new-branch: false` | `create-new-branch: true` |
| `chunk task run ... --new-branch` | `create-new-branch: true` | `create-new-branch: true` (unchanged) |
| `chunk task run ... --new-branch=false` | N/A (was default false) | `create-new-branch: false` |

**Breaking change:** Scripts that depended on the old silent default must add `--new-branch=false`.

## Example

```bash
# Default: agent creates a new branch (same as Web UI)
chunk task run --definition dev --prompt "Fix the flaky test"

# Opt out: commit on the checkout branch (previous default)
chunk task run --definition dev --prompt "Fix the flaky test" --new-branch=false
```

## Changes

| Area | Change |
|------|--------|
| `internal/cmd/task.go` | `--new-branch` default `false` → `true`; updated flag help |
| `docs/CLI.md` | Flag tree + Behavior Decisions note for default and opt-out |
| `acceptance/task_test.go` | `TestTaskRunHappyPath` expects `true`; `TestTaskRunNewBranchFalse` for `--new-branch=false` |
| `internal/task/task_test.go` | Happy path uses `NewBranch: true`; add `TestTriggerRunNoNewBranch` |

## Out of scope

- TTY confirmation prompt or `--yes` / `--force` for direct commits
- Server-side auto-override of `create-new-branch`
- Changes to `--branch` or `default_branch` resolution

## Test plan

- [x] `go test -race ./...`
- [x] `TestTaskRunHappyPath` — default payload sends `create-new-branch: true`
- [x] `TestTaskRunNewBranchFalse` — `--new-branch=false` sends `create-new-branch: false`
- [x] `TestTriggerRunNoNewBranch` — unit coverage for explicit `NewBranch: false`
