### PR TITLE
test: disable telemetry in acceptance tests

### DIFF
--- a/internal/testing/env/env.go
+++ b/internal/testing/env/env.go
@@ -45,6 +45,7 @@ func (e *TestEnv) Environ() []string {
 		"SHELL=/bin/zsh",
 		"NO_COLOR=1",
 		"TERM=dumb",
+		"CHUNK_NO_TELEMETRY=1",
 	}
 
 	if e.GithubToken != "" {


### PR DESCRIPTION
## Summary

- Adds `CHUNK_NO_TELEMETRY=1` to `TestEnv.Environ()` so every binary invocation spawned by acceptance tests opts out of telemetry

All binary-level tests go through `RunCLI` → `TestEnv.Environ()`, so this covers the full acceptance suite in one place.

## Test plan

- [ ] `go test -race ./acceptance/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)