### PR TITLE
validate: buffer command output and show timing on success

### DIFF
--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,6 +1,7 @@
 package validate
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -205,11 +206,16 @@ func runCommand(ctx context.Context, workDir, name, command string, timeoutSec i
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.Dir = workDir
-	cmd.Stdout = streams.Out
-	cmd.Stderr = streams.Err
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
 
+	start := time.Now()
 	err := cmd.Run()
+	elapsed := time.Since(start).Round(time.Millisecond)
+
 	if err != nil {
+		_, _ = io.Copy(streams.Err, &buf)
 		if ctx.Err() == context.DeadlineExceeded {
 			return fmt.Errorf("%s command timed out after %ds", name, timeoutSec)
 		}
@@ -219,6 +225,7 @@ func runCommand(ctx context.Context, workDir, name, command string, timeoutSec i
 		}
 		return fmt.Errorf("%s: %w", name, err)
 	}
+	status(iostream.LevelDone, fmt.Sprintf("%s passed (%s)", name, elapsed))
 	return nil
 }
 

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -168,12 +168,12 @@ func TestRunAll(t *testing.T) {
 			{Name: "install", Run: "echo installed"},
 			{Name: "test", Run: "echo tested"},
 		}}
-		streams, out, _ := newStreams()
+		streams, _, _ := newStreams()
 		var statusBuf bytes.Buffer
 
 		assert.NilError(t, RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams))
-		assert.Assert(t, strings.Contains(out.String(), "installed"), "got: %s", out.String())
-		assert.Assert(t, strings.Contains(out.String(), "tested"), "got: %s", out.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "install passed"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "test passed"), "got: %s", statusBuf.String())
 		assert.Assert(t, strings.Contains(statusBuf.String(), "Running install"), "got: %s", statusBuf.String())
 	})
 
@@ -217,11 +217,11 @@ func TestRunAll(t *testing.T) {
 		cfg := &config.ProjectConfig{Commands: []config.Command{
 			{Name: "test", Run: "echo ok"},
 		}}
-		streams, out, _ := newStreams()
+		streams, _, _ := newStreams()
 		var statusBuf bytes.Buffer
 
 		assert.NilError(t, RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams))
-		assert.Assert(t, strings.Contains(out.String(), "ok"), "got: %s", out.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "test passed"), "got: %s", statusBuf.String())
 	})
 }
 


### PR DESCRIPTION
## Summary

- Buffer stdout/stderr during command execution; only flush to stderr on failure
- Report elapsed time on success via the status callback (`install passed (123ms)`)
- Clean up pre-commit and Stop hook output — successful runs no longer stream raw command noise

## Events

- `LevelDone` status event fires with `"<name> passed (<elapsed>)"` after a successful command run

## Not collected

- Command output on success (suppressed by design)

## Opt-out

N/A — this affects all local `chunk validate` runs

## Implementation

`runCommand` in `internal/validate/validate.go` now writes both stdout and stderr into a `bytes.Buffer`. On failure the buffer is flushed to `streams.Err` so users still see full output. On success only the timing summary fires via `status`.

## Test plan

- [x] `TestRunAll` updated to assert on status messages instead of raw stream output
- [x] Failure path still copies buffer to stderr (existing error-path tests cover this)
- [x] `task test` passes with `-race`