### PR TITLE
Add chunk watch TUI dashboard with sidecar activity log

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -132,6 +132,9 @@ chunk
 │           --org-id <id>           # Organization ID
 │           --json                  # Output as JSON
 │
+├── watch [dir...]                  # Live TUI dashboard for active sidecars and recent activity
+│   --all                           # Watch all known projects, not just the current directory
+│
 ├── hook                            # Manage chunk hook execution
 │   --project <path>                # Override project directory
 │   ├── disable                     # Disable chunk validate hooks
@@ -167,6 +170,7 @@ chunk
   env var → `orgID` in `.chunk/config.json` → interactive org picker (TTY only).
   Non-interactive sessions (agents, CI) should set `orgID` in project config or
   pass `--org-id` / `CIRCLECI_ORG_ID`.
+- `watch` requires a TTY — it exits with an error if stdout is not a terminal. It polls sidecar state every 5 seconds and keeps an in-memory window of the 300 most recent event log entries. Use `j`/`k` or `↑`/`↓` to select a sidecar, `q` or `Esc` to quit. Running `watch` in a project also registers that project so `--all` finds it in future runs.
 - `chunk init` uses Claude to auto-detect the test command for the project.
   It generates `.claude/settings.json` with pre-commit hooks. It never touches
   CircleCI — tokens are prompted inline only when a command actually needs them.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -266,6 +266,39 @@ chunk validate --remote --env MY_VAR=value
 
 Variables from `--env` flags take precedence over those in `--env-file`. `.env.local` is gitignored by convention, so it's a safe place to store project-specific secrets.
 
+### Monitoring sidecars with chunk watch
+
+`chunk watch` opens a live TUI dashboard that shows all your sidecars and their activity in real time. Run it in any project directory while a sync or validation is in progress:
+
+```bash
+chunk watch
+```
+
+The dashboard refreshes every 5 seconds. The left pane lists your sidecars grouped by project, showing sync state and last activity time. The right pane shows the activity log — sync, validate, exec, and setup events — for the selected sidecar.
+
+```
+chunk watch  1 sidecar  main@a3f9e12                      15:04:32
+──────────────────────────────────────────────────────────────────
+ sidecars              │ activity  chunk-cli/my-sidecar
+                       │
+── chunk-cli           │ 14:58:01  sync      ✓  done
+▶ my-sidecar           │ 14:55:12  validate  ✓  done
+  ✓ in sync            │ 14:52:44  sync      ✓  done
+  6m ago               │
+──────────────────────────────────────────────────────────────────
+  ↑/↓ j/k  select  ·  q  quit
+```
+
+To watch multiple projects at once:
+
+```bash
+chunk watch                   # current directory only
+chunk watch /path/to/other    # add another project
+chunk watch --all             # all projects you've watched before
+```
+
+`watch` requires a TTY — it will not run in a non-interactive shell (CI, pipes).
+
 ### Snapshots
 
 Capture a configured environment so future sidecars boot fast:
@@ -409,6 +442,7 @@ Start coding session
 
 Make changes
     └─ chunk sidecar sync + chunk validate --remote   (or locally: chunk validate)
+    └─ chunk watch   (optional: live dashboard to see sync/validate progress)
 
 Before committing
     └─ Hook runs chunk validate automatically

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26
 require (
 	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8
+	charm.land/lipgloss/v2 v2.0.4
 	github.com/BurntSushi/toml v1.6.0
 	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/coder/websocket v1.8.15
@@ -31,7 +32,6 @@ tool (
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect
 	4d63.com/gochecknoglobals v0.2.2 // indirect
-	charm.land/lipgloss/v2 v2.0.4 // indirect
 	codeberg.org/chavacava/garif v0.2.0 // indirect
 	codeberg.org/polyfloyd/go-errorlint v1.9.0 // indirect
 	dev.gaijin.team/go/exhaustruct/v4 v4.0.0 // indirect

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -84,6 +84,7 @@ Configuration:
 	rootCmd.AddCommand(newHookCmd())
 	rootCmd.AddCommand(newUpgradeCmd())
 	rootCmd.AddCommand(newReceiveTelemetryCmd())
+	rootCmd.AddCommand(newWatchCmd())
 
 	rootCmd.AddCommand(newCommandsCmd())
 

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -16,6 +16,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/envbuilder"
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
@@ -495,11 +496,19 @@ func newSidecarSyncCmd() *cobra.Command {
 			if cwdErr != nil {
 				return fmt.Errorf("sync: %w", cwdErr)
 			}
+			syncFn := newStatusFunc(io)
+			if dataDir, dirErr := sidecar.StateDir(); dirErr == nil {
+				scName := ""
+				if as, _ := sidecar.LoadActive(cmd.Context()); as != nil && as.SidecarID == sidecarID {
+					scName = as.Name
+				}
+				syncFn = eventlog.WrapFromDir(dataDir, syncFn, eventlog.OpSync, sidecarID, scName, sidecar.CurrentBranch(cwd))
+			}
 			useBundle := !checkout
 			if useBundle {
-				err = sidecar.BundleSync(cmd.Context(), client, sidecarID, identityFile, authSock, workdir, cwd, newStatusFunc(io))
+				err = sidecar.BundleSync(cmd.Context(), client, sidecarID, identityFile, authSock, workdir, cwd, syncFn)
 			} else {
-				err = sidecar.Sync(cmd.Context(), client, sidecarID, identityFile, authSock, workdir, newStatusFunc(io))
+				err = sidecar.Sync(cmd.Context(), client, sidecarID, identityFile, authSock, workdir, syncFn)
 			}
 			if err != nil {
 				if _, ok := errors.AsType[*sidecar.NoOriginRemoteError](err); ok {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -288,56 +288,75 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 
 	statusFn(iostream.LevelStep, "chunk validate")
 
-	// Wire event log around the actual validate run (best-effort; never blocks on failure).
-	if dataDir, dirErr := sidecar.StateDir(); dirErr == nil {
-		scName := ""
-		if activeSidecar != nil && activeSidecar.SidecarID == opts.sidecarID {
-			scName = activeSidecar.Name
-		}
-		statusFn = eventlog.WrapFromDir(dataDir, statusFn, eventlog.OpValidate, opts.sidecarID, scName, sidecar.CurrentBranch(workDir))
+	freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, activeSidecar, statusFn, workDir, streams)
+	if err != nil {
+		return err
 	}
 
-	execErr := func() error {
-		freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, activeSidecar, statusFn, workDir, streams)
-		if err != nil {
-			return err
-		}
-		// Only load env vars and resolve secrets when a sidecar is actually
-		// being used — avoids parsing .env.local or hitting secrets APIs on
-		// purely local runs.
-		envVars, err := loadSidecarEnvVars(ctx, circleCIClient, opts, workDir, statusFn)
-		if err != nil {
-			return err
-		}
-		return runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
-	}()
+	// Wire event log only when a sidecar is involved. The wrap goes here — after
+	// setupRemote fills opts.sidecarID but before loadSidecarEnvVars — so that
+	// sync and env-resolve status events are captured. Skipping when there is no
+	// sidecar avoids writing events with an empty sidecar_id that the TUI would
+	// filter out and never display.
+	statusFn = wrapEventLogStatusFn(statusFn, opts.sidecarID, activeSidecar, workDir)
+
+	// Only load env vars and resolve secrets when a sidecar is actually
+	// being used — avoids parsing .env.local or hitting secrets APIs on
+	// purely local runs.
+	envVars, err := loadSidecarEnvVars(ctx, circleCIClient, opts, workDir, statusFn)
+	if err != nil {
+		return err
+	}
+
+	execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
+	return finishValidate(cmd, hook, execErr, start, opts.sidecarID, cfg, statusFn, streams)
+}
+
+// wrapEventLogStatusFn wraps statusFn with event log recording when a sidecar
+// is active. Returns statusFn unchanged when no sidecar is involved, so callers
+// with empty sidecar IDs never write events with a blank sidecar_id.
+func wrapEventLogStatusFn(statusFn iostream.StatusFunc, sidecarID string, activeSidecar *sidecar.ActiveSidecar, workDir string) iostream.StatusFunc {
+	if sidecarID == "" {
+		return statusFn
+	}
+	dataDir, err := sidecar.StateDir()
+	if err != nil {
+		return statusFn
+	}
+	scName := ""
+	if activeSidecar != nil && activeSidecar.SidecarID == sidecarID {
+		scName = activeSidecar.Name
+	}
+	return eventlog.WrapFromDir(dataDir, statusFn, eventlog.OpValidate, sidecarID, scName, sidecar.CurrentBranch(workDir))
+}
+
+// finishValidate reports the validate outcome and handles hook exit codes.
+func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start time.Time, sidecarID string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	if execErr != nil {
 		statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed)", ui.FormatDuration(time.Since(start))))
 	} else if hook == nil {
 		statusFn(iostream.LevelStep, fmt.Sprintf("done in %s", ui.FormatDuration(time.Since(start))))
 	}
-
-	if opts.sidecarID != "" {
+	if sidecarID != "" {
 		if execErr != nil {
 			statusFn(iostream.LevelError, "validate failed")
 		} else {
 			statusFn(iostream.LevelDone, "validate passed")
 		}
 	}
-
-	if hook != nil {
-		maxAttempts := cfg.StopHookMaxAttempts
-		if maxAttempts <= 0 {
-			maxAttempts = validate.DefaultMaxAttempts
-		}
-		hookErr := validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
-		if hookErr == nil && execErr == nil {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.Success(fmt.Sprintf("chunk validate passed (%s)", ui.FormatDuration(time.Since(start)))))
-			return nil
-		}
-		return hookErr
+	if hook == nil {
+		return execErr
 	}
-	return execErr
+	maxAttempts := cfg.StopHookMaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = validate.DefaultMaxAttempts
+	}
+	hookErr := validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
+	if hookErr == nil && execErr == nil {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.Success(fmt.Sprintf("chunk validate passed (%s)", ui.FormatDuration(time.Since(start)))))
+		return nil
+	}
+	return hookErr
 }
 
 func validateEnvFlag(envVarsFlag []string) error {
@@ -660,7 +679,7 @@ func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, side
 	}
 	// Fall back to any existing sidecar for this project before creating a new one.
 	// This prevents accumulation of one sidecar per Claude Code session.
-	if existing, err := sidecar.LoadAnyActive(); err == nil && existing != nil {
+	if existing, err := sidecar.LoadAnyActive(ctx); err == nil && existing != nil {
 		if saveErr := sidecar.SaveActive(ctx, *existing); saveErr != nil {
 			streams.ErrPrintf("warning: could not promote active sidecar: %v\n", saveErr)
 		}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
@@ -287,6 +288,15 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 
 	statusFn(iostream.LevelStep, "chunk validate")
 
+	// Wire event log around the actual validate run (best-effort; never blocks on failure).
+	if dataDir, dirErr := sidecar.StateDir(); dirErr == nil {
+		scName := ""
+		if activeSidecar != nil && activeSidecar.SidecarID == opts.sidecarID {
+			scName = activeSidecar.Name
+		}
+		statusFn = eventlog.WrapFromDir(dataDir, statusFn, eventlog.OpValidate, opts.sidecarID, scName, sidecar.CurrentBranch(workDir))
+	}
+
 	execErr := func() error {
 		freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, activeSidecar, statusFn, workDir, streams)
 		if err != nil {
@@ -305,6 +315,14 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed)", ui.FormatDuration(time.Since(start))))
 	} else if hook == nil {
 		statusFn(iostream.LevelStep, fmt.Sprintf("done in %s", ui.FormatDuration(time.Since(start))))
+	}
+
+	if opts.sidecarID != "" {
+		if execErr != nil {
+			statusFn(iostream.LevelError, "validate failed")
+		} else {
+			statusFn(iostream.LevelDone, "validate passed")
+		}
 	}
 
 	if hook != nil {
@@ -638,6 +656,15 @@ func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, side
 	}
 	if active != nil {
 		*sidecarID = active.SidecarID
+		return false, nil
+	}
+	// Fall back to any existing sidecar for this project before creating a new one.
+	// This prevents accumulation of one sidecar per Claude Code session.
+	if existing, err := sidecar.LoadAnyActive(); err == nil && existing != nil {
+		if saveErr := sidecar.SaveActive(ctx, *existing); saveErr != nil {
+			streams.ErrPrintf("warning: could not promote active sidecar: %v\n", saveErr)
+		}
+		*sidecarID = existing.SidecarID
 		return false, nil
 	}
 	streams.ErrPrintf("No active sidecar found, creating a new sidecar...\n")

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -3,17 +3,16 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
+	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
+	internaltui "github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/tui/watch"
 )
 
@@ -26,11 +25,14 @@ func newWatchCmd() *cobra.Command {
 		SilenceUsage: true,
 		Args:         cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !term.IsTerminal(int(os.Stdout.Fd())) {
+			if err := internaltui.RequireStdoutTTY(); err != nil {
 				return fmt.Errorf("watch requires a TTY")
 			}
 
-			cwd, _ := os.Getwd()
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("watch: could not determine working directory: %w", err)
+			}
 			roots := []string{cwd}
 			if all {
 				known, err := sidecar.AllProjectRoots()
@@ -48,8 +50,11 @@ func newWatchCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("watch: invalid path %q: %w", root, err)
 				}
-				if gitRoot := gitTopLevel(abs); gitRoot != "" {
+				if gitRoot := gitutil.TopLevelCtx(cmd.Context(), abs); gitRoot != "" {
 					abs = gitRoot
+				} else {
+					// Skip non-git paths: nothing to watch and no sidecar to find.
+					continue
 				}
 				if seen[abs] {
 					continue
@@ -79,21 +84,12 @@ func newWatchCmd() *cobra.Command {
 			}
 
 			m := watch.New(entries)
-			p := tea.NewProgram(m)
-			_, err := p.Run()
+			p := tea.NewProgram(m, tea.WithContext(cmd.Context()))
+			_, err = p.Run()
 			return err
 		},
 	}
 
 	cmd.Flags().BoolVar(&all, "all", false, "Watch all known projects, not just the current directory")
 	return cmd
-}
-
-// gitTopLevel returns the git repository root for dir, or "" if not in a git repo.
-func gitTopLevel(dir string) string {
-	out, err := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel").Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
 }

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
+	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
+	"github.com/CircleCI-Public/chunk-cli/internal/tui/watch"
+)
+
+func newWatchCmd() *cobra.Command {
+	var all bool
+
+	cmd := &cobra.Command{
+		Use:          "watch [dir...]",
+		Short:        "Live dashboard for active sidecars and recent activity",
+		SilenceUsage: true,
+		Args:         cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !term.IsTerminal(int(os.Stdout.Fd())) {
+				return fmt.Errorf("watch requires a TTY")
+			}
+
+			cwd, _ := os.Getwd()
+			roots := []string{cwd}
+			if all {
+				known, err := sidecar.AllProjectRoots()
+				if err != nil {
+					return fmt.Errorf("watch: could not list projects: %w", err)
+				}
+				roots = append(roots, known...)
+			}
+			roots = append(roots, args...)
+
+			seen := map[string]bool{}
+			var entries []watch.ProjectEntry
+			for _, root := range roots {
+				abs, err := filepath.Abs(root)
+				if err != nil {
+					return fmt.Errorf("watch: invalid path %q: %w", root, err)
+				}
+				if gitRoot := gitTopLevel(abs); gitRoot != "" {
+					abs = gitRoot
+				}
+				if seen[abs] {
+					continue
+				}
+				seen[abs] = true
+
+				dataDir, err := config.ProjectDataDir(abs)
+				if err != nil {
+					return fmt.Errorf("watch: data dir for %s: %w", abs, err)
+				}
+
+				// Register this project so future --all runs find it.
+				if err := os.MkdirAll(dataDir, 0o755); err == nil {
+					_ = os.WriteFile(filepath.Join(dataDir, "project-root"), []byte(abs), 0o644)
+				}
+
+				el, err := eventlog.Open(dataDir)
+				if err != nil {
+					return fmt.Errorf("watch: event log for %s: %w", abs, err)
+				}
+
+				entries = append(entries, watch.ProjectEntry{
+					Log:         el,
+					DataDir:     dataDir,
+					ProjectRoot: abs,
+				})
+			}
+
+			m := watch.New(entries)
+			p := tea.NewProgram(m)
+			_, err := p.Run()
+			return err
+		},
+	}
+
+	cmd.Flags().BoolVar(&all, "all", false, "Watch all known projects, not just the current directory")
+	return cmd
+}
+
+// gitTopLevel returns the git repository root for dir, or "" if not in a git repo.
+func gitTopLevel(dir string) string {
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -50,17 +50,35 @@ func AppData() (string, error) {
 // (symlinks resolved via EvalSymlinks, falling back to filepath.Clean), which
 // ensures callers that discover the root via different means — git's
 // --show-toplevel vs. a manual filesystem walk — always hash the same string.
+//
+// One-time migration: if the resolved path yields an empty directory but the
+// old unresolved path has existing data, the old directory is renamed to the
+// new location so users with symlinked project roots don't silently lose their
+// sidecar/snapshot/event-log state.
 func ProjectDataDir(projectRoot string) (string, error) {
 	base, err := AppData()
 	if err != nil {
 		return "", err
 	}
 	clean := filepath.Clean(projectRoot)
-	if resolved, err := filepath.EvalSymlinks(clean); err == nil {
-		clean = resolved
+	resolved := clean
+	if r, err := filepath.EvalSymlinks(clean); err == nil {
+		resolved = r
 	}
-	sum := sha256.Sum256([]byte(clean))
-	return filepath.Join(base, fmt.Sprintf("%x", sum)), nil
+	newDir := filepath.Join(base, fmt.Sprintf("%x", sha256.Sum256([]byte(resolved))))
+
+	// Only attempt migration when the symlink actually changed the path.
+	if resolved != clean {
+		oldDir := filepath.Join(base, fmt.Sprintf("%x", sha256.Sum256([]byte(clean))))
+		if _, statErr := os.Stat(oldDir); statErr == nil {
+			if entries, readErr := os.ReadDir(newDir); readErr == nil && len(entries) == 0 {
+				// Best-effort rename; ignore errors so callers always get a usable path.
+				_ = os.Rename(oldDir, newDir)
+			}
+		}
+	}
+
+	return newDir, nil
 }
 
 func configHome() (string, error) {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -46,14 +46,20 @@ func AppData() (string, error) {
 }
 
 // ProjectDataDir returns the per-project data directory keyed by projectRoot.
-// The directory name is the hex-encoded SHA-256 of the cleaned absolute path,
-// which is guaranteed collision-free across all valid path strings.
+// The directory name is the hex-encoded SHA-256 of the real absolute path
+// (symlinks resolved via EvalSymlinks, falling back to filepath.Clean), which
+// ensures callers that discover the root via different means — git's
+// --show-toplevel vs. a manual filesystem walk — always hash the same string.
 func ProjectDataDir(projectRoot string) (string, error) {
 	base, err := AppData()
 	if err != nil {
 		return "", err
 	}
-	sum := sha256.Sum256([]byte(filepath.Clean(projectRoot)))
+	clean := filepath.Clean(projectRoot)
+	if resolved, err := filepath.EvalSymlinks(clean); err == nil {
+		clean = resolved
+	}
+	sum := sha256.Sum256([]byte(clean))
 	return filepath.Join(base, fmt.Sprintf("%x", sum)), nil
 }
 

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -32,11 +32,25 @@ type Event struct {
 	SidecarName string    `json:"sidecar_name,omitempty"`
 	Branch      string    `json:"branch,omitempty"`
 	Op          Op        `json:"op"`
-	Level       string    `json:"level"` // "step", "info", "warn", "done"
+	Level       string    `json:"level"` // "step", "info", "warn", "done", "error"
 	Msg         string    `json:"msg"`
 }
 
 const logFile = "events.jsonl"
+
+const (
+	levelStep  = "step"
+	levelInfo  = "info"
+	levelWarn  = "warn"
+	levelDone  = "done"
+	levelError = "error"
+)
+
+// maxLogLines triggers a rotation; trimToLines is how many are kept.
+const (
+	maxLogLines = 2000
+	trimToLines = 500
+)
 
 // Log appends events to a JSONL file in a project data directory.
 type Log struct {
@@ -44,12 +58,46 @@ type Log struct {
 	path string
 }
 
-// Open opens (or creates) the event log in dataDir.
+// Open opens (or creates) the event log in dataDir, trimming if too large.
 func Open(dataDir string) (*Log, error) {
 	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		return nil, err
 	}
-	return &Log{path: filepath.Join(dataDir, logFile)}, nil
+	l := &Log{path: filepath.Join(dataDir, logFile)}
+	trimIfNeeded(l.path)
+	return l, nil
+}
+
+// trimIfNeeded rewrites the log to its last trimToLines lines when it exceeds
+// maxLogLines. Atomic write-then-rename; errors are silently ignored.
+func trimIfNeeded(path string) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	var lines [][]byte
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		b := sc.Bytes()
+		cp := make([]byte, len(b))
+		copy(cp, b)
+		lines = append(lines, cp)
+	}
+	_ = f.Close()
+	if len(lines) <= maxLogLines {
+		return
+	}
+	lines = lines[len(lines)-trimToLines:]
+	var buf bytes.Buffer
+	for _, l := range lines {
+		buf.Write(l)
+		buf.WriteByte('\n')
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, buf.Bytes(), 0o644); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, path)
 }
 
 // Append writes a single event to the log.
@@ -163,16 +211,16 @@ func (l *Log) TailFrom(offset int64) ([]Event, int64, error) {
 func levelStr(l iostream.Level) string {
 	switch l {
 	case iostream.LevelStep:
-		return "step"
+		return levelStep
 	case iostream.LevelInfo:
-		return "info"
+		return levelInfo
 	case iostream.LevelWarn:
-		return "warn"
+		return levelWarn
 	case iostream.LevelDone:
-		return "done"
+		return levelDone
 	case iostream.LevelError:
-		return "error"
+		return levelError
 	default:
-		return "info"
+		return levelInfo
 	}
 }

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -1,0 +1,178 @@
+package eventlog
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+)
+
+// Op identifies the kind of operation that generated an event.
+type Op string
+
+// Op values for each sidecar operation type.
+const (
+	OpSync     Op = "sync"
+	OpValidate Op = "validate"
+	OpExec     Op = "exec"
+	OpSetup    Op = "setup"
+)
+
+// Event is a single status event written to the log.
+type Event struct {
+	Ts          time.Time `json:"ts"`
+	SidecarID   string    `json:"sidecar_id,omitempty"`
+	SidecarName string    `json:"sidecar_name,omitempty"`
+	Branch      string    `json:"branch,omitempty"`
+	Op          Op        `json:"op"`
+	Level       string    `json:"level"` // "step", "info", "warn", "done"
+	Msg         string    `json:"msg"`
+}
+
+const logFile = "events.jsonl"
+
+// Log appends events to a JSONL file in a project data directory.
+type Log struct {
+	mu   sync.Mutex
+	path string
+}
+
+// Open opens (or creates) the event log in dataDir.
+func Open(dataDir string) (*Log, error) {
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return nil, err
+	}
+	return &Log{path: filepath.Join(dataDir, logFile)}, nil
+}
+
+// Append writes a single event to the log.
+func (l *Log) Append(e Event) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	f, err := os.OpenFile(l.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	encErr := json.NewEncoder(f).Encode(e)
+	return errors.Join(encErr, f.Close())
+}
+
+// Wrap returns a StatusFunc that calls inner and also appends each call to the
+// log. All events will be tagged with op, sidecarID, sidecarName, and branch.
+func (l *Log) Wrap(inner iostream.StatusFunc, op Op, sidecarID, sidecarName, branch string) iostream.StatusFunc {
+	return func(level iostream.Level, msg string) {
+		if inner != nil {
+			inner(level, msg)
+		}
+		_ = l.Append(Event{
+			Ts:          time.Now(),
+			SidecarID:   sidecarID,
+			SidecarName: sidecarName,
+			Branch:      branch,
+			Op:          op,
+			Level:       levelStr(level),
+			Msg:         msg,
+		})
+	}
+}
+
+// WrapFromDir wraps fn with event-log appending using the log in dataDir.
+// Errors opening the log are silently ignored (best-effort; never blocks).
+func WrapFromDir(dataDir string, fn iostream.StatusFunc, op Op, sidecarID, sidecarName, branch string) iostream.StatusFunc {
+	el, err := Open(dataDir)
+	if err != nil {
+		return fn
+	}
+	return el.Wrap(fn, op, sidecarID, sidecarName, branch)
+}
+
+// Recent returns up to n most recent events from the log.
+func (l *Log) Recent(n int) ([]Event, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	f, err := os.Open(l.path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	var all []Event
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var e Event
+		if json.Unmarshal(sc.Bytes(), &e) == nil {
+			all = append(all, e)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return all, err
+	}
+	if len(all) <= n {
+		return all, nil
+	}
+	return all[len(all)-n:], nil
+}
+
+// TailFrom returns events appended after offset, and the updated offset.
+func (l *Log) TailFrom(offset int64) ([]Event, int64, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	f, err := os.Open(l.path)
+	if os.IsNotExist(err) {
+		return nil, offset, nil
+	}
+	if err != nil {
+		return nil, offset, err
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, offset, err
+	}
+	if info.Size() <= offset {
+		return nil, offset, nil
+	}
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return nil, offset, err
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, offset, err
+	}
+	newOffset := offset + int64(len(data))
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	var events []Event
+	for sc.Scan() {
+		var e Event
+		if json.Unmarshal(sc.Bytes(), &e) == nil {
+			events = append(events, e)
+		}
+	}
+	return events, newOffset, sc.Err()
+}
+
+func levelStr(l iostream.Level) string {
+	switch l {
+	case iostream.LevelStep:
+		return "step"
+	case iostream.LevelInfo:
+		return "info"
+	case iostream.LevelWarn:
+		return "warn"
+	case iostream.LevelDone:
+		return "done"
+	case iostream.LevelError:
+		return "error"
+	default:
+		return "info"
+	}
+}

--- a/internal/eventlog/eventlog_test.go
+++ b/internal/eventlog/eventlog_test.go
@@ -1,0 +1,212 @@
+package eventlog
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+)
+
+func makeEvent(op Op, level, msg string) Event {
+	return Event{Ts: time.Now(), Op: op, Level: level, Msg: msg}
+}
+
+func TestAppendAndRecent(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := range 5 {
+		if err := l.Append(makeEvent(OpValidate, "info", fmt.Sprintf("msg%d", i))); err != nil {
+			t.Fatalf("Append %d: %v", i, err)
+		}
+	}
+
+	got, err := l.Recent(3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 events, got %d", len(got))
+	}
+	if got[0].Msg != "msg2" || got[2].Msg != "msg4" {
+		t.Errorf("unexpected tail: %v %v", got[0].Msg, got[2].Msg)
+	}
+}
+
+func TestRecentEmptyLog(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := l.Recent(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want 0 events, got %d", len(got))
+	}
+}
+
+func TestRecentAll(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range 3 {
+		if err := l.Append(makeEvent(OpSync, "info", fmt.Sprintf("m%d", i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := l.Recent(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want all 3, got %d", len(got))
+	}
+}
+
+func TestTailFrom(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := l.Append(makeEvent(OpSync, "info", "first")); err != nil {
+		t.Fatal(err)
+	}
+
+	got, offset, err := l.TailFrom(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Msg != "first" {
+		t.Errorf("want [first], got %v", got)
+	}
+	if offset == 0 {
+		t.Error("offset should advance past first event")
+	}
+
+	if err := l.Append(makeEvent(OpSync, "done", "second")); err != nil {
+		t.Fatal(err)
+	}
+
+	got2, _, err := l.TailFrom(offset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got2) != 1 || got2[0].Msg != "second" {
+		t.Errorf("want [second], got %v", got2)
+	}
+}
+
+func TestTailFromEmptyLog(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, offset, err := l.TailFrom(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 || offset != 0 {
+		t.Errorf("want empty/0, got len=%d offset=%d", len(got), offset)
+	}
+}
+
+func TestTailFromNoNewEvents(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Append(makeEvent(OpSync, "info", "only")); err != nil {
+		t.Fatal(err)
+	}
+	_, offset, err := l.TailFrom(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Tail again from the advanced offset — should return nothing.
+	got, offset2, err := l.TailFrom(offset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("want no new events, got %d", len(got))
+	}
+	if offset2 != offset {
+		t.Errorf("offset should be unchanged: want %d, got %d", offset, offset2)
+	}
+}
+
+func TestWrapForwardsAndLogs(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var innerCalls []string
+	inner := func(_ iostream.Level, msg string) {
+		innerCalls = append(innerCalls, msg)
+	}
+
+	wrapped := l.Wrap(inner, OpExec, "sc-id", "my-sc", "main")
+	wrapped(iostream.LevelStep, "step1")
+	wrapped(iostream.LevelDone, "done1")
+
+	if len(innerCalls) != 2 {
+		t.Fatalf("want 2 inner calls, got %d", len(innerCalls))
+	}
+
+	got, err := l.Recent(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 events, got %d", len(got))
+	}
+	if got[0].Level != levelStep || got[0].SidecarID != "sc-id" || got[0].Op != OpExec {
+		t.Errorf("unexpected event[0]: %+v", got[0])
+	}
+	if got[1].Level != levelDone || got[1].Msg != "done1" {
+		t.Errorf("unexpected event[1]: %+v", got[1])
+	}
+}
+
+func TestWrapNilInner(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapped := l.Wrap(nil, OpSync, "", "", "")
+	wrapped(iostream.LevelInfo, "should not panic")
+}
+
+func TestLevelStr(t *testing.T) {
+	tests := []struct {
+		in   iostream.Level
+		want string
+	}{
+		{iostream.LevelStep, levelStep},
+		{iostream.LevelInfo, levelInfo},
+		{iostream.LevelWarn, levelWarn},
+		{iostream.LevelDone, levelDone},
+		{iostream.LevelError, levelError},
+	}
+	for _, tt := range tests {
+		if got := levelStr(tt.in); got != tt.want {
+			t.Errorf("levelStr(%v) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -1,6 +1,7 @@
 package gitutil
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -114,7 +115,13 @@ func GeneratePatch(base string) (string, error) {
 
 // HeadRef returns the SHA of the current HEAD commit in the repo at cwd.
 func HeadRef(cwd string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", gitHEAD)
+	return HeadRefCtx(context.Background(), cwd)
+}
+
+// HeadRefCtx returns the SHA of the current HEAD commit in the repo at cwd,
+// honouring ctx for cancellation/timeout.
+func HeadRefCtx(ctx context.Context, cwd string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", gitHEAD)
 	cmd.Dir = cwd
 	out, err := cmd.Output()
 	if err != nil {
@@ -125,6 +132,17 @@ func HeadRef(cwd string) (string, error) {
 		return "", fmt.Errorf("resolve HEAD: empty output")
 	}
 	return sha, nil
+}
+
+// TopLevelCtx returns the git repository root for dir, or "" if not in a git
+// repo, honouring ctx for cancellation/timeout.
+func TopLevelCtx(ctx context.Context, dir string) string {
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--show-toplevel")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // CreateBundle creates a git bundle from base..HEAD in the repo at cwd and returns the raw bytes.

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
@@ -84,6 +85,47 @@ func LoadActive(ctx context.Context) (*ActiveSidecar, error) {
 	return LoadActiveFrom(ctx, dir)
 }
 
+// LoadAnyActive returns the most recently modified sidecar state file for the
+// current project, regardless of session ID. Use this as a fallback when
+// LoadActive returns nil to avoid creating a new sidecar unnecessarily.
+func LoadAnyActive() (*ActiveSidecar, error) {
+	dir, err := saveDir()
+	if err != nil {
+		return nil, err
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "sidecar*.json"))
+	if err != nil || len(matches) == 0 {
+		return nil, nil
+	}
+	var best string
+	var bestTime time.Time
+	for _, m := range matches {
+		info, statErr := os.Stat(m)
+		if statErr != nil {
+			continue
+		}
+		if info.ModTime().After(bestTime) {
+			bestTime = info.ModTime()
+			best = m
+		}
+	}
+	if best == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(best)
+	if err != nil {
+		return nil, err
+	}
+	var a ActiveSidecar
+	if err := json.Unmarshal(data, &a); err != nil {
+		return nil, err
+	}
+	if a.SidecarID == "" {
+		return nil, nil
+	}
+	return &a, nil
+}
+
 // LoadActiveFrom reads the active sidecar from dir.
 func LoadActiveFrom(ctx context.Context, dir string) (*ActiveSidecar, error) {
 	root, _ := projectRoot()
@@ -126,7 +168,51 @@ func SaveActiveTo(ctx context.Context, dir string, a ActiveSidecar) error {
 	}
 	root, _ := projectRoot()
 	branch := CurrentBranch(root)
-	return os.WriteFile(filepath.Join(dir, sidecarFileName(session.IDFromCtx(ctx), branch)), data, 0o644)
+	if err := os.WriteFile(filepath.Join(dir, sidecarFileName(session.IDFromCtx(ctx), branch)), data, 0o644); err != nil {
+		return err
+	}
+	// Write a breadcrumb so chunk watch --all can discover this project.
+	_ = os.WriteFile(filepath.Join(dir, "project-root"), []byte(root), 0o644)
+	return nil
+}
+
+// AllProjectRoots returns the roots of all projects that have ever saved a
+// sidecar state, by reading the breadcrumb files written by SaveActiveTo.
+func AllProjectRoots() ([]string, error) {
+	base, err := config.AppData()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var roots []string
+	seen := map[string]bool{}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		crumb := filepath.Join(base, e.Name(), "project-root")
+		data, readErr := os.ReadFile(crumb)
+		if readErr != nil {
+			continue
+		}
+		root := strings.TrimSpace(string(data))
+		if root == "" || seen[root] {
+			continue
+		}
+		// Only include projects where the root still exists.
+		if _, statErr := os.Stat(root); statErr != nil {
+			continue
+		}
+		seen[root] = true
+		roots = append(roots, root)
+	}
+	return roots, nil
 }
 
 // saveDir returns the XDG_DATA_HOME directory for the current project.

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -86,9 +86,12 @@ func LoadActive(ctx context.Context) (*ActiveSidecar, error) {
 }
 
 // LoadAnyActive returns the most recently modified sidecar state file for the
-// current project, regardless of session ID. Use this as a fallback when
-// LoadActive returns nil to avoid creating a new sidecar unnecessarily.
-func LoadAnyActive() (*ActiveSidecar, error) {
+// current project, regardless of session ID or branch. Cross-branch reuse is
+// intentional: the caller's next SaveActive re-keys the result under the
+// current session+branch, so only one sidecar accumulates per project even
+// when switching branches. ctx is accepted for signature consistency with
+// the other loaders, but is not used.
+func LoadAnyActive(_ context.Context) (*ActiveSidecar, error) {
 	dir, err := saveDir()
 	if err != nil {
 		return nil, err

--- a/internal/tui/tty.go
+++ b/internal/tui/tty.go
@@ -17,3 +17,12 @@ func requireTTY() error {
 	}
 	return nil
 }
+
+// RequireStdoutTTY returns ErrNoTTY if stdout is not an interactive terminal.
+// Use this for full-screen TUI programs that write to stdout.
+func RequireStdoutTTY() error {
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		return ErrNoTTY
+	}
+	return nil
+}

--- a/internal/tui/watch/model.go
+++ b/internal/tui/watch/model.go
@@ -1,0 +1,666 @@
+// Package watch implements the chunk watch TUI dashboard.
+package watch
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
+	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
+)
+
+const (
+	leftPaneWidth  = 28
+	divider        = " │ "
+	pollInterval   = 5 * time.Second
+	spinInterval   = 160 * time.Millisecond
+	runningTimeout = 5 * time.Minute
+	recentEvents   = 300
+
+	levelDone  = "done"
+	levelError = "error"
+)
+
+var spinFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+const logoBlankRow = "███                   ██████"
+
+var logoLines = []string{
+	"        █████████████████",
+	"      █████████████████████",
+	"    ███████████████████  ███",
+	"  ███                ███████",
+	logoBlankRow,
+	"███       ██ ██       ██████",
+	"███   ██         ██   ██████",
+	"███     █████████     ██████",
+	logoBlankRow,
+	"███                   ████",
+	"  ███                ██",
+	"    █████████████████",
+}
+
+// color/style helpers using lipgloss
+var (
+	styleDim    = lipgloss.NewStyle().Faint(true)
+	styleBold   = lipgloss.NewStyle().Bold(true)
+	styleGreen  = lipgloss.NewStyle().Foreground(lipgloss.Color("78"))
+	styleYellow = lipgloss.NewStyle().Foreground(lipgloss.Color("179"))
+	styleBlue   = lipgloss.NewStyle().Foreground(lipgloss.Color("110"))
+	stylePurple = lipgloss.NewStyle().Foreground(lipgloss.Color("140"))
+	styleTeal   = lipgloss.NewStyle().Foreground(lipgloss.Color("80"))
+	styleOrange = lipgloss.NewStyle().Foreground(lipgloss.Color("173"))
+	styleRed    = lipgloss.NewStyle().Foreground(lipgloss.Color("167"))
+	styleMuted  = lipgloss.NewStyle().Foreground(lipgloss.Color("242"))
+	styleVdim   = lipgloss.NewStyle().Foreground(lipgloss.Color("238"))
+)
+
+func dim(s string) string    { return styleDim.Render(s) }
+func bold(s string) string   { return styleBold.Render(s) }
+func green(s string) string  { return styleGreen.Render(s) }
+func yellow(s string) string { return styleYellow.Render(s) }
+func blue(s string) string   { return styleBlue.Render(s) }
+func purple(s string) string { return stylePurple.Render(s) }
+func teal(s string) string   { return styleTeal.Render(s) }
+func orange(s string) string { return styleOrange.Render(s) }
+func red(s string) string    { return styleRed.Render(s) }
+func muted(s string) string  { return styleMuted.Render(s) }
+func vdim(s string) string   { return styleVdim.Render(s) }
+
+// ProjectEntry holds everything the watch model needs for one project.
+type ProjectEntry struct {
+	Log         *eventlog.Log
+	DataDir     string
+	ProjectRoot string
+}
+
+// sidecarInfo holds display state for one sidecar.
+type sidecarInfo struct {
+	id              string
+	name            string
+	projectName     string
+	projectSnapshot bool // any snapshot*.json present in the project's data dir
+	lastSyncedRef   string
+	inSync          bool
+	running         bool
+	lastActivity    time.Time
+	lastOp          eventlog.Op
+}
+
+type tickMsg struct{}
+type spinMsg struct{}
+
+type dataMsg struct {
+	sidecars []sidecarInfo
+	events   []eventlog.Event
+	offsets  []int64
+	branches []string
+	headRefs []string
+}
+
+// Model is the BubbleTea model for the watch dashboard.
+type Model struct {
+	projects []ProjectEntry
+	offsets  []int64
+	branches []string // current branch per project, refreshed each poll
+	headRefs []string // HEAD SHA per project, refreshed each poll
+
+	sidecars    []sidecarInfo
+	selectedIdx int
+	events      []eventlog.Event
+
+	width      int
+	height     int
+	spinIdx    int
+	hasSpinner bool
+}
+
+// New creates a Model ready to run.
+func New(projects []ProjectEntry) Model {
+	return Model{
+		projects: projects,
+		offsets:  make([]int64, len(projects)),
+		branches: make([]string, len(projects)),
+		headRefs: make([]string, len(projects)),
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return tea.Batch(m.loadData, doSpin())
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyPressMsg:
+		switch msg.Code {
+		case 'q', tea.KeyEscape:
+			return m, tea.Quit
+		case 's', tea.KeyDown:
+			if m.selectedIdx < len(m.sidecars)-1 {
+				m.selectedIdx++
+			}
+		case 'w', tea.KeyUp:
+			if m.selectedIdx > 0 {
+				m.selectedIdx--
+			}
+		case 'c':
+			if msg.Mod == tea.ModCtrl {
+				return m, tea.Quit
+			}
+		}
+		return m, nil
+
+	case dataMsg:
+		m.sidecars = msg.sidecars
+		m.events = msg.events
+		m.offsets = msg.offsets
+		m.branches = msg.branches
+		m.headRefs = msg.headRefs
+		if m.selectedIdx >= len(m.sidecars) && len(m.sidecars) > 0 {
+			m.selectedIdx = len(m.sidecars) - 1
+		}
+		m.hasSpinner = anyRunning(m.sidecars)
+		return m, tea.Tick(pollInterval, func(time.Time) tea.Msg { return tickMsg{} })
+
+	case tickMsg:
+		return m, m.loadData
+
+	case spinMsg:
+		m.spinIdx++
+		if m.hasSpinner {
+			return m, doSpin()
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m Model) View() tea.View {
+	v := tea.NewView(m.render())
+	v.AltScreen = true
+	v.WindowTitle = "chunk watch"
+	return v
+}
+
+func (m Model) render() string {
+	if m.width == 0 {
+		return "loading...\n"
+	}
+	return m.renderHeader() +
+		m.renderSeparator() +
+		m.renderBody() +
+		m.renderFooter()
+}
+
+func (m Model) renderHeader() string {
+	count := fmt.Sprintf("%d sidecar", len(m.sidecars))
+	if len(m.sidecars) != 1 {
+		count += "s"
+	}
+
+	var contextTag string
+	if len(m.projects) > 1 {
+		contextTag = "  " + muted(fmt.Sprintf("%d projects", len(m.projects)))
+	} else if len(m.projects) == 1 {
+		branch := m.branches[0]
+		head := m.headRefs[0]
+		if branch != "" && head != "" {
+			contextTag = "  " + green(branch+"@"+head[:min(7, len(head))])
+		}
+	}
+
+	clock := time.Now().Format("15:04:05")
+	title := bold("chunk watch") + "  " + muted(count) + contextTag
+	right := vdim(clock)
+	gap := m.width - lipgloss.Width(title) - lipgloss.Width(right)
+	if gap < 1 {
+		gap = 1
+	}
+	return title + strings.Repeat(" ", gap) + right + "\n"
+}
+
+func (m Model) renderSeparator() string {
+	return vdim(strings.Repeat("─", m.width)) + "\n"
+}
+
+func (m Model) renderBody() string {
+	contentHeight := m.height - 4 // header + separator + footer + padding
+	if contentHeight < 1 {
+		contentHeight = 1
+	}
+
+	leftLines := m.renderSidecarPane(contentHeight)
+	rightLines := m.renderActivityPane(contentHeight)
+
+	var b strings.Builder
+	for i := 0; i < contentHeight; i++ {
+		l := ""
+		if i < len(leftLines) {
+			l = leftLines[i]
+		}
+		r := ""
+		if i < len(rightLines) {
+			r = rightLines[i]
+		}
+		lPad := padLine(l, leftPaneWidth)
+		b.WriteString(" " + lPad + " " + vdim("│") + " " + r + "\n")
+	}
+	return b.String()
+}
+
+func (m Model) renderSidecarPane(maxLines int) []string {
+	lines := make([]string, 0, maxLines)
+	add := func(s string) { lines = append(lines, s) }
+
+	add(vdim("sidecars"))
+	add("")
+
+	if len(m.sidecars) == 0 {
+		add(muted("no sidecars yet"))
+		add("")
+		add(dim("chunk sidecar create"))
+		return lines
+	}
+
+	var lastProject string
+
+	for i, sc := range m.sidecars {
+		if len(lines) >= maxLines-2 {
+			break
+		}
+
+		// Project separator — always shown so each sidecar has a project label.
+		if sc.projectName != lastProject {
+			if lastProject != "" {
+				add("")
+			}
+			label := truncate(sc.projectName, leftPaneWidth-4)
+			snap := ""
+			if sc.projectSnapshot {
+				snap = " " + vdim("◈")
+			}
+			add(vdim("── " + label + snap))
+			lastProject = sc.projectName
+		}
+
+		selected := i == m.selectedIdx
+		nameLine := truncate(sidecarDisplayName(sc.name, sc.id), leftPaneWidth-3)
+
+		if selected {
+			add(muted("▶ ") + bold(nameLine))
+		} else {
+			add("  " + nameLine)
+		}
+
+		switch {
+		case sc.running:
+			frame := spinFrames[m.spinIdx%len(spinFrames)]
+			add("  " + blue(frame+" "+string(sc.lastOp)+"..."))
+		case sc.inSync:
+			add("  " + green("✓ in sync"))
+		case sc.lastSyncedRef == "":
+			add("  " + muted("not synced"))
+		default:
+			add("  " + yellow("↑ needs sync"))
+		}
+
+		if !sc.lastActivity.IsZero() {
+			add("  " + vdim(ago(sc.lastActivity)))
+		} else {
+			add("")
+		}
+
+		// Suppress dotted divider when next sidecar starts a new project group.
+		if i < len(m.sidecars)-1 && m.sidecars[i+1].projectName == sc.projectName {
+			add(vdim(strings.Repeat("·", leftPaneWidth)))
+		}
+	}
+	return lines
+}
+
+func (m Model) renderActivityPane(maxLines int) []string {
+	lines := make([]string, 0, maxLines)
+
+	title := vdim("activity")
+	if m.selectedIdx < len(m.sidecars) {
+		sc := m.sidecars[m.selectedIdx]
+		displayName := sidecarDisplayName(sc.name, sc.id)
+		if sc.projectName != "" {
+			title += "  " + muted(sc.projectName+"/"+displayName)
+		} else {
+			title += "  " + muted(displayName)
+		}
+	}
+	lines = append(lines, title, "")
+
+	var filtered []eventlog.Event
+	if m.selectedIdx < len(m.sidecars) {
+		id := m.sidecars[m.selectedIdx].id
+		for _, e := range m.events {
+			if e.SidecarID == id {
+				filtered = append(filtered, e)
+			}
+		}
+	}
+
+	if len(filtered) == 0 {
+		// right pane width: total - 1 leading space - leftPaneWidth - 1 space - 1 divider - 1 space
+		rightWidth := m.width - leftPaneWidth - 4
+		logoMaxWidth := 0
+		for _, l := range logoLines {
+			if w := lipgloss.Width(l); w > logoMaxWidth {
+				logoMaxWidth = w
+			}
+		}
+		pad := (rightWidth - logoMaxWidth) / 2
+		if pad < 0 {
+			pad = 0
+		}
+		padStr := strings.Repeat(" ", pad)
+		lines = append(lines, muted("No activity yet."), "")
+		for _, l := range logoLines {
+			lines = append(lines, padStr+vdim(l))
+		}
+		return lines
+	}
+
+	return append(lines, buildActivityLines(filtered, maxLines-2)...)
+}
+
+// buildActivityLines renders events newest-first, grouped by op-run.
+func buildActivityLines(events []eventlog.Event, maxLines int) []string {
+	groups := groupEvents(events)
+	rendered := make([]string, 0, maxLines)
+	add := func(s string) { rendered = append(rendered, s) }
+
+	for gi := len(groups) - 1; gi >= 0 && len(rendered) < maxLines; gi-- {
+		if gi < len(groups)-1 {
+			add(vdim(strings.Repeat("─", 44)))
+		}
+		g := groups[gi]
+		for ei := len(g) - 1; ei >= 0 && len(rendered) < maxLines; ei-- {
+			add(renderEvent(g[ei]))
+		}
+	}
+	return rendered
+}
+
+// eventGroup is a slice of events from a single op-run.
+type eventGroup []eventlog.Event
+
+// groupEvents partitions events into op-runs. A run ends when a "done" or
+// "error" event arrives, or when the op changes.
+func groupEvents(events []eventlog.Event) []eventGroup {
+	var groups []eventGroup
+	cur := make(eventGroup, 0, len(events))
+	for _, e := range events {
+		if len(cur) > 0 && e.Op != cur[0].Op {
+			groups = append(groups, cur)
+			cur = make(eventGroup, 0, len(events)-len(groups))
+		}
+		cur = append(cur, e)
+		if e.Level == levelDone || e.Level == levelError {
+			groups = append(groups, cur)
+			cur = make(eventGroup, 0)
+		}
+	}
+	if len(cur) > 0 {
+		groups = append(groups, cur)
+	}
+	return groups
+}
+
+func renderEvent(e eventlog.Event) string {
+	ts := vdim(e.Ts.Format("15:04:05"))
+	op := opTag(e.Op)
+	icon, msg := iconAndMsg(e)
+	return ts + "  " + op + "  " + icon + "  " + msg
+}
+
+func opTag(op eventlog.Op) string {
+	switch op {
+	case eventlog.OpSync:
+		return blue("sync    ")
+	case eventlog.OpValidate:
+		return purple("validate")
+	case eventlog.OpExec:
+		return teal("exec    ")
+	case eventlog.OpSetup:
+		return orange("setup   ")
+	default:
+		return muted(fmt.Sprintf("%-8s", string(op)))
+	}
+}
+
+func iconAndMsg(e eventlog.Event) (string, string) {
+	switch e.Level {
+	case levelDone:
+		return green("✓"), green(e.Msg)
+	case "warn":
+		return yellow("⚠"), yellow(e.Msg)
+	case levelError:
+		return red("✗"), red(e.Msg)
+	default:
+		return vdim("›"), muted(e.Msg)
+	}
+}
+
+func (m Model) renderFooter() string {
+	keys := []struct{ key, action string }{
+		{"↑/↓", "select"},
+		{"q", "quit"},
+	}
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, vdim(k.key)+" "+dim(k.action))
+	}
+	bar := strings.Join(parts, "  "+vdim("·")+"  ")
+	return vdim(strings.Repeat("─", m.width)) + "\n" + "  " + bar + "\n"
+}
+
+// loadData reads sidecar state files and new event log entries from all projects.
+func (m Model) loadData() tea.Msg {
+	var allSidecars []sidecarInfo
+	allEvents := m.events
+	newOffsets := make([]int64, len(m.projects))
+	copy(newOffsets, m.offsets)
+	newBranches := make([]string, len(m.projects))
+	newHeadRefs := make([]string, len(m.projects))
+
+	for i, p := range m.projects {
+		newBranches[i] = sidecar.CurrentBranch(p.ProjectRoot)
+		newHeadRefs[i] = headRef(p.ProjectRoot)
+		snap := hasSnapshotFile(p.DataDir)
+		sidecars := loadSidecars(p.DataDir, p.ProjectRoot, snap, newHeadRefs[i])
+		allSidecars = append(allSidecars, sidecars...)
+
+		if p.Log == nil {
+			continue
+		}
+		offset := m.offsets[i]
+		if offset == 0 {
+			recent, _ := p.Log.Recent(recentEvents)
+			allEvents = append(allEvents, recent...)
+			_, newOff, _ := p.Log.TailFrom(0)
+			newOffsets[i] = newOff
+		} else {
+			newEvts, newOff, _ := p.Log.TailFrom(offset)
+			allEvents = append(allEvents, newEvts...)
+			newOffsets[i] = newOff
+		}
+	}
+
+	if len(allEvents) > recentEvents {
+		allEvents = allEvents[len(allEvents)-recentEvents:]
+	}
+
+	for i := range allSidecars {
+		sc := &allSidecars[i]
+		for j := len(allEvents) - 1; j >= 0; j-- {
+			e := allEvents[j]
+			if e.SidecarID != sc.id {
+				continue
+			}
+			if sc.lastActivity.IsZero() {
+				sc.lastActivity = e.Ts
+				sc.lastOp = e.Op
+			}
+			if e.Level != levelDone && e.Level != levelError && time.Since(e.Ts) < runningTimeout {
+				sc.running = true
+			}
+			break
+		}
+	}
+
+	return dataMsg{sidecars: allSidecars, events: allEvents, offsets: newOffsets, branches: newBranches, headRefs: newHeadRefs}
+}
+
+// loadSidecars reads all sidecar*.json files from dataDir, deduplicates by ID.
+func loadSidecars(dataDir, projectRoot string, snap bool, head string) []sidecarInfo {
+	matches, _ := filepath.Glob(filepath.Join(dataDir, "sidecar*.json"))
+	projectName := filepath.Base(projectRoot)
+	seen := map[string]bool{}
+	var result []sidecarInfo
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var as sidecar.ActiveSidecar
+		if json.Unmarshal(data, &as) != nil || as.SidecarID == "" {
+			continue
+		}
+		if seen[as.SidecarID] {
+			continue
+		}
+		seen[as.SidecarID] = true
+		inSync := head != "" && as.LastSyncedRef != "" && head == as.LastSyncedRef
+		result = append(result, sidecarInfo{
+			id:              as.SidecarID,
+			name:            as.Name,
+			projectName:     projectName,
+			projectSnapshot: snap,
+			lastSyncedRef:   as.LastSyncedRef,
+			inSync:          inSync,
+		})
+	}
+	return result
+}
+
+// hasSnapshotFile reports whether any snapshot*.json exists in dataDir.
+func hasSnapshotFile(dataDir string) bool {
+	matches, _ := filepath.Glob(filepath.Join(dataDir, "snapshot*.json"))
+	return len(matches) > 0
+}
+
+func anyRunning(sidecars []sidecarInfo) bool {
+	for _, sc := range sidecars {
+		if sc.running {
+			return true
+		}
+	}
+	return false
+}
+
+func doSpin() tea.Cmd {
+	return tea.Tick(spinInterval, func(time.Time) tea.Msg { return spinMsg{} })
+}
+
+// padLine pads s to exactly width visible characters, accounting for ANSI codes.
+func padLine(s string, width int) string {
+	vis := lipgloss.Width(s)
+	if vis >= width {
+		return lipgloss.NewStyle().MaxWidth(width).Render(s)
+	}
+	return s + strings.Repeat(" ", width-vis)
+}
+
+// truncate shortens s to at most n runes.
+func truncate(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	if n > 1 {
+		return string(runes[:n-1]) + "…"
+	}
+	return string(runes[:n])
+}
+
+// sidecarDisplayName returns the best human-readable name for a sidecar.
+// Uses Name if set, otherwise strips a UUID suffix from the ID.
+func sidecarDisplayName(name, id string) string {
+	if name != "" {
+		return name
+	}
+	if clean := stripUUIDSuffix(id); clean != "" && clean != id {
+		return clean
+	}
+	return id
+}
+
+// stripUUIDSuffix removes a "-<8hex>-<4hex>-..." UUID portion from s.
+// "chunk-cli-2d66488f-e67f-4c3a-9abc-112233445566" → "chunk-cli"
+func stripUUIDSuffix(s string) string {
+	for i := 0; i < len(s); i++ {
+		if s[i] != '-' {
+			continue
+		}
+		rest := s[i+1:]
+		if len(rest) >= 9 && isHex8(rest[:8]) && rest[8] == '-' && i > 0 {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+// isHex8 reports whether s is exactly 8 lowercase hex characters.
+func isHex8(s string) bool {
+	if len(s) != 8 {
+		return false
+	}
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// headRef returns the full HEAD SHA for the git repo at dir.
+func headRef(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// ago returns a human-readable duration since t.
+func ago(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds ago", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	default:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	}
+}

--- a/internal/tui/watch/model.go
+++ b/internal/tui/watch/model.go
@@ -2,10 +2,10 @@
 package watch
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -14,6 +14,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
+	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
 )
 
@@ -148,11 +149,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.Code {
 		case 'q', tea.KeyEscape:
 			return m, tea.Quit
-		case 's', tea.KeyDown:
+		case 'j', tea.KeyDown:
 			if m.selectedIdx < len(m.sidecars)-1 {
 				m.selectedIdx++
 			}
-		case 'w', tea.KeyUp:
+		case 'k', tea.KeyUp:
 			if m.selectedIdx > 0 {
 				m.selectedIdx--
 			}
@@ -409,7 +410,7 @@ func groupEvents(events []eventlog.Event) []eventGroup {
 	for _, e := range events {
 		if len(cur) > 0 && e.Op != cur[0].Op {
 			groups = append(groups, cur)
-			cur = make(eventGroup, 0, len(events)-len(groups))
+			cur = make(eventGroup, 0)
 		}
 		cur = append(cur, e)
 		if e.Level == levelDone || e.Level == levelError {
@@ -460,7 +461,7 @@ func iconAndMsg(e eventlog.Event) (string, string) {
 
 func (m Model) renderFooter() string {
 	keys := []struct{ key, action string }{
-		{"↑/↓", "select"},
+		{"↑/↓ j/k", "select"},
 		{"q", "quit"},
 	}
 	parts := make([]string, 0, len(keys))
@@ -492,9 +493,11 @@ func (m Model) loadData() tea.Msg {
 		}
 		offset := m.offsets[i]
 		if offset == 0 {
-			recent, _ := p.Log.Recent(recentEvents)
-			allEvents = append(allEvents, recent...)
-			_, newOff, _ := p.Log.TailFrom(0)
+			all, newOff, _ := p.Log.TailFrom(0)
+			if len(all) > recentEvents {
+				all = all[len(all)-recentEvents:]
+			}
+			allEvents = append(allEvents, all...)
 			newOffsets[i] = newOff
 		} else {
 			newEvts, newOff, _ := p.Log.TailFrom(offset)
@@ -645,11 +648,10 @@ func headRef(dir string) string {
 	if dir == "" {
 		return ""
 	}
-	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	sha, _ := gitutil.HeadRefCtx(ctx, dir)
+	return sha
 }
 
 // ago returns a human-readable duration since t.

--- a/internal/tui/watch/model_test.go
+++ b/internal/tui/watch/model_test.go
@@ -1,0 +1,267 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
+)
+
+// groupEvents tests
+
+func TestGroupEvents_empty(t *testing.T) {
+	if groups := groupEvents(nil); len(groups) != 0 {
+		t.Errorf("want 0 groups, got %d", len(groups))
+	}
+}
+
+func TestGroupEvents_singleRunning(t *testing.T) {
+	events := []eventlog.Event{
+		{Op: eventlog.OpValidate, Level: "step"},
+		{Op: eventlog.OpValidate, Level: "info"},
+	}
+	groups := groupEvents(events)
+	if len(groups) != 1 {
+		t.Fatalf("want 1 group, got %d", len(groups))
+	}
+	if len(groups[0]) != 2 {
+		t.Errorf("want 2 events in group, got %d", len(groups[0]))
+	}
+}
+
+func TestGroupEvents_terminatedByDone(t *testing.T) {
+	events := []eventlog.Event{
+		{Op: eventlog.OpSync, Level: "step"},
+		{Op: eventlog.OpSync, Level: "done"},
+		{Op: eventlog.OpSync, Level: "info"},
+	}
+	groups := groupEvents(events)
+	if len(groups) != 2 {
+		t.Fatalf("want 2 groups, got %d", len(groups))
+	}
+	if len(groups[0]) != 2 {
+		t.Errorf("first group: want 2 events, got %d", len(groups[0]))
+	}
+	if len(groups[1]) != 1 {
+		t.Errorf("second group: want 1 event, got %d", len(groups[1]))
+	}
+}
+
+func TestGroupEvents_terminatedByError(t *testing.T) {
+	events := []eventlog.Event{
+		{Op: eventlog.OpValidate, Level: "step"},
+		{Op: eventlog.OpValidate, Level: "error"},
+	}
+	groups := groupEvents(events)
+	if len(groups) != 1 || len(groups[0]) != 2 {
+		t.Fatalf("want 1 group of 2, got %d groups", len(groups))
+	}
+}
+
+func TestGroupEvents_opChange(t *testing.T) {
+	events := []eventlog.Event{
+		{Op: eventlog.OpSync, Level: "info"},
+		{Op: eventlog.OpValidate, Level: "info"},
+	}
+	groups := groupEvents(events)
+	if len(groups) != 2 {
+		t.Fatalf("want 2 groups, got %d", len(groups))
+	}
+	if groups[0][0].Op != eventlog.OpSync {
+		t.Errorf("group 0 should be sync, got %q", groups[0][0].Op)
+	}
+	if groups[1][0].Op != eventlog.OpValidate {
+		t.Errorf("group 1 should be validate, got %q", groups[1][0].Op)
+	}
+}
+
+func TestGroupEvents_doneFollowedByNewOp(t *testing.T) {
+	// done terminates the group, next event starts a fresh one even with same op.
+	events := []eventlog.Event{
+		{Op: eventlog.OpSync, Level: "step"},
+		{Op: eventlog.OpSync, Level: "done"},
+		{Op: eventlog.OpSync, Level: "step"},
+		{Op: eventlog.OpSync, Level: "info"},
+	}
+	groups := groupEvents(events)
+	if len(groups) != 2 {
+		t.Fatalf("want 2 groups, got %d", len(groups))
+	}
+	if len(groups[1]) != 2 {
+		t.Errorf("second run: want 2 events, got %d", len(groups[1]))
+	}
+}
+
+// stripUUIDSuffix tests
+
+func TestStripUUIDSuffix(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"chunk-cli-2d66488f-e67f-4c3a-9abc-112233445566", "chunk-cli"},
+		{"abc-deadbeef-rest", "abc"},
+		{"no-uuid-here", "no-uuid-here"},
+		{"", ""},
+		// Leading dash: i=0 fails the i>0 guard.
+		{"-2d66488f-rest", "-2d66488f-rest"},
+		// 'g' is not valid hex.
+		{"abc-2d66488g-rest", "abc-2d66488g-rest"},
+		{"plain", "plain"},
+	}
+	for _, tt := range tests {
+		if got := stripUUIDSuffix(tt.in); got != tt.want {
+			t.Errorf("stripUUIDSuffix(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// truncate tests
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		in   string
+		n    int
+		want string
+	}{
+		{"hello", 10, "hello"},
+		{"hello", 5, "hello"},
+		{"hello", 4, "hel…"},
+		{"hello", 1, "h"},
+		{"", 5, ""},
+		{"héllo", 3, "hé…"},
+	}
+	for _, tt := range tests {
+		if got := truncate(tt.in, tt.n); got != tt.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", tt.in, tt.n, got, tt.want)
+		}
+	}
+}
+
+// padLine tests
+
+func TestPadLine_padsShortString(t *testing.T) {
+	got := padLine("hi", 5)
+	// lipgloss.Width("hi") == 2; expect 3 spaces appended.
+	if got != "hi   " {
+		t.Errorf("want %q, got %q", "hi   ", got)
+	}
+}
+
+func TestPadLine_alreadyAtWidth(t *testing.T) {
+	got := padLine("hello", 5)
+	if got != "hello" {
+		t.Errorf("want %q, got %q", "hello", got)
+	}
+}
+
+// ago tests
+
+func TestAgo(t *testing.T) {
+	now := time.Now()
+
+	// Minutes bucket: clearly > 1 min, < 1 hour.
+	if got := ago(now.Add(-5*time.Minute - 30*time.Second)); got != "5m ago" {
+		t.Errorf("want '5m ago', got %q", got)
+	}
+
+	// Hours bucket.
+	if got := ago(now.Add(-3*time.Hour - 30*time.Minute)); got != "3h ago" {
+		t.Errorf("want '3h ago', got %q", got)
+	}
+
+	// Seconds bucket: verify format without asserting exact count.
+	if got := ago(now.Add(-30 * time.Second)); !strings.HasSuffix(got, "s ago") {
+		t.Errorf("seconds bucket: want 'Xs ago', got %q", got)
+	}
+}
+
+// loadSidecars tests
+
+func writeSidecarJSON(t *testing.T, dir, filename, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadSidecars_deduplicatesIDs(t *testing.T) {
+	dir := t.TempDir()
+	root := t.TempDir()
+
+	writeSidecarJSON(t, dir, "sidecar.json", `{"sidecar_id":"id1","name":"sc1","last_synced_ref":"abc123"}`)
+	writeSidecarJSON(t, dir, "sidecar.sess1.json", `{"sidecar_id":"id2","name":"sc2"}`)
+	// Duplicate id1 — should be deduplicated.
+	writeSidecarJSON(t, dir, "sidecar.sess2.json", `{"sidecar_id":"id1","name":"sc1"}`)
+
+	result := loadSidecars(dir, root, false, "abc123")
+	if len(result) != 2 {
+		t.Fatalf("want 2 unique sidecars, got %d", len(result))
+	}
+}
+
+func TestLoadSidecars_inSyncWhenHeadMatches(t *testing.T) {
+	dir := t.TempDir()
+	root := t.TempDir()
+
+	writeSidecarJSON(t, dir, "sidecar.json", `{"sidecar_id":"id1","name":"sc1","last_synced_ref":"abc123"}`)
+
+	result := loadSidecars(dir, root, false, "abc123")
+	if len(result) != 1 {
+		t.Fatalf("want 1, got %d", len(result))
+	}
+	if !result[0].inSync {
+		t.Error("sidecar should be in sync when lastSyncedRef matches head")
+	}
+}
+
+func TestLoadSidecars_notInSyncWhenHeadDiffers(t *testing.T) {
+	dir := t.TempDir()
+	root := t.TempDir()
+
+	writeSidecarJSON(t, dir, "sidecar.json", `{"sidecar_id":"id1","last_synced_ref":"oldref"}`)
+
+	result := loadSidecars(dir, root, false, "newref")
+	if len(result) != 1 {
+		t.Fatalf("want 1, got %d", len(result))
+	}
+	if result[0].inSync {
+		t.Error("sidecar should not be in sync when refs differ")
+	}
+}
+
+func TestLoadSidecars_emptyDir(t *testing.T) {
+	dir := t.TempDir()
+	root := t.TempDir()
+	if result := loadSidecars(dir, root, false, ""); len(result) != 0 {
+		t.Errorf("want 0, got %d", len(result))
+	}
+}
+
+func TestLoadSidecars_skipsEmptySidecarID(t *testing.T) {
+	dir := t.TempDir()
+	root := t.TempDir()
+
+	writeSidecarJSON(t, dir, "sidecar.json", `{"sidecar_id":"","name":"empty"}`)
+
+	if result := loadSidecars(dir, root, false, ""); len(result) != 0 {
+		t.Errorf("want 0 (skipped empty ID), got %d", len(result))
+	}
+}
+
+func TestLoadSidecars_snapshotFlag(t *testing.T) {
+	dir := t.TempDir()
+	root := t.TempDir()
+
+	writeSidecarJSON(t, dir, "sidecar.json", `{"sidecar_id":"id1","name":"sc1"}`)
+
+	result := loadSidecars(dir, root, true, "")
+	if len(result) != 1 {
+		t.Fatalf("want 1, got %d", len(result))
+	}
+	if !result[0].projectSnapshot {
+		t.Error("projectSnapshot should be true when snap=true")
+	}
+}


### PR DESCRIPTION
## Summary

Adds `chunk watch`, a live TUI dashboard showing active sidecars, sync state, and recent activity in a split-pane layout. 
- `--all` flag watches all known projects, not just the current direcotyr
- Sidecars are reused across sessions instead of spawning a new one per Claude Code session
- Adds an append only JSONL event log (internal/eventlog) written by chunk sidecar sync and chunk validate to feed the TUI
- Adds iostreamLevelError and emits done/error completion events from validate so the spinner clears correctly. 


https://github.com/user-attachments/assets/60134a5e-8b99-4944-aecd-2eaf3b428ff5


## Implementation

**New packages:**
- `internal/eventlog` — append-only JSONL log; `Log.Wrap` decorates any `StatusFunc` to mirror calls into the log tagged with sidecar ID, op, and branch
- `internal/tui/watch` — BubbleTea model: left pane lists sidecars with sync/running state, right pane shows events filtered to the selected sidecar grouped by op-run; polls every 2s and tails the log incrementally

**Wiring changes:**
- `internal/cmd/sidecar.go` — wraps `syncFn` with the event log before passing to `BundleSync`/`Sync`
- `internal/cmd/validate.go` — wraps `statusFn` with the event log before `runValidate`; emits `LevelDone`/`LevelError` after the run so the TUI knows when validation is complete
- `internal/cmd/root.go` — registers `newWatchCmd()`
- `internal/iostream/status.go` — adds `LevelError` constant
- `internal/ui/format.go` — adds `ErrFailure` for red stderr rendering
- `go.mod` — promotes `charm.land/lipgloss/v2` from indirect to direct dependency

## Test plan

- [ ] `task build && ./dist/chunk watch` — opens TUI; shows sidecars, updates every 2s
- [ ] `./dist/chunk sidecar sync` — sync events appear in right pane for the active sidecar
- [ ] `./dist/chunk validate` — validate events appear; spinner clears after `✓ validate passed`
- [ ] Validate failure — spinner clears with `✗ validate failed` in red
- [ ] `j`/`k` — navigates sidecars; right pane updates to show selected sidecar's events
- [ ] `q` / `Ctrl-C` — exits cleanly
- [ ] `task test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)