### PR TITLE
feat: attribute telemetry to CircleCI user ID when token is available

### DIFF
--- a/internal/circleci/circleci_test.go
+++ b/internal/circleci/circleci_test.go
@@ -41,7 +41,10 @@ func TestNewClient(t *testing.T) {
 		assert.NilError(t, err)
 
 		ctx := context.Background()
-		assert.NilError(t, c.GetCurrentUser(ctx))
+		u, err := c.GetCurrentUser(ctx)
+		assert.NilError(t, err)
+		assert.Equal(t, u.ID, "user-123")
+		assert.Equal(t, u.Login, "testuser")
 	})
 
 	t.Run("returns error when no token", func(t *testing.T) {

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -48,13 +48,20 @@ func NewClient(cfg Config) (*Client, error) {
 	return &Client{cl: cl}, nil
 }
 
-// GetCurrentUser calls GET /api/v2/me to validate the token.
-func (c *Client) GetCurrentUser(ctx context.Context) error {
-	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v2/me"))
+// CurrentUser holds the identity of the authenticated CircleCI user.
+type CurrentUser struct {
+	ID    string `json:"id"`
+	Login string `json:"login"`
+}
+
+// GetCurrentUser calls GET /api/v2/me and returns the authenticated user.
+func (c *Client) GetCurrentUser(ctx context.Context) (*CurrentUser, error) {
+	var u CurrentUser
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v2/me", hc.JSONDecoder(&u)))
 	if err != nil {
-		return mapErr("get current user", err)
+		return nil, mapErr("get current user", err)
 	}
-	return nil
+	return &u, nil
 }
 
 // V3 wire types — mirrors backplane-go DataEntity/envelope pattern.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/telemetry"
 )
@@ -129,16 +130,19 @@ func setupTelemetry(cmd *cobra.Command, version string) error {
 		executable = "chunk"
 	}
 
+	circleCIUserID := resolveCircleCIUserID(cmd)
+
 	tc, err := telemetry.NewSender(telemetry.Config{
 		Send:     send,
 		Log:      optedIn && os.Getenv("CHUNK_TELEMETRY_LOG") != "",
 		WriteKey: writeKey,
 		Binary:   executable,
 		Metadata: telemetry.Meta{
-			Version:     version,
-			InstanceID:  instanceID,
-			OS:          runtime.GOOS,
-			CodingAgent: telemetry.DetectCodingAgent(),
+			Version:        version,
+			InstanceID:     instanceID,
+			CircleCIUserID: circleCIUserID,
+			OS:             runtime.GOOS,
+			CodingAgent:    telemetry.DetectCodingAgent(),
 		},
 	})
 	if err != nil {
@@ -147,4 +151,26 @@ func setupTelemetry(cmd *cobra.Command, version string) error {
 
 	cmd.SetContext(telemetry.WithSender(cmd.Context(), tc))
 	return nil
+}
+
+// resolveCircleCIUserID fetches the CircleCI user ID for the current token on a
+// best-effort basis. Returns "" if no token is configured or the call fails.
+func resolveCircleCIUserID(cmd *cobra.Command) string {
+	insecure, _ := cmd.Root().PersistentFlags().GetBool("insecure-storage")
+	rc, err := config.Resolve("", "", insecure)
+	if err != nil || rc.CircleCIToken == "" {
+		return ""
+	}
+	cl, err := circleci.NewClient(circleci.Config{
+		Token:   rc.CircleCIToken,
+		BaseURL: rc.CircleCIBaseURL,
+	})
+	if err != nil {
+		return ""
+	}
+	u, err := cl.GetCurrentUser(cmd.Context())
+	if err != nil {
+		return ""
+	}
+	return u.ID
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -63,6 +63,11 @@ type Meta struct {
 	Version    string
 	InstanceID uuid.UUID
 
+	// CircleCIUserID is the authenticated user's CircleCI user ID, when a
+	// CircleCI token is available. When set it is used as the Segment UserId
+	// instead of InstanceID, matching the attribution approach in circleci-cli.
+	CircleCIUserID string
+
 	// OS is the operating system chunk-cli is running on, e.g. runtime.GOOS.
 	OS string
 	// CodingAgent is the AI coding agent chunk-cli was invoked from (e.g.
@@ -138,12 +143,17 @@ func (s *Sender) Track(eventName string, props map[string]any) error {
 		p.Set(key, val)
 	}
 
+	userID := s.meta.InstanceID.String()
+	if s.meta.CircleCIUserID != "" {
+		userID = s.meta.CircleCIUserID
+	}
+
 	return s.dest.Enqueue(analytics.Track{
 		Event:      eventName,
 		Timestamp:  time.Now(),
 		Properties: p,
 
-		UserId:  s.meta.InstanceID.String(),
+		UserId:  userID,
 		Context: s.meta.toContext(),
 	})
 }


### PR DESCRIPTION
## Summary

- `GetCurrentUser` now decodes the `/api/v2/me` response and returns a `CurrentUser{ID, Login}` struct instead of just an error
- `telemetry.Meta` gains a `CircleCIUserID` field; `Track` uses it as the Segment `UserId` when set, falling back to the anonymous `InstanceID` otherwise
- `setupTelemetry` calls a new `resolveCircleCIUserID` helper that best-effort fetches the user ID via the CircleCI client — any failure (no token, network error) silently falls back to the existing anonymous attribution

Mirrors the approach used in circleci-cli (`internal/telemetry/sender.go` + `internal/apiclient/me.go`).

## Test plan

- [ ] `go test -race ./internal/circleci/ ./internal/telemetry/ ./internal/cmd/` passes
- [ ] With a valid `CIRCLECI_TOKEN` set, verify `CHUNK_TELEMETRY_LOG=1 chunk version` logs an event with the CircleCI user ID as `UserId`
- [ ] Without a token, verify telemetry falls back to the anonymous instance ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)