### PR TITLE
Promote env detection to chunk env init, remove sidecar env/build

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Auto-detect your tech stack, install dependencies, and snapshot the result so fu
 # Detect environment, run install steps, and create a snapshot
 chunk sidecar setup --name my-sidecar
 
-# Or render a Dockerfile from the detected environment, then build it yourself
-chunk env detect --format dockerfile --dir .
+# Or generate a Dockerfile from the detected environment, then build it yourself
+chunk env init --dir .
 docker build -f Dockerfile.test -t myapp:test .
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ Auto-detect your tech stack, install dependencies, and snapshot the result so fu
 # Detect environment, run install steps, and create a snapshot
 chunk sidecar setup --name my-sidecar
 
-# Or build a local Docker test image from the detected environment
-chunk sidecar env | chunk sidecar build --dir .
+# Or render a Dockerfile from the detected environment, then build it yourself
+chunk env detect --format dockerfile --dir .
+docker build -f Dockerfile.test -t myapp:test .
 ```
 
 ##### Snapshots

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -60,7 +60,7 @@ tasks:
 
   env-harness:
     desc: |
-      Run chunk env detect/render against target repos, using Claude to improve
+      Run chunk env init against target repos, using Claude to improve
       envbuilder on failure. Args are passed through to harness/environment.py.
       Examples:
         task env-harness                                       # all known repos

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -60,7 +60,7 @@ tasks:
 
   env-harness:
     desc: |
-      Run chunk sidecar env/build against target repos, using Claude to improve
+      Run chunk env detect/render against target repos, using Claude to improve
       envbuilder on failure. Args are passed through to harness/environment.py.
       Examples:
         task env-harness                                       # all known repos

--- a/acceptance/env_detect_e2e_test.go
+++ b/acceptance/env_detect_e2e_test.go
@@ -78,8 +78,9 @@ func resolveRepos(t *testing.T) []repoEntry {
 	return entries
 }
 
-// TestSidecarsBuildEndToEnd clones real open-source repos, runs
-// `chunk sidecars build` to generate a Dockerfile.test, builds the image,
+// TestEnvDetectEndToEnd clones real open-source repos, runs
+// `chunk env detect` to get the environment spec, renders a Dockerfile.test
+// with `chunk env detect --format dockerfile`, builds the image with docker,
 // and runs the tests inside the container.
 //
 // Enable with: CHUNK_ENV_BUILDER_ACCEPTANCE=1
@@ -88,7 +89,7 @@ func resolveRepos(t *testing.T) []repoEntry {
 // To run a specific subset, set CHUNK_SIDECAR_REPOS to a comma-separated list
 // of known nicknames (e.g. "flask,serde") or full Git URLs
 // (e.g. "https://github.com/owner/repo.git"), or a mix of both.
-func TestSidecarsBuildEndToEnd(t *testing.T) {
+func TestEnvDetectEndToEnd(t *testing.T) {
 	if os.Getenv("CHUNK_ENV_BUILDER_ACCEPTANCE") == "" {
 		t.Skip("set CHUNK_ENV_BUILDER_ACCEPTANCE=1 to run")
 	}
@@ -113,10 +114,10 @@ func TestSidecarsBuildEndToEnd(t *testing.T) {
 			}
 			e2eCloneRepo(t, repo.URL, repo.Ref, cloneDir)
 
-			t.Log("Running chunk sidecar env...")
+			t.Log("Running chunk env detect...")
 			envJSON, envStderr, exitCode := e2eRunEnv(t, cloneDir)
 			assert.Equal(t, exitCode, 0,
-				"chunk sidecar env failed\nstdout: %s\nstderr: %s", envJSON, envStderr)
+				"chunk env detect failed\nstdout: %s\nstderr: %s", envJSON, envStderr)
 			t.Log(envStderr)
 			t.Log(envJSON)
 
@@ -133,13 +134,18 @@ func TestSidecarsBuildEndToEnd(t *testing.T) {
 
 			tag := "chunk-sidecar-" + repo.Name + "-test"
 
-			t.Log("Building Docker image...")
-			buildOutput, buildExitCode := e2eRunBuild(t, cloneDir, tag, envJSON)
-			assert.Equal(t, buildExitCode, 0,
-				"chunk sidecar build failed\n%s", lastLines(buildOutput, 30))
+			t.Log("Rendering Dockerfile.test...")
+			renderOutput, renderExitCode := e2eRenderDockerfile(t, cloneDir)
+			assert.Equal(t, renderExitCode, 0,
+				"chunk env detect --format dockerfile failed\n%s", lastLines(renderOutput, 30))
 
 			_, err := os.Stat(cloneDir + "/Dockerfile.test")
 			assert.NilError(t, err, "Dockerfile.test not created")
+
+			t.Log("Building Docker image...")
+			buildOutput, buildExitCode := e2eDockerBuild(t, cloneDir, tag)
+			assert.Equal(t, buildExitCode, 0,
+				"docker build failed\n%s", lastLines(buildOutput, 30))
 
 			t.Log("Running tests in container...")
 			testsOK, testOutput := e2eDockerRun(t, tag)
@@ -196,7 +202,7 @@ func e2eRunEnv(t *testing.T, dir string) (stdout, stderr string, exitCode int) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binary.Path(), "sidecar", "env", "--dir", dir)
+	cmd := exec.CommandContext(ctx, binary.Path(), "env", "detect", "--dir", dir)
 	cmd.Env = []string{
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 		fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
@@ -217,27 +223,55 @@ func e2eRunEnv(t *testing.T, dir string) (stdout, stderr string, exitCode int) {
 	return outBuf.String(), errBuf.String(), exitCode
 }
 
-func e2eRunBuild(t *testing.T, dir, tag, envJSON string) (output string, exitCode int) {
+// e2eRenderDockerfile runs `chunk env detect --format dockerfile` to write
+// Dockerfile.test into dir. Detection runs separately from e2eRunEnv because
+// the two output formats (JSON for env.json, Dockerfile for docker build) are
+// distinct invocations of the same command.
+func e2eRenderDockerfile(t *testing.T, dir string) (output string, exitCode int) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binary.Path(), "sidecar", "build", "--dir", dir, "--tag", tag)
+	cmd := exec.CommandContext(ctx, binary.Path(), "env", "detect", "--format", "dockerfile", "--dir", dir)
 	cmd.Env = []string{
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 		fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
 		"NO_COLOR=1",
 	}
-	cmd.Stdin = strings.NewReader(envJSON)
 	var outBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &outBuf
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return outBuf.String(), exitErr.ExitCode()
+		}
+		return outBuf.String(), 1
+	}
+	return outBuf.String(), 0
+}
 
-	err := cmd.Run()
-	if err != nil {
+func e2eDockerBuild(t *testing.T, dir, tag string) (output string, exitCode int) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "docker", "build", "-f", "Dockerfile.test", "-t", tag, ".")
+	cmd.Dir = dir
+	cmd.Env = []string{
+		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
+		fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
+		"NO_COLOR=1",
+	}
+	var outBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &outBuf
+	if err := cmd.Run(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = 1
 		}
 	}
 	return outBuf.String(), exitCode

--- a/acceptance/env_init_e2e_test.go
+++ b/acceptance/env_init_e2e_test.go
@@ -78,9 +78,9 @@ func resolveRepos(t *testing.T) []repoEntry {
 	return entries
 }
 
-// TestEnvDetectEndToEnd clones real open-source repos, runs
-// `chunk env detect` to get the environment spec, renders a Dockerfile.test
-// with `chunk env detect --format dockerfile`, builds the image with docker,
+// TestEnvInitEndToEnd clones real open-source repos, runs
+// `chunk env init --format json` to get the environment spec, writes
+// Dockerfile.test with `chunk env init`, builds the image with docker,
 // and runs the tests inside the container.
 //
 // Enable with: CHUNK_ENV_BUILDER_ACCEPTANCE=1
@@ -89,7 +89,7 @@ func resolveRepos(t *testing.T) []repoEntry {
 // To run a specific subset, set CHUNK_SIDECAR_REPOS to a comma-separated list
 // of known nicknames (e.g. "flask,serde") or full Git URLs
 // (e.g. "https://github.com/owner/repo.git"), or a mix of both.
-func TestEnvDetectEndToEnd(t *testing.T) {
+func TestEnvInitEndToEnd(t *testing.T) {
 	if os.Getenv("CHUNK_ENV_BUILDER_ACCEPTANCE") == "" {
 		t.Skip("set CHUNK_ENV_BUILDER_ACCEPTANCE=1 to run")
 	}
@@ -114,10 +114,10 @@ func TestEnvDetectEndToEnd(t *testing.T) {
 			}
 			e2eCloneRepo(t, repo.URL, repo.Ref, cloneDir)
 
-			t.Log("Running chunk env detect...")
+			t.Log("Running chunk env init --format json...")
 			envJSON, envStderr, exitCode := e2eRunEnv(t, cloneDir)
 			assert.Equal(t, exitCode, 0,
-				"chunk env detect failed\nstdout: %s\nstderr: %s", envJSON, envStderr)
+				"chunk env init --format json failed\nstdout: %s\nstderr: %s", envJSON, envStderr)
 			t.Log(envStderr)
 			t.Log(envJSON)
 
@@ -134,10 +134,10 @@ func TestEnvDetectEndToEnd(t *testing.T) {
 
 			tag := "chunk-sidecar-" + repo.Name + "-test"
 
-			t.Log("Rendering Dockerfile.test...")
-			renderOutput, renderExitCode := e2eRenderDockerfile(t, cloneDir)
+			t.Log("Running chunk env init (writes Dockerfile.test)...")
+			renderOutput, renderExitCode := e2eInitDockerfile(t, cloneDir)
 			assert.Equal(t, renderExitCode, 0,
-				"chunk env detect --format dockerfile failed\n%s", lastLines(renderOutput, 30))
+				"chunk env init failed\n%s", lastLines(renderOutput, 30))
 
 			_, err := os.Stat(cloneDir + "/Dockerfile.test")
 			assert.NilError(t, err, "Dockerfile.test not created")
@@ -202,7 +202,7 @@ func e2eRunEnv(t *testing.T, dir string) (stdout, stderr string, exitCode int) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binary.Path(), "env", "detect", "--dir", dir)
+	cmd := exec.CommandContext(ctx, binary.Path(), "env", "init", "--format", "json", "--dir", dir)
 	cmd.Env = []string{
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 		fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
@@ -223,16 +223,15 @@ func e2eRunEnv(t *testing.T, dir string) (stdout, stderr string, exitCode int) {
 	return outBuf.String(), errBuf.String(), exitCode
 }
 
-// e2eRenderDockerfile runs `chunk env detect --format dockerfile` to write
-// Dockerfile.test into dir. Detection runs separately from e2eRunEnv because
-// the two output formats (JSON for env.json, Dockerfile for docker build) are
-// distinct invocations of the same command.
-func e2eRenderDockerfile(t *testing.T, dir string) (output string, exitCode int) {
+// e2eInitDockerfile runs `chunk env init` (default dockerfile output) to write
+// Dockerfile.test into dir. Runs separately from e2eRunEnv because the JSON
+// step uses --format json and the dockerfile step uses the default.
+func e2eInitDockerfile(t *testing.T, dir string) (output string, exitCode int) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binary.Path(), "env", "detect", "--format", "dockerfile", "--dir", dir)
+	cmd := exec.CommandContext(ctx, binary.Path(), "env", "init", "--dir", dir)
 	cmd.Env = []string{
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 		fmt.Sprintf("HOME=%s", os.Getenv("HOME")),

--- a/acceptance/sidecar_gaps_test.go
+++ b/acceptance/sidecar_gaps_test.go
@@ -127,51 +127,14 @@ func TestSidecarExecAPIError(t *testing.T) {
 	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for 500 response")
 }
 
-// --- build error paths ---
+// --- env detect error paths ---
 
-func TestSidecarBuildMissingDockerfile(t *testing.T) {
+func TestEnvDetectEmptyDir(t *testing.T) {
 	dir := t.TempDir()
 
 	env := testenv.NewTestEnv(t)
 	result := binary.RunCLI(t, []string{
-		"sidecar", "build",
-		"--dir", dir,
-	}, env, env.HomeDir)
-
-	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit when Dockerfile.test missing")
-}
-
-func TestSidecarBuildInvalidTag(t *testing.T) {
-	env := testenv.NewTestEnv(t)
-	result := binary.RunCLI(t, []string{
-		"sidecar", "build",
-		"--tag", "!!!invalid",
-	}, env, env.HomeDir)
-
-	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for invalid tag")
-	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "Invalid image tag"),
-		"expected invalid tag error, got: %s", combined)
-}
-
-func TestSidecarBuildNonexistentDir(t *testing.T) {
-	env := testenv.NewTestEnv(t)
-	result := binary.RunCLI(t, []string{
-		"sidecar", "build",
-		"--dir", "/tmp/nonexistent-dir-abc123",
-	}, env, env.HomeDir)
-
-	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for nonexistent dir")
-}
-
-// --- env error paths ---
-
-func TestSidecarEnvEmptyDir(t *testing.T) {
-	dir := t.TempDir()
-
-	env := testenv.NewTestEnv(t)
-	result := binary.RunCLI(t, []string{
-		"sidecar", "env",
+		"env", "detect",
 		"--dir", dir,
 	}, env, env.HomeDir)
 
@@ -184,14 +147,48 @@ func TestSidecarEnvEmptyDir(t *testing.T) {
 	assert.NilError(t, err, "expected valid JSON on stdout, got: %s", result.Stdout)
 }
 
-func TestSidecarEnvNonexistentDir(t *testing.T) {
+func TestEnvDetectNonexistentDir(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	result := binary.RunCLI(t, []string{
-		"sidecar", "env",
+		"env", "detect",
 		"--dir", "/tmp/nonexistent-dir-xyz789",
 	}, env, env.HomeDir)
 
 	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for nonexistent dir")
+}
+
+func TestEnvDetectDockerfileFormat(t *testing.T) {
+	dir := t.TempDir()
+
+	env := testenv.NewTestEnv(t)
+	// --format dockerfile detects from --dir and writes Dockerfile.test,
+	// printing its path to stdout — no stdin spec required.
+	result := binary.RunCLI(t, []string{
+		"env", "detect",
+		"--format", "dockerfile",
+		"--dir", dir,
+		"--no-save",
+	}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stdout, "Dockerfile.test"),
+		"expected Dockerfile.test path on stdout, got: %s", result.Stdout)
+}
+
+func TestEnvDetectInvalidFormat(t *testing.T) {
+	dir := t.TempDir()
+
+	env := testenv.NewTestEnv(t)
+	result := binary.RunCLI(t, []string{
+		"env", "detect",
+		"--format", "bogus",
+		"--dir", dir,
+	}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for invalid format")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "Invalid --format"),
+		"expected invalid format error, got: %s", combined)
 }
 
 // --- create error paths ---

--- a/acceptance/sidecar_gaps_test.go
+++ b/acceptance/sidecar_gaps_test.go
@@ -127,45 +127,15 @@ func TestSidecarExecAPIError(t *testing.T) {
 	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for 500 response")
 }
 
-// --- env detect error paths ---
+// --- env init paths ---
 
-func TestEnvDetectEmptyDir(t *testing.T) {
+func TestEnvInitDefault(t *testing.T) {
 	dir := t.TempDir()
 
 	env := testenv.NewTestEnv(t)
+	// Default output is dockerfile: writes Dockerfile.test, prints path to stdout.
 	result := binary.RunCLI(t, []string{
-		"env", "detect",
-		"--dir", dir,
-	}, env, env.HomeDir)
-
-	// Empty dir should still succeed (unknown stack) and produce JSON on stdout.
-	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-
-	// Verify JSON output on stdout
-	var envOutput map[string]interface{}
-	err := json.Unmarshal([]byte(result.Stdout), &envOutput)
-	assert.NilError(t, err, "expected valid JSON on stdout, got: %s", result.Stdout)
-}
-
-func TestEnvDetectNonexistentDir(t *testing.T) {
-	env := testenv.NewTestEnv(t)
-	result := binary.RunCLI(t, []string{
-		"env", "detect",
-		"--dir", "/tmp/nonexistent-dir-xyz789",
-	}, env, env.HomeDir)
-
-	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for nonexistent dir")
-}
-
-func TestEnvDetectDockerfileFormat(t *testing.T) {
-	dir := t.TempDir()
-
-	env := testenv.NewTestEnv(t)
-	// --format dockerfile detects from --dir and writes Dockerfile.test,
-	// printing its path to stdout — no stdin spec required.
-	result := binary.RunCLI(t, []string{
-		"env", "detect",
-		"--format", "dockerfile",
+		"env", "init",
 		"--dir", dir,
 		"--no-save",
 	}, env, env.HomeDir)
@@ -175,12 +145,40 @@ func TestEnvDetectDockerfileFormat(t *testing.T) {
 		"expected Dockerfile.test path on stdout, got: %s", result.Stdout)
 }
 
-func TestEnvDetectInvalidFormat(t *testing.T) {
+func TestEnvInitJSONFormat(t *testing.T) {
 	dir := t.TempDir()
 
 	env := testenv.NewTestEnv(t)
 	result := binary.RunCLI(t, []string{
-		"env", "detect",
+		"env", "init",
+		"--format", "json",
+		"--dir", dir,
+	}, env, env.HomeDir)
+
+	// Empty dir should still succeed (unknown stack) and produce JSON on stdout.
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+
+	var envOutput map[string]interface{}
+	err := json.Unmarshal([]byte(result.Stdout), &envOutput)
+	assert.NilError(t, err, "expected valid JSON on stdout, got: %s", result.Stdout)
+}
+
+func TestEnvInitNonexistentDir(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	result := binary.RunCLI(t, []string{
+		"env", "init",
+		"--dir", "/tmp/nonexistent-dir-xyz789",
+	}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for nonexistent dir")
+}
+
+func TestEnvInitInvalidFormat(t *testing.T) {
+	dir := t.TempDir()
+
+	env := testenv.NewTestEnv(t)
+	result := binary.RunCLI(t, []string{
+		"env", "init",
 		"--format", "bogus",
 		"--dir", dir,
 	}, env, env.HomeDir)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -119,9 +119,9 @@ chunk
 │           --json                  # Output as JSON
 │
 ├── env                             # Detect and render project environments
-│   └── detect                      # Detect tech stack; output env spec (JSON) or Dockerfile
+│   └── init                        # Detect tech stack; write Dockerfile.test (default) or JSON spec
 │       --dir <path>                # Directory to analyse (default: .)
-│       --format <fmt>              # Output format: json (default) or dockerfile
+│       --format <fmt>              # Output format: dockerfile (default) or json
 │       --no-save                   # Do not save the detected spec to .chunk/config.json
 │
 ├── hook                            # Manage chunk hook execution

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -98,12 +98,6 @@ chunk
 │   │   --sidecar-id <id>           # Sidecar ID (defaults to active sidecar)
 │   │   --identity-file <path>      # SSH identity file
 │   │   --workdir <path>            # Destination path on sidecar (auto-detected when omitted)
-│   ├── env                         # Detect tech stack and print environment spec as JSON
-│   │   --dir <path>                # Directory to analyse (default: .)
-│   │   --no-save                   # Print only, do not save to .chunk/config.json
-│   ├── build                       # Generate Dockerfile and build test image from env spec
-│   │   --dir <path>                # Directory to write Dockerfile.test and build from
-│   │   --tag <tag>                 # Image tag (e.g. myapp:latest)
 │   ├── setup                       # Detect env, sync files, and run install steps
 │   │   --dir <path>                # Directory to detect environment in (default: .)
 │   │   --sidecar-id <id>           # Sidecar ID (defaults to active sidecar)
@@ -123,6 +117,12 @@ chunk
 │       └── list                    # List snapshots
 │           --org-id <id>           # Organization ID
 │           --json                  # Output as JSON
+│
+├── env                             # Detect and render project environments
+│   └── detect                      # Detect tech stack; output env spec (JSON) or Dockerfile
+│       --dir <path>                # Directory to analyse (default: .)
+│       --format <fmt>              # Output format: json (default) or dockerfile
+│       --no-save                   # Do not save the detected spec to .chunk/config.json
 │
 ├── hook                            # Manage chunk hook execution
 │   --project <path>                # Override project directory

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -223,7 +223,7 @@ The skill handles the full loop: auth checks → find active sidecar → sync �
 Auto-detect your tech stack and save it to config:
 
 ```bash
-chunk sidecar env   # detect stack, save to config
+chunk env detect   # detect stack, save to config
 ```
 
 ### Environment variables

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -223,7 +223,7 @@ The skill handles the full loop: auth checks → find active sidecar → sync �
 Auto-detect your tech stack and save it to config:
 
 ```bash
-chunk env detect   # detect stack, save to config
+chunk env init   # detect stack, write Dockerfile.test, save to config
 ```
 
 ### Environment variables

--- a/harness/environment.py
+++ b/harness/environment.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-environment: harness for `chunk sidecar env` + the sidecar build acceptance test.
+environment: harness for `chunk env detect` + the sidecar build acceptance test.
 Runs against target repos and uses the Claude Code SDK to improve
 internal/envbuilder when tests fail.
 
@@ -176,7 +176,7 @@ def _run_test(repo: TargetRepo, cache_dir: Path, timeout: int, extra_env: dict |
     }
     result = subprocess.run(
         ["go", "test", "-v", "-count=1", f"-timeout={timeout}s",
-         "-run", "TestSidecarsBuildEndToEnd", "./acceptance/"],
+         "-run", "TestEnvDetectEndToEnd", "./acceptance/"],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
@@ -277,7 +277,7 @@ After editing, run `go build -o {BINARY.relative_to(REPO_ROOT)} .` to verify it 
         else:
             prompt = f"""You are debugging an environment detection tool inside the chunk CLI.
 
-`chunk sidecar env` analyses a repository, detects its tech stack, and writes a
+`chunk env detect` analyses a repository, detects its tech stack, and writes a
 Dockerfile.test for running that repo's tests. It was run on the
 {repo.name} repo ({repo.url}).
 
@@ -453,7 +453,7 @@ def run_repo(repo: TargetRepo, timeout: int, max_iterations: int, persistent_cac
 
     try:
         # Phase 1: env-only — clone + detect env (no docker).
-        print("Running env detection (clone + sidecar env)...")
+        print("Running env detection (clone + env detect)...")
         current_env, env_output = run_env_only_test(repo, cache_dir, timeout)
         if current_env is None:
             print(f"  Env detection failed:\n{env_output}")
@@ -593,7 +593,7 @@ def main():
     known_names = [r["name"] for r in KNOWN_REPOS]
 
     parser = argparse.ArgumentParser(
-        description="environment: harness for chunk sidecar env/build. "
+        description="environment: harness for chunk env detect/dockerfile. "
                     "Uses Claude to improve envbuilder on failure.",
     )
     parser.add_argument(

--- a/harness/environment.py
+++ b/harness/environment.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-environment: harness for `chunk env detect` + the sidecar build acceptance test.
+environment: harness for `chunk env init` + the sidecar build acceptance test.
 Runs against target repos and uses the Claude Code SDK to improve
 internal/envbuilder when tests fail.
 
@@ -277,7 +277,7 @@ After editing, run `go build -o {BINARY.relative_to(REPO_ROOT)} .` to verify it 
         else:
             prompt = f"""You are debugging an environment detection tool inside the chunk CLI.
 
-`chunk env detect` analyses a repository, detects its tech stack, and writes a
+`chunk env init` analyses a repository, detects its tech stack, and writes a
 Dockerfile.test for running that repo's tests. It was run on the
 {repo.name} repo ({repo.url}).
 
@@ -453,7 +453,7 @@ def run_repo(repo: TargetRepo, timeout: int, max_iterations: int, persistent_cac
 
     try:
         # Phase 1: env-only — clone + detect env (no docker).
-        print("Running env detection (clone + env detect)...")
+        print("Running env detection (clone + env init)...")
         current_env, env_output = run_env_only_test(repo, cache_dir, timeout)
         if current_env is None:
             print(f"  Env detection failed:\n{env_output}")
@@ -593,7 +593,7 @@ def main():
     known_names = [r["name"] for r in KNOWN_REPOS]
 
     parser = argparse.ArgumentParser(
-        description="environment: harness for chunk env detect/dockerfile. "
+        description="environment: harness for chunk env init. "
                     "Uses Claude to improve envbuilder on failure.",
     )
     parser.add_argument(

--- a/harness/environment.py
+++ b/harness/environment.py
@@ -176,7 +176,7 @@ def _run_test(repo: TargetRepo, cache_dir: Path, timeout: int, extra_env: dict |
     }
     result = subprocess.run(
         ["go", "test", "-v", "-count=1", f"-timeout={timeout}s",
-         "-run", "TestEnvDetectEndToEnd", "./acceptance/"],
+         "-run", "TestEnvInitEndToEnd", "./acceptance/"],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,

--- a/internal/cmd/environment.go
+++ b/internal/cmd/environment.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/chunk-cli/envbuilder"
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+)
+
+const (
+	envFormatJSON       = "json"
+	envFormatDockerfile = "dockerfile"
+)
+
+func newEnvCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "env",
+		Short: "Detect and render project environments",
+		Long: `Detect a repository's tech stack and emit a build environment.
+
+Detection produces a spec that describes the stack, image, and setup steps.
+'env detect' prints that spec as JSON by default, or writes a Dockerfile with
+--format dockerfile. The spec is the source of truth — the Dockerfile is one
+rendering of it.
+
+Example:
+  chunk env detect --format dockerfile --dir .`,
+		RunE:               groupRunE,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+	}
+
+	cmd.AddCommand(newEnvDetectCmd())
+
+	return cmd
+}
+
+func newEnvDetectCmd() *cobra.Command {
+	var dir string
+	var noSave bool
+	var format string
+
+	cmd := &cobra.Command{
+		Use:   "detect",
+		Short: "Detect tech stack and output an environment spec or Dockerfile",
+		Long: `Analyse the repository at --dir and detect its tech stack.
+
+By default a JSON environment spec is printed to stdout. Pass
+--format dockerfile to instead write Dockerfile.test to --dir; its path is
+printed to stdout.
+
+The detected environment is saved to .chunk/config.json so that
+'chunk sidecar setup' can reuse it without re-detecting. Pass --no-save to
+skip writing the config.
+
+Examples:
+  chunk env detect                          # print the env spec as JSON
+  chunk env detect --format dockerfile      # write Dockerfile.test to --dir
+  chunk env detect --format dockerfile --dir .
+  docker build -f Dockerfile.test -t myapp:test .`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			streams := iostream.FromCmd(cmd)
+
+			if format != envFormatJSON && format != envFormatDockerfile {
+				return &userError{
+					msg:        fmt.Sprintf("Invalid --format %q.", format),
+					suggestion: "Use 'json' or 'dockerfile'.",
+					errMsg:     fmt.Sprintf("invalid format %q", format),
+				}
+			}
+
+			if _, err := os.Stat(dir); err != nil {
+				return &userError{
+					msg:        fmt.Sprintf("Directory %q not found.", dir),
+					suggestion: "Check the --dir path and try again.",
+					err:        err,
+				}
+			}
+			streams.ErrPrintf("Detecting environment in %s...\n", dir)
+
+			env, err := envbuilder.DetectEnvironment(cmd.Context(), dir)
+			if err != nil {
+				return &userError{
+					msg:        "Could not detect the environment.",
+					suggestion: "Check the directory contains a supported project.",
+					err:        err,
+				}
+			}
+
+			if !noSave {
+				cfg, loadErr := config.LoadProjectConfig(dir)
+				if loadErr != nil {
+					cfg = &config.ProjectConfig{}
+				}
+				cfg.Environment = env
+				if saveErr := config.SaveProjectConfig(dir, cfg); saveErr != nil {
+					streams.ErrPrintf("Warning: could not save environment to config: %v\n", saveErr)
+				}
+			}
+
+			if format == envFormatDockerfile {
+				dockerfilePath, err := envbuilder.WriteDockerfile(dir, env)
+				if err != nil {
+					return &userError{
+						msg:        "Could not write the Dockerfile.",
+						suggestion: "Check directory permissions and try again.",
+						err:        err,
+					}
+				}
+				streams.ErrPrintf("%s\n", ui.Success("Wrote "+dockerfilePath))
+				streams.Printf("%s\n", dockerfilePath)
+				return nil
+			}
+
+			out, err := json.MarshalIndent(env, "", "  ")
+			if err != nil {
+				return &userError{msg: "Could not encode the environment spec.", err: err}
+			}
+			streams.Printf("%s\n", out)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&dir, "dir", ".", "Directory to detect environment in")
+	cmd.Flags().BoolVar(&noSave, "no-save", false, "Print only without saving to .chunk/config.json")
+	cmd.Flags().StringVar(&format, "format", envFormatJSON, "Output format: json (env spec) or dockerfile")
+
+	return cmd
+}

--- a/internal/cmd/environment.go
+++ b/internal/cmd/environment.go
@@ -25,44 +25,43 @@ func newEnvCmd() *cobra.Command {
 		Long: `Detect a repository's tech stack and emit a build environment.
 
 Detection produces a spec that describes the stack, image, and setup steps.
-'env detect' prints that spec as JSON by default, or writes a Dockerfile with
---format dockerfile. The spec is the source of truth — the Dockerfile is one
-rendering of it.
+'env init' writes Dockerfile.test to --dir by default, or prints the spec as
+JSON with --format json. The spec is the source of truth — the Dockerfile is
+one rendering of it.
 
 Example:
-  chunk env detect --format dockerfile --dir .`,
+  chunk env init --dir .`,
 		RunE:               groupRunE,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
 
-	cmd.AddCommand(newEnvDetectCmd())
+	cmd.AddCommand(newEnvInitCmd())
 
 	return cmd
 }
 
-func newEnvDetectCmd() *cobra.Command {
+func newEnvInitCmd() *cobra.Command {
 	var dir string
 	var noSave bool
 	var format string
 
 	cmd := &cobra.Command{
-		Use:   "detect",
-		Short: "Detect tech stack and output an environment spec or Dockerfile",
-		Long: `Analyse the repository at --dir and detect its tech stack.
+		Use:   "init",
+		Short: "Detect tech stack and write Dockerfile.test (or output a JSON env spec)",
+		Long: `Analyse the repository at --dir, detect its tech stack, and write
+Dockerfile.test to --dir. The path to the written file is printed to stdout.
 
-By default a JSON environment spec is printed to stdout. Pass
---format dockerfile to instead write Dockerfile.test to --dir; its path is
-printed to stdout.
+Pass --format json to print the environment spec to stdout instead.
 
 The detected environment is saved to .chunk/config.json so that
 'chunk sidecar setup' can reuse it without re-detecting. Pass --no-save to
 skip writing the config.
 
 Examples:
-  chunk env detect                          # print the env spec as JSON
-  chunk env detect --format dockerfile      # write Dockerfile.test to --dir
-  chunk env detect --format dockerfile --dir .
-  docker build -f Dockerfile.test -t myapp:test .`,
+  chunk env init                            # write Dockerfile.test to --dir
+  chunk env init --dir .
+  docker build -f Dockerfile.test -t myapp:test .
+  chunk env init --format json              # print the env spec as JSON`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			streams := iostream.FromCmd(cmd)
 
@@ -127,8 +126,8 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&dir, "dir", ".", "Directory to detect environment in")
-	cmd.Flags().BoolVar(&noSave, "no-save", false, "Print only without saving to .chunk/config.json")
-	cmd.Flags().StringVar(&format, "format", envFormatJSON, "Output format: json (env spec) or dockerfile")
+	cmd.Flags().BoolVar(&noSave, "no-save", false, "Skip saving the detected environment to .chunk/config.json")
+	cmd.Flags().StringVar(&format, "format", envFormatDockerfile, "Output format: dockerfile (write Dockerfile.test) or json (env spec)")
 
 	return cmd
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -53,6 +53,7 @@ Configuration:
 	rootCmd.AddCommand(newSkillCmd())
 	rootCmd.AddCommand(newCompletionCmd())
 	rootCmd.AddCommand(newSidecarCmd())
+	rootCmd.AddCommand(newEnvCmd())
 	rootCmd.AddCommand(newTaskCmd())
 	rootCmd.AddCommand(newValidateCmd())
 	rootCmd.AddCommand(newHookCmd())

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -2,13 +2,9 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
-	"regexp"
 
 	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/spf13/cobra"
@@ -44,8 +40,6 @@ func newSidecarCmd() *cobra.Command {
 	cmd.AddCommand(newSidecarAddSSHKeyCmd())
 	cmd.AddCommand(newSidecarSSHCmd())
 	cmd.AddCommand(newSidecarSyncCmd())
-	cmd.AddCommand(newSidecarEnvCmd())
-	cmd.AddCommand(newSidecarBuildCmd())
 	cmd.AddCommand(newSidecarUseCmd())
 	cmd.AddCommand(newSidecarCurrentCmd())
 	cmd.AddCommand(newSidecarForgetCmd())
@@ -570,153 +564,6 @@ func newSidecarForgetCmd() *cobra.Command {
 			return nil
 		},
 	}
-}
-
-var validDockerTag = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/\-]*(:[a-zA-Z0-9._\-]+)?$`)
-
-func newSidecarEnvCmd() *cobra.Command {
-	var dir string
-	var noSave bool
-
-	cmd := &cobra.Command{
-		Use:   "env",
-		Short: "Detect tech stack and print environment spec as JSON",
-		Long: `Analyse the repository at --dir, detect its tech stack, and print
-a JSON environment spec to stdout. Pipe this into 'chunk sidecar build' to
-generate a Dockerfile and build a test image.
-
-By default the detected environment is saved to .chunk/config.json so that
-'chunk sidecar setup' can reuse it without re-detecting. Pass --no-save to
-print only without writing.`,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			io := iostream.FromCmd(cmd)
-			if _, err := os.Stat(dir); err != nil {
-				return &userError{
-					msg:        fmt.Sprintf("Directory %q not found.", dir),
-					suggestion: "Check the --dir path and try again.",
-					err:        err,
-				}
-			}
-			io.ErrPrintf("Detecting environment in %s...\n", dir)
-
-			env, err := envbuilder.DetectEnvironment(cmd.Context(), dir)
-			if err != nil {
-				return &userError{
-					msg:        "Could not detect the environment.",
-					suggestion: "Check the directory contains a supported project.",
-					err:        err,
-				}
-			}
-
-			if !noSave {
-				cfg, loadErr := config.LoadProjectConfig(dir)
-				if loadErr != nil {
-					cfg = &config.ProjectConfig{}
-				}
-				cfg.Environment = env
-				if saveErr := config.SaveProjectConfig(dir, cfg); saveErr != nil {
-					io.ErrPrintf("Warning: could not save environment to config: %v\n", saveErr)
-				}
-			}
-
-			out, err := json.MarshalIndent(env, "", "  ")
-			if err != nil {
-				return &userError{msg: "Could not encode the environment spec.", err: err}
-			}
-			io.Printf("%s\n", out)
-			return nil
-		},
-	}
-
-	cmd.Flags().StringVar(&dir, "dir", ".", "Directory to detect environment in")
-	cmd.Flags().BoolVar(&noSave, "no-save", false, "Print only without saving to .chunk/config.json")
-
-	return cmd
-}
-
-func newSidecarBuildCmd() *cobra.Command {
-	var dir, tag string
-
-	cmd := &cobra.Command{
-		Use:   "build",
-		Short: "Generate a Dockerfile from an environment spec and build a test image",
-		Long: `Read a JSON environment spec from stdin (produced by 'chunk sidecar env'),
-write Dockerfile.test to --dir, and build a Docker test image from it.
-
-Example:
-  chunk sidecar env --dir . | chunk sidecar build --dir .`,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			if tag != "" && !validDockerTag.MatchString(tag) {
-				return &userError{
-					msg:        fmt.Sprintf("Invalid image tag %q.", tag),
-					suggestion: "Use a tag like 'myapp:latest'.",
-					errMsg:     fmt.Sprintf("invalid docker tag %q", tag),
-				}
-			}
-
-			streams := iostream.FromCmd(cmd)
-
-			// Guard against interactive use: if stdin is a terminal (not a pipe),
-			// fail fast with a helpful message rather than blocking silently.
-			// Check cmd.InOrStdin() so injected readers (e.g. in tests) are not blocked.
-			if f, ok := cmd.InOrStdin().(*os.File); ok {
-				if fi, err := f.Stat(); err == nil && fi.Mode()&os.ModeCharDevice != 0 {
-					return &userError{
-						msg:        "No input on stdin.",
-						suggestion: "Pipe a JSON env spec, for example: chunk sidecar env | chunk sidecar build",
-						errMsg:     "no input on stdin",
-					}
-				}
-			}
-
-			raw, err := io.ReadAll(cmd.InOrStdin())
-			if err != nil {
-				return &userError{msg: "Could not read the environment spec from stdin.", err: err}
-			}
-			var env envbuilder.Environment
-			if err := json.Unmarshal(raw, &env); err != nil {
-				return &userError{
-					msg:        "Invalid environment spec.",
-					suggestion: "Pipe the output of 'chunk sidecar env' into this command.",
-					err:        err,
-				}
-			}
-
-			dockerfilePath, err := envbuilder.WriteDockerfile(dir, &env)
-			if err != nil {
-				return &userError{
-					msg:        "Could not write the Dockerfile.",
-					suggestion: "Check directory permissions and try again.",
-					err:        err,
-				}
-			}
-			streams.ErrPrintf("Wrote %s\n", dockerfilePath)
-
-			streams.ErrPrintf("Building Docker image in %s...\n", dir)
-
-			args := []string{"build", "-f", "Dockerfile.test"}
-			if tag != "" {
-				args = append(args, "-t", tag)
-			}
-			args = append(args, ".")
-
-			dockerCmd := exec.CommandContext(cmd.Context(), "docker", args...)
-			dockerCmd.Dir = dir
-			dockerCmd.Stdout = streams.Out
-			dockerCmd.Stderr = streams.Err
-			if err := dockerCmd.Run(); err != nil {
-				return &userError{msg: "Docker build failed.", suggestion: "Check the build output above for details.", err: err}
-			}
-
-			streams.ErrPrintf("%s\n", ui.Success("Docker image built successfully"))
-			return nil
-		},
-	}
-
-	cmd.Flags().StringVar(&dir, "dir", ".", "Directory to write Dockerfile.test and build from")
-	cmd.Flags().StringVar(&tag, "tag", "", "Image tag (e.g. myapp:latest)")
-
-	return cmd
 }
 
 func newSidecarSnapshotCmd() *cobra.Command {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -524,11 +524,11 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 			if freshlyCreated {
 				return newUserError(fmt.Sprintf("Workspace not found on newly created sidecar %s.", sidecarID)).
 					withCode("sidecar.workspace_missing").
-					withSuggestion("Run 'chunk sidecar env build' to prepare the workspace.").
+					withSuggestion("Run 'chunk sidecar sync' to prepare the workspace.").
 					withExitCode(ExitNotFound).
 					wrap(wsErr)
 			}
-			streams.ErrPrintf("warning: %v (%q); run 'chunk sidecar env build' to set up the workspace; running %s locally instead\n", wsErr, dest, commandNames(remoteCfg.Commands))
+			streams.ErrPrintf("warning: %v (%q); run 'chunk sidecar sync' to set up the workspace; running %s locally instead\n", wsErr, dest, commandNames(remoteCfg.Commands))
 			localCfg.Commands = append(remoteCfg.Commands, localCfg.Commands...)
 		} else {
 			runErr = validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, statusFn, streams)


### PR DESCRIPTION
## Summary
The thinking here: if we want to use dockerfiles as the basis for spinning up lots of sidecars, having a command to generate the dockerfile directly, rather than as a side effect of `chunk sidecar env | chunk sidecar build --dir`, may be a smoother experience.


- Adds `chunk env init` as a new top-level command that detects a repository's tech stack and writes `Dockerfile.test` to `--dir` (default), or prints the environment spec as JSON (`--format json`). The detected spec is saved to `.chunk/config.json` for reuse by `chunk sidecar setup`.
- Fixes a stale error message in `validate.go` that referenced `chunk sidecar env build` (a command that never existed); it now correctly suggests `chunk sidecar sync`.

## Before / after

```bash
# Before
chunk sidecar env | chunk sidecar build --dir .

# After
chunk env init --dir .
docker build -f Dockerfile.test -t myapp:test .
```

## Test plan

- [ ] `task test` passes (acceptance + unit)
- [ ] `chunk env init` writes `Dockerfile.test` and prints its path
- [ ] `chunk env init --format json` prints the env spec to stdout
- [ ] `chunk env init --no-save` skips writing `.chunk/config.json`
- [ ] `chunk sidecar setup` still works (reuses cached spec from config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)