### PR TITLE
Update sidecar snapshot to include uv on PATH

### DIFF
--- a/.chunk/config.json
+++ b/.chunk/config.json
@@ -39,7 +39,7 @@
     "repo": "chunk-cli"
   },
   "validation": {
-    "sidecarImage": "ac042eab-a45f-452e-a4f5-1d56e1b026bd"
+    "sidecarImage": "3c128769-f6a7-4219-8240-a3562d91ed17"
   },
   "environment": {
     "stack": "go",


### PR DESCRIPTION
## Summary

- The previous sidecar snapshot was missing `uv`, causing `chunk validate --remote` to fail when `task lint` tried to run `uv run --project harness pylint ...`
- Installed `uv` on a fresh sidecar, symlinked it to `/usr/local/bin`, confirmed all checks pass, and saved a new snapshot (`3c128769-f6a7-4219-8240-a3562d91ed17`)

## Test plan

- [ ] `chunk validate --remote` passes (test, lint, format all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)