### PR TITLE
Collect OS and detected AI coding agent in telemetry

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -216,6 +216,15 @@ package uses, because both tools currently share the same Segment write
 key/workspace; the `chunk_` prefix keeps chunk-cli's events unambiguous in
 the event stream.
 
+Every event's `Context` also carries the operating system (`runtime.GOOS`)
+and, if detected, the AI coding agent chunk-cli was invoked from (e.g.
+`claude-code`, `cursor`) — see `internal/telemetry/agent.go`'s
+`DetectCodingAgent`, which checks for well-known environment variables those
+agents set in the shells they spawn. The agent list is intentionally
+conservative: only signals confirmed to be set by the agent itself are
+included, to avoid misattributing invocations. Detection returns `""` when no
+known agent is found, the common case for a human running `chunk` directly.
+
 - `internal/cmd/root.go`'s `setupTelemetry` resolves the user's preference
   (opt-out env var → `telemetry` config field, first match wins) and
   attaches a `telemetry.Sender` to the command's context;

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/google/uuid"
@@ -133,8 +134,10 @@ func setupTelemetry(cmd *cobra.Command, version string) error {
 		WriteKey: writeKey,
 		Binary:   executable,
 		Metadata: telemetry.Meta{
-			Version:    version,
-			InstanceID: instanceID,
+			Version:     version,
+			InstanceID:  instanceID,
+			OS:          runtime.GOOS,
+			CodingAgent: telemetry.DetectCodingAgent(),
 		},
 	})
 	if err != nil {

--- a/internal/telemetry/agent.go
+++ b/internal/telemetry/agent.go
@@ -1,0 +1,38 @@
+package telemetry
+
+import "os"
+
+// Coding agent env vars and the stable agent names they map to.
+const (
+	envClaudeCode = "CLAUDECODE"
+	envCursor     = "CURSOR_TRACE_ID"
+
+	agentClaudeCode = "claude-code"
+	agentCursor     = "cursor"
+)
+
+// agentEnvSignals maps well-known environment variables that AI coding
+// agents set in the shells they spawn to a stable agent name. This list is
+// intentionally conservative — only signals confirmed to be set by the agent
+// itself are included, to avoid misattributing invocations. Extend it as
+// other agents' env vars are confirmed.
+var agentEnvSignals = []struct {
+	env   string
+	agent string
+}{
+	{envClaudeCode, agentClaudeCode},
+	{envCursor, agentCursor},
+}
+
+// DetectCodingAgent returns a stable name for the AI coding agent chunk-cli
+// appears to have been invoked from, based on well-known environment
+// variables those agents set in their shells. Returns "" if no known agent
+// is detected, which is the common case for a human running chunk directly.
+func DetectCodingAgent() string {
+	for _, sig := range agentEnvSignals {
+		if os.Getenv(sig.env) != "" {
+			return sig.agent
+		}
+	}
+	return ""
+}

--- a/internal/telemetry/agent.go
+++ b/internal/telemetry/agent.go
@@ -4,24 +4,23 @@ import "os"
 
 // Coding agent env vars and the stable agent names they map to.
 const (
-	envClaudeCode = "CLAUDECODE"
+	envClaudeCode = "CLAUDECODE" // set by Claude Code in every shell it spawns
 	envCursor     = "CURSOR_TRACE_ID"
 
 	agentClaudeCode = "claude-code"
 	agentCursor     = "cursor"
 )
 
-// agentEnvSignals maps well-known environment variables that AI coding
-// agents set in the shells they spawn to a stable agent name. This list is
-// intentionally conservative — only signals confirmed to be set by the agent
-// itself are included, to avoid misattributing invocations. Extend it as
-// other agents' env vars are confirmed.
-var agentEnvSignals = []struct {
-	env   string
-	agent string
-}{
-	{envClaudeCode, agentClaudeCode},
-	{envCursor, agentCursor},
+// agentEnvSignals returns the well-known environment variables that AI coding
+// agents set in the shells they spawn, paired with their stable agent names.
+// The list is intentionally conservative — only signals confirmed to be set by
+// the agent itself are included, to avoid misattributing invocations. Extend it
+// as other agents' env vars are confirmed.
+func agentEnvSignals() []struct{ env, agent string } {
+	return []struct{ env, agent string }{
+		{envClaudeCode, agentClaudeCode},
+		{envCursor, agentCursor},
+	}
 }
 
 // DetectCodingAgent returns a stable name for the AI coding agent chunk-cli
@@ -29,7 +28,7 @@ var agentEnvSignals = []struct {
 // variables those agents set in their shells. Returns "" if no known agent
 // is detected, which is the common case for a human running chunk directly.
 func DetectCodingAgent() string {
-	for _, sig := range agentEnvSignals {
+	for _, sig := range agentEnvSignals() {
 		if os.Getenv(sig.env) != "" {
 			return sig.agent
 		}

--- a/internal/telemetry/agent_test.go
+++ b/internal/telemetry/agent_test.go
@@ -23,7 +23,7 @@ func TestDetectCodingAgent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for _, sig := range agentEnvSignals {
+			for _, sig := range agentEnvSignals() {
 				t.Setenv(sig.env, "")
 			}
 			for k, v := range tt.env {

--- a/internal/telemetry/agent_test.go
+++ b/internal/telemetry/agent_test.go
@@ -1,0 +1,38 @@
+package telemetry
+
+import "testing"
+
+func TestDetectCodingAgent(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{name: "no signals", env: nil, want: ""},
+		{name: "claude code", env: map[string]string{envClaudeCode: "1"}, want: agentClaudeCode},
+		{name: "cursor", env: map[string]string{envCursor: "abc123"}, want: agentCursor},
+		{
+			name: "first match wins",
+			env: map[string]string{
+				envClaudeCode: "1",
+				envCursor:     "abc123",
+			},
+			want: agentClaudeCode,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, sig := range agentEnvSignals {
+				t.Setenv(sig.env, "")
+			}
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			if got := DetectCodingAgent(); got != tt.want {
+				t.Errorf("DetectCodingAgent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -3,9 +3,10 @@
 // Telemetry is opt-out: it fires unless disabled via a well-known opt-out
 // environment variable or the persisted telemetry config preference (see
 // internal/config.IsTelemetry).
-// Only the command path, the names (never values) of flags the user set,
-// and a per-install anonymous instance ID are ever collected — no flag
-// values, argument values, file paths, or other PII.
+// Only the command path, the names (never values) of flags the user set, a
+// per-install anonymous instance ID, the operating system, and the detected
+// AI coding agent (if any) are ever collected — no flag values, argument
+// values, file paths, or other PII.
 //
 // Modeled on circleci-cli's internal/telemetry package.
 package telemetry
@@ -61,16 +62,28 @@ type Config struct {
 type Meta struct {
 	Version    string
 	InstanceID uuid.UUID
+
+	// OS is the operating system chunk-cli is running on, e.g. runtime.GOOS.
+	OS string
+	// CodingAgent is the AI coding agent chunk-cli was invoked from (e.g.
+	// "claude-code", "cursor"), or "" if none was detected. See
+	// DetectCodingAgent.
+	CodingAgent string
 }
 
 func (m *Meta) toContext() *analytics.Context {
-	return &analytics.Context{
+	ctx := &analytics.Context{
 		App: analytics.AppInfo{
 			Name:    "chunk-cli",
 			Version: m.Version,
 		},
 		Device: analytics.DeviceInfo{Id: m.InstanceID.String()},
+		OS:     analytics.OSInfo{Name: m.OS},
 	}
+	if m.CodingAgent != "" {
+		ctx.Extra = map[string]interface{}{"codingAgent": m.CodingAgent}
+	}
+	return ctx
 }
 
 // NewSender creates a new Sender per cfg.

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -34,8 +34,10 @@ func TestSender_Track(t *testing.T) {
 	s, err := NewSender(Config{
 		TestDestination: fake,
 		Metadata: Meta{
-			Version:    "1.2.3",
-			InstanceID: instanceID,
+			Version:     "1.2.3",
+			InstanceID:  instanceID,
+			OS:          "linux",
+			CodingAgent: agentClaudeCode,
 		},
 	})
 	assert.NilError(t, err)
@@ -53,6 +55,17 @@ func TestSender_Track(t *testing.T) {
 	assert.Equal(t, tr.Properties["flags"], "json")
 	assert.Equal(t, tr.Context.App.Version, "1.2.3")
 	assert.Equal(t, tr.Context.Device.Id, instanceID.String())
+	assert.Equal(t, tr.Context.OS.Name, "linux")
+	assert.Equal(t, tr.Context.Extra["codingAgent"], agentClaudeCode)
+}
+
+func TestMeta_ToContext_OmitsCodingAgentWhenUndetected(t *testing.T) {
+	m := Meta{Version: "1.2.3", OS: "darwin"}
+	ctx := m.toContext()
+
+	assert.Equal(t, ctx.OS.Name, "darwin")
+	_, ok := ctx.Extra["codingAgent"]
+	assert.Assert(t, !ok)
 }
 
 func TestSender_CloseIsIdempotent(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #436: adds two fields to every telemetry event's `Context` —
the operating system and, if detected, the AI coding agent chunk-cli was
invoked from.

## Events

Existing `command_invocation` event context gains:

| Field | Value | Notes |
|---|---|---|
| `Context.OS.Name` | e.g. `darwin` | `runtime.GOOS` |
| `Context.Extra["codingAgent"]` | e.g. `claude-code`, `cursor` | Omitted entirely when no known agent is detected |

## What is NOT collected

- Any new PII — detection only checks for the *presence* of well-known
  environment variables (`CLAUDECODE`, `CURSOR_TRACE_ID`), never their values

## Implementation

- New `internal/telemetry/agent.go`: `DetectCodingAgent` checks a small,
  intentionally conservative list of environment variables confirmed to be
  set by the agent itself (Claude Code's `CLAUDECODE`, Cursor's
  `CURSOR_TRACE_ID`) and returns a stable agent name, or `""` if none match
  — the common case for a human running `chunk` directly
- `Meta` gains `OS` and `CodingAgent` fields; `toContext` sets
  `analytics.Context.OS.Name` and only populates `Context.Extra["codingAgent"]`
  when an agent was detected
- `internal/cmd/root.go`'s `setupTelemetry` populates both from
  `runtime.GOOS` and `telemetry.DetectCodingAgent()`
- Documented in `docs/ARCHITECTURE.md`

## Test plan

- [x] `task build`
- [x] `task test` (`-race`) — all pass
- [x] `task lint` — 0 issues
- [x] New unit tests for `DetectCodingAgent` (no signal, each known agent,
      first-match-wins when multiple are set) and for `Meta.toContext`
      omitting `codingAgent` when undetected