### PR TITLE
Handle API deprecation headers and 410 responses

### DIFF
--- a/acceptance/deprecation_test.go
+++ b/acceptance/deprecation_test.go
@@ -1,0 +1,95 @@
+package acceptance
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/chunk-cli/internal/testing/env"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+)
+
+// TestDeprecationWarning_SunsetInOutput checks that a Deprecation + Sunset
+// response header produces a styled warning on stderr while the command still
+// succeeds and returns normal output.
+func TestDeprecationWarning_SunsetInOutput(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.Sidecars = []fakes.Sidecar{
+		{ID: "sb-111", Name: "dev-sidecar", OrgID: "org-aaa"},
+	}
+	cci.ExtraHeaders = http.Header{
+		"Deprecation": []string{"true"},
+		"Sunset":      []string{"Sat, 01 Jan 2028 00:00:00 GMT"},
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, []string{"sidecar", "list", "--org-id", "org-aaa"}, env, env.HomeDir)
+
+	// Command succeeds — endpoint still works during the sunset window.
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stdout, "dev-sidecar"),
+		"expected sidecar in stdout, got: %s", result.Stdout)
+
+	// Warning appears on stderr with days-remaining count.
+	assert.Assert(t, strings.Contains(result.Stderr, "deprecated"),
+		"expected deprecation warning on stderr, got: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "days"),
+		"expected days-remaining in warning, got: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "upgrade"),
+		"expected upgrade hint in warning, got: %s", result.Stderr)
+}
+
+// TestGone_410ProducesUpgradeError checks that a 410 response causes the CLI
+// to exit non-zero with a clear "out of date" error and upgrade suggestion on
+// stderr rather than a generic API error.
+func TestGone_410ProducesUpgradeError(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.ListStatusCode = http.StatusGone
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, []string{"sidecar", "list", "--org-id", "org-aaa"}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit on 410")
+	assert.Assert(t, strings.Contains(result.Stderr, "out of date"),
+		"expected 'out of date' in stderr, got: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "upgrade"),
+		"expected upgrade suggestion in stderr, got: %s", result.Stderr)
+}
+
+// TestGone_410WithServerMessageInOutput checks that a server-provided message
+// in the 410 body is surfaced in the CLI error output.
+func TestGone_410WithServerMessageInOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Circle-Token") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusGone)
+		_, _ = w.Write([]byte(`{"error":"upgrade chunk CLI to v2.x or later to use this API"}`))
+	}))
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	result := binary.RunCLI(t, []string{"sidecar", "list", "--org-id", "org-aaa"}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit on 410")
+	assert.Assert(t, strings.Contains(result.Stderr, "out of date"),
+		"expected 'out of date' in stderr, got: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "upgrade chunk CLI to v2.x"),
+		"expected server message in stderr, got: %s", result.Stderr)
+}

--- a/internal/authprompt/authprompt.go
+++ b/internal/authprompt/authprompt.go
@@ -79,14 +79,17 @@ func ValidateAPIKey(ctx context.Context, apiKey, baseURL string) error {
 }
 
 // ResolveCircleCIClient returns a CircleCI client if credentials are available.
-// Returns ErrNeedsAuth when the caller must prompt.
-func ResolveCircleCIClient(rc config.ResolvedConfig) (*circleci.Client, error) {
+// Returns ErrNeedsAuth when the caller must prompt. onWarn is called with a
+// plain-text deprecation message when the server signals endpoint removal; pass
+// nil to silence warnings.
+func ResolveCircleCIClient(rc config.ResolvedConfig, onWarn func(string)) (*circleci.Client, error) {
 	if rc.CircleCIToken == "" {
 		return nil, ErrNeedsAuth
 	}
 	return circleci.NewClient(circleci.Config{
 		Token:   rc.CircleCIToken,
 		BaseURL: rc.CircleCIBaseURL,
+		OnWarn:  onWarn,
 	})
 }
 

--- a/internal/authprompt/authprompt_test.go
+++ b/internal/authprompt/authprompt_test.go
@@ -69,7 +69,7 @@ func TestResolveCircleCIClient_TokenInEnv(t *testing.T) {
 	t.Setenv(config.EnvCircleCIBaseURL, srv.URL)
 
 	rc, _ := config.Resolve("", "", insecureStorage)
-	client, err := authprompt.ResolveCircleCIClient(rc)
+	client, err := authprompt.ResolveCircleCIClient(rc, nil)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
 }
@@ -91,7 +91,7 @@ func TestResolveCircleCIClient_TokenInConfig(t *testing.T) {
 	assert.NilError(t, config.Save(cfg))
 
 	rc, _ := config.Resolve("", "", insecureStorage)
-	client, err := authprompt.ResolveCircleCIClient(rc)
+	client, err := authprompt.ResolveCircleCIClient(rc, nil)
 	assert.NilError(t, err)
 	assert.Assert(t, client != nil)
 }
@@ -102,7 +102,7 @@ func TestResolveCircleCIClient_NeedsAuth(t *testing.T) {
 	t.Setenv(config.EnvCircleCIToken, "")
 
 	rc, _ := config.Resolve("", "", insecureStorage)
-	_, err := authprompt.ResolveCircleCIClient(rc)
+	_, err := authprompt.ResolveCircleCIClient(rc, nil)
 	assert.Assert(t, errors.Is(err, authprompt.ErrNeedsAuth))
 }
 

--- a/internal/circleci/circleci_test.go
+++ b/internal/circleci/circleci_test.go
@@ -3,7 +3,9 @@ package circleci
 import (
 	"context"
 	"errors"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -358,6 +360,68 @@ func TestTriggerRun(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error on 500 response")
 		}
+	})
+}
+
+func TestMapErr_410_SurfacesBody(t *testing.T) {
+	t.Run("json error field", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusGone)
+			_, _ = w.Write([]byte(`{"error":"upgrade chunk CLI to v2.x or later"}`))
+		}))
+		defer srv.Close()
+
+		client := newTestClient(t, srv.URL)
+		_, err := client.ListSidecars(context.Background(), "org-1", false)
+
+		assert.Assert(t, err != nil)
+		assert.Assert(t, strings.Contains(err.Error(), "upgrade chunk CLI"), "error should include server message, got: %v", err)
+	})
+
+	t.Run("json message field", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusGone)
+			_, _ = w.Write([]byte(`{"message":"please upgrade"}`))
+		}))
+		defer srv.Close()
+
+		client := newTestClient(t, srv.URL)
+		_, err := client.ListSidecars(context.Background(), "org-1", false)
+
+		assert.Assert(t, err != nil)
+		assert.Assert(t, strings.Contains(err.Error(), "please upgrade"), "error should include server message, got: %v", err)
+	})
+
+	t.Run("non-json body falls back to raw string", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusGone)
+			_, _ = w.Write([]byte("this endpoint has been removed"))
+		}))
+		defer srv.Close()
+
+		client := newTestClient(t, srv.URL)
+		_, err := client.ListSidecars(context.Background(), "org-1", false)
+
+		assert.Assert(t, err != nil)
+		assert.Assert(t, strings.Contains(err.Error(), "this endpoint has been removed"), "error should include raw body, got: %v", err)
+	})
+
+	t.Run("empty body shows plain 410", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusGone)
+		}))
+		defer srv.Close()
+
+		client := newTestClient(t, srv.URL)
+		_, err := client.ListSidecars(context.Background(), "org-1", false)
+
+		assert.Assert(t, err != nil)
+		var se *hc.StatusError
+		assert.Assert(t, errors.As(err, &se))
+		assert.Equal(t, se.StatusCode, http.StatusGone)
+		assert.Equal(t, se.ServerMessage, "")
 	})
 }
 

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -2,6 +2,7 @@ package circleci
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -23,6 +24,9 @@ type StatusError = hc.StatusError
 type Config struct {
 	Token   string
 	BaseURL string
+	// OnWarn, when non-nil, is called with a plain-text deprecation warning.
+	// See httpcl.Config.OnWarn for details.
+	OnWarn func(msg string)
 }
 
 type Client struct {
@@ -39,6 +43,7 @@ func NewClient(cfg Config) (*Client, error) {
 		AuthHeader:       "Circle-Token",
 		UserAgent:        version.UserAgent(),
 		RetryOn429Budget: 30 * time.Second,
+		OnWarn:           cfg.OnWarn,
 	})
 	return &Client{cl: cl}, nil
 }
@@ -336,5 +341,30 @@ func mapErr(op string, err error) error {
 	if he.StatusCode == http.StatusUnauthorized || he.StatusCode == http.StatusForbidden {
 		return fmt.Errorf("%s: %w", op, ErrNotAuthorized)
 	}
-	return &StatusError{Op: op, StatusCode: he.StatusCode}
+	se := &StatusError{Op: op, StatusCode: he.StatusCode}
+	if he.StatusCode == http.StatusGone {
+		se.ServerMessage = extractServerMessage(he.Body)
+	}
+	return se
+}
+
+// extractServerMessage tries to pull a human-readable message from a JSON
+// error body. Falls back to the raw body string if JSON parsing fails.
+func extractServerMessage(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	var payload struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &payload); err == nil {
+		if payload.Error != "" {
+			return payload.Error
+		}
+		if payload.Message != "" {
+			return payload.Message
+		}
+	}
+	return string(body)
 }

--- a/internal/cmd/authhelper.go
+++ b/internal/cmd/authhelper.go
@@ -56,7 +56,9 @@ func printSaved(streams iostream.Streams, label string, insecureStorage bool) {
 
 func ensureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc config.ResolvedConfig, streams iostream.Streams, prompter func(string) (string, error)) (*circleci.Client, error) {
 	insecureStorage := insecureStorageFlag(cmd)
-	client, err := authprompt.ResolveCircleCIClient(rc)
+	client, err := authprompt.ResolveCircleCIClient(rc, func(msg string) {
+		streams.ErrPrintln(ui.ErrWarning(msg))
+	})
 	if err == nil {
 		return client, nil
 	}
@@ -132,6 +134,9 @@ func ensureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc config.Res
 	return circleci.NewClient(circleci.Config{
 		Token:   token,
 		BaseURL: rc.CircleCIBaseURL,
+		OnWarn: func(msg string) {
+			streams.ErrPrintln(ui.ErrWarning(msg))
+		},
 	})
 }
 

--- a/internal/cmd/usererr.go
+++ b/internal/cmd/usererr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -155,6 +156,27 @@ func errNoForce(action string) error {
 		withCode("interactivity.no_force").
 		withSuggestion("Pass --force to bypass this confirmation.").
 		withExitCode(ExitBadArgs)
+}
+
+// GoneError returns a formatted error when err contains a 410 Gone status,
+// which means the server no longer supports this version of the CLI. Returns
+// nil for any other error. Use at the top of main's error path to intercept
+// 410s before generic handling.
+func GoneError(err error) error {
+	var se *circleci.StatusError
+	if !errors.As(err, &se) || se.StatusCode != http.StatusGone {
+		return nil
+	}
+	detail := se.ServerMessage
+	if detail == "" {
+		detail = "This server no longer supports this version of chunk CLI."
+	}
+	return newUserError("chunk CLI is out of date.").
+		withCode("cli.upgrade_required").
+		withDetail(detail).
+		withSuggestion("Run `chunk upgrade` to get the latest version.").
+		withExitCode(ExitAPIError).
+		wrap(err)
 }
 
 // nonInteractive reports whether the process is running in a CI/CD environment.

--- a/internal/httpcl/client.go
+++ b/internal/httpcl/client.go
@@ -17,6 +17,31 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
+// checkDeprecation calls onWarn when the response carries Deprecation or Sunset
+// headers, signalling that the endpoint will be removed. The message passed to
+// onWarn is plain text — no prefix or newline — so the caller controls formatting.
+func checkDeprecation(onWarn func(string), h http.Header) {
+	dep := h.Get("Deprecation")
+	sunset := h.Get("Sunset")
+	if dep == "" && sunset == "" {
+		return
+	}
+	if sunset != "" {
+		if t, err := http.ParseTime(sunset); err == nil {
+			days := int(time.Until(t).Hours() / 24)
+			if days > 0 {
+				onWarn(fmt.Sprintf("this API endpoint is deprecated and will be removed in %d days — upgrade chunk CLI", days))
+			} else {
+				onWarn("this API endpoint is deprecated and removal is imminent — upgrade chunk CLI")
+			}
+		} else {
+			onWarn(fmt.Sprintf("this API endpoint is deprecated and will be removed on %s — upgrade chunk CLI", sunset))
+		}
+	} else {
+		onWarn("this API endpoint is deprecated and will be removed — upgrade chunk CLI")
+	}
+}
+
 // retryCtxKey is the context key for the per-call retry state.
 type retryCtxKey struct{}
 
@@ -52,6 +77,10 @@ type Config struct {
 	RetryOn429Budget time.Duration
 	// Transport overrides the HTTP transport (useful for testing).
 	Transport http.RoundTripper
+	// OnWarn, when non-nil, is called with a plain-text warning message when the
+	// server signals endpoint removal via Deprecation or Sunset response headers.
+	// The caller is responsible for formatting (prefix, newline, colour).
+	OnWarn func(msg string)
 }
 
 // Client is a simple HTTP client with JSON defaults and automatic retries.
@@ -62,6 +91,7 @@ type Client struct {
 	userAgent        string
 	timeout          time.Duration
 	retryOn429Budget time.Duration
+	onWarn           func(string)
 	http             *retryablehttp.Client
 }
 
@@ -126,6 +156,7 @@ func New(cfg Config) *Client {
 		userAgent:        cfg.UserAgent,
 		timeout:          timeout,
 		retryOn429Budget: cfg.RetryOn429Budget,
+		onWarn:           cfg.OnWarn,
 		http:             rc,
 	}
 }
@@ -221,6 +252,9 @@ func (c *Client) Call(ctx context.Context, r Request) (int, error) {
 	status := resp.StatusCode
 
 	if status >= 200 && status < 300 {
+		if c.onWarn != nil {
+			checkDeprecation(c.onWarn, resp.Header)
+		}
 		if r.decoder != nil {
 			if err := r.decoder(resp.Body); err != nil {
 				return status, fmt.Errorf("httpcl: decode response: %w", err)

--- a/internal/httpcl/client_test.go
+++ b/internal/httpcl/client_test.go
@@ -280,6 +280,85 @@ func TestRetryOn429_5xxStillCapsAtThreeWithBudgetSet(t *testing.T) {
 	}
 }
 
+func TestDeprecationWarning_SunsetHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Deprecation", "true")
+		w.Header().Set("Sunset", "Sat, 01 Jan 2028 00:00:00 GMT")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var msgs []string
+	c := hc.New(hc.Config{BaseURL: srv.URL, OnWarn: func(msg string) { msgs = append(msgs, msg) }})
+
+	_, err := c.Call(context.Background(), hc.NewRequest("GET", "/"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(msgs) == 0 {
+		t.Fatal("expected deprecation warning, got none")
+	}
+	if !strings.Contains(msgs[0], "deprecated") {
+		t.Errorf("expected deprecation warning, got %q", msgs[0])
+	}
+	if !strings.Contains(msgs[0], "days") {
+		t.Errorf("expected days-remaining in warning, got %q", msgs[0])
+	}
+}
+
+func TestDeprecationWarning_DeprecationOnly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Deprecation", "true")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var msgs []string
+	c := hc.New(hc.Config{BaseURL: srv.URL, OnWarn: func(msg string) { msgs = append(msgs, msg) }})
+
+	_, err := c.Call(context.Background(), hc.NewRequest("GET", "/"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(msgs) == 0 || !strings.Contains(msgs[0], "deprecated") {
+		t.Errorf("expected deprecation warning, got %v", msgs)
+	}
+}
+
+func TestDeprecationWarning_NoCallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Deprecation", "true")
+		w.Header().Set("Sunset", "Sat, 01 Jan 2027 00:00:00 GMT")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// no OnWarn — must not panic
+	c := hc.New(hc.Config{BaseURL: srv.URL})
+	_, err := c.Call(context.Background(), hc.NewRequest("GET", "/"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeprecationWarning_NoHeadersNoCallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	called := false
+	c := hc.New(hc.Config{BaseURL: srv.URL, OnWarn: func(msg string) { called = true }})
+
+	_, err := c.Call(context.Background(), hc.NewRequest("GET", "/"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("OnWarn should not be called without deprecation headers")
+	}
+}
+
 func TestRouteParamsMultiple(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v2/agents/org/org-1/project/proj-2/runs" {

--- a/internal/httpcl/error.go
+++ b/internal/httpcl/error.go
@@ -22,15 +22,20 @@ func (e *HTTPError) Error() string {
 // StatusError is a structured HTTP error for use by API client packages. It
 // records the operation name and HTTP status code without exposing HTTPError.
 type StatusError struct {
-	Op         string
-	StatusCode int
+	Op            string
+	StatusCode    int
+	ServerMessage string // optional message from the server response body
 }
 
 func (e *StatusError) Error() string {
+	base := fmt.Sprintf("%d %s", e.StatusCode, http.StatusText(e.StatusCode))
 	if e.Op != "" {
-		return fmt.Sprintf("%s: %d %s", e.Op, e.StatusCode, http.StatusText(e.StatusCode))
+		base = e.Op + ": " + base
 	}
-	return fmt.Sprintf("%d %s", e.StatusCode, http.StatusText(e.StatusCode))
+	if e.ServerMessage != "" {
+		return base + " — " + e.ServerMessage
+	}
+	return base
 }
 
 // HasStatusCode checks if err is an *HTTPError with any of the given status codes.

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -92,6 +92,25 @@ type FakeCircleCI struct {
 	ListSnapshotsStatusCode  int // override for GET /sidecar/snapshots
 	GetCommandStatusCode     int // override for GET /sidecar/commands/:id
 	CreateOrgStatusCode      int // override for POST /api/v2/organization
+
+	// ExtraHeaders are added to every response. Use to inject Deprecation/Sunset
+	// headers without changing individual handler logic.
+	ExtraHeaders http.Header
+}
+
+// ServeHTTP injects ExtraHeaders into every response before delegating to the
+// embedded gin handler. Headers must be set before the first Write or
+// WriteHeader call, which gin does internally — setting them here satisfies
+// that ordering.
+func (f *FakeCircleCI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.mu.RLock()
+	for k, vals := range f.ExtraHeaders {
+		for _, v := range vals {
+			w.Header().Add(k, v)
+		}
+	}
+	f.mu.RUnlock()
+	f.Handler.ServeHTTP(w, r)
 }
 
 func NewFakeCircleCI() *FakeCircleCI {

--- a/main.go
+++ b/main.go
@@ -34,6 +34,10 @@ func main() {
 		if ec, ok := err.(interface{ ExitCode() int }); ok {
 			os.Exit(ec.ExitCode())
 		}
+		// 410 anywhere means the CLI needs upgrading — override before display.
+		if ge := cmd.GoneError(err); ge != nil {
+			err = ge
+		}
 		m, d, s, exitCode := errorDetails(err)
 		if jsonFlagPresent() {
 			type jsonErr struct {


### PR DESCRIPTION
## Summary

- **Sunset warning**: `httpcl.Client` checks `Deprecation` and `Sunset` response headers on 2xx responses and calls an `OnWarn` callback with a plain-text message. The `Sunset` date is parsed and rendered as N days remaining. The cmd layer passes a styled callback so warnings appear as `⚠ ... will be removed in N days` on stderr while the command still succeeds.
- **410 Gone**: `mapErr` extracts a human-readable message from the 410 response body (`error` or `message` JSON field, falling back to raw string). `GoneError` in `usererr.go` wraps any 410 into a `userError` with `"chunk CLI is out of date."`, the server body as detail, and `"Run chunk upgrade"` suggestion. Applied in `main.go` before rendering so all commands get consistent output.
- **`FakeCircleCI.ExtraHeaders`**: new field + `ServeHTTP` override so acceptance tests can inject deprecation headers without per-handler changes.
- Three acceptance tests demonstrate the actual output for both phases.