### PR TITLE
Add bundle-based sidecar sync as the default

### DIFF
--- a/acceptance/sidecar_test.go
+++ b/acceptance/sidecar_test.go
@@ -354,6 +354,32 @@ func TestSidecarsAddSSHKeyPrivateKeyRejected(t *testing.T) {
 		"expected private key error, got: %s", combined)
 }
 
+// TestSidecarsSyncCheckoutFlag verifies that --checkout is a recognised flag
+// and that the command progresses past flag parsing before failing at SSH.
+func TestSidecarsSyncCheckoutFlag(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, []string{
+		"sidecar", "sync",
+		"--sidecar-id", "sb-111",
+		"--identity-file", "/tmp/fake-key",
+		"--checkout",
+	}, env, env.HomeDir)
+
+	// Must fail at SSH, not at flag parsing ("unknown flag: --checkout").
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit (SSH fails)")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, !strings.Contains(combined, "unknown flag"),
+		"--checkout flag must be recognised; got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "SSH key not found"),
+		"expected SSH key error (proves flag was accepted); got: %s", combined)
+}
+
 // TestSidecarsSshSyncFlags verifies that SSH/sync flags are accepted and
 // code progresses past flag parsing (fails at SSH step, not at parsing).
 func TestSidecarsSshSyncFlags(t *testing.T) {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -88,7 +88,7 @@ chunk
 │   │   --sidecar-id <id>           # Sidecar ID (defaults to active sidecar)
 │   │   --public-key <key>          # SSH public key string
 │   │   --public-key-file <path>    # Path to public key file
-│   ├── ssh                         # SSH into sidecar
+│   ├── ssh                         # SSH into sidecar (stdin forwarded when piped)
 │   │   --sidecar-id <id>           # Sidecar ID (defaults to active sidecar)
 │   │   --identity-file <path>      # SSH identity file
 │   │   -e / --env KEY=VALUE        # Set env var in remote session (repeatable)
@@ -97,6 +97,7 @@ chunk
 │   │   --sidecar-id <id>           # Sidecar ID (defaults to active sidecar)
 │   │   --identity-file <path>      # SSH identity file
 │   │   --workdir <path>            # Destination path on sidecar (auto-detected when omitted)
+│   │   --checkout                  # Sync via git checkout/patch instead of bundle (requires branch pushed to GitHub)
 │   ├── env                         # Detect tech stack and print environment spec as JSON
 │   │   --dir <path>                # Directory to analyse (default: .)
 │   │   --no-save                   # Print only, do not save to .chunk/config.json
@@ -154,6 +155,12 @@ chunk
 - `chunk init` uses Claude to auto-detect the test command for the project.
   It generates `.claude/settings.json` with pre-commit hooks. It never touches
   CircleCI — tokens are prompted inline only when a command actually needs them.
+- `sidecar sync` sends a full git bundle on first use, then incremental bundles
+  (`<lastRef>..HEAD`) on subsequent syncs. The branch does not need to be pushed
+  to GitHub. Pass `--checkout` to fall back to the git checkout/patch approach
+  (requires the branch to be pushed).
+- `sidecar ssh -- <cmd>` forwards stdin when the process stdin is a pipe, enabling
+  patterns like `cat bundle | chunk sidecar ssh -- git fetch ...`.
 - Commands that require a CircleCI token (`task run`, `task config`, `sidecar *`,
   `validate --sidecar-id`) prompt for it inline at the point of need rather than
   failing with an error.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -218,6 +218,20 @@ run the tests on the sidecar
 
 The skill handles the full loop: auth checks → find active sidecar → sync → validate → interpret failures → fix locally → repeat.
 
+### Syncing
+
+`chunk sidecar sync` uses git bundle by default — the first sync sends a full bundle of HEAD, and subsequent syncs send only the new commits since the last sync (`<lastRef>..HEAD`). Uncommitted working-tree changes are applied on top as a patch. The branch does not need to be pushed to GitHub.
+
+```bash
+chunk sidecar sync
+```
+
+To fall back to the git checkout/patch approach (requires the branch to be pushed to GitHub):
+
+```bash
+chunk sidecar sync --checkout
+```
+
 ### Environment setup
 
 Auto-detect your tech stack and save it to config:

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -423,7 +423,11 @@ func newSidecarSSHCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = sidecar.SSH(cmd.Context(), client, sidecarID, identityFile, authSock, args, envVars, io)
+			var stdin *os.File
+			if fi, statErr := os.Stdin.Stat(); statErr == nil && fi.Mode()&os.ModeCharDevice == 0 {
+				stdin = os.Stdin
+			}
+			err = sidecar.SSH(cmd.Context(), client, sidecarID, identityFile, authSock, args, envVars, io, stdin)
 			if err != nil {
 				if err := sshSessionError(err); err != nil {
 					return err
@@ -447,6 +451,7 @@ func newSidecarSSHCmd() *cobra.Command {
 
 func newSidecarSyncCmd() *cobra.Command {
 	var sidecarID, identityFile, workdir string
+	var checkout bool
 
 	cmd := &cobra.Command{
 		Use:   "sync",
@@ -463,7 +468,16 @@ func newSidecarSyncCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = sidecar.Sync(cmd.Context(), client, sidecarID, identityFile, authSock, workdir, newStatusFunc(io))
+			cwd, cwdErr := os.Getwd()
+			if cwdErr != nil {
+				return fmt.Errorf("sync: %w", cwdErr)
+			}
+			useBundle := !checkout
+			if useBundle {
+				err = sidecar.BundleSync(cmd.Context(), client, sidecarID, identityFile, authSock, workdir, cwd, newStatusFunc(io))
+			} else {
+				err = sidecar.Sync(cmd.Context(), client, sidecarID, identityFile, authSock, workdir, newStatusFunc(io))
+			}
 			if err != nil {
 				if _, ok := errors.AsType[*sidecar.NoOriginRemoteError](err); ok {
 					return &userError{
@@ -501,6 +515,7 @@ func newSidecarSyncCmd() *cobra.Command {
 	cmd.Flags().StringVar(&sidecarID, "sidecar-id", "", "Sidecar ID (defaults to active sidecar)")
 	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file")
 	cmd.Flags().StringVar(&workdir, "workdir", "", "Destination path on sidecar (defaults to /home/user/<repo> when omitted)")
+	cmd.Flags().BoolVar(&checkout, "checkout", false, "Sync via git checkout/patch instead of bundle (requires branch pushed to GitHub)")
 
 	return cmd
 }
@@ -952,7 +967,7 @@ Example:
 
 			// Step 4: Sync files to sidecar.
 			if !skipSync {
-				if err := sidecarSetupSync(cmd.Context(), client, sidecarID, identityFile, authSock, status); err != nil {
+				if err := sidecarSetupSync(cmd.Context(), client, sidecarID, identityFile, authSock, true, dir, status); err != nil {
 					return err
 				}
 			}
@@ -1070,10 +1085,17 @@ func sidecarSetupSync(
 	ctx context.Context,
 	client *circleci.Client,
 	sidecarID, identityFile, authSock string,
+	useBundle bool,
+	cwd string,
 	status iostream.StatusFunc,
 ) error {
 	status(iostream.LevelStep, "Syncing files to sidecar...")
-	err := sidecar.Sync(ctx, client, sidecarID, identityFile, authSock, "", status)
+	var err error
+	if useBundle {
+		err = sidecar.BundleSync(ctx, client, sidecarID, identityFile, authSock, "", cwd, status)
+	} else {
+		err = sidecar.Sync(ctx, client, sidecarID, identityFile, authSock, "", status)
+	}
 	if err == nil {
 		return nil
 	}

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -13,6 +13,8 @@ import (
 // set but origin/HEAD is not — a common state after git init + push without fetch.
 var ErrNoOriginHEAD = errors.New("origin/HEAD is not set")
 
+const gitHEAD = "HEAD"
+
 // RepoRoot returns the root directory of the current git repository
 // by walking up from the given directory looking for .git/.
 func RepoRoot(from string) (string, error) {
@@ -32,12 +34,12 @@ func RepoRoot(from string) (string, error) {
 // CurrentBranch returns the current git branch name.
 // Returns an error if in detached HEAD state or not in a git repo.
 func CurrentBranch() (string, error) {
-	out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
+	out, err := exec.Command("git", "rev-parse", "--abbrev-ref", gitHEAD).Output()
 	if err != nil {
 		return "", fmt.Errorf("get current branch: %w", err)
 	}
 	branch := strings.TrimSpace(string(out))
-	if branch == "HEAD" {
+	if branch == gitHEAD {
 		return "", fmt.Errorf("detached HEAD state")
 	}
 	return branch, nil
@@ -98,7 +100,7 @@ func GeneratePatch(base string) (string, error) {
 			return "", fmt.Errorf("stage untracked files: %w", err)
 		}
 		defer func() {
-			args := append([]string{"reset", "HEAD", "--"}, untracked...)
+			args := append([]string{"reset", gitHEAD, "--"}, untracked...)
 			_ = exec.Command("git", args...).Run()
 		}()
 	}
@@ -108,6 +110,39 @@ func GeneratePatch(base string) (string, error) {
 		return "", fmt.Errorf("generate diff: %w", err)
 	}
 	return string(out), nil
+}
+
+// HeadRef returns the SHA of the current HEAD commit in the repo at cwd.
+func HeadRef(cwd string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", gitHEAD)
+	cmd.Dir = cwd
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("resolve HEAD: %w", err)
+	}
+	sha := strings.TrimSpace(string(out))
+	if sha == "" {
+		return "", fmt.Errorf("resolve HEAD: empty output")
+	}
+	return sha, nil
+}
+
+// CreateBundle creates a git bundle from base..HEAD in the repo at cwd and returns the raw bytes.
+// If base is empty, the full history up to HEAD is bundled.
+func CreateBundle(base, cwd string) ([]byte, error) {
+	var args []string
+	if base == "" {
+		args = []string{"bundle", "create", "-", gitHEAD}
+	} else {
+		args = []string{"bundle", "create", "-", base + "..HEAD"}
+	}
+	cmd := exec.Command("git", args...)
+	cmd.Dir = cwd
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("create bundle: %w", err)
+	}
+	return out, nil
 }
 
 func splitNonEmpty(s string) []string {

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -18,9 +18,10 @@ import (
 
 // ActiveSidecar holds the currently active sidecar for a project.
 type ActiveSidecar struct {
-	SidecarID string `json:"sidecar_id"`
-	Name      string `json:"name,omitempty"`
-	Workspace string `json:"workspace,omitempty"`
+	SidecarID     string `json:"sidecar_id"`
+	Name          string `json:"name,omitempty"`
+	Workspace     string `json:"workspace,omitempty"`
+	LastSyncedRef string `json:"last_synced_ref,omitempty"`
 }
 
 // CurrentBranch returns the current git branch for the repo rooted at root.

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -3,6 +3,7 @@ package sidecar
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -43,7 +44,9 @@ func AddSSHKey(ctx context.Context, client *circleci.Client, sidecarID, publicKe
 }
 
 // SSH opens a session and either runs a command or starts an interactive shell.
-func SSH(ctx context.Context, client *circleci.Client, sidecarID, identityFile, authSock string, args []string, envVars map[string]string, io iostream.Streams) error {
+// stdin is forwarded to the remote command when non-nil; callers should pass
+// os.Stdin when the process stdin is a pipe, nil otherwise.
+func SSH(ctx context.Context, client *circleci.Client, sidecarID, identityFile, authSock string, args []string, envVars map[string]string, streams iostream.Streams, stdin io.Reader) error {
 	session, err := OpenSession(ctx, client, sidecarID, identityFile, authSock)
 	if err != nil {
 		return err
@@ -54,16 +57,16 @@ func SSH(ctx context.Context, client *circleci.Client, sidecarID, identityFile, 
 	}
 
 	command := ShellJoin(args)
-	result, err := ExecOverSSH(ctx, session, command, nil, envVars)
+	result, err := ExecOverSSH(ctx, session, command, stdin, envVars)
 	if err != nil {
 		return err
 	}
 
 	if result.Stdout != "" {
-		_, _ = fmt.Fprint(io.Out, result.Stdout)
+		_, _ = fmt.Fprint(streams.Out, result.Stdout)
 	}
 	if result.Stderr != "" {
-		_, _ = fmt.Fprint(io.Err, result.Stderr)
+		_, _ = fmt.Fprint(streams.Err, result.Stderr)
 	}
 	if result.ExitCode != 0 {
 		return fmt.Errorf("%q exited with status %d", command, result.ExitCode)

--- a/internal/sidecar/sync.go
+++ b/internal/sidecar/sync.go
@@ -1,6 +1,7 @@
 package sidecar
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -113,6 +114,152 @@ func Sync(ctx context.Context,
 	}
 
 	status(iostream.LevelDone, "Synced")
+	return nil
+}
+
+// BundleSync synchronises local commits and working-tree changes to a sidecar
+// using git bundle, without requiring the branch to be pushed to GitHub.
+//
+// On first sync (no LastSyncedRef) a full bundle of HEAD is sent. On subsequent
+// syncs only commits since the last synced ref are bundled (incremental). In
+// both cases any uncommitted working-tree changes are applied on top as a patch.
+func BundleSync(ctx context.Context,
+	client *circleci.Client, sidecarID, identityFile, authSock, workdir, cwd string, status iostream.StatusFunc) error {
+
+	session, err := OpenSession(ctx, client, sidecarID, identityFile, authSock)
+	if err != nil {
+		return err
+	}
+
+	_, repo, err := gitremote.DetectOrgAndRepo(cwd)
+	if err != nil {
+		return &NoOriginRemoteError{Err: err}
+	}
+
+	repoPath, err := ResolveWorkspace(ctx, workdir, repo)
+	if err != nil {
+		return fmt.Errorf("bundle sync: %w", err)
+	}
+	if err := persistWorkspace(ctx, repoPath); err != nil {
+		status(iostream.LevelWarn, fmt.Sprintf("Could not save workspace: %v", err))
+	}
+
+	active, err := LoadActive(ctx)
+	if err != nil {
+		return fmt.Errorf("bundle sync: load active sidecar: %w", err)
+	}
+	if active == nil {
+		active = &ActiveSidecar{SidecarID: sidecarID}
+	}
+	lastRef := active.LastSyncedRef
+	if active.SidecarID != sidecarID {
+		lastRef = "" // sidecar changed; force full bundle
+		active.SidecarID = sidecarID
+	}
+
+	headRef, err := gitutil.HeadRef(cwd)
+	if err != nil {
+		return fmt.Errorf("bundle sync: %w", err)
+	}
+
+	// Ensure the destination directory exists.
+	parentDir := filepath.Dir(repoPath)
+	if result, err := ExecOverSSH(ctx, session, "mkdir -p "+ShellEscape(parentDir), nil, nil); err != nil {
+		return fmt.Errorf("bundle sync: mkdir: %w", err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("bundle sync: mkdir -p %s: %s", parentDir, result.Stderr)
+	}
+
+	// Check whether a git repo already exists at the destination.
+	testResult, err := ExecOverSSH(ctx, session, "test -d "+ShellEscape(repoPath+"/.git"), nil, nil)
+	if err != nil {
+		return fmt.Errorf("bundle sync: check repo: %w", err)
+	}
+	if testResult.ExitCode != 0 {
+		if result, err := ExecOverSSH(ctx, session, "git init "+ShellEscape(repoPath), nil, nil); err != nil {
+			return fmt.Errorf("bundle sync: git init: %w", err)
+		} else if result.ExitCode != 0 {
+			return fmt.Errorf("bundle sync: git init: %s", result.Stderr)
+		}
+		lastRef = "" // force full bundle for a fresh repo
+	}
+
+	resetRef := "HEAD"
+	if lastRef == headRef {
+		status(iostream.LevelInfo, "No new commits since last sync.")
+	} else {
+		if err := sendBundle(ctx, session, lastRef, cwd, repo, repoPath, status); err != nil {
+			return err
+		}
+		resetRef = "FETCH_HEAD"
+	}
+
+	// Always reset and clean so the patch applies cleanly from a known state.
+	resetCmd := fmt.Sprintf("git -C %s reset --hard %s", ShellEscape(repoPath), resetRef)
+	cleanCmd := fmt.Sprintf("git -C %s clean -fd", ShellEscape(repoPath))
+	if result, err := ExecOverSSH(ctx, session, resetCmd, nil, nil); err != nil {
+		return fmt.Errorf("bundle sync: reset: %w", err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("bundle sync: reset: %s", result.Stderr)
+	}
+	if result, err := ExecOverSSH(ctx, session, cleanCmd, nil, nil); err != nil {
+		return fmt.Errorf("bundle sync: clean: %w", err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("bundle sync: clean: %s", result.Stderr)
+	}
+
+	// Apply any uncommitted working-tree changes as a patch on top.
+	patch, err := gitutil.GeneratePatch(headRef)
+	if err != nil {
+		return fmt.Errorf("bundle sync: %w", err)
+	}
+	if patch != "" {
+		status(iostream.LevelInfo, fmt.Sprintf("Applying working-tree changes (%d bytes)...", len(patch)))
+		applyCmd := fmt.Sprintf("git -C %s apply", ShellEscape(repoPath))
+		if result, err := ExecOverSSH(ctx, session, applyCmd, strings.NewReader(patch), nil); err != nil {
+			return fmt.Errorf("bundle sync: apply patch: %w", err)
+		} else if result.ExitCode != 0 {
+			return fmt.Errorf("bundle sync: apply patch: %s", result.Stderr)
+		}
+	}
+
+	// Persist the synced ref.
+	active.LastSyncedRef = headRef
+	if err := SaveActive(ctx, *active); err != nil {
+		status(iostream.LevelWarn, fmt.Sprintf("Could not save last synced ref: %v", err))
+	}
+
+	status(iostream.LevelDone, "Synced")
+	return nil
+}
+
+// sendBundle creates and transfers a git bundle (full or incremental) to the
+// sidecar, then fetches it into the remote repo.
+func sendBundle(ctx context.Context, session *Session, lastRef, cwd, repo, repoPath string, status iostream.StatusFunc) error {
+	label := "incremental bundle"
+	if lastRef == "" {
+		label = "full bundle"
+	}
+
+	bundle, err := gitutil.CreateBundle(lastRef, cwd)
+	if err != nil {
+		return fmt.Errorf("bundle sync: %w", err)
+	}
+	status(iostream.LevelInfo, fmt.Sprintf("Sending %s (%d bytes)...", label, len(bundle)))
+
+	bundlePath := fmt.Sprintf("/tmp/chunk-sync-%s.bundle", repo)
+	if result, err := ExecOverSSH(ctx, session, "tee "+ShellEscape(bundlePath), bytes.NewReader(bundle), nil); err != nil {
+		return fmt.Errorf("bundle sync: write bundle: %w", err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("bundle sync: write bundle: %s", result.Stderr)
+	}
+
+	fetchCmd := fmt.Sprintf("git -C %s fetch %s HEAD", ShellEscape(repoPath), ShellEscape(bundlePath))
+	if result, err := ExecOverSSH(ctx, session, fetchCmd, nil, nil); err != nil {
+		return fmt.Errorf("bundle sync: fetch: %w", err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("bundle sync: fetch: %s", result.Stderr)
+	}
 	return nil
 }
 

--- a/internal/sidecar/sync_test.go
+++ b/internal/sidecar/sync_test.go
@@ -147,3 +147,101 @@ func TestSync_FetchBeforeReset(t *testing.T) {
 	assert.Assert(t, fetchIdx < resetIdx,
 		"fetch (index %d) must come before reset (index %d); commands: %v", fetchIdx, resetIdx, cmds)
 }
+
+// TestBundleSync_SendsBundle verifies that BundleSync transfers the bundle via
+// tee and fetches it without using the HEAD:HEAD refspec that caused ambiguity
+// and non-fast-forward rejections on incremental syncs.
+func TestBundleSync_SendsBundle(t *testing.T) {
+	keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+
+	sshSrv := fakes.NewSSHServer(t, pubKey)
+	sshSrv.SetResult("", 0)
+
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = sshSrv.Addr()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	t.Setenv(config.EnvHome, t.TempDir())
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
+
+	repoDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	t.Chdir(repoDir)
+
+	cl := newClient(t, srv.URL)
+	noopStatus := iostream.StatusFunc(func(_ iostream.Level, _ string) {})
+
+	err := sidecar.BundleSync(context.Background(), cl, "sb-1", keyFile, "", "", repoDir, noopStatus)
+	assert.NilError(t, err)
+
+	cmds := sshSrv.Commands()
+
+	// Bundle must be written via tee (no shell redirect needed).
+	assert.Assert(t, containsMatch(cmds, "tee"), "expected tee for bundle write; got: %v", cmds)
+
+	// Fetch must use plain HEAD (no HEAD:HEAD or --update-head-ok).
+	var fetchCmd string
+	for _, c := range cmds {
+		if strings.Contains(c, "git") && strings.Contains(c, "fetch") && strings.Contains(c, ".bundle") {
+			fetchCmd = c
+			break
+		}
+	}
+	assert.Assert(t, fetchCmd != "", "expected a bundle fetch command; got: %v", cmds)
+	assert.Assert(t, !strings.Contains(fetchCmd, "HEAD:HEAD"),
+		"fetch must not use HEAD:HEAD refspec; got: %q", fetchCmd)
+	assert.Assert(t, !strings.Contains(fetchCmd, "--update-head-ok"),
+		"fetch must not use --update-head-ok; got: %q", fetchCmd)
+
+	// After a bundle fetch, reset must target FETCH_HEAD.
+	assert.Assert(t, containsMatch(cmds, "reset --hard FETCH_HEAD"),
+		"expected reset --hard FETCH_HEAD after bundle; got: %v", cmds)
+}
+
+// TestBundleSync_NoOpSkipsBundle verifies that when HEAD has not changed since
+// the last sync, no bundle is sent and the reset target is HEAD.
+func TestBundleSync_NoOpSkipsBundle(t *testing.T) {
+	keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+
+	sshSrv := fakes.NewSSHServer(t, pubKey)
+	sshSrv.SetResult("", 0)
+
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = sshSrv.Addr()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	t.Setenv(config.EnvHome, t.TempDir())
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
+
+	repoDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	t.Chdir(repoDir)
+
+	cl := newClient(t, srv.URL)
+	noopStatus := iostream.StatusFunc(func(_ iostream.Level, _ string) {})
+
+	// First sync records LastSyncedRef.
+	assert.NilError(t, sidecar.BundleSync(context.Background(), cl, "sb-1", keyFile, "", "", repoDir, noopStatus))
+
+	// Second sync: HEAD unchanged — no bundle should be sent.
+	sshSrv.Reset()
+	assert.NilError(t, sidecar.BundleSync(context.Background(), cl, "sb-1", keyFile, "", "", repoDir, noopStatus))
+
+	cmds := sshSrv.Commands()
+	for _, cmd := range cmds {
+		assert.Assert(t, !strings.Contains(cmd, "tee"),
+			"no bundle should be sent on no-op sync; got command: %q", cmd)
+	}
+	// On a no-op sync the reset target is HEAD (not FETCH_HEAD).
+	assert.Assert(t, containsMatch(cmds, "reset --hard HEAD"),
+		"expected reset --hard HEAD on no-op sync; got: %v", cmds)
+}
+
+func containsMatch(cmds []string, substr string) bool {
+	for _, c := range cmds {
+		if strings.Contains(c, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/testing/fakes/ssh.go
+++ b/internal/testing/fakes/ssh.go
@@ -133,6 +133,13 @@ func (s *SSHServer) Commands() []string {
 	return out
 }
 
+// Reset clears the recorded commands so a test can assert on a fresh sync.
+func (s *SSHServer) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.commands = nil
+}
+
 // EnvVars returns a copy of all environment variables received via "env" requests.
 func (s *SSHServer) EnvVars() map[string]string {
 	s.mu.Lock()


### PR DESCRIPTION
## Summary

Revives and extends #292.

`chunk sidecar sync` now uses git bundle by default, removing the requirement to push the branch to GitHub before syncing:

- **First sync**: sends a full bundle of HEAD to the sidecar, initialising a bare repo there if absent
- **Subsequent syncs**: sends only `<lastRef>..HEAD` (incremental), skipping the bundle entirely when HEAD has not advanced
- **Uncommitted changes**: applied on top as a patch after each bundle transfer
- **Opt out**: pass `--checkout` to fall back to the previous checkout/patch approach (requires branch pushed to GitHub)

Both `chunk sidecar sync` and `chunk sidecar setup` use bundle sync by default. The `bundleSync` config field has been removed since bundle sync is now the default.

Also included: stdin piping through `chunk sidecar ssh` — when the process stdin is a pipe it is forwarded to the remote command, enabling patterns like `cat bundle | chunk sidecar ssh -- git fetch ...`.

## Test plan

- [x] `chunk sidecar sync` on a fresh sidecar performs a full bundle sync
- [x] Re-running `chunk sidecar sync` skips the bundle and only applies the working-tree patch
- [x] `chunk sidecar sync --checkout` falls back to the checkout/patch approach
- [ ] `chunk validate test --remote` passes after a bundle sync
- [ ] `cat bundle | chunk sidecar ssh -- git fetch ...` works (stdin piping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)