### PR TITLE
Wire validate to the async sidecar exec API and harden streaming

### DIFF
--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -206,6 +207,39 @@ func (c *Client) Exec(ctx context.Context, sidecarID, command string, args []str
 		Stderr:    attrs.Stderr,
 		ExitCode:  attrs.ExitCode,
 	}, nil
+}
+
+// ExecAsync starts a command on a sidecar asynchronously and returns its command ID.
+// The caller should use StreamCommandOutput and GetCommand to observe progress and result.
+func (c *Client) ExecAsync(ctx context.Context, sidecarID, command string, args []string, envVars map[string]string, workingDir string) (string, error) {
+	var resp v3Envelope
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodPost, "/api/v3/sidecar/instances/%s/exec",
+		hc.RouteParams(sidecarID),
+		hc.Body(AsyncExecRequest{
+			Command:    command,
+			Args:       args,
+			Env:        envVars,
+			WorkingDir: workingDir,
+		}),
+		hc.JSONDecoder(&resp),
+	))
+	if err != nil {
+		return "", mapErr("exec async", err)
+	}
+	return resp.Data.ID, nil
+}
+
+// StreamCommandOutput opens the JSONL output stream for a command starting at the given line offset.
+// The caller must close the returned ReadCloser when done or on reconnect.
+func (c *Client) StreamCommandOutput(ctx context.Context, commandID string, offset int) (io.ReadCloser, error) {
+	body, err := c.cl.Stream(ctx, hc.NewRequest(http.MethodGet, "/api/v3/sidecar/commands/%s/output",
+		hc.RouteParams(commandID),
+		hc.QueryParam("offset", fmt.Sprintf("%d", offset)),
+	))
+	if err != nil {
+		return nil, mapErr("stream command output", err)
+	}
+	return body, nil
 }
 
 type commandAttrs struct {

--- a/internal/circleci/types.go
+++ b/internal/circleci/types.go
@@ -65,3 +65,21 @@ type Command struct {
 	Phase             string  `json:"phase"`
 	SidecarInstanceID string  `json:"sidecar_instance_id"`
 }
+
+type AsyncExecRequest struct {
+	Command    string            `json:"command"`
+	Args       []string          `json:"args,omitempty"`
+	Env        map[string]string `json:"env,omitempty"`
+	WorkingDir string            `json:"working_dir,omitempty"`
+}
+
+// CommandOutputLine is one entry from the JSONL output stream at
+// GET /api/v3/sidecar/commands/:id/output.
+// When CommandID is non-empty the entry is a terminal event carrying the exit code.
+type CommandOutputLine struct {
+	Index     int    `json:"index"`
+	Stream    string `json:"stream,omitempty"`
+	Line      string `json:"line,omitempty"`
+	CommandID string `json:"command_id,omitempty"`
+	ExitCode  *int   `json:"exit_code,omitempty"`
+}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -281,7 +281,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return err
 	}
 
-	execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.identityFile, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
+	execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
 
 	if hook != nil {
 		maxAttempts := cfg.StopHookMaxAttempts
@@ -316,7 +316,7 @@ func runValidateDryRun(name, inlineCmd string, cfg *config.ProjectConfig, status
 // provided options. It is shared by both direct and hook invocations.
 // allRemote is true when --remote is passed explicitly (all commands run on the
 // sidecar); false means only commands with Remote:true are routed to the sidecar.
-func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, freshlyCreated bool, identityFile, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, freshlyCreated bool, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	// --cmd: inline command (always local in per-command mode)
 	if inlineCmd != "" {
 		cmdName := name
@@ -330,22 +330,22 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 			streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", cmdName)))
 		}
 		if sidecarID != "" && allRemote {
-			execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc, streams)
+			execFn, dest, err := openAsyncExec(ctx, client, sidecarID, workdir, envVars, rc, statusFn, streams)
 			if err != nil {
 				return err
 			}
-			return validate.RunRemoteInline(ctx, execFn, cmdName, inlineCmd, dest, statusFn, streams)
+			return validate.RunRemoteInline(ctx, execFn, cmdName, inlineCmd, dest, statusFn)
 		}
 		return validate.RunInline(ctx, workDir, cmdName, inlineCmd, statusFn, streams)
 	}
 
 	// All-remote execution (--remote flag): send everything to the sidecar.
 	if sidecarID != "" && allRemote {
-		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc, streams)
+		execFn, dest, err := openAsyncExec(ctx, client, sidecarID, workdir, envVars, rc, statusFn, streams)
 		if err != nil {
 			return err
 		}
-		return validate.RunRemote(ctx, execFn, cfg, name, dest, workDir, statusFn, streams)
+		return validate.RunRemote(ctx, execFn, cfg, name, dest, workDir, statusFn)
 	}
 
 	// Per-command remote routing: commands with Remote:true go to the sidecar,
@@ -354,16 +354,16 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 		if name != "" {
 			if cmd := cfg.FindCommand(name); cmd != nil && cmd.Remote {
 				statusFn(iostream.LevelInfo, fmt.Sprintf("running %s on sidecar %s", name, sidecarID))
-				execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc, streams)
+				execFn, dest, err := openAsyncExec(ctx, client, sidecarID, workdir, envVars, rc, statusFn, streams)
 				if err != nil {
 					return err
 				}
-				return validate.RunRemote(ctx, execFn, cfg, name, dest, workDir, statusFn, streams)
+				return validate.RunRemote(ctx, execFn, cfg, name, dest, workDir, statusFn)
 			}
 			statusFn(iostream.LevelInfo, fmt.Sprintf("running %s locally (not marked remote)", name))
 			// Named command is not marked remote; fall through to local execution.
 		} else {
-			return runSplitCommands(ctx, client, sidecarID, freshlyCreated, identityFile, workdir, workDir, envVars, rc, cfg, statusFn, streams)
+			return runSplitCommands(ctx, client, sidecarID, freshlyCreated, workdir, workDir, envVars, rc, cfg, statusFn, streams)
 		}
 	}
 
@@ -440,24 +440,10 @@ func syncToSidecar(ctx context.Context, client *circleci.Client, sidecarID, iden
 	return &userError{msg: "Could not sync to sidecar.", err: err}
 }
 
-// openSSHSession establishes an SSH session to the sidecar and returns an
-// exec function and the resolved remote working directory.
-func openSSHSession(ctx context.Context, client *circleci.Client, sidecarID, identityFile, workdir string, envVars map[string]string, rc config.ResolvedConfig, streams iostream.Streams) (func(context.Context, string) (string, string, int, error), string, error) {
-	if identityFile == "" && rc.UseSSHIdentityFile {
-		var keyErr error
-		identityFile, keyErr = sidecar.DefaultKeyPath()
-		if keyErr != nil {
-			streams.ErrPrintf("warning: could not resolve SSH identity file: %v\n", keyErr)
-		}
-	}
-	var authSock string
-	if identityFile == "" {
-		authSock = os.Getenv(config.EnvSSHAuthSock)
-	}
-	session, err := sidecar.OpenSession(ctx, client, sidecarID, identityFile, authSock)
-	if err != nil {
-		return nil, "", &userError{msg: "Could not open SSH session to sidecar.", err: err}
-	}
+// openAsyncExec returns an exec function that runs scripts on a remote sidecar
+// via the async HTTP API, streaming output in real time, and the resolved
+// remote working directory.
+func openAsyncExec(ctx context.Context, client *circleci.Client, sidecarID, workdir string, envVars map[string]string, rc config.ResolvedConfig, statusFn iostream.StatusFunc, streams iostream.Streams) (func(context.Context, string) (int, error), string, error) {
 	cwd, _ := os.Getwd()
 	_, repo, _ := gitremote.DetectOrgAndRepo(cwd)
 	dest, err := sidecar.ResolveWorkspace(ctx, workdir, repo)
@@ -471,12 +457,8 @@ func openSSHSession(ctx context.Context, client *circleci.Client, sidecarID, ide
 	for k, v := range envVars {
 		merged[k] = v
 	}
-	execFn := func(ctx context.Context, script string) (string, string, int, error) {
-		result, err := sidecar.ExecOverSSH(ctx, session, "sh -c "+sidecar.ShellEscape(script), nil, merged)
-		if err != nil {
-			return "", "", 0, err
-		}
-		return result.Stdout, result.Stderr, result.ExitCode, nil
+	execFn := func(ctx context.Context, script string) (int, error) {
+		return sidecar.ExecAsync(ctx, client, sidecarID, script, merged, statusFn, streams)
 	}
 	return execFn, dest, nil
 }
@@ -499,7 +481,7 @@ func hostForwardEnv(token string) map[string]string {
 // When freshlyCreated is true, SSH failures are hard errors rather than
 // silent local fallbacks (a newly provisioned sidecar that can't be reached
 // indicates a real problem, not temporary unavailability).
-func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, identityFile, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	remoteCfg, localCfg := splitByRemote(cfg)
 	if len(remoteCfg.Commands) > 0 {
 		statusFn(iostream.LevelInfo, fmt.Sprintf("running on sidecar %s: %s", sidecarID, commandNames(remoteCfg.Commands)))
@@ -509,7 +491,7 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 	}
 	var runErr error
 	if len(remoteCfg.Commands) > 0 {
-		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc, streams)
+		execFn, dest, err := openAsyncExec(ctx, client, sidecarID, workdir, envVars, rc, statusFn, streams)
 		if err != nil {
 			if freshlyCreated {
 				return newUserError(fmt.Sprintf("Could not reach newly created sidecar %s.", sidecarID)).
@@ -531,7 +513,7 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 			streams.ErrPrintf("warning: %v (%q); run 'chunk sidecar env build' to set up the workspace; running %s locally instead\n", wsErr, dest, commandNames(remoteCfg.Commands))
 			localCfg.Commands = append(remoteCfg.Commands, localCfg.Commands...)
 		} else {
-			runErr = validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, statusFn, streams)
+			runErr = validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, statusFn)
 		}
 	}
 	if len(localCfg.Commands) > 0 {

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,10 +14,8 @@ import (
 
 	"gotest.tools/v3/assert"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
-	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 )
 
 // hookPayload is the JSON Claude Code sends to Stop hooks via stdin.
@@ -140,90 +137,6 @@ func TestHostForwardEnv(t *testing.T) {
 		_, hasAlias := env[config.EnvCircleCIToken]
 		assert.Assert(t, !hasAlias)
 	})
-}
-
-// setupSSHSession starts fake CCI + SSH servers and sets env vars so
-// ensureCircleCIClient resolves to the fake. Returns the SSH server and the
-// identity key file path.
-func setupSSHSession(t *testing.T) (*fakes.SSHServer, string) {
-	t.Helper()
-	isolateConfig(t)
-
-	keyFile, pubKey := fakes.GenerateSSHKeypair(t)
-	sshSrv := fakes.NewSSHServer(t, pubKey)
-	sshSrv.SetResult("hello\n", 0)
-
-	cci := fakes.NewFakeCircleCI()
-	cci.AddKeyURL = sshSrv.Addr()
-	cciSrv := httptest.NewServer(cci)
-	t.Cleanup(cciSrv.Close)
-
-	t.Setenv(config.EnvCircleToken, "test-token")
-	t.Setenv(config.EnvCircleCIBaseURL, cciSrv.URL)
-
-	return sshSrv, keyFile
-}
-
-func TestOpenSSHSessionPassesEnvVars(t *testing.T) {
-	sshSrv, keyFile := setupSSHSession(t)
-
-	client, err := circleci.NewClient(circleci.Config{
-		Token:   "test-token",
-		BaseURL: os.Getenv(config.EnvCircleCIBaseURL),
-	})
-	assert.NilError(t, err)
-
-	envVars := map[string]string{"FOO": "bar", "BAZ": "qux"}
-	execFn, _, err := openSSHSession(context.Background(), client, "sidecar-123", keyFile, "", envVars, config.ResolvedConfig{}, discardStreams())
-	assert.NilError(t, err)
-
-	_, _, _, err = execFn(context.Background(), "echo hello")
-	assert.NilError(t, err)
-
-	got := sshSrv.EnvVars()
-	assert.Equal(t, got["FOO"], "bar")
-	assert.Equal(t, got["BAZ"], "qux")
-}
-
-func TestOpenSSHSessionUsesIdentityFileWhenUseSSHIdentityFile(t *testing.T) {
-	sshSrv, keyFile := setupSSHSession(t)
-
-	client, err := circleci.NewClient(circleci.Config{
-		Token:   "test-token",
-		BaseURL: os.Getenv(config.EnvCircleCIBaseURL),
-	})
-	assert.NilError(t, err)
-
-	// Write the key to the path that sidecar.DefaultKeyPath() would return so
-	// we can pass it explicitly as the identity file — verifying the UseSSHIdentityFile
-	// path uses the provided key rather than SSH_AUTH_SOCK.
-	rc := config.ResolvedConfig{UseSSHIdentityFile: true}
-	execFn, _, err := openSSHSession(context.Background(), client, "sidecar-123", keyFile, "", nil, rc, discardStreams())
-	assert.NilError(t, err)
-
-	sshSrv.SetResult("ok\n", 0)
-	_, _, code, err := execFn(context.Background(), "true")
-	assert.NilError(t, err)
-	assert.Equal(t, code, 0)
-}
-
-func TestOpenSSHSessionFallsBackToAuthSockWhenNoIdentityFile(t *testing.T) {
-	_, keyFile := setupSSHSession(t)
-	t.Setenv(config.EnvSSHAuthSock, "")
-
-	client, err := circleci.NewClient(circleci.Config{
-		Token:   "test-token",
-		BaseURL: os.Getenv(config.EnvCircleCIBaseURL),
-	})
-	assert.NilError(t, err)
-
-	// No identity file provided and UseSSHIdentityFile=false: the session open
-	// attempt will use an empty authSock, which should fail gracefully.
-	rc := config.ResolvedConfig{UseSSHIdentityFile: false}
-	_, _, err = openSSHSession(context.Background(), client, "sidecar-123", keyFile, "", nil, rc, discardStreams())
-	// With a key file explicitly provided the session opens; the important thing
-	// is that UseSSHIdentityFile=false does not attempt DefaultKeyPath resolution.
-	assert.NilError(t, err)
 }
 
 func TestValidateEnvFlagBadValue(t *testing.T) {

--- a/internal/httpcl/client.go
+++ b/internal/httpcl/client.go
@@ -181,6 +181,57 @@ func parseRetryAfter(resp *http.Response) time.Duration {
 	return 0
 }
 
+// Stream makes a GET request and returns the response body for line-by-line reading.
+// Unlike Call, it does not drain or close the response body — the caller must close it.
+// Non-2xx responses return an *HTTPError.
+func (c *Client) Stream(ctx context.Context, r Request) (io.ReadCloser, error) {
+	u, err := url.Parse(c.baseURL + r.URL())
+	if err != nil {
+		return nil, fmt.Errorf("httpcl: bad url: %w", err)
+	}
+	if len(r.query) > 0 {
+		u.RawQuery = r.query.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, r.method, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("httpcl: new request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+	if c.authToken != "" {
+		if c.authHeader != "" {
+			req.Header.Set(c.authHeader, c.authToken)
+		} else {
+			req.Header.Set("Authorization", "Bearer "+c.authToken)
+		}
+	}
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
+	}
+	for k, vals := range r.headers {
+		for _, v := range vals {
+			req.Header.Add(k, v)
+		}
+	}
+
+	resp, err := c.http.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		return nil, &HTTPError{
+			Method:     r.method,
+			Route:      r.route,
+			StatusCode: resp.StatusCode,
+			Body:       body,
+		}
+	}
+	return resp.Body, nil
+}
+
 // Call executes the request and returns the HTTP status code.
 // Non-2xx responses return an *HTTPError. If a decoder is set and the
 // response is 2xx, the response body is decoded.

--- a/internal/sidecar/exec_async.go
+++ b/internal/sidecar/exec_async.go
@@ -1,0 +1,120 @@
+package sidecar
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+)
+
+const maxReconnects = 5
+
+// ExecAsync executes a shell script on a remote sidecar via the async HTTP API.
+// Output lines are written to streams in real time as they arrive.
+// On dropped connections the stream reconnects automatically up to maxReconnects times.
+func ExecAsync(ctx context.Context, client *circleci.Client, sidecarID, script string, envVars map[string]string, statusFn iostream.StatusFunc, streams iostream.Streams) (int, error) {
+	commandID, err := client.ExecAsync(ctx, sidecarID, "sh", []string{"-c", script}, envVars, "")
+	if err != nil {
+		return 0, fmt.Errorf("start remote command: %w", err)
+	}
+	return streamWithReconnect(ctx, client, commandID, statusFn, streams)
+}
+
+func streamWithReconnect(ctx context.Context, client *circleci.Client, commandID string, statusFn iostream.StatusFunc, streams iostream.Streams) (int, error) {
+	offset := 0
+	reconnects := 0
+
+	for {
+		exitCode, done, newOffset, err := readStream(ctx, client, commandID, offset, streams)
+		offset = newOffset
+		if done {
+			return exitCode, nil
+		}
+		if ctx.Err() != nil {
+			return 0, ctx.Err()
+		}
+
+		// A clean EOF (err == nil) means the server closed the stream without a
+		// terminal event. If the command has already ended, finish via a status
+		// poll rather than burning reconnect attempts on a stream that will not
+		// resume. Otherwise the command is still running and we reconnect to
+		// resume streaming from the current offset.
+		if err == nil {
+			if code, ok := endedExitCode(ctx, client, commandID); ok {
+				return code, nil
+			}
+		}
+
+		reconnects++
+		if reconnects > maxReconnects {
+			// Fall back to status poll when we can no longer stream.
+			if code, ok := endedExitCode(ctx, client, commandID); ok {
+				return code, nil
+			}
+			return 0, fmt.Errorf("output stream disconnected: %w", err)
+		}
+		if err != nil {
+			statusFn(iostream.LevelWarn, "connection interrupted, reconnecting...")
+		}
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(reconnectBackoff(reconnects)):
+		}
+	}
+}
+
+// endedExitCode polls the command status and returns its exit code if the
+// command has ended. ok is false when the command is still running or its
+// status could not be retrieved.
+func endedExitCode(ctx context.Context, client *circleci.Client, commandID string) (code int, ok bool) {
+	cmd, err := client.GetCommand(ctx, commandID)
+	if err != nil || cmd.Phase != "ended" || cmd.ExitCode == nil {
+		return 0, false
+	}
+	return *cmd.ExitCode, true
+}
+
+func readStream(ctx context.Context, client *circleci.Client, commandID string, offset int, streams iostream.Streams) (exitCode int, done bool, newOffset int, err error) {
+	body, err := client.StreamCommandOutput(ctx, commandID, offset)
+	if err != nil {
+		return 0, false, offset, err
+	}
+	defer func() { _ = body.Close() }()
+
+	newOffset = offset
+	scanner := bufio.NewScanner(body)
+	for scanner.Scan() {
+		var line circleci.CommandOutputLine
+		if jsonErr := json.Unmarshal(scanner.Bytes(), &line); jsonErr != nil {
+			continue
+		}
+		if line.CommandID != "" {
+			code := 0
+			if line.ExitCode != nil {
+				code = *line.ExitCode
+			}
+			return code, true, newOffset, nil
+		}
+		newOffset = line.Index + 1
+		switch line.Stream {
+		case "stdout":
+			_, _ = fmt.Fprintf(streams.Out, "%s\n", line.Line)
+		case "stderr":
+			_, _ = fmt.Fprintf(streams.Err, "%s\n", line.Line)
+		}
+	}
+	return 0, false, newOffset, scanner.Err()
+}
+
+func reconnectBackoff(attempt int) time.Duration {
+	d := time.Duration(attempt) * 500 * time.Millisecond
+	if d > 4*time.Second {
+		return 4 * time.Second
+	}
+	return d
+}

--- a/internal/sidecar/exec_async_test.go
+++ b/internal/sidecar/exec_async_test.go
@@ -1,0 +1,143 @@
+package sidecar_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+)
+
+func intPtr(n int) *int { return &n }
+
+// capture collects the output/error streams and any warning status messages
+// produced during an ExecAsync run.
+type capture struct {
+	out, errOut bytes.Buffer
+	warns       []string
+}
+
+func (c *capture) streams() iostream.Streams {
+	return iostream.Streams{Out: &c.out, Err: &c.errOut}
+}
+
+func (c *capture) statusFn() iostream.StatusFunc {
+	return func(level iostream.Level, msg string) {
+		if level == iostream.LevelWarn {
+			c.warns = append(c.warns, msg)
+		}
+	}
+}
+
+func TestExecAsyncHappyPath(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.OutputStreamFunc = func(_ int, w io.Writer) {
+		fakes.WriteOutputLines(w, []fakes.OutputLine{
+			{Index: 0, Stream: "stdout", Line: "hello"},
+			{Index: 1, Stream: "stderr", Line: "a warning"},
+			{Index: 2, Stream: "stdout", Line: "world"},
+			{CommandID: "cmd-123", ExitCode: intPtr(0)},
+		})
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	cp := &capture{}
+	code, err := sidecar.ExecAsync(context.Background(), newClient(t, srv.URL),
+		"sb-1", "echo hello", nil, cp.statusFn(), cp.streams())
+
+	assert.NilError(t, err)
+	assert.Equal(t, code, 0)
+	// The server sends bare lines; the client re-adds a single newline each.
+	assert.Equal(t, cp.out.String(), "hello\nworld\n")
+	assert.Equal(t, cp.errOut.String(), "a warning\n")
+	assert.Equal(t, len(cp.warns), 0)
+}
+
+func TestExecAsyncNonZeroExit(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.OutputStreamFunc = func(_ int, w io.Writer) {
+		fakes.WriteOutputLines(w, []fakes.OutputLine{
+			{Index: 0, Stream: "stderr", Line: "boom"},
+			{CommandID: "cmd-123", ExitCode: intPtr(2)},
+		})
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	cp := &capture{}
+	code, err := sidecar.ExecAsync(context.Background(), newClient(t, srv.URL),
+		"sb-1", "false", nil, cp.statusFn(), cp.streams())
+
+	assert.NilError(t, err)
+	assert.Equal(t, code, 2)
+	assert.Equal(t, cp.errOut.String(), "boom\n")
+}
+
+// A clean EOF with no terminal event on an already-ended command should finish
+// via a status poll rather than spending reconnect attempts.
+func TestExecAsyncCleanEOFEndedCommand(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.OutputStreamFunc = func(_ int, w io.Writer) {
+		fakes.WriteOutputLines(w, []fakes.OutputLine{
+			{Index: 0, Stream: "stdout", Line: "done"},
+		})
+	}
+	cci.CommandResponse = &fakes.CommandResponse{
+		ID:       "cmd-123",
+		Phase:    "ended",
+		ExitCode: intPtr(0),
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	cp := &capture{}
+	code, err := sidecar.ExecAsync(context.Background(), newClient(t, srv.URL),
+		"sb-1", "echo done", nil, cp.statusFn(), cp.streams())
+
+	assert.NilError(t, err)
+	assert.Equal(t, code, 0)
+	assert.Equal(t, cp.out.String(), "done\n")
+	// No reconnect attempts, so no interruption warnings.
+	assert.Equal(t, len(cp.warns), 0)
+}
+
+// When the stream closes cleanly while the command is still running, the loop
+// reconnects and resumes from the recorded offset.
+func TestExecAsyncReconnectResumesFromOffset(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	// First connection (offset 0) delivers two lines then closes cleanly with
+	// no terminal event; the reconnect (offset 2) delivers the terminal event.
+	cci.OutputStreamFunc = func(offset int, w io.Writer) {
+		if offset == 0 {
+			fakes.WriteOutputLines(w, []fakes.OutputLine{
+				{Index: 0, Stream: "stdout", Line: "line one"},
+				{Index: 1, Stream: "stdout", Line: "line two"},
+			})
+			return
+		}
+		fakes.WriteOutputLines(w, []fakes.OutputLine{
+			{Index: 2, Stream: "stdout", Line: "line three"},
+			{CommandID: "cmd-123", ExitCode: intPtr(0)},
+		})
+	}
+	// Command is still running when the first stream closes, forcing a reconnect.
+	cci.CommandResponse = &fakes.CommandResponse{ID: "cmd-123", Phase: "running"}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	cp := &capture{}
+	code, err := sidecar.ExecAsync(context.Background(), newClient(t, srv.URL),
+		"sb-1", "echo", nil, cp.statusFn(), cp.streams())
+
+	assert.NilError(t, err)
+	assert.Equal(t, code, 0)
+	// Each line appears exactly once — the offset prevents replaying line one/two.
+	assert.Equal(t, cp.out.String(), "line one\nline two\nline three\n")
+}

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -3,13 +3,33 @@ package fakes
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"strconv"
 	"sync"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/recorder"
 )
+
+// OutputLine is one JSONL record from the command output stream. A record with
+// a non-empty CommandID is the terminal event carrying the exit code.
+type OutputLine struct {
+	Index     int    `json:"index"`
+	Stream    string `json:"stream,omitempty"`
+	Line      string `json:"line,omitempty"`
+	CommandID string `json:"command_id,omitempty"`
+	ExitCode  *int   `json:"exit_code,omitempty"`
+}
+
+// WriteOutputLines encodes lines as JSONL to w. Convenience for OutputStreamFunc.
+func WriteOutputLines(w io.Writer, lines []OutputLine) {
+	enc := json.NewEncoder(w)
+	for _, l := range lines {
+		_ = enc.Encode(l)
+	}
+}
 
 type Collaboration struct {
 	ID      string `json:"id"`
@@ -80,6 +100,12 @@ type FakeCircleCI struct {
 	CommandResponse *CommandResponse
 	RunStatusCode   int // override status code for trigger run endpoint
 
+	// OutputStreamFunc handles GET /api/v3/sidecar/commands/:id/output. It
+	// receives the requested line offset and writes the JSONL response body
+	// (use WriteOutputLines). Returning without writing a terminal event
+	// simulates a clean EOF. When nil the endpoint returns an empty stream.
+	OutputStreamFunc func(offset int, w io.Writer)
+
 	// Per-endpoint status code overrides for testing error responses.
 	CollaborationsStatusCode int // override for GET /me/collaborations
 	ListStatusCode           int // override for GET /sidecar/instances
@@ -138,8 +164,9 @@ func NewFakeCircleCI() *FakeCircleCI {
 	r.POST("/api/v3/sidecar/snapshots", f.handleCreateSnapshot)
 	r.GET("/api/v3/sidecar/snapshots/:id", f.handleGetSnapshot)
 
-	// Command V3 endpoint
+	// Command V3 endpoints
 	r.GET("/api/v3/sidecar/commands/:id", f.handleGetCommand)
+	r.GET("/api/v3/sidecar/commands/:id/output", f.handleCommandOutput)
 
 	// Task run endpoint
 	r.POST("/api/v2/agents/org/:org_id/project/:project_id/runs", f.handleTriggerRun)
@@ -397,6 +424,21 @@ func (f *FakeCircleCI) handleGetCommand(c *gin.Context) {
 			},
 		},
 	})
+}
+
+func (f *FakeCircleCI) handleCommandOutput(c *gin.Context) {
+	if !f.requireToken(c) {
+		return
+	}
+	f.mu.RLock()
+	fn := f.OutputStreamFunc
+	f.mu.RUnlock()
+
+	offset, _ := strconv.Atoi(c.Query("offset"))
+	c.Status(http.StatusOK)
+	if fn != nil {
+		fn(offset, c.Writer)
+	}
 }
 
 func (f *FakeCircleCI) handleCreateSnapshot(c *gin.Context) {

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -22,8 +22,8 @@ var ErrNotConfigured = errors.New("no validate commands configured")
 var ErrWorkspaceNotFound = errors.New("workspace directory not found on sidecar")
 
 // WorkspaceExists checks whether dest exists as a directory on the remote sidecar.
-func WorkspaceExists(ctx context.Context, execFn func(context.Context, string) (string, string, int, error), dest string) error {
-	_, _, exitCode, err := execFn(ctx, "test -d "+shellEscape(dest))
+func WorkspaceExists(ctx context.Context, execFn func(context.Context, string) (int, error), dest string) error {
+	exitCode, err := execFn(ctx, "test -d "+shellEscape(dest))
 	if err != nil {
 		return err
 	}
@@ -106,10 +106,11 @@ func RunDryRun(cfg *config.ProjectConfig, name string, status iostream.StatusFun
 	return nil
 }
 
-// RunRemote runs commands on a remote sidecar via SSH.
+// RunRemote runs commands on a remote sidecar.
 // If name is non-empty, only the named command is run.
 // workDir is the local repository root used to expand {{CHANGED_PACKAGES}}.
-func RunRemote(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), cfg *config.ProjectConfig, name, dest, workDir string, status iostream.StatusFunc, streams iostream.Streams) error {
+// execFn is responsible for writing output to its own streams as lines arrive.
+func RunRemote(ctx context.Context, execFn func(ctx context.Context, script string) (int, error), cfg *config.ProjectConfig, name, dest, workDir string, status iostream.StatusFunc) error {
 	commands := cfg.Commands
 	if name != "" {
 		c := cfg.FindCommand(name)
@@ -122,15 +123,9 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 		run := expandCommand(workDir, c.Run)
 		script := "cd " + shellEscape(dest) + " && " + run
 		status(iostream.LevelInfo, fmt.Sprintf("Running %s (remote): %s", c.Name, c.Run))
-		stdout, stderr, exitCode, err := execFn(ctx, script)
+		exitCode, err := execFn(ctx, script)
 		if err != nil {
 			return fmt.Errorf("remote %s: %w", c.Name, err)
-		}
-		if stdout != "" {
-			_, _ = fmt.Fprint(streams.Out, stdout)
-		}
-		if stderr != "" {
-			_, _ = fmt.Fprint(streams.Err, stderr)
 		}
 		if exitCode != 0 {
 			return fmt.Errorf("remote %s failed with exit code %d", c.Name, exitCode)
@@ -139,19 +134,14 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 	return nil
 }
 
-// RunRemoteInline runs a single inline command on a remote sidecar via SSH.
-func RunRemoteInline(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), name, command, dest string, status iostream.StatusFunc, streams iostream.Streams) error {
+// RunRemoteInline runs a single inline command on a remote sidecar.
+// execFn is responsible for writing output to its own streams as lines arrive.
+func RunRemoteInline(ctx context.Context, execFn func(ctx context.Context, script string) (int, error), name, command, dest string, status iostream.StatusFunc) error {
 	script := "cd " + shellEscape(dest) + " && " + command
 	status(iostream.LevelInfo, fmt.Sprintf("Running %s (remote): %s", name, command))
-	stdout, stderr, exitCode, err := execFn(ctx, script)
+	exitCode, err := execFn(ctx, script)
 	if err != nil {
 		return fmt.Errorf("remote %s: %w", name, err)
-	}
-	if stdout != "" {
-		_, _ = fmt.Fprint(streams.Out, stdout)
-	}
-	if stderr != "" {
-		_, _ = fmt.Fprint(streams.Err, stderr)
 	}
 	if exitCode != 0 {
 		return fmt.Errorf("remote %s failed with exit code %d", name, exitCode)

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,11 +12,8 @@ import (
 
 	"gotest.tools/v3/assert"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
-	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
-	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 )
 
 func TestShellEscape(t *testing.T) {
@@ -270,227 +266,112 @@ func TestCommandFileExtOmitted(t *testing.T) {
 func TestRunRemote(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		var execCount int
-		execFn := func(_ context.Context, _ string) (string, string, int, error) {
+		var out bytes.Buffer
+		execFn := func(_ context.Context, _ string) (int, error) {
 			execCount++
-			return "remote output\n", "", 0, nil
+			_, _ = fmt.Fprint(&out, "remote output\n")
+			return 0, nil
 		}
 
 		cfg := &config.ProjectConfig{Commands: []config.Command{
 			{Name: "install", Run: "echo install"},
 			{Name: "test", Run: "echo test"},
 		}}
-		streams, out, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams))
+		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), func(iostream.Level, string) {}))
 		assert.Assert(t, strings.Contains(out.String(), "remote output"), "got: %s", out.String())
 		assert.Equal(t, execCount, 2)
 	})
 
 	t.Run("non-zero exit code", func(t *testing.T) {
-		execFn := func(_ context.Context, _ string) (string, string, int, error) {
-			return "", "", 1, nil
+		execFn := func(_ context.Context, _ string) (int, error) {
+			return 1, nil
 		}
 
 		cfg := &config.ProjectConfig{Commands: []config.Command{
 			{Name: "test", Run: "failing"},
 		}}
-		streams, _, _ := newStreams()
 
-		err := RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams)
+		err := RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), func(iostream.Level, string) {})
 		assert.ErrorContains(t, err, "remote test failed")
-	})
-
-	t.Run("empty stdout not written", func(t *testing.T) {
-		execFn := func(_ context.Context, _ string) (string, string, int, error) {
-			return "", "", 0, nil
-		}
-
-		cfg := &config.ProjectConfig{Commands: []config.Command{
-			{Name: "test", Run: "silent"},
-		}}
-		streams, out, _ := newStreams()
-
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams))
-		assert.Equal(t, out.Len(), 0)
 	})
 
 	t.Run("named runs only matching command", func(t *testing.T) {
 		var capturedScripts []string
-		execFn := func(_ context.Context, script string) (string, string, int, error) {
+		execFn := func(_ context.Context, script string) (int, error) {
 			capturedScripts = append(capturedScripts, script)
-			return "", "", 0, nil
+			return 0, nil
 		}
 
 		cfg := &config.ProjectConfig{Commands: []config.Command{
 			{Name: "install", Run: "echo install"},
 			{Name: "test", Run: "echo test"},
 		}}
-		streams, _, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "test", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams))
+		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "test", "/workspace", t.TempDir(), func(iostream.Level, string) {}))
 		assert.Equal(t, len(capturedScripts), 1)
 		assert.Assert(t, strings.Contains(capturedScripts[0], "echo test"), "got: %s", capturedScripts[0])
 	})
 
 	t.Run("named returns error for unknown command", func(t *testing.T) {
-		execFn := func(_ context.Context, _ string) (string, string, int, error) {
-			return "", "", 0, nil
+		execFn := func(_ context.Context, _ string) (int, error) {
+			return 0, nil
 		}
 
 		cfg := &config.ProjectConfig{Commands: []config.Command{
 			{Name: "test", Run: "echo test"},
 		}}
-		streams, _, _ := newStreams()
 
-		err := RunRemote(context.Background(), execFn, cfg, "lint", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams)
+		err := RunRemote(context.Background(), execFn, cfg, "lint", "/workspace", t.TempDir(), func(iostream.Level, string) {})
 		assert.ErrorContains(t, err, `"lint" not configured`)
 	})
 
 	t.Run("script uses dest directory", func(t *testing.T) {
 		var capturedScript string
-		execFn := func(_ context.Context, script string) (string, string, int, error) {
+		execFn := func(_ context.Context, script string) (int, error) {
 			capturedScript = script
-			return "", "", 0, nil
+			return 0, nil
 		}
 
 		cfg := &config.ProjectConfig{Commands: []config.Command{
 			{Name: "test", Run: "go test ./..."},
 		}}
-		streams, _, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/custom/path", t.TempDir(), func(iostream.Level, string) {}, streams))
+		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/custom/path", t.TempDir(), func(iostream.Level, string) {}))
 		assert.Assert(t, strings.HasPrefix(capturedScript, "cd '/custom/path' &&"), "got: %s", capturedScript)
-	})
-}
-
-// TestRunRemoteSSH tests RunRemote end-to-end with a real fake SSH server,
-// verifying the exec callback correctly passes stdout/stderr/exitCode through.
-func TestRunRemoteSSH(t *testing.T) {
-	newCCIClient := func(t *testing.T, serverURL string) *circleci.Client {
-		t.Helper()
-		client, err := circleci.NewClient(circleci.Config{Token: "test-token", BaseURL: serverURL})
-		assert.NilError(t, err)
-		return client
-	}
-
-	execCallback := func(t *testing.T, session *sidecar.Session) func(context.Context, string) (string, string, int, error) {
-		t.Helper()
-		return func(ctx context.Context, script string) (string, string, int, error) {
-			result, err := sidecar.ExecOverSSH(ctx, session, "sh -c "+sidecar.ShellEscape(script), nil, nil)
-			if err != nil {
-				return "", "", 0, err
-			}
-			return result.Stdout, result.Stderr, result.ExitCode, nil
-		}
-	}
-
-	t.Run("success", func(t *testing.T) {
-		keyFile, pubKey := fakes.GenerateSSHKeypair(t)
-		sshSrv := fakes.NewSSHServer(t, pubKey)
-		sshSrv.SetResult("hello from remote\n", 0)
-
-		cci := fakes.NewFakeCircleCI()
-		cci.AddKeyURL = sshSrv.Addr()
-		cciSrv := httptest.NewServer(cci)
-		defer cciSrv.Close()
-
-		t.Setenv(config.EnvHome, t.TempDir())
-		client := newCCIClient(t, cciSrv.URL)
-		session, err := sidecar.OpenSession(context.Background(), client, "sidecar-123", keyFile, "")
-		assert.NilError(t, err)
-
-		cfg := &config.ProjectConfig{Commands: []config.Command{
-			{Name: "test", Run: "echo hello"},
-		}}
-		streams, out, _ := newStreams()
-
-		assert.NilError(t, RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), func(iostream.Level, string) {}, streams))
-		assert.Assert(t, strings.Contains(out.String(), "hello from remote"), "got: %s", out.String())
-		assert.Equal(t, len(sshSrv.Commands()), 1)
-	})
-
-	t.Run("non-zero exit code", func(t *testing.T) {
-		keyFile, pubKey := fakes.GenerateSSHKeypair(t)
-		sshSrv := fakes.NewSSHServer(t, pubKey)
-		sshSrv.SetResult("", 1)
-
-		cci := fakes.NewFakeCircleCI()
-		cci.AddKeyURL = sshSrv.Addr()
-		cciSrv := httptest.NewServer(cci)
-		defer cciSrv.Close()
-
-		t.Setenv(config.EnvHome, t.TempDir())
-		client := newCCIClient(t, cciSrv.URL)
-		session, err := sidecar.OpenSession(context.Background(), client, "sidecar-123", keyFile, "")
-		assert.NilError(t, err)
-
-		cfg := &config.ProjectConfig{Commands: []config.Command{
-			{Name: "test", Run: "false"},
-		}}
-		streams, _, _ := newStreams()
-
-		err = RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), func(iostream.Level, string) {}, streams)
-		assert.ErrorContains(t, err, "remote test failed")
-	})
-
-	t.Run("multiple commands stop on first failure", func(t *testing.T) {
-		keyFile, pubKey := fakes.GenerateSSHKeypair(t)
-		sshSrv := fakes.NewSSHServer(t, pubKey)
-		sshSrv.SetResult("", 1)
-
-		cci := fakes.NewFakeCircleCI()
-		cci.AddKeyURL = sshSrv.Addr()
-		cciSrv := httptest.NewServer(cci)
-		defer cciSrv.Close()
-
-		t.Setenv(config.EnvHome, t.TempDir())
-		client := newCCIClient(t, cciSrv.URL)
-		session, err := sidecar.OpenSession(context.Background(), client, "sidecar-123", keyFile, "")
-		assert.NilError(t, err)
-
-		cfg := &config.ProjectConfig{Commands: []config.Command{
-			{Name: "install", Run: "npm install"},
-			{Name: "test", Run: "npm test"},
-		}}
-		streams, _, _ := newStreams()
-
-		err = RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), func(iostream.Level, string) {}, streams)
-		assert.ErrorContains(t, err, "remote install failed")
-		assert.Equal(t, len(sshSrv.Commands()), 1)
 	})
 }
 
 func TestRunRemoteInline(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		var capturedScript string
-		execFn := func(_ context.Context, script string) (string, string, int, error) {
+		var out bytes.Buffer
+		execFn := func(_ context.Context, script string) (int, error) {
 			capturedScript = script
-			return "inline output\n", "", 0, nil
+			_, _ = fmt.Fprint(&out, "inline output\n")
+			return 0, nil
 		}
-		streams, out, _ := newStreams()
 
-		assert.NilError(t, RunRemoteInline(context.Background(), execFn, "custom", "echo hello", "/workspace/repo", func(iostream.Level, string) {}, streams))
+		assert.NilError(t, RunRemoteInline(context.Background(), execFn, "custom", "echo hello", "/workspace/repo", func(iostream.Level, string) {}))
 		assert.Assert(t, strings.Contains(out.String(), "inline output"), "got: %s", out.String())
 		assert.Assert(t, strings.HasPrefix(capturedScript, "cd '/workspace/repo' &&"), "got: %s", capturedScript)
 	})
 
 	t.Run("non-zero exit code", func(t *testing.T) {
-		execFn := func(_ context.Context, _ string) (string, string, int, error) {
-			return "", "", 1, nil
+		execFn := func(_ context.Context, _ string) (int, error) {
+			return 1, nil
 		}
-		streams, _, _ := newStreams()
 
-		err := RunRemoteInline(context.Background(), execFn, "custom", "false", "/workspace", func(iostream.Level, string) {}, streams)
+		err := RunRemoteInline(context.Background(), execFn, "custom", "false", "/workspace", func(iostream.Level, string) {})
 		assert.ErrorContains(t, err, "remote custom failed")
 	})
 
 	t.Run("exec error", func(t *testing.T) {
-		execFn := func(_ context.Context, _ string) (string, string, int, error) {
-			return "", "", 0, fmt.Errorf("connection lost")
+		execFn := func(_ context.Context, _ string) (int, error) {
+			return 0, fmt.Errorf("connection lost")
 		}
-		streams, _, _ := newStreams()
 
-		err := RunRemoteInline(context.Background(), execFn, "custom", "echo hi", "/workspace", func(iostream.Level, string) {}, streams)
+		err := RunRemoteInline(context.Background(), execFn, "custom", "echo hi", "/workspace", func(iostream.Level, string) {})
 		assert.ErrorContains(t, err, "remote custom")
 		assert.ErrorContains(t, err, "connection lost")
 	})


### PR DESCRIPTION
## Summary

Replaces the synchronous SSH-based `validate` path with the async HTTP exec API. Output lines stream in real time as they arrive, and the connection reconnects automatically on drops, falling back to a status poll when streaming is exhausted.

Streaming behavior details (`internal/sidecar/exec_async.go`):

- On a clean EOF with no terminal event, polls `GetCommand` once and reconnects only when the command is still running — an already-ended command finishes immediately instead of burning reconnect attempts.
- Reconnects resume from the recorded line offset, so output is never replayed or dropped.
- The server sends bare output lines; the client re-adds a single newline per line.

New test coverage adds a fake command-output streaming endpoint (`GET /commands/:id/output`) with tests for the happy path, non-zero exit, clean-EOF-on-ended-command, and reconnect-resumes-from-offset.

## Testing

- `task test` (with `-race`) — passing
- `task lint` — 0 issues
- `task fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)