### PR TITLE
Add auth signup and org create commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ Chunk init will install skills for working with Chunk sidecars. After the init, 
 Create and work in cloud sidecar environments. Sidecars are available to all CircleCI customers, including the free plans. Share feedback in the [CircleCI Discord](https://discord.gg/circleci).
 
 ```bash
-# Authenticate
+# Authenticate (browser OAuth — recommended)
+chunk auth login
+
+# Or set a token directly
 chunk auth set circleci
 
 # Create a sidecar (sets it as active automatically)
@@ -120,7 +123,8 @@ chunk skill install
 ## Commands
 
 ```
-chunk auth set|status|remove               Authentication
+chunk auth login|signup|set|status|remove  Authentication
+chunk org create                           Manage CircleCI organizations
 chunk sidecar list|create|exec|ssh         Manage cloud sidecar environments
 chunk sidecar sync|env|build               Sync files, detect env, build images
 chunk sidecar use|current|forget           Manage active sidecar

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Create and work in cloud sidecar environments. Sidecars are available to all Cir
 # Authenticate (browser OAuth — recommended)
 To create a new account:
 chunk auth signup
-or , to log in to an existing account:
+or, to log in to an existing account:
 chunk auth login
 
 # Or set a token directly

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Create and work in cloud sidecar environments. Sidecars are available to all Cir
 
 ```bash
 # Authenticate (browser OAuth — recommended)
+To create a new account:
+chunk auth signup
+or , to log in to an existing account:
 chunk auth login
 
 # Or set a token directly

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -7,9 +7,16 @@ Complete command reference for the `chunk` CLI.
 ```
 chunk
 ├── auth
+│   ├── login                       # Log in to CircleCI via browser (recommended)
+│   │   --no-browser                # Print the login URL instead of opening a browser
+│   ├── signup                      # Sign up for a new CircleCI account via browser
+│   │   --no-browser                # Print the signup URL instead of opening a browser
 │   ├── set <provider>               # Store credential (circleci | anthropic | github)
 │   ├── status                      # Check authentication status (CircleCI, Anthropic, GitHub)
 │   └── remove <provider>           # Remove stored credential (circleci | anthropic | github)
+│
+├── org                             # Manage CircleCI organizations
+│   └── create <name>               # Create a new standalone CircleCI organization
 │
 ├── build-prompt                    # Mine PR comments → analyze → generate prompt
 │   --org <org>                     # GitHub org (auto-detected from git remote)
@@ -139,6 +146,9 @@ chunk
 
 ## Behavior Decisions
 
+- `auth login` and `auth signup` both use OAuth and store the resulting token in the system keychain (or `~/.config/chunk/config.json` with `--insecure-storage`). They differ only in which page the browser opens: login for existing accounts, signup for new ones. Use `--no-browser` to print the URL instead of opening it automatically.
+- `auth signup` fails with a user-friendly error if a CircleCI token is already stored; run `chunk auth remove circleci` first to clear it. Existing accounts should use `chunk auth login`.
+- `org create` is hidden from the default help output. It requires CircleCI authentication and creates a standalone org (not tied to a VCS provider), printing the org name, ID, and slug on success.
 - `build-prompt` auto-detects org and repos from the git remote when flags
   are omitted. If `--org` is provided explicitly, `--repos` is required.
 - `build-prompt --output` creates parent directories automatically.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -54,7 +54,13 @@ Store credentials for the services you plan to use:
 ```bash
 chunk auth set anthropic   # required for build-prompt and init
 chunk auth set github      # required for build-prompt
-chunk auth set circleci    # required for sidecars and task runs
+
+# For CircleCI (required for sidecars and task runs), browser OAuth is recommended:
+chunk auth login           # existing CircleCI account
+chunk auth signup          # new CircleCI account
+
+# Or set a personal API token directly:
+chunk auth set circleci
 ```
 
 Check status at any time:

--- a/internal/circleci/circleci_test.go
+++ b/internal/circleci/circleci_test.go
@@ -408,4 +408,11 @@ func TestAuthRequired(t *testing.T) {
 			t.Fatal("expected error")
 		}
 	})
+
+	t.Run("CreateOrg", func(t *testing.T) {
+		_, err := client.CreateOrg(ctx, "my-org")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
 }

--- a/internal/circleci/orgs.go
+++ b/internal/circleci/orgs.go
@@ -1,0 +1,29 @@
+package circleci
+
+import (
+	"context"
+	"net/http"
+
+	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+)
+
+// OrgInfo is the response from POST /api/v2/organization.
+type OrgInfo struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Slug    string `json:"slug"`
+	VcsType string `json:"vcs_type"`
+}
+
+// CreateOrg creates a new standalone CircleCI organization.
+func (c *Client) CreateOrg(ctx context.Context, name string) (*OrgInfo, error) {
+	var org OrgInfo
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodPost, "/api/v2/organization",
+		hc.Body(map[string]string{"name": name, "vcs_type": "circleci"}),
+		hc.JSONDecoder(&org),
+	))
+	if err != nil {
+		return nil, mapErr("create org", err)
+	}
+	return &org, nil
+}

--- a/internal/circleci/orgs_test.go
+++ b/internal/circleci/orgs_test.go
@@ -22,9 +22,9 @@ func TestCreateOrg(t *testing.T) {
 
 		org, err := client.CreateOrg(ctx, "my-org")
 		assert.NilError(t, err)
-		assert.Assert(t, org.ID != "", "expected non-empty org ID")
+		assert.Equal(t, org.ID, "org-new-1")
 		assert.Equal(t, org.Name, "my-org")
-		assert.Assert(t, org.Slug != "", "expected non-empty org slug")
+		assert.Equal(t, org.Slug, "my-org")
 	})
 
 	t.Run("sends POST to /api/v2/organization with auth token and body", func(t *testing.T) {

--- a/internal/circleci/orgs_test.go
+++ b/internal/circleci/orgs_test.go
@@ -1,0 +1,86 @@
+package circleci
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+)
+
+func TestCreateOrg(t *testing.T) {
+	t.Run("creates org and returns info", func(t *testing.T) {
+		fake := fakes.NewFakeCircleCI()
+		srv := httptest.NewServer(fake)
+		defer srv.Close()
+
+		client := newTestClient(t, srv.URL)
+		ctx := context.Background()
+
+		org, err := client.CreateOrg(ctx, "my-org")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if org.ID == "" {
+			t.Error("expected non-empty org ID")
+		}
+		if org.Name != "my-org" {
+			t.Errorf("expected name my-org, got %s", org.Name)
+		}
+		if org.Slug == "" {
+			t.Error("expected non-empty org slug")
+		}
+	})
+
+	t.Run("sends POST to /api/v2/organization with auth token", func(t *testing.T) {
+		fake := fakes.NewFakeCircleCI()
+		srv := httptest.NewServer(fake)
+		defer srv.Close()
+
+		client := newTestClient(t, srv.URL)
+		ctx := context.Background()
+
+		fake.Recorder.AllRequests() // baseline
+		_, err := client.CreateOrg(ctx, "test-org")
+		assert.NilError(t, err)
+
+		reqs := fake.Recorder.AllRequests()
+		last := reqs[len(reqs)-1]
+		assert.Equal(t, last.Method, "POST")
+		assert.Equal(t, last.URL.Path, "/api/v2/organization")
+		assert.Equal(t, last.Header.Get("Circle-Token"), "test-token")
+	})
+
+	t.Run("returns error on server failure", func(t *testing.T) {
+		fake := fakes.NewFakeCircleCI()
+		fake.CreateOrgStatusCode = 500
+		srv := httptest.NewServer(fake)
+		defer srv.Close()
+
+		client := newTestClient(t, srv.URL)
+		ctx := context.Background()
+
+		_, err := client.CreateOrg(ctx, "my-org")
+		assert.Assert(t, err != nil, "expected error for 500 response")
+	})
+
+	t.Run("maps 401 to ErrNotAuthorized", func(t *testing.T) {
+		fake := fakes.NewFakeCircleCI()
+		fake.CreateOrgStatusCode = 401
+		srv := httptest.NewServer(fake)
+		defer srv.Close()
+
+		client := newTestClient(t, srv.URL)
+		ctx := context.Background()
+
+		_, err := client.CreateOrg(ctx, "my-org")
+		assert.Assert(t, err != nil)
+		if !errors.Is(err, ErrNotAuthorized) {
+			t.Errorf("expected ErrNotAuthorized, got %v", err)
+		}
+	})
+
+}

--- a/internal/circleci/orgs_test.go
+++ b/internal/circleci/orgs_test.go
@@ -2,7 +2,7 @@ package circleci
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
 
@@ -21,21 +21,13 @@ func TestCreateOrg(t *testing.T) {
 		ctx := context.Background()
 
 		org, err := client.CreateOrg(ctx, "my-org")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if org.ID == "" {
-			t.Error("expected non-empty org ID")
-		}
-		if org.Name != "my-org" {
-			t.Errorf("expected name my-org, got %s", org.Name)
-		}
-		if org.Slug == "" {
-			t.Error("expected non-empty org slug")
-		}
+		assert.NilError(t, err)
+		assert.Assert(t, org.ID != "", "expected non-empty org ID")
+		assert.Equal(t, org.Name, "my-org")
+		assert.Assert(t, org.Slug != "", "expected non-empty org slug")
 	})
 
-	t.Run("sends POST to /api/v2/organization with auth token", func(t *testing.T) {
+	t.Run("sends POST to /api/v2/organization with auth token and body", func(t *testing.T) {
 		fake := fakes.NewFakeCircleCI()
 		srv := httptest.NewServer(fake)
 		defer srv.Close()
@@ -43,7 +35,6 @@ func TestCreateOrg(t *testing.T) {
 		client := newTestClient(t, srv.URL)
 		ctx := context.Background()
 
-		fake.Recorder.AllRequests() // baseline
 		_, err := client.CreateOrg(ctx, "test-org")
 		assert.NilError(t, err)
 
@@ -52,6 +43,11 @@ func TestCreateOrg(t *testing.T) {
 		assert.Equal(t, last.Method, "POST")
 		assert.Equal(t, last.URL.Path, "/api/v2/organization")
 		assert.Equal(t, last.Header.Get("Circle-Token"), "test-token")
+
+		var body map[string]string
+		assert.NilError(t, json.Unmarshal(last.Body, &body))
+		assert.Equal(t, body["name"], "test-org")
+		assert.Equal(t, body["vcs_type"], "circleci")
 	})
 
 	t.Run("returns error on server failure", func(t *testing.T) {
@@ -77,10 +73,7 @@ func TestCreateOrg(t *testing.T) {
 		ctx := context.Background()
 
 		_, err := client.CreateOrg(ctx, "my-org")
-		assert.Assert(t, err != nil)
-		if !errors.Is(err, ErrNotAuthorized) {
-			t.Errorf("expected ErrNotAuthorized, got %v", err)
-		}
+		assert.ErrorIs(t, err, ErrNotAuthorized)
 	})
 
 }

--- a/internal/circleci/projects.go
+++ b/internal/circleci/projects.go
@@ -67,25 +67,3 @@ func (c *Client) GetProjectBySlug(ctx context.Context, slug string) (*ProjectDet
 	}
 	return &resp, nil
 }
-
-// OrgInfo is the response from POST /api/v2/organization.
-type OrgInfo struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Slug    string `json:"slug"`
-	VcsType string `json:"vcs_type"`
-}
-
-// CreateOrg creates a new CircleCI organization. vcsType must be one of
-// "circleci" (standalone), "github", or "bitbucket".
-func (c *Client) CreateOrg(ctx context.Context, name, vcsType string) (*OrgInfo, error) {
-	var org OrgInfo
-	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodPost, "/api/v2/organization",
-		hc.Body(map[string]string{"name": name, "vcs_type": vcsType}),
-		hc.JSONDecoder(&org),
-	))
-	if err != nil {
-		return nil, mapErr("create org", err)
-	}
-	return &org, nil
-}

--- a/internal/circleci/projects.go
+++ b/internal/circleci/projects.go
@@ -67,3 +67,25 @@ func (c *Client) GetProjectBySlug(ctx context.Context, slug string) (*ProjectDet
 	}
 	return &resp, nil
 }
+
+// OrgInfo is the response from POST /api/v2/organization.
+type OrgInfo struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Slug    string `json:"slug"`
+	VcsType string `json:"vcs_type"`
+}
+
+// CreateOrg creates a new CircleCI organization. vcsType must be one of
+// "circleci" (standalone), "github", or "bitbucket".
+func (c *Client) CreateOrg(ctx context.Context, name, vcsType string) (*OrgInfo, error) {
+	var org OrgInfo
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodPost, "/api/v2/organization",
+		hc.Body(map[string]string{"name": name, "vcs_type": vcsType}),
+		hc.JSONDecoder(&org),
+	))
+	if err != nil {
+		return nil, mapErr("create org", err)
+	}
+	return &org, nil
+}

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -31,6 +31,7 @@ func newAuthCmd() *cobra.Command {
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
 	cmd.AddCommand(newAuthLoginCmd())
+	cmd.AddCommand(newAuthSignupCmd())
 	cmd.AddCommand(newAuthSetCmd())
 	cmd.AddCommand(newAuthStatusCmd())
 	cmd.AddCommand(newAuthRemoveCmd())
@@ -39,7 +40,6 @@ func newAuthCmd() *cobra.Command {
 
 func newAuthLoginCmd() *cobra.Command {
 	var noBrowser bool
-	var signup bool
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to CircleCI via browser (recommended)",
@@ -48,17 +48,44 @@ func newAuthLoginCmd() *cobra.Command {
 			insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
 			rc, _ := config.Resolve("", "", insecureStorage)
 			io := iostream.FromCmd(cmd)
-			return authLogin(cmd.Context(), io, rc.CircleCIBaseURL, noBrowser, signup, insecureStorage)
+			return authLogin(cmd.Context(), io, rc.CircleCIBaseURL, noBrowser, false, insecureStorage)
 		},
 	}
 	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Print the login URL instead of opening a browser")
-	cmd.Flags().BoolVar(&signup, "signup", false, "Route to the signup page instead of login")
+	return cmd
+}
+
+func newAuthSignupCmd() *cobra.Command {
+	var noBrowser bool
+	cmd := &cobra.Command{
+		Use:   "signup",
+		Short: "Sign up for a new CircleCI account via browser",
+		Long:  "Create a CircleCI account using OAuth. Opens your browser to the signup page.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
+			rc, _ := config.Resolve("", "", insecureStorage)
+			io := iostream.FromCmd(cmd)
+			if rc.CircleCIToken != "" {
+				return &userError{
+					msg:        "Already authenticated.",
+					suggestion: "Run `chunk auth remove circleci` to clear your token first, then re-run `chunk auth signup`. If you already have a CircleCI account, use `chunk auth login`.",
+					errMsg:     "auth signup: already authenticated",
+				}
+			}
+			return authLogin(cmd.Context(), io, rc.CircleCIBaseURL, noBrowser, true, insecureStorage)
+		},
+	}
+	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Print the signup URL instead of opening a browser")
 	return cmd
 }
 
 func authLogin(ctx context.Context, streams iostream.Streams, baseURL string, noBrowser, signup, insecureStorage bool) error {
 	streams.Println("")
-	streams.Println(ui.Bold("Chunk CLI - CircleCI Login"))
+	if signup {
+		streams.Println(ui.Bold("Chunk CLI - CircleCI Sign Up"))
+	} else {
+		streams.Println(ui.Bold("Chunk CLI - CircleCI Login"))
+	}
 	streams.Println("")
 
 	token, err := oauth.Login(ctx, oauth.LoginConfig{

--- a/internal/cmd/auth_test.go
+++ b/internal/cmd/auth_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+)
+
+func TestAuthSignupAlreadyAuthenticated(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv(config.EnvCircleToken, "test-token-abc")
+
+	cmd := newAuthSignupCmd()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	assert.Assert(t, err != nil)
+
+	var ue *userError
+	assert.Assert(t, errors.As(err, &ue))
+	assert.Assert(t, strings.Contains(ue.UserMessage(), "Already authenticated."),
+		"expected 'Already authenticated.' in message, got: %s", ue.UserMessage())
+	assert.Assert(t, strings.Contains(ue.Suggestion(), "chunk auth remove"),
+		"expected suggestion to mention 'chunk auth remove', got: %s", ue.Suggestion())
+}

--- a/internal/cmd/org.go
+++ b/internal/cmd/org.go
@@ -15,6 +15,7 @@ func newOrgCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                "org",
 		Short:              "Manage CircleCI organizations",
+		Hidden:             true,
 		RunE:               groupRunE,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
@@ -44,7 +45,7 @@ func newOrgCreateCmd() *cobra.Command {
 			}
 
 			io.ErrPrintln(ui.Dim("Creating organization..."))
-			org, err := client.CreateOrg(cmd.Context(), name, "circleci")
+			org, err := client.CreateOrg(cmd.Context(), name)
 			if err != nil {
 				return &userError{
 					msg: fmt.Sprintf("Failed to create organization %q.", name),

--- a/internal/cmd/org.go
+++ b/internal/cmd/org.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/tui"
+	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+)
+
+func newOrgCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "org",
+		Short:              "Manage CircleCI organizations",
+		RunE:               groupRunE,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+	}
+	cmd.AddCommand(newOrgCreateCmd())
+	return cmd
+}
+
+func newOrgCreateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a new standalone CircleCI organization",
+		Long:  "Create a new standalone CircleCI organization.\n\nRequires: CircleCI token (chunk auth login)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
+			rc, _ := config.Resolve("", "", insecureStorage)
+			io := iostream.FromCmd(cmd)
+
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, tui.PromptHidden)
+			if err != nil {
+				return &userError{
+					msg:        "CircleCI authentication required.",
+					suggestion: suggestionCircleCIAuth,
+					err:        fmt.Errorf("resolve circleci client: %w", err),
+				}
+			}
+
+			io.ErrPrintln(ui.Dim("Creating organization..."))
+			org, err := client.CreateOrg(cmd.Context(), name, "circleci")
+			if err != nil {
+				return &userError{
+					msg: fmt.Sprintf("Failed to create organization %q.", name),
+					err: fmt.Errorf("create org: %w", err),
+				}
+			}
+
+			io.Println("")
+			io.Println(ui.Success(fmt.Sprintf("Organization %q created.", org.Name)))
+			io.Println("")
+			io.Printf("  ID:   %s\n", org.ID)
+			io.Printf("  Slug: %s\n", org.Slug)
+			io.Println("")
+			return nil
+		},
+	}
+}

--- a/internal/cmd/org_test.go
+++ b/internal/cmd/org_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+)
+
+func TestOrgCreateHappyPath(t *testing.T) {
+	isolateConfig(t)
+
+	fake := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	t.Setenv(config.EnvCircleToken, "test-token")
+	t.Setenv(config.EnvCircleCIBaseURL, srv.URL)
+
+	cmd := newOrgCreateCmd()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"my-new-org"})
+
+	err := cmd.Execute()
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(out.String(), "my-new-org"),
+		"expected org name in output, got: %s", out.String())
+	assert.Assert(t, strings.Contains(out.String(), "ID:"),
+		"expected ID field in output, got: %s", out.String())
+	assert.Assert(t, strings.Contains(out.String(), "Slug:"),
+		"expected Slug field in output, got: %s", out.String())
+}
+
+func TestOrgCreateAPIError(t *testing.T) {
+	isolateConfig(t)
+
+	fake := fakes.NewFakeCircleCI()
+	fake.CreateOrgStatusCode = 500
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	t.Setenv(config.EnvCircleToken, "test-token")
+	t.Setenv(config.EnvCircleCIBaseURL, srv.URL)
+
+	cmd := newOrgCreateCmd()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"failing-org"})
+
+	err := cmd.Execute()
+	assert.Assert(t, err != nil)
+
+	var ue *userError
+	assert.Assert(t, errors.As(err, &ue))
+	assert.Assert(t, strings.Contains(ue.UserMessage(), "failing-org"),
+		"expected org name in error message, got: %s", ue.UserMessage())
+}
+
+func TestOrgCreateRequiresAuth(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv(config.EnvCircleToken, "")
+	t.Setenv(config.EnvCircleCIToken, "")
+
+	cmd := newOrgCreateCmd()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"my-org"})
+
+	err := cmd.Execute()
+	assert.Assert(t, err != nil)
+
+	var ue *userError
+	assert.Assert(t, errors.As(err, &ue))
+	assert.Assert(t, strings.Contains(ue.UserMessage(), "CircleCI authentication required."),
+		"expected auth error, got: %s", ue.UserMessage())
+}
+
+func TestOrgCreateRequiresName(t *testing.T) {
+	cmd := newOrgCreateCmd()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	assert.Assert(t, err != nil, "expected error when no name argument given")
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -72,6 +72,7 @@ Configuration:
 
 	rootCmd.AddCommand(newInitCmd())
 	rootCmd.AddCommand(newAuthCmd())
+	rootCmd.AddCommand(newOrgCmd())
 	rootCmd.AddCommand(newConfigCmd())
 	rootCmd.AddCommand(newBuildPromptCmd())
 	rootCmd.AddCommand(newSkillCmd())

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -69,6 +69,7 @@ type FakeCircleCI struct {
 
 	mu              sync.RWMutex
 	snapshotCounter int
+	orgCounter      int
 	Collaborations  []Collaboration
 	Projects        []Project
 	Sidecars        []Sidecar
@@ -90,6 +91,7 @@ type FakeCircleCI struct {
 	GetSnapshotStatusCode    int // override for GET /sidecar/snapshots/:id
 	ListSnapshotsStatusCode  int // override for GET /sidecar/snapshots
 	GetCommandStatusCode     int // override for GET /sidecar/commands/:id
+	CreateOrgStatusCode      int // override for POST /api/v2/organization
 }
 
 func NewFakeCircleCI() *FakeCircleCI {
@@ -122,6 +124,9 @@ func NewFakeCircleCI() *FakeCircleCI {
 
 	// Task run endpoint
 	r.POST("/api/v2/agents/org/:org_id/project/:project_id/runs", f.handleTriggerRun)
+
+	// Org endpoint
+	r.POST("/api/v2/organization", f.handleCreateOrg)
 
 	return f
 }
@@ -520,5 +525,41 @@ func (f *FakeCircleCI) handleTriggerRun(c *gin.Context) {
 	c.JSON(http.StatusOK, RunResponse{
 		RunID:      "run-abc-123",
 		PipelineID: "pipeline-def-456",
+	})
+}
+
+func (f *FakeCircleCI) handleCreateOrg(c *gin.Context) {
+	if !f.requireToken(c) {
+		return
+	}
+
+	f.mu.Lock()
+	statusCode := f.CreateOrgStatusCode
+	f.mu.Unlock()
+
+	if statusCode != 0 {
+		c.JSON(statusCode, gin.H{"message": "API error"})
+		return
+	}
+
+	var body struct {
+		Name    string `json:"name"`
+		VCSType string `json:"vcs_type"`
+	}
+	if err := json.NewDecoder(c.Request.Body).Decode(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "Bad request"})
+		return
+	}
+
+	f.mu.Lock()
+	f.orgCounter++
+	id := fmt.Sprintf("org-new-%d", f.orgCounter)
+	f.mu.Unlock()
+
+	c.JSON(http.StatusCreated, gin.H{
+		"id":       id,
+		"name":     body.Name,
+		"slug":     body.Name,
+		"vcs_type": body.VCSType,
 	})
 }


### PR DESCRIPTION
## Summary

- Adds `chunk auth signup` to open the CircleCI signup flow via browser OAuth (mirrors `chunk auth login` but routes to the signup page)
- Adds `chunk org create <name>` to create a new standalone CircleCI organization via `POST /api/v2/organization`

## Test plan

- [ ] `chunk auth signup` opens browser to CircleCI signup and saves token on completion
- [ ] `chunk auth signup` with an existing token surfaces a clear error with remediation hint
- [ ] `chunk org create my-org` creates a standalone org and prints the ID and slug
- [ ] `chunk org create` without a name exits with a usage error
- [ ] Both commands respect `--insecure-storage` and `CI` (non-interactive) mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)