### PR TITLE
Add per-command summary block to Stop hook validate output

### DIFF
--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -281,14 +281,17 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return err
 	}
 
-	execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.identityFile, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
+	results, execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.identityFile, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
 
 	if hook != nil {
+		if len(results) > 1 {
+			validate.PrintSummary(results, streams.Err)
+		}
 		maxAttempts := cfg.StopHookMaxAttempts
 		if maxAttempts <= 0 {
 			maxAttempts = validate.DefaultMaxAttempts
 		}
-		return validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
+		return validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, validate.LastFailed(results), streams.Err)
 	}
 	return execErr
 }
@@ -316,7 +319,8 @@ func runValidateDryRun(name, inlineCmd string, cfg *config.ProjectConfig, status
 // provided options. It is shared by both direct and hook invocations.
 // allRemote is true when --remote is passed explicitly (all commands run on the
 // sidecar); false means only commands with Remote:true are routed to the sidecar.
-func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, freshlyCreated bool, identityFile, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+// Results are non-nil only for the local run-all path; other paths return nil.
+func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, freshlyCreated bool, identityFile, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) ([]validate.CommandResult, error) {
 	// --cmd: inline command (always local in per-command mode)
 	if inlineCmd != "" {
 		cmdName := name
@@ -325,27 +329,27 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 		}
 		if save {
 			if err := config.SaveCommand(workDir, cmdName, inlineCmd); err != nil {
-				return &userError{msg: "Could not save command to .chunk/config.json.", err: err}
+				return nil, &userError{msg: "Could not save command to .chunk/config.json.", err: err}
 			}
 			streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", cmdName)))
 		}
 		if sidecarID != "" && allRemote {
 			execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc, streams)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			return validate.RunRemoteInline(ctx, execFn, cmdName, inlineCmd, dest, statusFn, streams)
+			return nil, validate.RunRemoteInline(ctx, execFn, cmdName, inlineCmd, dest, statusFn, streams)
 		}
-		return validate.RunInline(ctx, workDir, cmdName, inlineCmd, statusFn, streams)
+		return nil, validate.RunInline(ctx, workDir, cmdName, inlineCmd, statusFn, streams)
 	}
 
 	// All-remote execution (--remote flag): send everything to the sidecar.
 	if sidecarID != "" && allRemote {
 		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc, streams)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		return validate.RunRemote(ctx, execFn, cfg, name, dest, workDir, statusFn, streams)
+		return validate.RunRemoteWithResults(ctx, execFn, cfg, name, dest, workDir, statusFn, streams)
 	}
 
 	// Per-command remote routing: commands with Remote:true go to the sidecar,
@@ -356,9 +360,9 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 				statusFn(iostream.LevelInfo, fmt.Sprintf("running %s on sidecar %s", name, sidecarID))
 				execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc, streams)
 				if err != nil {
-					return err
+					return nil, err
 				}
-				return validate.RunRemote(ctx, execFn, cfg, name, dest, workDir, statusFn, streams)
+				return nil, validate.RunRemote(ctx, execFn, cfg, name, dest, workDir, statusFn, streams)
 			}
 			statusFn(iostream.LevelInfo, fmt.Sprintf("running %s locally (not marked remote)", name))
 			// Named command is not marked remote; fall through to local execution.
@@ -371,7 +375,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 	if name != "" {
 		if cfg.FindCommand(name) == nil {
 			if !term.IsTerminal(int(os.Stdin.Fd())) {
-				return &userError{
+				return nil, &userError{
 					msg:        fmt.Sprintf("Command %q is not configured.", name),
 					suggestion: "Add it to .chunk/config.json.",
 					errMsg:     fmt.Sprintf("command %q is not configured", name),
@@ -382,28 +386,29 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 			streams.ErrPrintf("What command should %s run? ", ui.Bold(name))
 			scanner := bufio.NewScanner(os.Stdin)
 			if !scanner.Scan() {
-				return &userError{msg: "No command entered.", errMsg: "no input received"}
+				return nil, &userError{msg: "No command entered.", errMsg: "no input received"}
 			}
 			input := strings.TrimSpace(scanner.Text())
 			if input == "" {
 				streams.ErrPrintln(ui.Dim("No command entered, aborting."))
-				return &userError{msg: "No command entered.", errMsg: "no command entered"}
+				return nil, &userError{msg: "No command entered.", errMsg: "no command entered"}
 			}
 			if err := config.SaveCommand(workDir, name, input); err != nil {
-				return &userError{msg: "Could not save command to .chunk/config.json.", err: err}
+				return nil, &userError{msg: "Could not save command to .chunk/config.json.", err: err}
 			}
 			streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", name)))
 			var err error
 			cfg, err = config.LoadProjectConfig(workDir)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
-		return mapValidateError(validate.RunNamed(ctx, workDir, name, cfg, statusFn, streams))
+		return nil, mapValidateError(validate.RunNamed(ctx, workDir, name, cfg, statusFn, streams))
 	}
 
-	// Run all
-	return mapValidateError(validate.RunAll(ctx, workDir, cfg, statusFn, streams))
+	// Run all: collect per-command results for hook summary.
+	results, err := validate.RunAllWithResults(ctx, workDir, cfg, statusFn, streams)
+	return results, mapValidateError(err)
 }
 
 // setupRemote resolves (or creates) the sidecar ID based on the validate flags
@@ -499,7 +504,7 @@ func hostForwardEnv(token string) map[string]string {
 // When freshlyCreated is true, SSH failures are hard errors rather than
 // silent local fallbacks (a newly provisioned sidecar that can't be reached
 // indicates a real problem, not temporary unavailability).
-func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, identityFile, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, identityFile, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) ([]validate.CommandResult, error) {
 	remoteCfg, localCfg := splitByRemote(cfg)
 	if len(remoteCfg.Commands) > 0 {
 		statusFn(iostream.LevelInfo, fmt.Sprintf("running on sidecar %s: %s", sidecarID, commandNames(remoteCfg.Commands)))
@@ -507,12 +512,13 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 	if len(localCfg.Commands) > 0 {
 		statusFn(iostream.LevelInfo, fmt.Sprintf("running locally: %s", commandNames(localCfg.Commands)))
 	}
+	var allResults []validate.CommandResult
 	var runErr error
 	if len(remoteCfg.Commands) > 0 {
 		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc, streams)
 		if err != nil {
 			if freshlyCreated {
-				return newUserError(fmt.Sprintf("Could not reach newly created sidecar %s.", sidecarID)).
+				return nil, newUserError(fmt.Sprintf("Could not reach newly created sidecar %s.", sidecarID)).
 					withCode("sidecar.unreachable").
 					withSuggestion("The sidecar may still be starting. Try again in a moment.").
 					withExitCode(ExitAPIError).
@@ -522,7 +528,7 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 			localCfg.Commands = append(remoteCfg.Commands, localCfg.Commands...)
 		} else if wsErr := validate.WorkspaceExists(ctx, execFn, dest); wsErr != nil {
 			if freshlyCreated {
-				return newUserError(fmt.Sprintf("Workspace not found on newly created sidecar %s.", sidecarID)).
+				return nil, newUserError(fmt.Sprintf("Workspace not found on newly created sidecar %s.", sidecarID)).
 					withCode("sidecar.workspace_missing").
 					withSuggestion("Run 'chunk sidecar env build' to prepare the workspace.").
 					withExitCode(ExitNotFound).
@@ -531,15 +537,19 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 			streams.ErrPrintf("warning: %v (%q); run 'chunk sidecar env build' to set up the workspace; running %s locally instead\n", wsErr, dest, commandNames(remoteCfg.Commands))
 			localCfg.Commands = append(remoteCfg.Commands, localCfg.Commands...)
 		} else {
-			runErr = validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, statusFn, streams)
+			remoteResults, err := validate.RunRemoteWithResults(ctx, execFn, remoteCfg, "", dest, workDir, statusFn, streams)
+			allResults = append(allResults, remoteResults...)
+			runErr = err
 		}
 	}
 	if len(localCfg.Commands) > 0 {
-		if err := mapValidateError(validate.RunAll(ctx, workDir, localCfg, statusFn, streams)); err != nil {
-			runErr = errors.Join(runErr, err)
+		localResults, err := validate.RunAllWithResults(ctx, workDir, localCfg, statusFn, streams)
+		allResults = append(allResults, localResults...)
+		if err != nil {
+			runErr = errors.Join(runErr, mapValidateError(err))
 		}
 	}
-	return runErr
+	return allResults, runErr
 }
 
 // splitByRemote partitions cfg.Commands into two configs: one containing only

--- a/internal/validate/hook_test.go
+++ b/internal/validate/hook_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 
@@ -79,7 +80,7 @@ func TestResetAttempts_ClearsCounter(t *testing.T) {
 func TestWrapHookResult_NilError_ResetsAndReturnsNil(t *testing.T) {
 	sid := sessionID(t)
 	TrackFailedAttempt(sid, nil) // prime the counter
-	err := WrapHookResult(sid, nil, DefaultMaxAttempts, nil)
+	err := WrapHookResult(sid, nil, DefaultMaxAttempts, nil, nil)
 	assert.NilError(t, err)
 	// counter should be reset: next failure starts at 1
 	assert.Equal(t, TrackFailedAttempt(sid, nil), 1)
@@ -87,7 +88,7 @@ func TestWrapHookResult_NilError_ResetsAndReturnsNil(t *testing.T) {
 
 func TestWrapHookResult_Error_ReturnsExitCode2(t *testing.T) {
 	sid := sessionID(t)
-	err := WrapHookResult(sid, errors.New("failed"), DefaultMaxAttempts, nil)
+	err := WrapHookResult(sid, errors.New("failed"), DefaultMaxAttempts, nil, nil)
 	assert.Assert(t, err != nil)
 	type exitCoder interface{ ExitCode() int }
 	ec, ok := err.(exitCoder)
@@ -100,11 +101,11 @@ func TestWrapHookResult_GivesUpAfterMaxAttempts(t *testing.T) {
 	var buf bytes.Buffer
 
 	for attempt := 1; attempt < DefaultMaxAttempts; attempt++ {
-		err := WrapHookResult(sid, errors.New("failed"), DefaultMaxAttempts, &buf)
+		err := WrapHookResult(sid, errors.New("failed"), DefaultMaxAttempts, nil, &buf)
 		assert.Assert(t, err != nil, "attempt %d: expected exit 2", attempt)
 	}
 	// final attempt: should give up
-	err := WrapHookResult(sid, errors.New("failed"), DefaultMaxAttempts, &buf)
+	err := WrapHookResult(sid, errors.New("failed"), DefaultMaxAttempts, nil, &buf)
 	assert.NilError(t, err, "expected nil after max attempts")
 	assert.Assert(t, strings.Contains(buf.String(), "ask the user"), "got: %s", buf.String())
 }
@@ -112,9 +113,31 @@ func TestWrapHookResult_GivesUpAfterMaxAttempts(t *testing.T) {
 func TestWrapHookResult_CustomMaxAttempts(t *testing.T) {
 	sid := sessionID(t)
 	var buf bytes.Buffer
-	err := WrapHookResult(sid, errors.New("failed"), 1, &buf)
+	err := WrapHookResult(sid, errors.New("failed"), 1, nil, &buf)
 	assert.NilError(t, err, "expected give-up after 1 attempt")
 	assert.Assert(t, strings.Contains(buf.String(), "ask the user"), "got: %s", buf.String())
+}
+
+func TestWrapHookResult_GiveUpIncludesLastFailure(t *testing.T) {
+	sid := sessionID(t)
+	var buf bytes.Buffer
+	failure := &CommandResult{Name: "lint", ExitCode: 1, Duration: 2*time.Second + 100*time.Millisecond, Status: RunFailed}
+	err := WrapHookResult(sid, errors.New("failed"), 1, failure, &buf)
+	assert.NilError(t, err, "expected give-up after 1 attempt")
+	got := buf.String()
+	assert.Assert(t, strings.Contains(got, "lint"), "expected last failure name in output, got: %s", got)
+	assert.Assert(t, strings.Contains(got, "exit 1"), "expected exit code in output, got: %s", got)
+}
+
+func TestWrapHookResult_GiveUpIncludesTimeoutFailure(t *testing.T) {
+	sid := sessionID(t)
+	var buf bytes.Buffer
+	failure := &CommandResult{Name: "test", Duration: 300 * time.Second, Status: RunFailed, Timeout: true}
+	err := WrapHookResult(sid, errors.New("failed"), 1, failure, &buf)
+	assert.NilError(t, err, "expected give-up after 1 attempt")
+	got := buf.String()
+	assert.Assert(t, strings.Contains(got, "test"), "expected command name in output, got: %s", got)
+	assert.Assert(t, strings.Contains(got, "timed out"), "expected timeout in output, got: %s", got)
 }
 
 // --- HooksDisabled ---

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -18,6 +18,25 @@ import (
 // ErrNotConfigured indicates no validate commands are configured.
 var ErrNotConfigured = errors.New("no validate commands configured")
 
+// RunStatus represents the outcome of a single command execution.
+type RunStatus int
+
+// RunPassed, RunFailed, RunSkipped are the possible outcomes of a command run.
+const (
+	RunPassed RunStatus = iota
+	RunFailed
+	RunSkipped
+)
+
+// CommandResult records the outcome of one command execution.
+type CommandResult struct {
+	Name     string
+	Duration time.Duration
+	ExitCode int
+	Status   RunStatus
+	Timeout  bool
+}
+
 // ErrWorkspaceNotFound is returned when the remote workspace directory does not exist.
 var ErrWorkspaceNotFound = errors.New("workspace directory not found on sidecar")
 
@@ -68,18 +87,91 @@ func RunNamed(ctx context.Context, workDir, name string, cfg *config.ProjectConf
 	return runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, status, streams)
 }
 
-// RunAll runs all configured commands, stopping at the first failure.
-func RunAll(ctx context.Context, workDir string, cfg *config.ProjectConfig, status iostream.StatusFunc, streams iostream.Streams) error {
+// RunAllWithResults runs all configured commands and returns per-command results
+// alongside the first error encountered.
+func RunAllWithResults(ctx context.Context, workDir string, cfg *config.ProjectConfig, status iostream.StatusFunc, streams iostream.Streams) ([]CommandResult, error) {
 	if !cfg.HasCommands() {
-		return ErrNotConfigured
+		return nil, ErrNotConfigured
 	}
-
+	results := make([]CommandResult, 0, len(cfg.Commands))
 	for i, c := range cfg.Commands {
-		if err := runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, status, streams); err != nil {
+		start := time.Now()
+		err := runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, status, streams)
+		dur := time.Since(start)
+		if err != nil {
+			var timeoutErr *commandTimeoutError
+			isTimeout := errors.As(err, &timeoutErr)
+			exitCode := 0
+			if !isTimeout {
+				exitCode = exitCodeFromErr(err)
+			}
+			results = append(results, CommandResult{Name: c.Name, Duration: dur, ExitCode: exitCode, Status: RunFailed, Timeout: isTimeout})
 			for j := i + 1; j < len(cfg.Commands); j++ {
 				status(iostream.LevelWarn, fmt.Sprintf("%s: skipped (%s failed)", cfg.Commands[j].Name, c.Name))
+				results = append(results, CommandResult{Name: cfg.Commands[j].Name, Status: RunSkipped})
 			}
-			return err
+			return results, err
+		}
+		results = append(results, CommandResult{Name: c.Name, Duration: dur, Status: RunPassed})
+	}
+	return results, nil
+}
+
+// RunAll runs all configured commands, stopping at the first failure.
+func RunAll(ctx context.Context, workDir string, cfg *config.ProjectConfig, status iostream.StatusFunc, streams iostream.Streams) error {
+	_, err := RunAllWithResults(ctx, workDir, cfg, status, streams)
+	return err
+}
+
+// PrintSummary writes a per-command result table to w.
+func PrintSummary(results []CommandResult, w io.Writer) {
+	if len(results) == 0 {
+		return
+	}
+	anyFailed := false
+	for _, r := range results {
+		if r.Status == RunFailed {
+			anyFailed = true
+			break
+		}
+	}
+	if anyFailed {
+		_, _ = fmt.Fprintln(w, "\nValidation failed:")
+	} else {
+		_, _ = fmt.Fprintln(w, "\nValidation passed:")
+	}
+	maxName := 0
+	for _, r := range results {
+		if len(r.Name) > maxName {
+			maxName = len(r.Name)
+		}
+	}
+	for _, r := range results {
+		var symbol, detail string
+		switch r.Status {
+		case RunPassed:
+			symbol = "✓"
+			detail = fmt.Sprintf("%.1fs", r.Duration.Seconds())
+		case RunFailed:
+			symbol = "✗"
+			if r.Timeout {
+				detail = fmt.Sprintf("%.1fs   timeout", r.Duration.Seconds())
+			} else {
+				detail = fmt.Sprintf("%.1fs   exit %d", r.Duration.Seconds(), r.ExitCode)
+			}
+		case RunSkipped:
+			symbol = "—"
+			detail = "skipped"
+		}
+		_, _ = fmt.Fprintf(w, "  %-*s   %s   %s\n", maxName, r.Name, symbol, detail)
+	}
+}
+
+// LastFailed returns the first CommandResult with RunFailed status, or nil.
+func LastFailed(results []CommandResult) *CommandResult {
+	for i := range results {
+		if results[i].Status == RunFailed {
+			return &results[i]
 		}
 	}
 	return nil
@@ -106,37 +198,58 @@ func RunDryRun(cfg *config.ProjectConfig, name string, status iostream.StatusFun
 	return nil
 }
 
-// RunRemote runs commands on a remote sidecar via SSH.
+// RunRemoteWithResults runs commands on a remote sidecar via SSH and returns
+// per-command results alongside the first error encountered.
 // If name is non-empty, only the named command is run.
 // workDir is the local repository root used to expand {{CHANGED_PACKAGES}}.
-func RunRemote(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), cfg *config.ProjectConfig, name, dest, workDir string, status iostream.StatusFunc, streams iostream.Streams) error {
+func RunRemoteWithResults(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), cfg *config.ProjectConfig, name, dest, workDir string, status iostream.StatusFunc, streams iostream.Streams) ([]CommandResult, error) {
 	commands := cfg.Commands
 	if name != "" {
 		c := cfg.FindCommand(name)
 		if c == nil {
-			return fmt.Errorf("command %q not configured", name)
+			return nil, fmt.Errorf("command %q not configured", name)
 		}
 		commands = []config.Command{*c}
 	}
-	for _, c := range commands {
+	results := make([]CommandResult, 0, len(commands))
+	for i, c := range commands {
 		run := expandCommand(workDir, c.Run)
 		script := "cd " + shellEscape(dest) + " && " + run
 		status(iostream.LevelInfo, fmt.Sprintf("Running %s (remote): %s", c.Name, c.Run))
+		start := time.Now()
 		stdout, stderr, exitCode, err := execFn(ctx, script)
-		if err != nil {
-			return fmt.Errorf("remote %s: %w", c.Name, err)
-		}
+		dur := time.Since(start)
 		if stdout != "" {
 			_, _ = fmt.Fprint(streams.Out, stdout)
 		}
 		if stderr != "" {
 			_, _ = fmt.Fprint(streams.Err, stderr)
 		}
-		if exitCode != 0 {
-			return fmt.Errorf("remote %s failed with exit code %d", c.Name, exitCode)
+		if err != nil {
+			results = append(results, CommandResult{Name: c.Name, Duration: dur, ExitCode: exitCode, Status: RunFailed})
+			for j := i + 1; j < len(commands); j++ {
+				results = append(results, CommandResult{Name: commands[j].Name, Status: RunSkipped})
+			}
+			return results, fmt.Errorf("remote %s: %w", c.Name, err)
 		}
+		if exitCode != 0 {
+			results = append(results, CommandResult{Name: c.Name, Duration: dur, ExitCode: exitCode, Status: RunFailed})
+			for j := i + 1; j < len(commands); j++ {
+				results = append(results, CommandResult{Name: commands[j].Name, Status: RunSkipped})
+			}
+			return results, fmt.Errorf("remote %s failed with exit code %d", c.Name, exitCode)
+		}
+		results = append(results, CommandResult{Name: c.Name, Duration: dur, Status: RunPassed})
 	}
-	return nil
+	return results, nil
+}
+
+// RunRemote runs commands on a remote sidecar via SSH.
+// If name is non-empty, only the named command is run.
+// workDir is the local repository root used to expand {{CHANGED_PACKAGES}}.
+func RunRemote(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), cfg *config.ProjectConfig, name, dest, workDir string, status iostream.StatusFunc, streams iostream.Streams) error {
+	_, err := RunRemoteWithResults(ctx, execFn, cfg, name, dest, workDir, status, streams)
+	return err
 }
 
 // RunRemoteInline runs a single inline command on a remote sidecar via SSH.
@@ -193,6 +306,23 @@ func expandCommand(workDir, command string) string {
 	return strings.ReplaceAll(command, "{{CHANGED_PACKAGES}}", expanded)
 }
 
+type commandTimeoutError struct {
+	name    string
+	timeout int
+}
+
+func (e *commandTimeoutError) Error() string {
+	return fmt.Sprintf("%s command timed out after %ds", e.name, e.timeout)
+}
+
+func exitCodeFromErr(err error) int {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return 1
+}
+
 func runCommand(ctx context.Context, workDir, name, command string, timeoutSec int, status iostream.StatusFunc, streams iostream.Streams) error {
 	command = expandCommand(workDir, command)
 	status(iostream.LevelInfo, fmt.Sprintf("Running %s: %s", name, command))
@@ -211,11 +341,11 @@ func runCommand(ctx context.Context, workDir, name, command string, timeoutSec i
 	err := cmd.Run()
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			return fmt.Errorf("%s command timed out after %ds", name, timeoutSec)
+			return &commandTimeoutError{name: name, timeout: timeoutSec}
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() != 0 {
-			return fmt.Errorf("%s command failed with exit code %d", name, exitErr.ExitCode())
+			return fmt.Errorf("%s command failed with exit code %d: %w", name, exitErr.ExitCode(), err)
 		}
 		return fmt.Errorf("%s: %w", name, err)
 	}
@@ -264,7 +394,9 @@ func HasGitChanges(workDir string) bool {
 // commands. On success it resets the attempt counter. On failure it increments
 // the counter and returns a HookExitError with code 2 to re-signal the agent,
 // or prints a give-up message and returns nil once maxAttempts is reached.
-func WrapHookResult(sessionID string, execErr error, maxAttempts int, warn io.Writer) error {
+// lastFailure is optional: when non-nil its name and exit info are included in
+// the give-up message so the agent has structured context about what failed.
+func WrapHookResult(sessionID string, execErr error, maxAttempts int, lastFailure *CommandResult, warn io.Writer) error {
 	if execErr == nil {
 		ResetAttempts(sessionID)
 		return nil
@@ -272,6 +404,13 @@ func WrapHookResult(sessionID string, execErr error, maxAttempts int, warn io.Wr
 	n := TrackFailedAttempt(sessionID, warn)
 	if n >= maxAttempts {
 		_, _ = fmt.Fprintf(warn, "chunk validate: validation has failed %d time(s) in a row.\n", n)
+		if lastFailure != nil {
+			if lastFailure.Timeout {
+				_, _ = fmt.Fprintf(warn, "Last failure: %s (timed out after %.0fs)\n", lastFailure.Name, lastFailure.Duration.Seconds())
+			} else {
+				_, _ = fmt.Fprintf(warn, "Last failure: %s (exit %d, %.1fs)\n", lastFailure.Name, lastFailure.ExitCode, lastFailure.Duration.Seconds())
+			}
+		}
 		_, _ = fmt.Fprintf(warn, "The failures above do not appear to be resolving automatically.\n")
 		_, _ = fmt.Fprintf(warn, "Stop attempting to fix this and ask the user for guidance instead.\n")
 		return nil

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -10,8 +10,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
@@ -225,6 +227,133 @@ func TestRunAll(t *testing.T) {
 	})
 }
 
+// --- RunAllWithResults tests ---
+
+func TestRunAllWithResults(t *testing.T) {
+	t.Run("all pass returns results", func(t *testing.T) {
+		cfg := &config.ProjectConfig{Commands: []config.Command{
+			{Name: "fmt", Run: "true"},
+			{Name: "lint", Run: "true"},
+		}}
+		streams, _, _ := newStreams()
+
+		results, err := RunAllWithResults(context.Background(), ".", cfg, func(iostream.Level, string) {}, streams)
+		assert.NilError(t, err)
+		assert.Equal(t, len(results), 2)
+		assert.Check(t, cmp.Equal(results[0].Name, "fmt"))
+		assert.Check(t, cmp.Equal(results[0].Status, RunPassed))
+		assert.Check(t, results[0].Duration >= 0)
+		assert.Check(t, cmp.Equal(results[1].Name, "lint"))
+		assert.Check(t, cmp.Equal(results[1].Status, RunPassed))
+	})
+
+	t.Run("failure marks remaining as skipped", func(t *testing.T) {
+		cfg := &config.ProjectConfig{Commands: []config.Command{
+			{Name: "fmt", Run: "true"},
+			{Name: "lint", Run: "false"},
+			{Name: "test", Run: "true"},
+		}}
+		streams, _, _ := newStreams()
+
+		results, err := RunAllWithResults(context.Background(), ".", cfg, func(iostream.Level, string) {}, streams)
+		assert.Assert(t, err != nil)
+		assert.Equal(t, len(results), 3)
+		assert.Check(t, cmp.Equal(results[0].Status, RunPassed), "fmt should pass")
+		assert.Check(t, cmp.Equal(results[1].Status, RunFailed), "lint should fail")
+		assert.Check(t, cmp.Equal(results[1].ExitCode, 1))
+		assert.Check(t, cmp.Equal(results[2].Status, RunSkipped), "test should be skipped")
+	})
+
+	t.Run("no commands returns ErrNotConfigured", func(t *testing.T) {
+		cfg := &config.ProjectConfig{}
+		streams, _, _ := newStreams()
+
+		results, err := RunAllWithResults(context.Background(), ".", cfg, func(iostream.Level, string) {}, streams)
+		assert.Check(t, cmp.Nil(results))
+		assert.ErrorContains(t, err, "no validate commands")
+	})
+}
+
+// --- PrintSummary tests ---
+
+func TestPrintSummary(t *testing.T) {
+	t.Run("all passed", func(t *testing.T) {
+		results := []CommandResult{
+			{Name: "fmt", Duration: 300 * time.Millisecond, Status: RunPassed},
+			{Name: "lint", Duration: 2100 * time.Millisecond, Status: RunPassed},
+		}
+		var buf bytes.Buffer
+		PrintSummary(results, &buf)
+		got := buf.String()
+		assert.Assert(t, strings.Contains(got, "Validation passed"), "got: %s", got)
+		assert.Assert(t, strings.Contains(got, "✓"), "got: %s", got)
+		assert.Assert(t, strings.Contains(got, "fmt"), "got: %s", got)
+		assert.Assert(t, strings.Contains(got, "lint"), "got: %s", got)
+	})
+
+	t.Run("failure and skipped", func(t *testing.T) {
+		results := []CommandResult{
+			{Name: "fmt", Duration: 300 * time.Millisecond, Status: RunPassed},
+			{Name: "lint", Duration: 2100 * time.Millisecond, ExitCode: 1, Status: RunFailed},
+			{Name: "test", Status: RunSkipped},
+		}
+		var buf bytes.Buffer
+		PrintSummary(results, &buf)
+		got := buf.String()
+		assert.Assert(t, strings.Contains(got, "Validation failed"), "got: %s", got)
+		assert.Assert(t, strings.Contains(got, "✓"), "got: %s", got)
+		assert.Assert(t, strings.Contains(got, "✗"), "got: %s", got)
+		assert.Assert(t, strings.Contains(got, "—"), "got: %s", got)
+		assert.Assert(t, strings.Contains(got, "exit 1"), "got: %s", got)
+		assert.Assert(t, strings.Contains(got, "skipped"), "got: %s", got)
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		results := []CommandResult{
+			{Name: "test", Duration: 300 * time.Second, Status: RunFailed, Timeout: true},
+		}
+		var buf bytes.Buffer
+		PrintSummary(results, &buf)
+		got := buf.String()
+		assert.Assert(t, strings.Contains(got, "timeout"), "got: %s", got)
+		assert.Assert(t, !strings.Contains(got, "exit"), "should not show exit code for timeout, got: %s", got)
+	})
+
+	t.Run("no-op on empty", func(t *testing.T) {
+		var buf bytes.Buffer
+		PrintSummary(nil, &buf)
+		assert.Equal(t, buf.Len(), 0)
+	})
+}
+
+// --- LastFailed tests ---
+
+func TestLastFailed(t *testing.T) {
+	t.Run("returns nil for empty", func(t *testing.T) {
+		assert.Check(t, cmp.Nil(LastFailed(nil)))
+	})
+
+	t.Run("returns nil when all passed", func(t *testing.T) {
+		results := []CommandResult{
+			{Name: "fmt", Status: RunPassed},
+			{Name: "lint", Status: RunPassed},
+		}
+		assert.Check(t, cmp.Nil(LastFailed(results)))
+	})
+
+	t.Run("returns first failed result", func(t *testing.T) {
+		results := []CommandResult{
+			{Name: "fmt", Status: RunPassed},
+			{Name: "lint", ExitCode: 1, Status: RunFailed},
+			{Name: "test", Status: RunSkipped},
+		}
+		got := LastFailed(results)
+		assert.Assert(t, got != nil)
+		assert.Check(t, cmp.Equal(got.Name, "lint"))
+		assert.Check(t, cmp.Equal(got.ExitCode, 1))
+	})
+}
+
 // --- Config with FileExt / Timeout tests ---
 
 func TestCommandFileExtRoundTrip(t *testing.T) {
@@ -360,6 +489,64 @@ func TestRunRemote(t *testing.T) {
 
 		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/custom/path", t.TempDir(), func(iostream.Level, string) {}, streams))
 		assert.Assert(t, strings.HasPrefix(capturedScript, "cd '/custom/path' &&"), "got: %s", capturedScript)
+	})
+}
+
+// --- RunRemoteWithResults tests ---
+
+func TestRunRemoteWithResults(t *testing.T) {
+	t.Run("all pass returns results with timing", func(t *testing.T) {
+		execFn := func(_ context.Context, _ string) (string, string, int, error) {
+			return "ok\n", "", 0, nil
+		}
+		cfg := &config.ProjectConfig{Commands: []config.Command{
+			{Name: "fmt", Run: "true"},
+			{Name: "lint", Run: "true"},
+		}}
+		streams, _, _ := newStreams()
+
+		results, err := RunRemoteWithResults(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams)
+		assert.NilError(t, err)
+		assert.Equal(t, len(results), 2)
+		assert.Check(t, cmp.Equal(results[0].Name, "fmt"))
+		assert.Check(t, cmp.Equal(results[0].Status, RunPassed))
+		assert.Check(t, results[0].Duration >= 0)
+		assert.Check(t, cmp.Equal(results[1].Name, "lint"))
+		assert.Check(t, cmp.Equal(results[1].Status, RunPassed))
+	})
+
+	t.Run("failure marks remaining as skipped", func(t *testing.T) {
+		execFn := func(_ context.Context, _ string) (string, string, int, error) {
+			return "", "", 1, nil
+		}
+		cfg := &config.ProjectConfig{Commands: []config.Command{
+			{Name: "fmt", Run: "true"},
+			{Name: "lint", Run: "false"},
+			{Name: "test", Run: "true"},
+		}}
+		streams, _, _ := newStreams()
+
+		results, err := RunRemoteWithResults(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams)
+		assert.Assert(t, err != nil)
+		assert.Equal(t, len(results), 3)
+		assert.Check(t, cmp.Equal(results[0].Status, RunFailed), "fmt should fail (exitCode 1)")
+		assert.Check(t, cmp.Equal(results[0].ExitCode, 1))
+		assert.Check(t, cmp.Equal(results[1].Status, RunSkipped), "lint should be skipped")
+		assert.Check(t, cmp.Equal(results[2].Status, RunSkipped), "test should be skipped")
+	})
+
+	t.Run("unknown named command returns nil results", func(t *testing.T) {
+		execFn := func(_ context.Context, _ string) (string, string, int, error) {
+			return "", "", 0, nil
+		}
+		cfg := &config.ProjectConfig{Commands: []config.Command{
+			{Name: "test", Run: "echo test"},
+		}}
+		streams, _, _ := newStreams()
+
+		results, err := RunRemoteWithResults(context.Background(), execFn, cfg, "lint", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams)
+		assert.ErrorContains(t, err, `"lint" not configured`)
+		assert.Check(t, cmp.Nil(results))
 	})
 }
 


### PR DESCRIPTION
## Summary

- Adds a `✓`/`✗`/`—` result table with per-command timing at the end of every multi-command `chunk validate` run in hook context, so the agent gets structured signal instead of having to parse raw command output
- Extends the `WrapHookResult` give-up message to include the last failed command's name, exit code, and duration
- Covers both local (`RunAllWithResults`) and remote/sidecar (`RunRemoteWithResults`) execution paths — the sidecar path now also collects results and shows the summary

## Events / Not collected

The summary is written to stderr and only appears in the Claude Code Stop hook feedback block. No new telemetry events are emitted. No flag values, file paths, or timing data leave the process.

## Opt-out

The summary only fires when `hook != nil && len(results) > 1`. Interactive and single-command runs are unchanged.

## Implementation

- `validate.RunAllWithResults` / `validate.RunRemoteWithResults` — new functions that return `[]CommandResult` alongside the existing error; existing `RunAll` / `RunRemote` delegate to them
- `validate.PrintSummary` — writes the aligned table to any `io.Writer`
- `validate.LastFailed` — returns the first failed result for the give-up message
- `cmd/validate.runValidate` — returns `([]CommandResult, error)`; all-remote and split-command paths now populate results
- `cmd/validate.runSplitCommands` — returns `([]CommandResult, error)`, merging remote + local results

## Test plan

- [ ] `go test -race ./internal/validate/... ./internal/cmd/...` — all pass
- [ ] Trigger a Stop hook with multiple commands configured (at least one failing) and verify the summary table appears at the bottom of the feedback block
- [ ] Verify `chunk validate` output is unchanged in non-hook (interactive) invocations