### PR TITLE
Add anonymous usage telemetry

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,7 @@ builds:
       - -trimpath
 
     ldflags:
-      - "-s -w -X main.version={{.Version}}"
+      - "-s -w -X main.version={{.Version}} -X github.com/CircleCI-Public/chunk-cli/internal/cmd.writeKey={{.Env.SEGMENT_WRITE_KEY}}"
 
     goos:
       - linux

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,7 @@ builds:
       - -trimpath
 
     ldflags:
-      - "-s -w -X main.version={{.Version}} -X github.com/CircleCI-Public/chunk-cli/internal/cmd.writeKey={{.Env.SEGMENT_WRITE_KEY}}"
+      - "-s -w -X main.version={{.Version}}"
 
     goos:
       - linux

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,6 +38,8 @@ chunk-cli/
     ├── secrets/               # Secret resolution (env var value expansion)
     ├── session/               # Session ID tracking for Stop hook context
     ├── settings/              # .claude/settings.json build and merge
+    ├── telemetry/             # Anonymous usage telemetry (Segment)
+    │   └── receiver/          # Forwards buffered events to Segment (used by receive-telemetry)
     ├── testing/recorder/      # HTTP recorder for tests
     ├── tui/                   # Terminal UI components (confirm, input, select)
     ├── ui/                    # Colors, formatting, spinner
@@ -197,6 +199,36 @@ in `config.Resolve` and makes clients testable.
 | `CHUNK_HOOKS_DISABLED` | validate, hook | Disable Stop-hook validation when set (any non-empty value) |
 | `XDG_CONFIG_HOME` | config | User config directory (default: `~/.config`) |
 | `XDG_DATA_HOME` | sidecar | Per-project state directory (default: `~/.local/share`) |
+| `CHUNK_NO_TELEMETRY` | telemetry | Disable anonymous usage telemetry (any non-empty value) |
+| `NO_ANALYTICS` | telemetry | Disable anonymous usage telemetry (any non-empty value) |
+| `DO_NOT_TRACK` | telemetry | Disable anonymous usage telemetry (any non-empty value) |
+| `CI` | telemetry | Also disables anonymous usage telemetry (set by most CI systems) |
+| `CHUNK_TELEMETRY_LOG` | telemetry | Log telemetry events to stderr instead of (or alongside) sending them |
+
+## Telemetry (`internal/telemetry/`)
+
+Modeled on circleci-cli's `internal/telemetry` package. Every command reports
+a single `command_invocation` event containing the command path and the
+names (never values) of flags the user set — no flag values, argument
+values, file paths, or other PII.
+
+- `internal/cmd/root.go`'s `setupTelemetry` resolves the user's preference
+  (opt-out env var → `noTelemetry` config field, first match wins) and
+  attaches a `telemetry.Sender` to the command's context;
+  `RecordForSubcommands` wraps every subcommand's `RunE` so it reports its
+  event automatically, with no per-command changes needed.
+- Events are never sent inline. `Sender.Close()` marshals buffered events to
+  JSON and hands them to a detached `chunk receive-telemetry` subprocess
+  (see `internal/telemetry/delegate.go` and the hidden command in
+  `internal/cmd/receivetelemetry.go`), so a slow or unreachable Segment
+  endpoint never delays CLI exit. The subprocess forwards them via
+  `internal/telemetry/receiver`.
+- `CHUNK_TELEMETRY_LOG=1` logs event payloads to stderr instead of (or
+  alongside) sending them — useful for verifying what a command reports
+  without touching the network.
+- The Segment write key (`telemetry.SegmentWriteKey`) is hardcoded, not
+  injected at build time: Segment write keys can only send events, never
+  read data, so they aren't secret.
 
 ## Pre-Commit Hooks
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -217,7 +217,7 @@ key/workspace; the `chunk_` prefix keeps chunk-cli's events unambiguous in
 the event stream.
 
 - `internal/cmd/root.go`'s `setupTelemetry` resolves the user's preference
-  (opt-out env var → `noTelemetry` config field, first match wins) and
+  (opt-out env var → `telemetry` config field, first match wins) and
   attaches a `telemetry.Sender` to the command's context;
   `RecordForSubcommands` wraps every subcommand's `RunE` so it reports its
   event automatically, with no per-command changes needed.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -208,9 +208,13 @@ in `config.Resolve` and makes clients testable.
 ## Telemetry (`internal/telemetry/`)
 
 Modeled on circleci-cli's `internal/telemetry` package. Every command reports
-a single `command_invocation` event containing the command path and the
+a single `chunk_command_invocation` event containing the command path and the
 names (never values) of flags the user set — no flag values, argument
-values, file paths, or other PII.
+values, file paths, or other PII. The event is named `chunk_command_invocation`
+rather than the generic `command_invocation` circleci-cli's own telemetry
+package uses, because both tools currently share the same Segment write
+key/workspace; the `chunk_` prefix keeps chunk-cli's events unambiguous in
+the event stream.
 
 - `internal/cmd/root.go`'s `setupTelemetry` resolves the user's preference
   (opt-out env var → `noTelemetry` config field, first match wins) and
@@ -228,10 +232,11 @@ values, file paths, or other PII.
   without touching the network.
 - The Segment write key (`cmd.writeKey`) is a hardcoded constant, like
   circleci-cli's — write keys are not secret, they can only send events, not
-  read data, so checking one into git is safe. It's currently `""` pending
-  Segment workspace access; `setupTelemetry` never sends with an empty key,
-  so telemetry stays a no-op until the real key is added. `CHUNK_TELEMETRY_LOG`
-  still works without a write key, since it never touches the network.
+  read data, so checking one into git is safe. Events sent with it are
+  tagged as chunk-cli invocations via `Context.App.Name` ("chunk-cli") in
+  `Meta.toContext` (`internal/telemetry/telemetry.go`), keeping them
+  distinguishable from circleci-cli's own telemetry. `CHUNK_TELEMETRY_LOG`
+  still works without touching the network, independent of the write key.
 - `setupTelemetry` also checks `testing.Testing()` before sending, so a real
   write key committed to source still can't trigger sends (or the recursive
   subprocess spawning that implies) from a `go test` binary.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -226,12 +226,15 @@ values, file paths, or other PII.
 - `CHUNK_TELEMETRY_LOG=1` logs event payloads to stderr instead of (or
   alongside) sending them — useful for verifying what a command reports
   without touching the network.
-- The Segment write key (`cmd.writeKey`) is injected at build time via
-  `-ldflags` in `.goreleaser.yaml` from the `SEGMENT_WRITE_KEY` release env
-  var. It's empty in dev/local builds (`task build`, `go run .`), which
-  disables sending regardless of the user's preference — no `task build`
-  binary can ever send real telemetry. `CHUNK_TELEMETRY_LOG` still works
-  without a write key, since it never touches the network.
+- The Segment write key (`cmd.writeKey`) is a hardcoded constant, like
+  circleci-cli's — write keys are not secret, they can only send events, not
+  read data, so checking one into git is safe. It's currently `""` pending
+  Segment workspace access; `setupTelemetry` never sends with an empty key,
+  so telemetry stays a no-op until the real key is added. `CHUNK_TELEMETRY_LOG`
+  still works without a write key, since it never touches the network.
+- `setupTelemetry` also checks `testing.Testing()` before sending, so a real
+  write key committed to source still can't trigger sends (or the recursive
+  subprocess spawning that implies) from a `go test` binary.
 
 ## Pre-Commit Hooks
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -226,9 +226,12 @@ values, file paths, or other PII.
 - `CHUNK_TELEMETRY_LOG=1` logs event payloads to stderr instead of (or
   alongside) sending them — useful for verifying what a command reports
   without touching the network.
-- The Segment write key (`telemetry.SegmentWriteKey`) is hardcoded, not
-  injected at build time: Segment write keys can only send events, never
-  read data, so they aren't secret.
+- The Segment write key (`cmd.writeKey`) is injected at build time via
+  `-ldflags` in `.goreleaser.yaml` from the `SEGMENT_WRITE_KEY` release env
+  var. It's empty in dev/local builds (`task build`, `go run .`), which
+  disables sending regardless of the user's preference — no `task build`
+  binary can ever send real telemetry. `CHUNK_TELEMETRY_LOG` still works
+  without a write key, since it never touches the network.
 
 ## Pre-Commit Hooks
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -146,8 +146,11 @@ chunk
 - `build-prompt` does not write intermediate files by default. Pass `--debug` to write the raw details JSON, analysis markdown, and PR rankings CSV alongside the prompt — useful when diagnosing unexpected prompt output.
 - `task run` defaults to pipeline-as-tool mode; use `--no-pipeline-as-tool`
   to disable.
-- `config set` user keys: `model`. Project keys (`.chunk/config.json`): `orgID`,
-  `validation.sidecarImage`. Credentials use `chunk auth set`, not `config set`.
+- `config set` user keys: `model`, `telemetry`. Project keys (`.chunk/config.json`):
+  `orgID`, `validation.sidecarImage`. Credentials use `chunk auth set`, not `config set`.
+- Telemetry is anonymous and opt-out. It's disabled by the
+  `CHUNK_NO_TELEMETRY` / `NO_ANALYTICS` / `DO_NOT_TRACK` / `CI` environment
+  variables (first match wins, in that order), or `chunk config set telemetry false`.
 - **Org ID resolution** for `sidecar create`, `sidecar list`, and other sidecar
   subcommands that need an org (in order): `--org-id` flag → `CIRCLECI_ORG_ID`
   env var → `orgID` in `.chunk/config.json` → interactive org picker (TTY only).
@@ -168,6 +171,7 @@ chunk
 | Key | Scope | Description |
 |-----|-------|-------------|
 | `model` | user config (`~/.config/chunk/config.json`) | Claude model override |
+| `telemetry` | user config (`~/.config/chunk/config.json`) | Anonymous usage telemetry (`true`/`false`, default: `true`) |
 | `orgID` | `.chunk/config.json` | CircleCI organization ID for sidecar subcommands |
 | `validation.sidecarImage` | `.chunk/config.json` | Snapshot or image ID for sidecar bootstrap and validate |
 

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,12 @@ require (
 	github.com/coder/websocket v1.8.15
 	github.com/dustinkirkland/golang-petname v0.0.0-20260215035315-f0c533e9ce9b
 	github.com/gin-gonic/gin v1.12.0
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
+	github.com/segmentio/analytics-go/v3 v3.3.0
 	github.com/sethvargo/go-envconfig v1.3.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.53.0
 	golang.org/x/term v0.44.0
@@ -59,6 +62,7 @@ require (
 	github.com/bitfield/gotestdox v0.2.2 // indirect
 	github.com/bkielbasa/cyclop v1.2.3 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bombsimon/wsl/v4 v4.7.0 // indirect
 	github.com/bombsimon/wsl/v5 v5.8.0 // indirect
 	github.com/breml/bidichk v0.3.3 // indirect
@@ -213,6 +217,7 @@ require (
 	github.com/sashamelentyev/interfacebloat v1.1.0 // indirect
 	github.com/sashamelentyev/usestdlibvars v1.29.0 // indirect
 	github.com/securego/gosec/v2 v2.26.1 // indirect
+	github.com/segmentio/backo-go v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/sivchari/containedctx v1.0.3 // indirect
 	github.com/sonatard/noctx v0.5.1 // indirect
@@ -220,7 +225,6 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.12.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/bkielbasa/cyclop v1.2.3 h1:faIVMIGDIANuGPWH031CZJTi2ymOQBULs9H21HSMa5
 github.com/bkielbasa/cyclop v1.2.3/go.mod h1:kHTwA9Q0uZqOADdupvcFJQtp/ksSnytRMe8ztxG8Fuo=
 github.com/blizzy78/varnamelen v0.8.0 h1:oqSblyuQvFsW1hbBHh1zfwrKe3kcSj0rnXkKzsQ089M=
 github.com/blizzy78/varnamelen v0.8.0/go.mod h1:V9TzQZ4fLJ1DSrjVDfl89H7aMnTvKkApdHeyESmyR7k=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bombsimon/wsl/v4 v4.7.0 h1:1Ilm9JBPRczjyUs6hvOPKvd7VL1Q++PL8M0SXBDf+jQ=
 github.com/bombsimon/wsl/v4 v4.7.0/go.mod h1:uV/+6BkffuzSAVYD+yGyld1AChO7/EuLrCF/8xTiapg=
 github.com/bombsimon/wsl/v5 v5.8.0 h1:JTkyfs4yl8SPejrCF2GdABXE+mO1WvM7iUYzRWlsxDs=
@@ -369,6 +371,8 @@ github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83/go.mod h1:MxpfABSjhmI
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gordonklaus/ineffassign v0.2.0 h1:Uths4KnmwxNJNzq87fwQQDDnbNb7De00VOk9Nu0TySs=
@@ -601,6 +605,10 @@ github.com/sashamelentyev/usestdlibvars v1.29.0 h1:8J0MoRrw4/NAXtjQqTHrbW9NN+3iM
 github.com/sashamelentyev/usestdlibvars v1.29.0/go.mod h1:8PpnjHMk5VdeWlVb4wCdrB8PNbLqZ3wBZTZWkrpZZL8=
 github.com/securego/gosec/v2 v2.26.1 h1:gdkttGhQFVehqRJ8grKH4DrpqM/QlPKNHBnl8QgcEC4=
 github.com/securego/gosec/v2 v2.26.1/go.mod h1:57UW4p0uoP3kxoTkhoo3axLdVAi+OWrLg/Ax/kdqtPE=
+github.com/segmentio/analytics-go/v3 v3.3.0 h1:8VOMaVGBW03pdBrj1CMFfY9o/rnjJC+1wyQHlVxjw5o=
+github.com/segmentio/analytics-go/v3 v3.3.0/go.mod h1:p8owAF8X+5o27jmvUognuXxdtqvSGtD0ZrfY2kcS9bE=
+github.com/segmentio/backo-go v1.0.0 h1:kbOAtGJY2DqOR0jfRkYEorx/b18RgtepGtY3+Cpe6qA=
+github.com/segmentio/backo-go v1.0.0/go.mod h1:kJ9mm9YmoWSkk+oQ+5Cj8DEoRCX2JT6As4kEtIIOp1M=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sethvargo/go-envconfig v1.3.0 h1:gJs+Fuv8+f05omTpwWIu6KmuseFAXKrIaOZSh8RMt0U=

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -43,6 +43,12 @@ func newConfigShowCmd() *cobra.Command {
 			}
 			orgID, orgIDSource := config.ResolveOrgID(workDir)
 
+			userCfg, userCfgErr := config.Load()
+			if userCfgErr != nil {
+				io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", userCfgErr)))
+			}
+			telemetryEnabled := config.IsTelemetryEnabled(userCfg)
+
 			if jsonOut {
 				type configEntry struct {
 					Value  string `json:"value"`
@@ -55,6 +61,7 @@ func newConfigShowCmd() *cobra.Command {
 					GitHubToken        configEntry `json:"gitHubToken"`
 					OrgID              configEntry `json:"orgID"`
 					UseSSHIdentityFile bool        `json:"useSSHIdentityFile"`
+					Telemetry          bool        `json:"telemetry"`
 				}
 				maskOrEmpty := func(key string) string {
 					if key == "" {
@@ -69,6 +76,7 @@ func newConfigShowCmd() *cobra.Command {
 					GitHubToken:        configEntry{Value: maskOrEmpty(rc.GitHubToken), Source: rc.GitHubTokenSource},
 					OrgID:              configEntry{Value: orgID, Source: orgIDSource},
 					UseSSHIdentityFile: rc.UseSSHIdentityFile,
+					Telemetry:          telemetryEnabled,
 				})
 			}
 
@@ -100,6 +108,7 @@ func newConfigShowCmd() *cobra.Command {
 			}
 
 			io.Printf("%s %v\n", ui.Label("useSSHIdentityFile:", w), rc.UseSSHIdentityFile)
+			io.Printf("%s %v\n", ui.Label("telemetry:", w), telemetryEnabled)
 
 			return nil
 		},
@@ -114,7 +123,7 @@ func newConfigSetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "set <key> <value>",
 		Short: "Set a config value",
-		Long:  "Set a config value. Use 'chunk auth set <provider>' to store credentials with validation.\n\nUser keys: model, useSSHIdentityFile\nProject keys: orgID, validation.sidecarImage",
+		Long:  "Set a config value. Use 'chunk auth set <provider>' to store credentials with validation.\n\nUser keys: model, useSSHIdentityFile, telemetry\nProject keys: orgID, validation.sidecarImage",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
@@ -150,7 +159,7 @@ func newConfigSetCmd() *cobra.Command {
 			if !config.ValidConfigKeys[key] {
 				return &userError{
 					msg:    fmt.Sprintf("Unknown config key: %q.", key),
-					detail: "Supported keys: model, useSSHIdentityFile, orgID, validation.sidecarImage.",
+					detail: "Supported keys: model, useSSHIdentityFile, telemetry, orgID, validation.sidecarImage.",
 					errMsg: fmt.Sprintf("unknown config key %q", key),
 				}
 			}
@@ -172,6 +181,19 @@ func newConfigSetCmd() *cobra.Command {
 				default:
 					return &userError{
 						msg:    fmt.Sprintf("Invalid value %q for useSSHIdentityFile.", value),
+						detail: "Accepted values: true, false.",
+						errMsg: fmt.Sprintf("invalid boolean value %q", value),
+					}
+				}
+			case "telemetry":
+				switch value {
+				case "true", "1":
+					cfg.NoTelemetry = false
+				case "false", "0":
+					cfg.NoTelemetry = true
+				default:
+					return &userError{
+						msg:    fmt.Sprintf("Invalid value %q for telemetry.", value),
 						detail: "Accepted values: true, false.",
 						errMsg: fmt.Sprintf("invalid boolean value %q", value),
 					}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -47,7 +47,7 @@ func newConfigShowCmd() *cobra.Command {
 			if userCfgErr != nil {
 				io.ErrPrintln(ui.Warning(fmt.Sprintf("Could not load config: %v", userCfgErr)))
 			}
-			telemetryEnabled := config.IsTelemetryEnabled(userCfg)
+			telemetryEnabled := config.IsTelemetry(userCfg)
 
 			if jsonOut {
 				type configEntry struct {
@@ -188,9 +188,11 @@ func newConfigSetCmd() *cobra.Command {
 			case "telemetry":
 				switch value {
 				case "true", "1":
-					cfg.NoTelemetry = false
+					enabled := true
+					cfg.Telemetry = &enabled
 				case "false", "0":
-					cfg.NoTelemetry = true
+					enabled := false
+					cfg.Telemetry = &enabled
 				default:
 					return &userError{
 						msg:    fmt.Sprintf("Invalid value %q for telemetry.", value),

--- a/internal/cmd/receivetelemetry.go
+++ b/internal/cmd/receivetelemetry.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/telemetry"
+	"github.com/CircleCI-Public/chunk-cli/internal/telemetry/receiver"
+)
+
+// newReceiveTelemetryCmd builds the hidden receive-telemetry command. chunk
+// re-execs itself with this subcommand to deliver buffered telemetry events
+// out of process (see internal/telemetry/delegate.go): the parent serializes
+// events as JSON to this command's stdin, and this command forwards them to
+// Segment. Telemetry is disabled here so receiving telemetry never emits its own.
+func newReceiveTelemetryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "receive-telemetry",
+		Short:        "Receive telemetry events and forward them to Segment",
+		Hidden:       true,
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return receiver.Receive(cmd.InOrStdin())
+		},
+	}
+	telemetry.DisableTelemetry(cmd)
+	return cmd
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -11,12 +11,16 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/telemetry"
 )
 
-// writeKey is the Segment write key for chunk-cli, injected at build time via
-// -ldflags in .goreleaser.yaml (see the SEGMENT_WRITE_KEY release env var).
-// It is empty in dev/local builds, which disables sending telemetry
-// regardless of the user's preference — so no events are ever sent from a
-// `task build` or `go run .` binary.
-var writeKey string
+// writeKey is the Segment write key for chunk-cli's anonymous usage
+// telemetry. Segment write keys are not secret — they only allow sending
+// events, not reading data — so checking it into git, as circleci-cli does
+// (see internal/cmd/root/root.go there), is safe.
+//
+// Empty until CircleCI's Segment workspace admin provisions a chunk-cli
+// source; telemetry.NewSender never sends with an empty key (see
+// setupTelemetry below), so this is a no-op until then. Once a key exists,
+// set it here — no other changes needed.
+const writeKey = ""
 
 func NewRootCmd(version string) *cobra.Command {
 	cobra.EnableTraverseRunHooks = true

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -10,6 +10,13 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/telemetry"
 )
 
+// writeKey is the Segment write key for chunk-cli, injected at build time via
+// -ldflags in .goreleaser.yaml (see the SEGMENT_WRITE_KEY release env var).
+// It is empty in dev/local builds, which disables sending telemetry
+// regardless of the user's preference — so no events are ever sent from a
+// `task build` or `go run .` binary.
+var writeKey string
+
 func NewRootCmd(version string) *cobra.Command {
 	cobra.EnableTraverseRunHooks = true
 
@@ -94,10 +101,11 @@ func setupTelemetry(cmd *cobra.Command, version string) error {
 		return err
 	}
 
-	enabled := config.IsTelemetryEnabled(cfg)
+	optedIn := config.IsTelemetryEnabled(cfg)
+	send := optedIn && writeKey != ""
 
 	var instanceID uuid.UUID
-	if enabled {
+	if optedIn {
 		instanceID, err = config.EnsureInstanceID()
 		if err != nil {
 			return err
@@ -110,9 +118,9 @@ func setupTelemetry(cmd *cobra.Command, version string) error {
 	}
 
 	tc, err := telemetry.NewSender(telemetry.Config{
-		Send:     enabled,
-		Log:      enabled && os.Getenv("CHUNK_TELEMETRY_LOG") != "",
-		WriteKey: telemetry.SegmentWriteKey,
+		Send:     send,
+		Log:      optedIn && os.Getenv("CHUNK_TELEMETRY_LOG") != "",
+		WriteKey: writeKey,
 		Binary:   executable,
 		Metadata: telemetry.Meta{
 			Version:    version,

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,7 +1,13 @@
 package cmd
 
 import (
+	"os"
+
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/telemetry"
 )
 
 func NewRootCmd(version string) *cobra.Command {
@@ -14,7 +20,10 @@ func NewRootCmd(version string) *cobra.Command {
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			return nil
+			return setupTelemetry(cmd, version)
+		},
+		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
+			return telemetry.FromContext(cmd.Context()).Close()
 		},
 	}
 
@@ -38,7 +47,10 @@ Environment Variables:
   GITHUB_API_URL                  GitHub API URL [default: https://api.github.com]
   SSH_AUTH_SOCK                   SSH agent socket for sidecar key auth
   NO_COLOR                        Disable colored output
-  CI                              Disable interactive prompts (set by most CI systems)
+  CI                              Disable interactive prompts (set by most CI systems); also disables telemetry
+  CHUNK_NO_TELEMETRY               Disable anonymous usage telemetry (any non-empty value)
+  NO_ANALYTICS                    Disable anonymous usage telemetry (any non-empty value)
+  DO_NOT_TRACK                    Disable anonymous usage telemetry (any non-empty value)
 
 Configuration:
   ~/.config/chunk/config.json     User credentials and settings ($XDG_CONFIG_HOME/chunk/config.json)
@@ -57,11 +69,60 @@ Configuration:
 	rootCmd.AddCommand(newValidateCmd())
 	rootCmd.AddCommand(newHookCmd())
 	rootCmd.AddCommand(newUpgradeCmd())
+	rootCmd.AddCommand(newReceiveTelemetryCmd())
 
 	rootCmd.AddCommand(newCommandsCmd())
 
 	rootCmd.PersistentFlags().Bool("insecure-storage", false, "do not use the system's secure storage for storing tokens")
 	_ = rootCmd.PersistentFlags().MarkHidden("insecure-storage")
 
+	telemetry.RecordForSubcommands(rootCmd)
+
 	return rootCmd
+}
+
+// setupTelemetry resolves the user's telemetry preference and attaches a
+// telemetry.Sender to cmd's context so RecordNow can report a
+// command_invocation event once the command finishes.
+func setupTelemetry(cmd *cobra.Command, version string) error {
+	if telemetry.IsTelemetryDisabled(cmd) {
+		return nil
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	enabled := config.IsTelemetryEnabled(cfg)
+
+	var instanceID uuid.UUID
+	if enabled {
+		instanceID, err = config.EnsureInstanceID()
+		if err != nil {
+			return err
+		}
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		executable = "chunk"
+	}
+
+	tc, err := telemetry.NewSender(telemetry.Config{
+		Send:     enabled,
+		Log:      enabled && os.Getenv("CHUNK_TELEMETRY_LOG") != "",
+		WriteKey: telemetry.SegmentWriteKey,
+		Binary:   executable,
+		Metadata: telemetry.Meta{
+			Version:    version,
+			InstanceID: instanceID,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(telemetry.WithSender(cmd.Context(), tc))
+	return nil
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -106,7 +106,7 @@ func setupTelemetry(cmd *cobra.Command, version string) error {
 		return err
 	}
 
-	optedIn := config.IsTelemetryEnabled(cfg)
+	optedIn := config.IsTelemetry(cfg)
 	// testing.Testing() guards against re-exec'ing os.Executable() as a
 	// "receive-telemetry" subprocess when the running binary is a `go test`
 	// binary: that binary has no such subcommand, so it silently re-runs its

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -16,11 +16,11 @@ import (
 // events, not reading data — so checking it into git, as circleci-cli does
 // (see internal/cmd/root/root.go there), is safe.
 //
-// Empty until CircleCI's Segment workspace admin provisions a chunk-cli
-// source; telemetry.NewSender never sends with an empty key (see
-// setupTelemetry below), so this is a no-op until then. Once a key exists,
-// set it here — no other changes needed.
-const writeKey = ""
+// Events sent with this key are tagged as chunk-cli invocations via
+// Meta.toContext's App.Name ("chunk-cli") in internal/telemetry/telemetry.go,
+// so they stay distinguishable from circleci-cli's own telemetry even if
+// both ever land in the same Segment workspace.
+const writeKey = "AbgkrgN4cbRhAVEwlzMkHbwvrXnxHh35"
 
 func NewRootCmd(version string) *cobra.Command {
 	cobra.EnableTraverseRunHooks = true
@@ -95,7 +95,7 @@ Configuration:
 
 // setupTelemetry resolves the user's telemetry preference and attaches a
 // telemetry.Sender to cmd's context so RecordNow can report a
-// command_invocation event once the command finishes.
+// chunk_command_invocation event once the command finishes.
 func setupTelemetry(cmd *cobra.Command, version string) error {
 	if telemetry.IsTelemetryDisabled(cmd) {
 		return nil

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"testing"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -102,7 +103,12 @@ func setupTelemetry(cmd *cobra.Command, version string) error {
 	}
 
 	optedIn := config.IsTelemetryEnabled(cfg)
-	send := optedIn && writeKey != ""
+	// testing.Testing() guards against re-exec'ing os.Executable() as a
+	// "receive-telemetry" subprocess when the running binary is a `go test`
+	// binary: that binary has no such subcommand, so it silently re-runs its
+	// entire test suite instead, which can itself trigger more sends and
+	// spawn runaway recursive subprocesses.
+	send := optedIn && writeKey != "" && !testing.Testing()
 
 	var instanceID uuid.UUID
 	if optedIn {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,8 +118,12 @@ type UserConfig struct {
 	GitHubToken        string `json:"gitHubToken,omitempty"`
 	Model              string `json:"model,omitempty"`
 	UseSSHIdentityFile bool   `json:"useSSHIdentityFile,omitempty"`
-	NoTelemetry        bool   `json:"noTelemetry,omitempty"`
 	InstanceID         string `json:"instanceID,omitempty"`
+
+	// Telemetry is the persisted telemetry preference: true enables it,
+	// false disables it. nil means no preference has been set, in which
+	// case telemetry defaults to enabled (it is opt-out).
+	Telemetry *bool `json:"telemetry,omitempty"`
 
 	// LegacyAPIKey reads the pre-rename "apiKey" field so existing users don't
 	// silently lose their stored Anthropic key on upgrade. Migrated into
@@ -208,16 +212,20 @@ func Clear(key string) error {
 	return Save(cfg)
 }
 
-// IsTelemetryEnabled reports whether telemetry should be collected, honoring
-// (in order) well-known opt-out environment variables and the persisted
-// noTelemetry preference.
-func IsTelemetryEnabled(cfg UserConfig) bool {
+// IsTelemetry reports whether telemetry should be collected, honoring (in
+// order) well-known opt-out environment variables and the persisted
+// telemetry preference. Telemetry is opt-out: it defaults to enabled when no
+// preference has been set.
+func IsTelemetry(cfg UserConfig) bool {
 	for _, env := range noTelemetryEnvVars {
 		if os.Getenv(env) != "" {
 			return false
 		}
 	}
-	return !cfg.NoTelemetry
+	if cfg.Telemetry == nil {
+		return true
+	}
+	return *cfg.Telemetry
 }
 
 // EnsureInstanceID returns the persisted anonymous instance ID used to

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/sethvargo/go-envconfig"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/keyring"
@@ -58,6 +59,7 @@ const (
 	EnvModel              = "CODE_REVIEW_CLI_MODEL"
 	EnvCircleCIOrgID      = "CIRCLECI_ORG_ID"
 	EnvChunkHooksDisabled = "CHUNK_HOOKS_DISABLED"
+	EnvChunkNoTelemetry   = "CHUNK_NO_TELEMETRY"
 )
 
 // System/standard environment variable names.
@@ -69,7 +71,14 @@ const (
 	EnvXDGConfigHome = "XDG_CONFIG_HOME"
 	EnvXDGStateHome  = "XDG_STATE_HOME"
 	EnvXDGDataHome   = "XDG_DATA_HOME"
+	EnvNoAnalytics   = "NO_ANALYTICS"
+	EnvDoNotTrack    = "DO_NOT_TRACK"
+	EnvCI            = "CI"
 )
+
+// noTelemetryEnvVars are well-known environment variables that disable
+// telemetry regardless of the persisted user preference.
+var noTelemetryEnvVars = []string{EnvChunkNoTelemetry, EnvNoAnalytics, EnvDoNotTrack, EnvCI}
 
 // EnvVars holds all environment variables the application reads.
 //
@@ -109,6 +118,8 @@ type UserConfig struct {
 	GitHubToken        string `json:"gitHubToken,omitempty"`
 	Model              string `json:"model,omitempty"`
 	UseSSHIdentityFile bool   `json:"useSSHIdentityFile,omitempty"`
+	NoTelemetry        bool   `json:"noTelemetry,omitempty"`
+	InstanceID         string `json:"instanceID,omitempty"`
 
 	// LegacyAPIKey reads the pre-rename "apiKey" field so existing users don't
 	// silently lose their stored Anthropic key on upgrade. Migrated into
@@ -195,6 +206,40 @@ func Clear(key string) error {
 		return fmt.Errorf("unknown config key: %s", key)
 	}
 	return Save(cfg)
+}
+
+// IsTelemetryEnabled reports whether telemetry should be collected, honoring
+// (in order) well-known opt-out environment variables and the persisted
+// noTelemetry preference.
+func IsTelemetryEnabled(cfg UserConfig) bool {
+	for _, env := range noTelemetryEnvVars {
+		if os.Getenv(env) != "" {
+			return false
+		}
+	}
+	return !cfg.NoTelemetry
+}
+
+// EnsureInstanceID returns the persisted anonymous instance ID used to
+// associate telemetry events with a single install, generating and saving
+// one on first run.
+func EnsureInstanceID() (uuid.UUID, error) {
+	cfg, err := Load()
+	if err != nil {
+		return uuid.Nil, err
+	}
+	if cfg.InstanceID != "" {
+		id, err := uuid.Parse(cfg.InstanceID)
+		if err == nil {
+			return id, nil
+		}
+	}
+	id := uuid.New()
+	cfg.InstanceID = id.String()
+	if err := Save(cfg); err != nil {
+		return uuid.Nil, err
+	}
+	return id, nil
 }
 
 // Resolve computes the final config from flags, env, and file.
@@ -322,6 +367,7 @@ func ResolveOrgID(workDir string) (value, source string) {
 var ValidConfigKeys = map[string]bool{
 	"model":              true,
 	"useSSHIdentityFile": true,
+	"telemetry":          true,
 }
 
 // ValidProjectConfigKeys are the keys accepted by "config set" that write to

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"gotest.tools/v3/assert"
 )
 
@@ -343,6 +344,66 @@ func TestResolve_ModelFromConfig(t *testing.T) {
 func TestValidConfigKeys(t *testing.T) {
 	assert.Assert(t, ValidConfigKeys["model"])
 	assert.Assert(t, ValidConfigKeys["useSSHIdentityFile"])
+	assert.Assert(t, ValidConfigKeys["telemetry"])
 	assert.Assert(t, !ValidConfigKeys["anthropicAPIKey"])
 	assert.Assert(t, !ValidConfigKeys["badkey"])
+}
+
+// --- IsTelemetryEnabled ---
+
+// clearTelemetryEnv clears every opt-out env var so tests aren't affected by
+// the ambient environment (e.g. CI, which is set on every CircleCI job
+// including the one running this test suite).
+func clearTelemetryEnv(t *testing.T) {
+	t.Helper()
+	for _, e := range noTelemetryEnvVars {
+		t.Setenv(e, "")
+	}
+}
+
+func TestIsTelemetryEnabled_DefaultTrue(t *testing.T) {
+	clearTelemetryEnv(t)
+	assert.Assert(t, IsTelemetryEnabled(UserConfig{}))
+}
+
+func TestIsTelemetryEnabled_ConfigPreferenceDisables(t *testing.T) {
+	clearTelemetryEnv(t)
+	assert.Assert(t, !IsTelemetryEnabled(UserConfig{NoTelemetry: true}))
+}
+
+func TestIsTelemetryEnabled_EnvVarsDisable(t *testing.T) {
+	for _, e := range noTelemetryEnvVars {
+		t.Run(e, func(t *testing.T) {
+			clearTelemetryEnv(t)
+			t.Setenv(e, "1")
+			assert.Assert(t, !IsTelemetryEnabled(UserConfig{}))
+		})
+	}
+}
+
+// --- EnsureInstanceID ---
+
+func TestEnsureInstanceID_GeneratesAndPersists(t *testing.T) {
+	setupTempConfig(t)
+
+	id1, err := EnsureInstanceID()
+	assert.NilError(t, err)
+	assert.Assert(t, id1 != uuid.Nil)
+
+	id2, err := EnsureInstanceID()
+	assert.NilError(t, err)
+	assert.Equal(t, id1, id2)
+
+	cfg, err := Load()
+	assert.NilError(t, err)
+	assert.Equal(t, cfg.InstanceID, id1.String())
+}
+
+func TestEnsureInstanceID_InvalidStoredValueRegenerates(t *testing.T) {
+	setupTempConfig(t)
+	assert.NilError(t, Save(UserConfig{InstanceID: "not-a-uuid"}))
+
+	id, err := EnsureInstanceID()
+	assert.NilError(t, err)
+	assert.Assert(t, id != uuid.Nil)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -349,7 +349,7 @@ func TestValidConfigKeys(t *testing.T) {
 	assert.Assert(t, !ValidConfigKeys["badkey"])
 }
 
-// --- IsTelemetryEnabled ---
+// --- IsTelemetry ---
 
 // clearTelemetryEnv clears every opt-out env var so tests aren't affected by
 // the ambient environment (e.g. CI, which is set on every CircleCI job
@@ -361,22 +361,29 @@ func clearTelemetryEnv(t *testing.T) {
 	}
 }
 
-func TestIsTelemetryEnabled_DefaultTrue(t *testing.T) {
+func TestIsTelemetry_DefaultTrue(t *testing.T) {
 	clearTelemetryEnv(t)
-	assert.Assert(t, IsTelemetryEnabled(UserConfig{}))
+	assert.Assert(t, IsTelemetry(UserConfig{}))
 }
 
-func TestIsTelemetryEnabled_ConfigPreferenceDisables(t *testing.T) {
+func TestIsTelemetry_ConfigPreferenceDisables(t *testing.T) {
 	clearTelemetryEnv(t)
-	assert.Assert(t, !IsTelemetryEnabled(UserConfig{NoTelemetry: true}))
+	disabled := false
+	assert.Assert(t, !IsTelemetry(UserConfig{Telemetry: &disabled}))
 }
 
-func TestIsTelemetryEnabled_EnvVarsDisable(t *testing.T) {
+func TestIsTelemetry_ConfigPreferenceEnables(t *testing.T) {
+	clearTelemetryEnv(t)
+	enabled := true
+	assert.Assert(t, IsTelemetry(UserConfig{Telemetry: &enabled}))
+}
+
+func TestIsTelemetry_EnvVarsDisable(t *testing.T) {
 	for _, e := range noTelemetryEnvVars {
 		t.Run(e, func(t *testing.T) {
 			clearTelemetryEnv(t)
 			t.Setenv(e, "1")
-			assert.Assert(t, !IsTelemetryEnabled(UserConfig{}))
+			assert.Assert(t, !IsTelemetry(UserConfig{}))
 		})
 	}
 }

--- a/internal/telemetry/delegate.go
+++ b/internal/telemetry/delegate.go
@@ -1,0 +1,90 @@
+package telemetry
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	"github.com/segmentio/analytics-go/v3"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/telemetry/receiver"
+)
+
+// delegateDestination buffers events and, on Close, re-execs the chunk
+// binary as a detached "receive-telemetry" subprocess to deliver them. This
+// keeps Segment's network round trip off the CLI's exit path.
+type delegateDestination struct {
+	bin      string
+	writeKey string
+	endpoint string
+
+	mu       sync.RWMutex
+	messages []analytics.Track
+}
+
+func (d *delegateDestination) Enqueue(message analytics.Track) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.messages = append(d.messages, message)
+	return nil
+}
+
+func (d *delegateDestination) Close() error {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if len(d.messages) == 0 {
+		return nil
+	}
+
+	buf, err := json.Marshal(d.messages)
+	if err != nil {
+		return err
+	}
+
+	_ = d.send(bytes.NewReader(buf))
+
+	return nil
+}
+
+func (d *delegateDestination) send(in io.Reader) error {
+	bin := d.bin
+	if abs, err := filepath.Abs(bin); err == nil {
+		bin = abs
+	}
+
+	//#nosec:G204 // This is the path of our own binary
+	cmd := exec.Command(bin, "receive-telemetry")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true} // avoid signals sent to the parent (e.g. Ctrl-C) reaching this subprocess too
+	cmd.Env = append(os.Environ(),
+		receiver.EnvWriteKey+"="+d.writeKey,
+		receiver.EnvTelemetryEndpoint+"="+d.endpoint,
+	)
+	if filepath.IsAbs(bin) {
+		cmd.Dir = os.TempDir()
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		_ = stdin.Close()
+		return err
+	}
+
+	_, _ = io.Copy(stdin, in)
+	_ = stdin.Close()
+
+	return cmd.Process.Release()
+}

--- a/internal/telemetry/delegate_test.go
+++ b/internal/telemetry/delegate_test.go
@@ -1,0 +1,98 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/segmentio/analytics-go/v3"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/poll"
+)
+
+// receiverBinPath is the path to a stub "chunk receive-telemetry" binary,
+// built once by TestMain from testdata/receiverbin. Pointing
+// delegateDestination.bin at it lets tests spawn a real subprocess and
+// assert on what it sends to Segment, without any risk of re-execing the
+// "go test" binary itself (the stub has no subcommands at all).
+var receiverBinPath string
+
+func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+func runTestMain(m *testing.M) int {
+	dir, err := os.MkdirTemp("", "chunk-telemetry-test")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer os.RemoveAll(dir)
+
+	receiverBinPath = filepath.Join(dir, "receiverbin")
+	build := exec.Command("go", "build", "-o", receiverBinPath, "./testdata/receiverbin")
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "build receiverbin:", err)
+		return 1
+	}
+
+	return m.Run()
+}
+
+func TestDelegateDestination_Close_DeliversToSegment(t *testing.T) {
+	var mu sync.Mutex
+	var batch []map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+		body, err := io.ReadAll(r.Body)
+		assert.NilError(t, err)
+
+		var payload struct {
+			Batch []map[string]any `json:"batch"`
+		}
+		assert.NilError(t, json.Unmarshal(body, &payload))
+
+		mu.Lock()
+		batch = append(batch, payload.Batch...)
+		mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := &delegateDestination{
+		bin:      receiverBinPath,
+		writeKey: "test-write-key",
+		endpoint: srv.URL,
+	}
+
+	assert.NilError(t, d.Enqueue(analytics.Track{
+		Event:  "test_event",
+		UserId: "user-1",
+	}))
+	assert.NilError(t, d.Close())
+
+	poll.WaitOn(t, func(t poll.LogT) poll.Result {
+		mu.Lock()
+		defer mu.Unlock()
+		if len(batch) == 1 {
+			return poll.Success()
+		}
+		return poll.Continue("received %d events, want 1", len(batch))
+	}, poll.WithTimeout(5*time.Second))
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, batch[0]["event"], "test_event")
+	assert.Equal(t, batch[0]["userId"], "user-1")
+}

--- a/internal/telemetry/log.go
+++ b/internal/telemetry/log.go
@@ -1,0 +1,20 @@
+package telemetry
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/segmentio/analytics-go/v3"
+)
+
+// loggingDestination writes track calls to stderr, gated behind
+// CHUNK_TELEMETRY_LOG so contributors can inspect event payloads without
+// sending anything to Segment.
+type loggingDestination struct{}
+
+func (l *loggingDestination) Close() error { return nil }
+
+func (l *loggingDestination) Enqueue(m analytics.Track) error {
+	_, err := fmt.Fprintf(os.Stderr, "[telemetry] track %s %v\n", m.Event, m.Properties)
+	return err
+}

--- a/internal/telemetry/multi.go
+++ b/internal/telemetry/multi.go
@@ -1,0 +1,32 @@
+package telemetry
+
+import (
+	"errors"
+
+	"github.com/segmentio/analytics-go/v3"
+)
+
+// multiDestination fans a single Enqueue/Close out to every added destination.
+type multiDestination struct {
+	delegates []destination
+}
+
+func (mc *multiDestination) Close() error {
+	errs := make([]error, 0, len(mc.delegates))
+	for _, d := range mc.delegates {
+		errs = append(errs, d.Close())
+	}
+	return errors.Join(errs...)
+}
+
+func (mc *multiDestination) Enqueue(m analytics.Track) error {
+	errs := make([]error, 0, len(mc.delegates))
+	for _, d := range mc.delegates {
+		errs = append(errs, d.Enqueue(m))
+	}
+	return errors.Join(errs...)
+}
+
+func (mc *multiDestination) Add(d destination) {
+	mc.delegates = append(mc.delegates, d)
+}

--- a/internal/telemetry/receiver/receiver.go
+++ b/internal/telemetry/receiver/receiver.go
@@ -1,0 +1,59 @@
+// Package receiver forwards buffered telemetry events to Segment. It runs
+// inside the detached "chunk receive-telemetry" subprocess spawned by
+// internal/telemetry's delegateDestination, out of the parent CLI's exit path.
+package receiver
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/segmentio/analytics-go/v3"
+)
+
+const (
+	// EnvWriteKey configures the Segment write key for the delegate subprocess.
+	EnvWriteKey = "__CHUNK_TELEMETRY_WRITE_KEY"
+	// EnvTelemetryEndpoint configures the Segment endpoint for the delegate subprocess.
+	EnvTelemetryEndpoint = "__CHUNK_TELEMETRY_ENDPOINT"
+)
+
+// Receive decodes a JSON array of analytics.Track events from in and
+// forwards them to Segment using the write key and endpoint from the
+// environment.
+func Receive(in io.Reader) (err error) {
+	writeKey := os.Getenv(EnvWriteKey)
+	endpoint := os.Getenv(EnvTelemetryEndpoint)
+
+	var messages []analytics.Track
+	if err := json.NewDecoder(in).Decode(&messages); err != nil {
+		return err
+	}
+
+	if writeKey == "" {
+		return errors.New("write key is required")
+	}
+	c, err := analytics.NewWithConfig(writeKey, analytics.Config{
+		Endpoint: endpoint,
+	})
+	if err != nil {
+		return fmt.Errorf("create segment client: %w", err)
+	}
+
+	defer func() {
+		cerr := c.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+
+	for _, m := range messages {
+		if err := c.Enqueue(m); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/telemetry/record.go
+++ b/internal/telemetry/record.go
@@ -42,7 +42,8 @@ func IsTelemetryDisabled(cmd *cobra.Command) bool {
 }
 
 // RecordForSubcommands wraps every descendant command's RunE so it reports a
-// command_invocation event after running, without requiring per-command changes.
+// chunk_command_invocation event after running, without requiring
+// per-command changes.
 func RecordForSubcommands(cmd *cobra.Command) {
 	for _, c := range cmd.Commands() {
 		record(c)
@@ -63,9 +64,15 @@ func record(cmd *cobra.Command) {
 	}
 }
 
-// RecordNow reports a command_invocation event immediately: the full command
-// path and the sorted, comma-joined names (never values) of flags the user
-// explicitly set.
+// RecordNow reports a chunk_command_invocation event immediately: the full
+// command path and the sorted, comma-joined names (never values) of flags
+// the user explicitly set.
+//
+// The event name is prefixed with "chunk_" (rather than the more generic
+// "command_invocation" that circleci-cli's own telemetry package uses)
+// because both tools currently send to the same Segment write key/workspace;
+// the prefix keeps chunk-cli's events unambiguous in the event stream
+// without requiring anyone to inspect the nested Context.App.Name field.
 func RecordNow(cmd *cobra.Command) {
 	tc := FromContext(cmd.Context())
 	if tc == nil {
@@ -78,7 +85,7 @@ func RecordNow(cmd *cobra.Command) {
 	})
 	slices.Sort(flags)
 
-	_ = tc.Track("command_invocation", map[string]any{
+	_ = tc.Track("chunk_command_invocation", map[string]any{
 		"command": cmd.CommandPath(),
 		"flags":   strings.Join(flags, ","),
 	})

--- a/internal/telemetry/record.go
+++ b/internal/telemetry/record.go
@@ -1,0 +1,85 @@
+package telemetry
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type senderKey struct{}
+
+// WithSender attaches s to ctx so descendant commands can record events via
+// RecordNow.
+func WithSender(ctx context.Context, s *Sender) context.Context {
+	return context.WithValue(ctx, senderKey{}, s)
+}
+
+// FromContext returns the Sender attached to ctx, or nil if none was attached.
+func FromContext(ctx context.Context) *Sender {
+	v := ctx.Value(senderKey{})
+	if v == nil {
+		return nil
+	}
+	return v.(*Sender)
+}
+
+// DisableTelemetry marks cmd so RecordForSubcommands skips wrapping it. Used
+// for commands that should never report their own invocation, such as the
+// hidden receive-telemetry command.
+func DisableTelemetry(cmd *cobra.Command) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations["telemetry"] = "disabled"
+}
+
+// IsTelemetryDisabled reports whether DisableTelemetry was called on cmd.
+func IsTelemetryDisabled(cmd *cobra.Command) bool {
+	return cmd.Annotations["telemetry"] == "disabled"
+}
+
+// RecordForSubcommands wraps every descendant command's RunE so it reports a
+// command_invocation event after running, without requiring per-command changes.
+func RecordForSubcommands(cmd *cobra.Command) {
+	for _, c := range cmd.Commands() {
+		record(c)
+		RecordForSubcommands(c)
+	}
+}
+
+func record(cmd *cobra.Command) {
+	if IsTelemetryDisabled(cmd) || cmd.RunE == nil {
+		return
+	}
+
+	next := cmd.RunE
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		runErr := next(cmd, args)
+		RecordNow(cmd)
+		return runErr
+	}
+}
+
+// RecordNow reports a command_invocation event immediately: the full command
+// path and the sorted, comma-joined names (never values) of flags the user
+// explicitly set.
+func RecordNow(cmd *cobra.Command) {
+	tc := FromContext(cmd.Context())
+	if tc == nil {
+		return
+	}
+
+	var flags []string
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		flags = append(flags, f.Name)
+	})
+	slices.Sort(flags)
+
+	_ = tc.Track("command_invocation", map[string]any{
+		"command": cmd.CommandPath(),
+		"flags":   strings.Join(flags, ","),
+	})
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -20,11 +20,6 @@ import (
 	"github.com/segmentio/analytics-go/v3"
 )
 
-// SegmentWriteKey is the Segment write key for chunk-cli. Segment write keys
-// are not secret — they only allow sending events, not reading data — so
-// hardcoding it here (as circleci-cli does) is safe.
-const SegmentWriteKey = "REPLACE_WITH_CHUNK_CLI_SEGMENT_WRITE_KEY"
-
 // Sender tracks anonymous command-usage events. A nil *Sender is valid and
 // silently drops events, so callers never need to nil-check it.
 type Sender struct {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,141 @@
+// Package telemetry sends anonymous command-usage events to Segment.
+//
+// Telemetry is opt-out: it fires unless disabled via a well-known opt-out
+// environment variable or the persisted noTelemetry config preference (see
+// internal/config.IsTelemetryEnabled).
+// Only the command path, the names (never values) of flags the user set,
+// and a per-install anonymous instance ID are ever collected — no flag
+// values, argument values, file paths, or other PII.
+//
+// Modeled on circleci-cli's internal/telemetry package.
+package telemetry
+
+import (
+	"errors"
+	"io"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/segmentio/analytics-go/v3"
+)
+
+// SegmentWriteKey is the Segment write key for chunk-cli. Segment write keys
+// are not secret — they only allow sending events, not reading data — so
+// hardcoding it here (as circleci-cli does) is safe.
+const SegmentWriteKey = "REPLACE_WITH_CHUNK_CLI_SEGMENT_WRITE_KEY"
+
+// Sender tracks anonymous command-usage events. A nil *Sender is valid and
+// silently drops events, so callers never need to nil-check it.
+type Sender struct {
+	dest destination
+	meta Meta
+
+	closed atomic.Bool
+}
+
+type destination interface {
+	io.Closer
+	Enqueue(track analytics.Track) error
+}
+
+// Config configures a Sender.
+type Config struct {
+	// Send enables sending events to Segment via the delegate subprocess.
+	Send bool
+	// Log enables logging events to stderr for debugging.
+	Log bool
+
+	// Binary is re-exec'd with JSON-encoded events on stdin when Send is true.
+	Binary string
+	// WriteKey is the Segment write key used by the delegate subprocess.
+	WriteKey string
+	// Endpoint is the Segment endpoint. Optional; defaults to segment.io.
+	// Normally only set for testing.
+	Endpoint string
+
+	// TestDestination, when non-nil, is added as an event destination so
+	// tests can record events and assert on them synchronously without
+	// spawning a subprocess or hitting the network.
+	TestDestination destination
+
+	Metadata Meta
+}
+
+// Meta describes the fields attached to every tracked event.
+type Meta struct {
+	Version    string
+	InstanceID uuid.UUID
+}
+
+func (m *Meta) toContext() *analytics.Context {
+	return &analytics.Context{
+		App: analytics.AppInfo{
+			Name:    "chunk-cli",
+			Version: m.Version,
+		},
+		Device: analytics.DeviceInfo{Id: m.InstanceID.String()},
+	}
+}
+
+// NewSender creates a new Sender per cfg.
+func NewSender(cfg Config) (*Sender, error) {
+	dest := &multiDestination{}
+
+	if cfg.TestDestination != nil {
+		dest.Add(cfg.TestDestination)
+	}
+
+	if cfg.Log {
+		dest.Add(&loggingDestination{})
+	}
+
+	if cfg.Send {
+		if cfg.Binary == "" {
+			return nil, errors.New("binary is required")
+		}
+		dest.Add(&delegateDestination{
+			bin:      cfg.Binary,
+			writeKey: cfg.WriteKey,
+			endpoint: cfg.Endpoint,
+		})
+	}
+
+	return &Sender{
+		dest: dest,
+		meta: cfg.Metadata,
+	}, nil
+}
+
+// Close flushes buffered events to their destinations. Safe to call multiple
+// times and on a nil Sender.
+func (s *Sender) Close() error {
+	if s == nil {
+		return nil
+	}
+	if s.closed.Swap(true) {
+		return nil
+	}
+	return s.dest.Close()
+}
+
+// Track records an analytics event. Safe to call on a nil Sender.
+func (s *Sender) Track(eventName string, props map[string]any) error {
+	if s == nil {
+		return nil
+	}
+
+	p := analytics.NewProperties()
+	for key, val := range props {
+		p.Set(key, val)
+	}
+
+	return s.dest.Enqueue(analytics.Track{
+		Event:      eventName,
+		Timestamp:  time.Now(),
+		Properties: p,
+
+		UserId:  s.meta.InstanceID.String(),
+		Context: s.meta.toContext(),
+	})
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,8 +1,8 @@
 // Package telemetry sends anonymous command-usage events to Segment.
 //
 // Telemetry is opt-out: it fires unless disabled via a well-known opt-out
-// environment variable or the persisted noTelemetry config preference (see
-// internal/config.IsTelemetryEnabled).
+// environment variable or the persisted telemetry config preference (see
+// internal/config.IsTelemetry).
 // Only the command path, the names (never values) of flags the user set,
 // and a per-install anonymous instance ID are ever collected — no flag
 // values, argument values, file paths, or other PII.

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -99,7 +99,7 @@ func TestRecordForSubcommands_TracksCommandInvocation(t *testing.T) {
 	assert.NilError(t, root.Execute())
 
 	assert.Equal(t, len(fake.tracks), 1)
-	assert.Equal(t, fake.tracks[0].Event, "command_invocation")
+	assert.Equal(t, fake.tracks[0].Event, "chunk_command_invocation")
 	assert.Equal(t, fake.tracks[0].Properties["command"], "chunk show")
 	assert.Equal(t, fake.tracks[0].Properties["flags"], "json")
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,132 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/segmentio/analytics-go/v3"
+	"github.com/spf13/cobra"
+	"gotest.tools/v3/assert"
+)
+
+// fakeDestination records Enqueue calls synchronously so tests can assert on
+// them without spawning a subprocess or hitting the network.
+type fakeDestination struct {
+	tracks []analytics.Track
+	closed bool
+}
+
+func (f *fakeDestination) Enqueue(t analytics.Track) error {
+	f.tracks = append(f.tracks, t)
+	return nil
+}
+
+func (f *fakeDestination) Close() error {
+	f.closed = true
+	return nil
+}
+
+func TestSender_Track(t *testing.T) {
+	fake := &fakeDestination{}
+	instanceID := uuid.New()
+
+	s, err := NewSender(Config{
+		TestDestination: fake,
+		Metadata: Meta{
+			Version:    "1.2.3",
+			InstanceID: instanceID,
+		},
+	})
+	assert.NilError(t, err)
+
+	assert.NilError(t, s.Track("command_invocation", map[string]any{
+		"command": "chunk config show",
+		"flags":   "json",
+	}))
+
+	assert.Equal(t, len(fake.tracks), 1)
+	tr := fake.tracks[0]
+	assert.Equal(t, tr.Event, "command_invocation")
+	assert.Equal(t, tr.UserId, instanceID.String())
+	assert.Equal(t, tr.Properties["command"], "chunk config show")
+	assert.Equal(t, tr.Properties["flags"], "json")
+	assert.Equal(t, tr.Context.App.Version, "1.2.3")
+	assert.Equal(t, tr.Context.Device.Id, instanceID.String())
+}
+
+func TestSender_CloseIsIdempotent(t *testing.T) {
+	fake := &fakeDestination{}
+	s, err := NewSender(Config{TestDestination: fake})
+	assert.NilError(t, err)
+
+	assert.NilError(t, s.Close())
+	assert.NilError(t, s.Close())
+	assert.Assert(t, fake.closed)
+}
+
+func TestSender_NilSenderIsSafe(t *testing.T) {
+	var s *Sender
+	assert.NilError(t, s.Track("command_invocation", nil))
+	assert.NilError(t, s.Close())
+}
+
+func TestNewSender_SendWithoutBinaryErrors(t *testing.T) {
+	_, err := NewSender(Config{Send: true})
+	assert.ErrorContains(t, err, "binary is required")
+}
+
+// --- RecordForSubcommands ---
+
+func TestRecordForSubcommands_TracksCommandInvocation(t *testing.T) {
+	fake := &fakeDestination{}
+	s, err := NewSender(Config{TestDestination: fake})
+	assert.NilError(t, err)
+
+	root := &cobra.Command{Use: "chunk"}
+	child := &cobra.Command{
+		Use: "show",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return nil
+		},
+	}
+	child.Flags().Bool("json", false, "")
+	root.AddCommand(child)
+	RecordForSubcommands(root)
+
+	root.SetContext(WithSender(context.Background(), s))
+	root.SetArgs([]string{"show", "--json"})
+	assert.NilError(t, root.Execute())
+
+	assert.Equal(t, len(fake.tracks), 1)
+	assert.Equal(t, fake.tracks[0].Event, "command_invocation")
+	assert.Equal(t, fake.tracks[0].Properties["command"], "chunk show")
+	assert.Equal(t, fake.tracks[0].Properties["flags"], "json")
+}
+
+func TestRecordForSubcommands_SkipsDisabledCommand(t *testing.T) {
+	fake := &fakeDestination{}
+	s, err := NewSender(Config{TestDestination: fake})
+	assert.NilError(t, err)
+
+	root := &cobra.Command{Use: "chunk"}
+	child := &cobra.Command{
+		Use: "receive-telemetry",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return nil
+		},
+	}
+	DisableTelemetry(child)
+	root.AddCommand(child)
+	RecordForSubcommands(root)
+
+	root.SetContext(WithSender(context.Background(), s))
+	root.SetArgs([]string{"receive-telemetry"})
+	assert.NilError(t, root.Execute())
+
+	assert.Equal(t, len(fake.tracks), 0)
+}
+
+func TestFromContext_NoSenderAttached(t *testing.T) {
+	assert.Assert(t, FromContext(t.Context()) == nil)
+}

--- a/internal/telemetry/testdata/receiverbin/main.go
+++ b/internal/telemetry/testdata/receiverbin/main.go
@@ -1,0 +1,18 @@
+// Command receiverbin is a minimal stand-in for the chunk binary's hidden
+// "receive-telemetry" subcommand, built by TestMain in delegate_test.go. It
+// has no other subcommands, so pointing delegateDestination.bin at it lets
+// tests exercise the real subprocess spawn/stdin/env-var path without any
+// risk of the "go test" binary re-execing itself.
+package main
+
+import (
+	"os"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/telemetry/receiver"
+)
+
+func main() {
+	if err := receiver.Receive(os.Stdin); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary

Adds anonymous usage telemetry to chunk via Segment. All events are opt-out and no PII is collected.

## Events

### `command_invocation`

Fired after every CLI command completes.

| Property | Value | Notes |
|---|---|---|
| `userId` | stable UUID | Generated on first send, persisted as `instanceID` in `~/.config/chunk/config.json` |
| `command` | e.g. `chunk build-prompt` | Full command path; never includes flag values |
| `flags` | e.g. `model,output` | Sorted comma-separated list of flag *names* that were explicitly set; no values |

## What is NOT collected

- Flag values, argument values, file or directory names
- Tokens, API keys, or any credentials
- Error messages or stack traces
- Any personally identifiable information

## Opt-out

Telemetry is disabled by any of:

- `CHUNK_NO_TELEMETRY` environment variable (any non-empty value)
- `NO_ANALYTICS` environment variable set
- `DO_NOT_TRACK` environment variable set
- `CI` environment variable set (set by most CI systems)
- `chunk config set telemetry false` (persisted to `~/.config/chunk/config.json`)

## Implementation

- New `internal/telemetry` package: `Sender` fans events out to a `multiDestination` — a `loggingDestination` (stderr, gated behind `CHUNK_TELEMETRY_LOG`) and/or a `delegateDestination` (production)
- Events are buffered in-process and only flushed on `Sender.Close()`, which re-execs the `chunk` binary as a detached `receive-telemetry` subprocess (`internal/telemetry/delegate.go`, hidden command in `internal/cmd/receivetelemetry.go`) — this keeps Segment's network round trip off the CLI's exit path
- `internal/telemetry/receiver` decodes the JSON payload from stdin inside that subprocess and forwards it to Segment
- `instanceID` UUID is generated and persisted to `~/.config/chunk/config.json` on first send via `config.EnsureInstanceID`
- Every subcommand is instrumented automatically via `telemetry.RecordForSubcommands`, which wraps each `RunE` — no per-command changes needed. `telemetry.DisableTelemetry` opts a command out (used for `receive-telemetry` itself, so receiving telemetry never emits its own)
- The Segment write key (`cmd.writeKey`) is a hardcoded constant, matching circleci-cli's pattern — write keys are push-only, not secret, so checking one into git is safe. **It's currently `""`** pending Segment workspace access (see below); `setupTelemetry` never sends with an empty key, so this is a no-op until then, and dropping in the real key later is a one-line change.
- `setupTelemetry` also checks `testing.Testing()` before sending — see "Bug found during manual testing" below for why this matters independently of the write key being empty.

## Bug found during manual testing (fixed)

While manually verifying the delegate/receiver mechanism end-to-end against a fake local Segment server, I found that a non-empty write key causes a real problem under `go test`: `delegateDestination` re-execs `os.Executable()`, which under `go test` resolves to the compiled test binary (not `chunk`). Invoking it with `receive-telemetry` doesn't run that subcommand — it silently reruns the package's *entire, unfiltered* test suite, which re-triggers the same send from any test that exercises the real CLI pipeline (`hook_test.go`, `validate_test.go`). Each recursive rerun spawns more copies of itself. This produced **over 2000 orphaned background processes** on my machine before I caught and killed them, and is almost certainly the real cause of the `resource temporarily unavailable` test flakiness seen earlier on this branch (previously misattributed to environment noise).

Fixed with `testing.Testing()` in `setupTelemetry`, which blocks sending outright under `go test` — verified by forcing a fake key directly into the `go test` binary (both via `-ldflags` and by hardcoding it in source, matching how the real key will eventually be added) and confirming zero subprocesses spawn either way. This guard is independent of whether the key is build-injected or hardcoded, so it protects us permanently once a real key lands here.

## Test plan

- [x] `task build`
- [x] `go test ./internal/telemetry/... ./internal/config/... ./internal/cmd/...` — all pass, verified zero leaked `receive-telemetry` processes after
- [x] `task lint` — 0 issues
- [x] Built with a fake write key and confirmed `receive-telemetry` correctly posts a valid Segment `/v1/batch` payload to a local fake server
- [x] Hardcoded a fake key directly in source (simulating the real key landing here) and confirmed `testing.Testing()` still prevents any subprocess spawn under `go test`
- [x] `CHUNK_TELEMETRY_LOG=1` logs `[telemetry] track command_invocation` to stderr with correct properties
- [ ] Set `CHUNK_NO_TELEMETRY=1` and confirm no events are emitted (only verified via the `IsTelemetryEnabled` unit tests so far, not a manual run)
- [ ] Once a real write key is added: confirm events actually show up in Segment's debugger for a real command run