### PR TITLE
Use snapshot ID from config when --image is not passed to sidecar create

### DIFF
--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -213,6 +213,12 @@ func newSidecarCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if image == "" {
+				cfg, _ := config.LoadProjectConfig(cwd)
+				if cfg.HasSidecarImage() {
+					image = cfg.Validation.SidecarImage
+				}
+			}
 			sb, err := sidecar.Create(cmd.Context(), client, resolvedOrgID, name, image)
 			if err != nil {
 				if err := notAuthorized("create sidecars", err); err != nil {

--- a/internal/cmd/sidecar_test.go
+++ b/internal/cmd/sidecar_test.go
@@ -1,11 +1,46 @@
 package cmd
 
 import (
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 )
+
+func setupSidecarCreateFake(t *testing.T) *fakes.FakeCircleCI {
+	t.Helper()
+	isolateConfig(t)
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	t.Cleanup(srv.Close)
+	t.Setenv(config.EnvCircleToken, "test-token")
+	t.Setenv(config.EnvCircleCIBaseURL, srv.URL)
+	return cci
+}
+
+func TestSidecarCreateUsesImageFromConfig(t *testing.T) {
+	cci := setupSidecarCreateFake(t)
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	assert.NilError(t, config.SaveProjectConfig(dir, &config.ProjectConfig{
+		OrgID:      "org-abc",
+		Validation: &config.ValidationConfig{SidecarImage: "snap-from-config"},
+	}))
+
+	cmd := newSidecarCreateCmd()
+	cmd.Flags().Bool("insecure-storage", false, "")
+	_ = cmd.Flags().Set("insecure-storage", "true")
+	cmd.SetArgs([]string{"--org-id", "org-abc"})
+	assert.NilError(t, cmd.Execute())
+
+	assert.Equal(t, len(cci.Sidecars), 1)
+	assert.Equal(t, cci.Sidecars[0].Image, "snap-from-config")
+}
 
 func TestSnapshotCreateNameTooLong(t *testing.T) {
 	cmd := newSidecarSnapshotCreateCmd()


### PR DESCRIPTION
## Summary

- `chunk sidecar create` now falls back to `validation.sidecarImage` in `.chunk/config.json` when `--image` is not provided
- This matches the behaviour already present in `chunk validate` via `resolveImage`
- Added a test covering the config fallback path

## Test plan

- [ ] `task test` passes
- [ ] `chunk sidecar create` without `--image` in a repo with `validation.sidecarImage` set in `.chunk/config.json` creates the sidecar with the configured snapshot ID
- [ ] `chunk sidecar create --image <id>` still uses the explicit flag value

🤖 Generated with [Claude Code](https://claude.com/claude-code)