### PR TITLE
Add parallel sidecars

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -250,16 +250,12 @@ chunk sidecar create --count 3                 # 3 fresh sidecars, set as the ac
 chunk sidecar create --count 3 --name pr-1234  # named pr-1234-1, pr-1234-2, pr-1234-3
 ```
 
-Once a group is active, `sync` and `run` fan out to all of its sidecars automatically (or target an explicit set with `--sidecar-ids`):
+Once a group is active, `sync` fans out to all of its sidecars automatically (or target an explicit set with `--sidecar-ids`):
 
 ```bash
 chunk sidecar current                          # lists every sidecar in the active group
 chunk sidecar sync                             # one bundle, delivered to all in parallel
-chunk sidecar run -- go test ./...             # run a command on each, in parallel
-chunk sidecar run --sidecar-ids a,b -- make    # target specific sidecars
 ```
-
-`chunk sidecar run` prints each sidecar's output under a labelled header and reports an `N/M passed` summary, exiting non-zero if any command fails. Add `--json` for machine-readable per-sidecar results.
 
 `chunk validate` uses a group on its own: when two or more commands are marked `remote` in `.chunk/config.json` (and you're not forcing everything remote with `--remote`), it creates one sidecar per remote command and runs them in parallel, then runs any local commands. An existing active group with a matching sidecar count is reused instead of creating new ones.
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -201,6 +201,9 @@ Sidecars let you run validations in a clean cloud environment. The typical loop:
 chunk sidecar create
 chunk sidecar create --name my-sidecar
 
+# Create several at once (see "Parallel sidecars" below)
+chunk sidecar create --count 3
+
 # Set it as active
 chunk sidecar use <id>
 
@@ -237,6 +240,28 @@ To fall back to the git checkout/patch approach (requires the branch to be pushe
 ```bash
 chunk sidecar sync --checkout
 ```
+
+### Parallel sidecars
+
+A single sidecar is just a group of one — the same commands work for any number. Pass `--count` to `create` to spin several up in parallel and set them as the active group:
+
+```bash
+chunk sidecar create --count 3                 # 3 fresh sidecars, set as the active group
+chunk sidecar create --count 3 --name pr-1234  # named pr-1234-1, pr-1234-2, pr-1234-3
+```
+
+Once a group is active, `sync` and `run` fan out to all of its sidecars automatically (or target an explicit set with `--sidecar-ids`):
+
+```bash
+chunk sidecar current                          # lists every sidecar in the active group
+chunk sidecar sync                             # one bundle, delivered to all in parallel
+chunk sidecar run -- go test ./...             # run a command on each, in parallel
+chunk sidecar run --sidecar-ids a,b -- make    # target specific sidecars
+```
+
+`chunk sidecar run` prints each sidecar's output under a labelled header and reports an `N/M passed` summary, exiting non-zero if any command fails. Add `--json` for machine-readable per-sidecar results.
+
+`chunk validate` uses a group on its own: when two or more commands are marked `remote` in `.chunk/config.json` (and you're not forcing everything remote with `--remote`), it creates one sidecar per remote command and runs them in parallel, then runs any local commands. An existing active group with a matching sidecar count is reused instead of creating new ones.
 
 ### Environment setup
 

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -47,7 +47,6 @@ func newSidecarCmd() *cobra.Command {
 	cmd.AddCommand(newSidecarCreateCmd())
 	cmd.AddCommand(newSidecarDeleteCmd())
 	cmd.AddCommand(newSidecarExecCmd())
-	cmd.AddCommand(newSidecarRunCmd())
 	cmd.AddCommand(newSidecarAddSSHKeyCmd())
 	cmd.AddCommand(newSidecarSSHCmd())
 	cmd.AddCommand(newSidecarSyncCmd())
@@ -1362,117 +1361,6 @@ func sidecarSetupRunSetup(ctx context.Context, opts sidecarRunSetupOpts) error {
 	return nil
 }
 
-type sidecarRunResult struct {
-	SidecarID string `json:"sidecar_id"`
-	Stdout    string `json:"stdout"`
-	Stderr    string `json:"stderr"`
-	ExitCode  int    `json:"exit_code"`
-	Error     string `json:"error,omitempty"`
-}
-
-func newSidecarRunCmd() *cobra.Command {
-	var sidecarIDs, identityFile string
-	var jsonOut bool
-
-	cmd := &cobra.Command{
-		Use:   "run --sidecar-ids <ids> [flags] -- <command...>",
-		Short: "Run a command on multiple sidecars in parallel",
-		Args:  cobra.ArbitraryArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return &userError{msg: "A command is required after --.", suggestion: "Example: chunk sidecar run --sidecar-ids a,b -- make test"}
-			}
-			ids, err := resolveSidecarGroupIDs(cmd.Context(), sidecarIDs)
-			if err != nil {
-				return err
-			}
-			if len(ids) == 0 {
-				return &userError{
-					msg:        "No active sidecar group.",
-					suggestion: "Pass --sidecar-ids, or run 'chunk sidecar create --count <n>'.",
-					errMsg:     "no active sidecar group and --sidecar-ids not provided",
-				}
-			}
-
-			io := iostream.FromCmd(cmd)
-			insecureStorage := insecureStorageFlag(cmd)
-			rc, _ := config.Resolve("", "", insecureStorage)
-			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, tui.PromptHidden)
-			if err != nil {
-				return err
-			}
-			authSock := os.Getenv(config.EnvSSHAuthSock)
-			command := sidecar.ShellJoin(args)
-
-			results := make([]sidecarRunResult, len(ids))
-			var wg sync.WaitGroup
-			for i, id := range ids {
-				wg.Add(1)
-				go func(i int, id string) {
-					defer wg.Done()
-					results[i].SidecarID = id
-					sess, err := sidecar.OpenSession(cmd.Context(), client, id, identityFile, authSock)
-					if err != nil {
-						results[i].Error = err.Error()
-						return
-					}
-					res, err := sidecar.ExecOverSSH(cmd.Context(), sess, command, nil, nil)
-					if err != nil {
-						results[i].Error = err.Error()
-						return
-					}
-					results[i].Stdout = res.Stdout
-					results[i].Stderr = res.Stderr
-					results[i].ExitCode = res.ExitCode
-				}(i, id)
-			}
-			wg.Wait()
-
-			if jsonOut {
-				return iostream.PrintJSON(io.Out, results)
-			}
-
-			anyFailed := false
-			for _, r := range results {
-				label := sidecarLabel(r.SidecarID)
-				if r.Error != "" {
-					io.ErrPrintf("[%s] error: %s\n", label, r.Error)
-					anyFailed = true
-					continue
-				}
-				for _, line := range splitLines(r.Stdout) {
-					io.Printf("[%s] %s\n", label, line)
-				}
-				for _, line := range splitLines(r.Stderr) {
-					io.ErrPrintf("[%s] %s\n", label, line)
-				}
-				if r.ExitCode != 0 {
-					anyFailed = true
-				}
-			}
-
-			passed := 0
-			for _, r := range results {
-				if r.Error == "" && r.ExitCode == 0 {
-					passed++
-				}
-			}
-			io.ErrPrintf("\n%d/%d passed\n", passed, len(results))
-
-			if anyFailed {
-				return fmt.Errorf("%d/%d sidecars failed", len(results)-passed, len(results))
-			}
-			return nil
-		},
-	}
-
-	cmd.Flags().StringVar(&sidecarIDs, "sidecar-ids", "", "Comma-separated sidecar IDs (defaults to the active sidecar group)")
-	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file")
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output results as JSON")
-
-	return cmd
-}
-
 // splitIDs splits a comma-separated sidecar ID string, trimming whitespace and
 // dropping empty entries.
 func splitIDs(s string) []string {
@@ -1497,13 +1385,4 @@ func sidecarLabel(id string) string {
 		return id
 	}
 	return id[:12]
-}
-
-// splitLines splits s into lines, dropping a trailing empty line.
-func splitLines(s string) []string {
-	if s == "" {
-		return nil
-	}
-	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
-	return lines
 }

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strings"
+	"sync"
 
 	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/spf13/cobra"
@@ -27,7 +29,11 @@ func randomSidecarName() string {
 	return petname.Generate(3, "-")
 }
 
-const cmdList = "list"
+const (
+	cmdList             = "list"
+	msgNoOriginRemote   = "Could not detect repository from git remote."
+	suggestionAddOrigin = "Pass --workdir to set the destination path, or run: git remote add origin <url>"
+)
 
 func newSidecarCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -41,6 +47,7 @@ func newSidecarCmd() *cobra.Command {
 	cmd.AddCommand(newSidecarCreateCmd())
 	cmd.AddCommand(newSidecarDeleteCmd())
 	cmd.AddCommand(newSidecarExecCmd())
+	cmd.AddCommand(newSidecarRunCmd())
 	cmd.AddCommand(newSidecarAddSSHKeyCmd())
 	cmd.AddCommand(newSidecarSSHCmd())
 	cmd.AddCommand(newSidecarSyncCmd())
@@ -55,6 +62,24 @@ func newSidecarCmd() *cobra.Command {
 	return cmd
 }
 
+// resolveSidecarGroupIDs returns the sidecar IDs for fan-out commands.
+// If flagVal is set it is split and returned directly. Otherwise the active
+// sidecar state is consulted for a sidecar group (SidecarIDs). Returns nil (no
+// error) when neither source has IDs — callers that require IDs must error.
+func resolveSidecarGroupIDs(ctx context.Context, flagVal string) ([]string, error) {
+	if flagVal != "" {
+		return splitIDs(flagVal), nil
+	}
+	active, err := sidecar.LoadActive(ctx)
+	if err != nil {
+		return nil, &userError{msg: msgCouldNotLoadSidecar, suggestion: configFilePermHint, err: err}
+	}
+	if active != nil && len(active.SidecarIDs) > 0 {
+		return active.SidecarIDs, nil
+	}
+	return nil, nil
+}
+
 // resolveSidecarID fills in sidecarID from the active sidecar file if it is empty.
 func resolveSidecarID(ctx context.Context, sidecarID *string) error {
 	if *sidecarID != "" {
@@ -64,14 +89,14 @@ func resolveSidecarID(ctx context.Context, sidecarID *string) error {
 	if err != nil {
 		return &userError{msg: msgCouldNotLoadSidecar, suggestion: configFilePermHint, err: err}
 	}
-	if active == nil {
+	if active.ID() == "" {
 		return &userError{
 			msg:        "No active sidecar is set.",
 			suggestion: "Pass --sidecar-id, or run 'chunk sidecar use <id>' or 'chunk sidecar create'.",
 			errMsg:     "no active sidecar and --sidecar-id not provided",
 		}
 	}
-	*sidecarID = active.SidecarID
+	*sidecarID = active.ID()
 	return nil
 }
 
@@ -189,21 +214,23 @@ func newSidecarListCmd() *cobra.Command {
 
 func newSidecarCreateCmd() *cobra.Command {
 	var orgID, name, image string
+	var count int
+	var jsonOut bool
 
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a sidecar",
-		Long:  "Create a sidecar.",
+		Short: "Create one or more sidecars",
+		Long:  "Create one or more sidecars. Pass --count to create several in parallel and set them as the active group.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
+			if count < 1 {
+				return &userError{msg: "--count must be at least 1."}
+			}
 			insecureStorage := insecureStorageFlag(cmd)
 			rc, _ := config.Resolve("", "", insecureStorage)
 			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, tui.PromptHidden)
 			if err != nil {
 				return err
-			}
-			if name == "" {
-				name = randomSidecarName()
 			}
 			cwd, err := os.Getwd()
 			if err != nil {
@@ -219,38 +246,127 @@ func newSidecarCreateCmd() *cobra.Command {
 					image = cfg.Validation.SidecarImage
 				}
 			}
-			sb, err := sidecar.Create(cmd.Context(), client, resolvedOrgID, name, image)
-			if err != nil {
-				if err := notAuthorized("create sidecars", err); err != nil {
+
+			// Create all sidecars in parallel (trivially just one when count == 1).
+			sidecars, createErr := createSidecars(cmd.Context(), client, resolvedOrgID, sidecarNames(name, count), image)
+
+			// Persist and report successes before surfacing any error, so a partial
+			// failure still leaves the created sidecars usable.
+			createdIDs := make([]string, len(sidecars))
+			for i, sb := range sidecars {
+				createdIDs[i] = sb.ID
+			}
+			if len(createdIDs) > 0 {
+				active := sidecar.ActiveSidecar{SidecarIDs: createdIDs}
+				if len(sidecars) == 1 {
+					active.Name = sidecars[0].Name
+				}
+				if saveErr := sidecar.SaveActive(cmd.Context(), active); saveErr != nil {
+					io.ErrPrintf("warning: could not save active sidecar: %v\n", saveErr)
+				}
+			}
+
+			if jsonOut {
+				if err := iostream.PrintJSON(io.Out, sidecars); err != nil {
 					return err
 				}
-				var se *circleci.StatusError
-				if image != "" && errors.As(err, &se) && (se.StatusCode == 400 || se.StatusCode == 404) {
-					return newUserError("Could not create the sidecar.").
-						withSuggestion("--image requires a snapshot ID. Create one with 'chunk sidecar snapshot create'.").
-						wrap(err)
-				}
-				return &userError{
-					msg:        "Could not create the sidecar.",
-					suggestion: suggestionNetworkRetry,
-					err:        err,
-				}
-			}
-			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Created sidecar %s (%s)", sb.Name, sb.ID)))
-			if err := sidecar.SaveActive(cmd.Context(), sidecar.ActiveSidecar{SidecarID: sb.ID, Name: sb.Name}); err != nil {
-				io.ErrPrintf("warning: could not save active sidecar: %v\n", err)
 			} else {
-				io.ErrPrintf("Set %s as active sidecar\n", sb.ID)
+				for _, sb := range sidecars {
+					io.Printf("%s\n", sb.ID)
+					io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Created sidecar %s (%s)", sb.Name, sb.ID)))
+				}
+				switch len(createdIDs) {
+				case 0:
+				case 1:
+					io.ErrPrintf("Set %s as active sidecar\n", createdIDs[0])
+				default:
+					io.ErrPrintf("Set %d sidecars as active\n", len(createdIDs))
+				}
 			}
-			return nil
+
+			return mapCreateSidecarError(createErr, image)
 		},
 	}
 
+	cmd.Flags().IntVar(&count, "count", 1, "Number of sidecars to create in parallel")
 	cmd.Flags().StringVar(&orgID, "org-id", "", "Organization ID")
-	cmd.Flags().StringVar(&name, "name", "", "Sidecar name (auto-generated if not provided)")
+	cmd.Flags().StringVar(&name, "name", "", "Sidecar name (auto-generated if omitted); used as a prefix when --count > 1")
 	cmd.Flags().StringVar(&image, "image", "", "Snapshot ID (from 'chunk sidecar snapshot create')")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 
 	return cmd
+}
+
+// sidecarNames builds count sidecar names from the --name flag: the name as-is
+// for a single sidecar, "<name>-<n>" as a prefix when creating several, and a
+// random name for each slot when name is empty.
+func sidecarNames(name string, count int) []string {
+	names := make([]string, count)
+	for i := range count {
+		n := name
+		if count > 1 && name != "" {
+			n = fmt.Sprintf("%s-%d", name, i+1)
+		}
+		if n == "" {
+			n = randomSidecarName()
+		}
+		names[i] = n
+	}
+	return names
+}
+
+// createSidecars creates one sidecar per name in parallel, preserving order. It
+// returns the sidecars that were created and a joined error for any that failed.
+func createSidecars(ctx context.Context, client *circleci.Client, orgID string, names []string, image string) ([]*circleci.Sidecar, error) {
+	type result struct {
+		sb  *circleci.Sidecar
+		err error
+	}
+	results := make([]result, len(names))
+	var wg sync.WaitGroup
+	for i, name := range names {
+		wg.Add(1)
+		go func(i int, name string) {
+			defer wg.Done()
+			sb, err := sidecar.Create(ctx, client, orgID, name, image)
+			results[i] = result{sb, err}
+		}(i, name)
+	}
+	wg.Wait()
+
+	var sidecars []*circleci.Sidecar
+	var errs []error
+	for _, r := range results {
+		if r.err != nil {
+			errs = append(errs, r.err)
+		} else {
+			sidecars = append(sidecars, r.sb)
+		}
+	}
+	return sidecars, errors.Join(errs...)
+}
+
+// mapCreateSidecarError converts a sidecar-creation error into a user-facing
+// error, surfacing the authorization and snapshot-image hints. Returns nil when
+// err is nil.
+func mapCreateSidecarError(err error, image string) error {
+	if err == nil {
+		return nil
+	}
+	if authErr := notAuthorized("create sidecars", err); authErr != nil {
+		return authErr
+	}
+	var se *circleci.StatusError
+	if image != "" && errors.As(err, &se) && (se.StatusCode == 400 || se.StatusCode == 404) {
+		return newUserError("Could not create the sidecar.").
+			withSuggestion("--image requires a snapshot ID. Create one with 'chunk sidecar snapshot create'.").
+			wrap(err)
+	}
+	return &userError{
+		msg:        "Could not create the sidecar.",
+		suggestion: suggestionNetworkRetry,
+		err:        err,
+	}
 }
 
 func newSidecarDeleteCmd() *cobra.Command {
@@ -282,7 +398,7 @@ func newSidecarDeleteCmd() *cobra.Command {
 			}
 			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Deleted sidecar %s", sidecarID)))
 
-			if active, lerr := sidecar.LoadActive(cmd.Context()); lerr == nil && active != nil && active.SidecarID == sidecarID {
+			if active, lerr := sidecar.LoadActive(cmd.Context()); lerr == nil && active != nil && active.ID() == sidecarID {
 				if cerr := sidecar.ClearActive(cmd.Context()); cerr != nil {
 					io.ErrPrintf("Warning: could not clear active sidecar state: %v\n", cerr)
 				} else {
@@ -456,7 +572,7 @@ func newSidecarSSHCmd() *cobra.Command {
 }
 
 func newSidecarSyncCmd() *cobra.Command {
-	var sidecarID, identityFile, workdir string
+	var sidecarID, sidecarIDs, identityFile, workdir, source string
 	var checkout bool
 
 	cmd := &cobra.Command{
@@ -464,9 +580,6 @@ func newSidecarSyncCmd() *cobra.Command {
 		Short: "Sync files to a sidecar",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
-			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
-				return err
-			}
 			authSock := os.Getenv(config.EnvSSHAuthSock)
 			insecureStorage := insecureStorageFlag(cmd)
 			rc, _ := config.Resolve("", "", insecureStorage)
@@ -474,9 +587,48 @@ func newSidecarSyncCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
 			cwd, cwdErr := os.Getwd()
 			if cwdErr != nil {
 				return fmt.Errorf("sync: %w", cwdErr)
+			}
+			if source != "" {
+				cwd = source
+			}
+
+			// Fan-out path: sync one bundle to multiple sidecars in parallel.
+			// Activated by --sidecar-ids flag or when the active state is a sidecar group.
+			ids, err := resolveSidecarGroupIDs(cmd.Context(), sidecarIDs)
+			if err != nil {
+				return err
+			}
+			if len(ids) > 0 {
+				if checkout {
+					return &userError{msg: "--checkout is not supported with multiple sidecars."}
+				}
+				err = sidecar.BundleSyncFanOut(cmd.Context(), client, ids, identityFile, authSock, workdir, cwd, newStatusFunc(io))
+				if err != nil {
+					if _, ok := errors.AsType[*sidecar.NoOriginRemoteError](err); ok {
+						return &userError{
+							msg:        msgNoOriginRemote,
+							suggestion: suggestionAddOrigin,
+							err:        err,
+						}
+					}
+					if err := sshSessionError(err); err != nil {
+						return err
+					}
+					if err := notAuthorized("sync files", err); err != nil {
+						return err
+					}
+					return &userError{msg: "The fan-out sync operation failed.", err: err}
+				}
+				return nil
+			}
+
+			// Single-sidecar path.
+			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
+				return err
 			}
 			useBundle := !checkout
 			if useBundle {
@@ -487,8 +639,8 @@ func newSidecarSyncCmd() *cobra.Command {
 			if err != nil {
 				if _, ok := errors.AsType[*sidecar.NoOriginRemoteError](err); ok {
 					return &userError{
-						msg:        "Git remote \"origin\" is required for sidecar sync.",
-						suggestion: "Run: git remote add origin <url>",
+						msg:        msgNoOriginRemote,
+						suggestion: suggestionAddOrigin,
 						err:        err,
 					}
 				}
@@ -519,8 +671,10 @@ func newSidecarSyncCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&sidecarID, "sidecar-id", "", "Sidecar ID (defaults to active sidecar)")
+	cmd.Flags().StringVar(&sidecarIDs, "sidecar-ids", "", "Comma-separated sidecar IDs for fan-out sync")
 	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file")
 	cmd.Flags().StringVar(&workdir, "workdir", "", "Destination path on sidecar (defaults to /home/user/<repo> when omitted)")
+	cmd.Flags().StringVar(&source, "source", "", "Local directory to sync from (defaults to current directory)")
 	cmd.Flags().BoolVar(&checkout, "checkout", false, "Sync via git checkout/patch instead of bundle (requires branch pushed to GitHub)")
 
 	return cmd
@@ -533,7 +687,7 @@ func newSidecarUseCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
-			if err := sidecar.SaveActive(cmd.Context(), sidecar.ActiveSidecar{SidecarID: args[0]}); err != nil {
+			if err := sidecar.SaveActive(cmd.Context(), sidecar.ActiveSidecar{SidecarIDs: []string{args[0]}}); err != nil {
 				return &userError{msg: "Could not save the active sidecar.", suggestion: configFilePermHint, err: err}
 			}
 			io.ErrPrintf("Set %s as active sidecar\n", args[0])
@@ -565,9 +719,9 @@ func newSidecarCurrentCmd() *cobra.Command {
 				return iostream.PrintJSON(io.Out, active)
 			}
 			if active.Name != "" {
-				io.Printf("%s  %s\n", active.Name, active.SidecarID)
+				io.Printf("%s  %s\n", active.Name, sidecarIDDisplay(active))
 			} else {
-				io.Printf("%s\n", active.SidecarID)
+				io.Printf("%s\n", sidecarIDDisplay(active))
 			}
 			return nil
 		},
@@ -792,7 +946,7 @@ snapshot with 'chunk sidecar create --image <snapshot-id>'.`,
 			}
 			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Deleted sidecar %s", sidecarID)))
 
-			if active, lerr := sidecar.LoadActive(cmd.Context()); lerr == nil && active != nil && active.SidecarID == sidecarID {
+			if active, lerr := sidecar.LoadActive(cmd.Context()); lerr == nil && active != nil && active.ID() == sidecarID {
 				if cerr := sidecar.ClearActive(cmd.Context()); cerr != nil {
 					io.ErrPrintf("Warning: could not clear active sidecar state: %v\n", cerr)
 				}
@@ -1040,8 +1194,8 @@ func sidecarSetupResolveSidecar(
 		return "", "", &userError{msg: msgCouldNotLoadSidecar, suggestion: configFilePermHint, err: err}
 	}
 	if active != nil {
-		status(iostream.LevelInfo, fmt.Sprintf("using active sidecar %s", active.SidecarID))
-		return active.SidecarID, active.Name, nil
+		status(iostream.LevelInfo, fmt.Sprintf("using active sidecar %s", active.ID()))
+		return active.ID(), active.Name, nil
 	}
 	if name == "" {
 		name = randomSidecarName()
@@ -1062,7 +1216,7 @@ func sidecarSetupResolveSidecar(
 			err:        err,
 		}
 	}
-	if saveErr := sidecar.SaveActive(ctx, sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); saveErr != nil {
+	if saveErr := sidecar.SaveActive(ctx, sidecar.ActiveSidecar{SidecarIDs: []string{sc.ID}, Name: sc.Name}); saveErr != nil {
 		streams.ErrPrintf("warning: could not save active sidecar: %v\n", saveErr)
 	}
 	status(iostream.LevelDone, fmt.Sprintf("Created sidecar %s (%s)", sc.Name, sc.ID))
@@ -1107,8 +1261,8 @@ func sidecarSetupSync(
 	}
 	if _, ok := errors.AsType[*sidecar.NoOriginRemoteError](err); ok {
 		return &userError{
-			msg:        "Git remote \"origin\" is required for sidecar sync.",
-			suggestion: "Run: git remote add origin <url>",
+			msg:        msgNoOriginRemote,
+			suggestion: suggestionAddOrigin,
 			err:        err,
 		}
 	}
@@ -1203,4 +1357,150 @@ func sidecarSetupRunSetup(ctx context.Context, opts sidecarRunSetupOpts) error {
 		opts.status(iostream.LevelDone, fmt.Sprintf("Step %q complete", step.Name))
 	}
 	return nil
+}
+
+type sidecarRunResult struct {
+	SidecarID string `json:"sidecar_id"`
+	Stdout    string `json:"stdout"`
+	Stderr    string `json:"stderr"`
+	ExitCode  int    `json:"exit_code"`
+	Error     string `json:"error,omitempty"`
+}
+
+func newSidecarRunCmd() *cobra.Command {
+	var sidecarIDs, identityFile string
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "run --sidecar-ids <ids> [flags] -- <command...>",
+		Short: "Run a command on multiple sidecars in parallel",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return &userError{msg: "A command is required after --.", suggestion: "Example: chunk sidecar run --sidecar-ids a,b -- make test"}
+			}
+			ids, err := resolveSidecarGroupIDs(cmd.Context(), sidecarIDs)
+			if err != nil {
+				return err
+			}
+			if len(ids) == 0 {
+				return &userError{
+					msg:        "No active sidecar group.",
+					suggestion: "Pass --sidecar-ids, or run 'chunk sidecar create --count <n>'.",
+					errMsg:     "no active sidecar group and --sidecar-ids not provided",
+				}
+			}
+
+			io := iostream.FromCmd(cmd)
+			insecureStorage := insecureStorageFlag(cmd)
+			rc, _ := config.Resolve("", "", insecureStorage)
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, tui.PromptHidden)
+			if err != nil {
+				return err
+			}
+			authSock := os.Getenv(config.EnvSSHAuthSock)
+			command := sidecar.ShellJoin(args)
+
+			results := make([]sidecarRunResult, len(ids))
+			var wg sync.WaitGroup
+			for i, id := range ids {
+				wg.Add(1)
+				go func(i int, id string) {
+					defer wg.Done()
+					results[i].SidecarID = id
+					sess, err := sidecar.OpenSession(cmd.Context(), client, id, identityFile, authSock)
+					if err != nil {
+						results[i].Error = err.Error()
+						return
+					}
+					res, err := sidecar.ExecOverSSH(cmd.Context(), sess, command, nil, nil)
+					if err != nil {
+						results[i].Error = err.Error()
+						return
+					}
+					results[i].Stdout = res.Stdout
+					results[i].Stderr = res.Stderr
+					results[i].ExitCode = res.ExitCode
+				}(i, id)
+			}
+			wg.Wait()
+
+			if jsonOut {
+				return iostream.PrintJSON(io.Out, results)
+			}
+
+			anyFailed := false
+			for _, r := range results {
+				label := sidecarLabel(r.SidecarID)
+				if r.Error != "" {
+					io.ErrPrintf("[%s] error: %s\n", label, r.Error)
+					anyFailed = true
+					continue
+				}
+				for _, line := range splitLines(r.Stdout) {
+					io.Printf("[%s] %s\n", label, line)
+				}
+				for _, line := range splitLines(r.Stderr) {
+					io.ErrPrintf("[%s] %s\n", label, line)
+				}
+				if r.ExitCode != 0 {
+					anyFailed = true
+				}
+			}
+
+			passed := 0
+			for _, r := range results {
+				if r.Error == "" && r.ExitCode == 0 {
+					passed++
+				}
+			}
+			io.ErrPrintf("\n%d/%d passed\n", passed, len(results))
+
+			if anyFailed {
+				return fmt.Errorf("%d/%d sidecars failed", len(results)-passed, len(results))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&sidecarIDs, "sidecar-ids", "", "Comma-separated sidecar IDs (defaults to the active sidecar group)")
+	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output results as JSON")
+
+	return cmd
+}
+
+// splitIDs splits a comma-separated sidecar ID string, trimming whitespace and
+// dropping empty entries.
+func splitIDs(s string) []string {
+	var ids []string
+	for _, id := range strings.Split(s, ",") {
+		if id = strings.TrimSpace(id); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// sidecarIDDisplay renders the active sidecar's ID(s) for human output: a single
+// ID as-is, or a comma-separated list when a sidecar group is active.
+func sidecarIDDisplay(active *sidecar.ActiveSidecar) string {
+	return strings.Join(active.SidecarIDs, ", ")
+}
+
+// sidecarLabel returns a short display label for a sidecar ID.
+func sidecarLabel(id string) string {
+	if len(id) <= 12 {
+		return id
+	}
+	return id[:12]
+}
+
+// splitLines splits s into lines, dropping a trailing empty line.
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	return lines
 }

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 
@@ -397,7 +398,7 @@ func newSidecarDeleteCmd() *cobra.Command {
 			}
 			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Deleted sidecar %s", sidecarID)))
 
-			if active, lerr := sidecar.LoadActive(cmd.Context()); lerr == nil && active != nil && active.ID() == sidecarID {
+			if active, lerr := sidecar.LoadActive(cmd.Context()); lerr == nil && active != nil && slices.Contains(active.SidecarIDs, sidecarID) {
 				if cerr := sidecar.ClearActive(cmd.Context()); cerr != nil {
 					io.ErrPrintf("Warning: could not clear active sidecar state: %v\n", cerr)
 				} else {
@@ -629,7 +630,9 @@ func newSidecarSyncCmd() *cobra.Command {
 			}
 
 			// Single-sidecar path.
-			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
+			if len(ids) == 1 {
+				sidecarID = ids[0]
+			} else if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
 				return err
 			}
 			useBundle := !checkout
@@ -948,7 +951,7 @@ snapshot with 'chunk sidecar create --image <snapshot-id>'.`,
 			}
 			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Deleted sidecar %s", sidecarID)))
 
-			if active, lerr := sidecar.LoadActive(cmd.Context()); lerr == nil && active != nil && active.ID() == sidecarID {
+			if active, lerr := sidecar.LoadActive(cmd.Context()); lerr == nil && active != nil && slices.Contains(active.SidecarIDs, sidecarID) {
 				if cerr := sidecar.ClearActive(cmd.Context()); cerr != nil {
 					io.ErrPrintf("Warning: could not clear active sidecar state: %v\n", cerr)
 				}

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -602,9 +602,12 @@ func newSidecarSyncCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if len(ids) > 0 {
+			if len(ids) > 1 {
 				if checkout {
-					return &userError{msg: "--checkout is not supported with multiple sidecars."}
+					return &userError{
+						msg:        "--checkout is not supported with multiple sidecars.",
+						suggestion: "Pass --sidecar-id to target a single sidecar.",
+					}
 				}
 				err = sidecar.BundleSyncFanOut(cmd.Context(), client, ids, identityFile, authSock, workdir, cwd, newStatusFunc(io))
 				if err != nil {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -181,6 +181,9 @@ func syncToSidecarsOpts(ctx context.Context, client *circleci.Client, opts *vali
 	authSock := os.Getenv(config.EnvSSHAuthSock)
 	err := sidecar.BundleSyncFanOut(ctx, client, opts.sidecarIDs, opts.identityFile, authSock, opts.workdir, workDir, statusFn)
 	if err != nil {
+		if _, ok := errors.AsType[*sidecar.NoOriginRemoteError](err); ok {
+			return &userError{msg: msgNoOriginRemote, suggestion: suggestionAddOrigin, err: err}
+		}
 		return &userError{msg: "Could not sync to sidecars.", err: err}
 	}
 	return nil

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -82,6 +83,7 @@ func runValidateList(workDir string, jsonOut bool, streams iostream.Streams, sta
 
 type validateOpts struct {
 	sidecarID    string
+	sidecarIDs   []string // group mode: one sidecar per remote command
 	identityFile string
 	workdir      string
 	orgID        string
@@ -158,17 +160,30 @@ func validateNeedsSidecar(explicitRemote bool, cfg *config.ProjectConfig, hook *
 }
 
 func loadSidecarEnvVars(ctx context.Context, client *circleci.Client, opts *validateOpts, workDir string, statusFn iostream.StatusFunc) (map[string]string, error) {
-	if opts.sidecarID == "" {
+	if opts.sidecarID == "" && len(opts.sidecarIDs) == 0 {
 		return nil, nil
 	}
 	envVars, err := resolveEnvVars(ctx, workDir, opts.envFile, opts.envVarsFlag)
 	if err != nil {
 		return nil, err
 	}
+	if len(opts.sidecarIDs) > 0 {
+		return envVars, syncToSidecarsOpts(ctx, client, opts, workDir, statusFn)
+	}
 	if err := syncToSidecar(ctx, client, opts.sidecarID, opts.identityFile, opts.workdir, statusFn); err != nil {
 		return nil, err
 	}
 	return envVars, nil
+}
+
+// syncToSidecarsOpts synchronises the working tree to all sidecars in the group in parallel.
+func syncToSidecarsOpts(ctx context.Context, client *circleci.Client, opts *validateOpts, workDir string, statusFn iostream.StatusFunc) error {
+	authSock := os.Getenv(config.EnvSSHAuthSock)
+	err := sidecar.BundleSyncFanOut(ctx, client, opts.sidecarIDs, opts.identityFile, authSock, opts.workdir, workDir, statusFn)
+	if err != nil {
+		return &userError{msg: "Could not sync to sidecars.", err: err}
+	}
+	return nil
 }
 
 func maybeEnsureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc config.ResolvedConfig, needsSidecar bool, streams iostream.Streams) (*circleci.Client, error) {
@@ -268,6 +283,22 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return err
 	}
 
+	// Sidecar-group path: create one sidecar per remote command and run them in parallel.
+	if shouldUseSidecarGroup(name, opts, cfg, allRemote) && needsSidecar {
+		created, err := setupSidecarGroup(ctx, circleCIClient, opts, image, cfg, activeSidecar, statusFn, workDir, streams)
+		if err != nil {
+			return err
+		}
+		if len(opts.sidecarIDs) > 0 {
+			envVars, err := loadSidecarEnvVars(ctx, circleCIClient, opts, workDir, statusFn)
+			if err != nil {
+				return err
+			}
+			execErr := runSplitCommands(ctx, circleCIClient, opts.sidecarIDs, created, opts.identityFile, opts.workdir, workDir, envVars, rc, cfg, statusFn, streams)
+			return wrapHookExec(hook, cfg, execErr, streams.Err)
+		}
+	}
+
 	freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, hook, activeSidecar, statusFn, workDir, streams)
 	if err != nil {
 		return err
@@ -282,15 +313,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	}
 
 	execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.identityFile, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
-
-	if hook != nil {
-		maxAttempts := cfg.StopHookMaxAttempts
-		if maxAttempts <= 0 {
-			maxAttempts = validate.DefaultMaxAttempts
-		}
-		return validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
-	}
-	return execErr
+	return wrapHookExec(hook, cfg, execErr, streams.Err)
 }
 
 func validateEnvFlag(envVarsFlag []string) error {
@@ -363,7 +386,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 			statusFn(iostream.LevelInfo, fmt.Sprintf("running %s locally (not marked remote)", name))
 			// Named command is not marked remote; fall through to local execution.
 		} else {
-			return runSplitCommands(ctx, client, sidecarID, freshlyCreated, identityFile, workdir, workDir, envVars, rc, cfg, statusFn, streams)
+			return runSplitCommands(ctx, client, []string{sidecarID}, freshlyCreated, identityFile, workdir, workDir, envVars, rc, cfg, statusFn, streams)
 		}
 	}
 
@@ -495,51 +518,160 @@ func hostForwardEnv(token string) map[string]string {
 }
 
 // runSplitCommands handles per-command remote routing when no specific command
-// name is given: remote-tagged commands go to the sidecar, the rest run locally.
-// When freshlyCreated is true, SSH failures are hard errors rather than
-// silent local fallbacks (a newly provisioned sidecar that can't be reached
-// indicates a real problem, not temporary unavailability).
-func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, identityFile, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+// name is given: remote-tagged commands go to the sidecar(s), the rest run
+// locally. It works the same way for any number of sidecars — a single sidecar
+// is just a group of length one. Remote commands are assigned to sidecars
+// round-robin, so with one sidecar every command runs on it (sequentially, in
+// one session), and with one sidecar per command each runs on its own box.
+//
+// Groups run in parallel across sidecars; commands within a group run
+// sequentially. With a single active sidecar output streams live; with several,
+// each group's output is buffered and printed under a labelled header so the
+// parallel streams don't interleave.
+//
+// When freshlyCreated is true, SSH/workspace failures are hard errors rather
+// than silent local fallbacks (a newly provisioned sidecar that can't be
+// reached indicates a real problem, not temporary unavailability).
+func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarIDs []string, freshlyCreated bool, identityFile, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	remoteCfg, localCfg := splitByRemote(cfg)
-	if len(remoteCfg.Commands) > 0 {
-		statusFn(iostream.LevelInfo, fmt.Sprintf("running on sidecar %s: %s", sidecarID, commandNames(remoteCfg.Commands)))
+
+	// Assign remote commands to sidecars round-robin; groups[k] runs on sidecarIDs[k].
+	groups := assignCommandsToSidecars(remoteCfg.Commands, len(sidecarIDs))
+	var active []int // indices of non-empty groups
+	for k, cmds := range groups {
+		if len(cmds) > 0 {
+			active = append(active, k)
+			statusFn(iostream.LevelInfo, fmt.Sprintf("running on sidecar %s: %s", sidecarLabel(sidecarIDs[k]), commandNames(cmds)))
+		}
 	}
 	if len(localCfg.Commands) > 0 {
 		statusFn(iostream.LevelInfo, fmt.Sprintf("running locally: %s", commandNames(localCfg.Commands)))
 	}
+
 	var runErr error
-	if len(remoteCfg.Commands) > 0 {
-		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc, streams)
-		if err != nil {
-			if freshlyCreated {
-				return newUserError(fmt.Sprintf("Could not reach newly created sidecar %s.", sidecarID)).
-					withCode("sidecar.unreachable").
-					withSuggestion("The sidecar may still be starting. Try again in a moment.").
-					withExitCode(ExitAPIError).
-					wrap(err)
+	var fellBack []config.Command // remote commands that must fall back to local execution
+
+	if len(active) <= 1 {
+		// Single active sidecar: run live so output streams as it happens.
+		for _, k := range active {
+			fb, cmdErr, setupErr := runGroupOnSidecar(ctx, client, sidecarIDs[k], freshlyCreated, identityFile, workdir, workDir, groups[k], envVars, rc, statusFn, streams)
+			if setupErr != nil {
+				return setupErr
 			}
-			streams.ErrPrintf("warning: could not reach sidecar (%v); running %s locally instead\n", err, commandNames(remoteCfg.Commands))
-			localCfg.Commands = append(remoteCfg.Commands, localCfg.Commands...)
-		} else if wsErr := validate.WorkspaceExists(ctx, execFn, dest); wsErr != nil {
-			if freshlyCreated {
-				return newUserError(fmt.Sprintf("Workspace not found on newly created sidecar %s.", sidecarID)).
-					withCode("sidecar.workspace_missing").
-					withSuggestion("Run 'chunk sidecar env build' to prepare the workspace.").
-					withExitCode(ExitNotFound).
-					wrap(wsErr)
+			fellBack = append(fellBack, fb...)
+			runErr = errors.Join(runErr, cmdErr)
+		}
+	} else {
+		// Multiple sidecars: run groups in parallel with buffered output.
+		type groupResult struct {
+			k        int
+			stdout   string
+			stderr   string
+			fellBack []config.Command
+			cmdErr   error
+			setupErr error
+		}
+		results := make([]groupResult, len(active))
+		var wg sync.WaitGroup
+		for idx, k := range active {
+			wg.Add(1)
+			go func(idx, k int) {
+				defer wg.Done()
+				var outBuf, errBuf strings.Builder
+				buf := iostream.Streams{Out: &outBuf, Err: &errBuf}
+				fb, cmdErr, setupErr := runGroupOnSidecar(ctx, client, sidecarIDs[k], freshlyCreated, identityFile, workdir, workDir, groups[k], envVars, rc, func(iostream.Level, string) {}, buf)
+				results[idx] = groupResult{k, outBuf.String(), errBuf.String(), fb, cmdErr, setupErr}
+			}(idx, k)
+		}
+		wg.Wait()
+
+		for _, r := range results {
+			header := commandNames(groups[r.k])
+			if r.stdout != "" || r.stderr != "" {
+				streams.ErrPrintf("%s\n", ui.ErrBold(header+":"))
 			}
-			streams.ErrPrintf("warning: %v (%q); run 'chunk sidecar env build' to set up the workspace; running %s locally instead\n", wsErr, dest, commandNames(remoteCfg.Commands))
-			localCfg.Commands = append(remoteCfg.Commands, localCfg.Commands...)
-		} else {
-			runErr = validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, statusFn, streams)
+			if r.stdout != "" {
+				_, _ = fmt.Fprint(streams.Out, r.stdout)
+			}
+			if r.stderr != "" {
+				_, _ = fmt.Fprint(streams.Err, r.stderr)
+			}
+			if r.setupErr != nil {
+				runErr = errors.Join(runErr, r.setupErr)
+				continue
+			}
+			fellBack = append(fellBack, r.fellBack...)
+			if r.cmdErr != nil {
+				statusFn(iostream.LevelWarn, fmt.Sprintf("%s failed: %v", header, r.cmdErr))
+				runErr = errors.Join(runErr, r.cmdErr)
+			} else if len(r.fellBack) == 0 {
+				statusFn(iostream.LevelDone, fmt.Sprintf("%s passed", header))
+			}
+		}
+		// A freshly created sidecar that couldn't be set up is fatal; don't
+		// proceed to run commands locally.
+		if freshlyCreated && runErr != nil {
+			return runErr
 		}
 	}
-	if len(localCfg.Commands) > 0 {
+
+	// Run local commands, with any fell-back remote commands ahead of them.
+	local := make([]config.Command, 0, len(fellBack)+len(localCfg.Commands))
+	local = append(local, fellBack...)
+	local = append(local, localCfg.Commands...)
+	if len(local) > 0 {
+		localCfg := &config.ProjectConfig{Commands: local}
 		if err := mapValidateError(validate.RunAll(ctx, workDir, localCfg, statusFn, streams)); err != nil {
 			runErr = errors.Join(runErr, err)
 		}
 	}
 	return runErr
+}
+
+// assignCommandsToSidecars distributes cmds across n sidecars round-robin,
+// returning a slice of n command groups where groups[k] runs on sidecar k. With
+// n == 1 every command lands in the single group (all on one sidecar); with
+// n == len(cmds) each command gets its own group (one sidecar per command).
+func assignCommandsToSidecars(cmds []config.Command, n int) [][]config.Command {
+	groups := make([][]config.Command, n)
+	for i, c := range cmds {
+		k := i % n
+		groups[k] = append(groups[k], c)
+	}
+	return groups
+}
+
+// runGroupOnSidecar runs a group of remote commands sequentially on one sidecar,
+// using the provided streams and status function. It returns the commands that
+// should fall back to local execution (when the sidecar is unreachable and not
+// freshly created), the command execution error, and a fatal setup error (only
+// when freshlyCreated). Exactly one of cmdErr/setupErr may be non-nil.
+func runGroupOnSidecar(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, identityFile, workdir, workDir string, cmds []config.Command, envVars map[string]string, rc config.ResolvedConfig, statusFn iostream.StatusFunc, streams iostream.Streams) (fellBack []config.Command, cmdErr, setupErr error) {
+	execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc, streams)
+	if err != nil {
+		if freshlyCreated {
+			return nil, nil, newUserError(fmt.Sprintf("Could not reach newly created sidecar %s.", sidecarID)).
+				withCode("sidecar.unreachable").
+				withSuggestion("The sidecar may still be starting. Try again in a moment.").
+				withExitCode(ExitAPIError).
+				wrap(err)
+		}
+		streams.ErrPrintf("warning: could not reach sidecar (%v); running %s locally instead\n", err, commandNames(cmds))
+		return cmds, nil, nil
+	}
+	if wsErr := validate.WorkspaceExists(ctx, execFn, dest); wsErr != nil {
+		if freshlyCreated {
+			return nil, nil, newUserError(fmt.Sprintf("Workspace not found on newly created sidecar %s.", sidecarID)).
+				withCode("sidecar.workspace_missing").
+				withSuggestion("Run 'chunk sidecar env build' to prepare the workspace.").
+				withExitCode(ExitNotFound).
+				wrap(wsErr)
+		}
+		streams.ErrPrintf("warning: %v (%q); run 'chunk sidecar env build' to set up the workspace; running %s locally instead\n", wsErr, dest, commandNames(cmds))
+		return cmds, nil, nil
+	}
+	groupCfg := &config.ProjectConfig{Commands: cmds}
+	return nil, validate.RunRemote(ctx, execFn, groupCfg, "", dest, workDir, statusFn, streams), nil
 }
 
 // splitByRemote partitions cfg.Commands into two configs: one containing only
@@ -588,7 +720,7 @@ func resolveImage(name string, cfg *config.ProjectConfig) string {
 func resolveSidecar(ctx context.Context, client *circleci.Client, sidecarID *string, orgID, image, workDir string, hook *hookContext, active *sidecar.ActiveSidecar, streams iostream.Streams) bool {
 	statusFn := newStatusFunc(streams)
 	if active != nil {
-		*sidecarID = active.SidecarID
+		*sidecarID = active.ID()
 		statusFn(iostream.LevelInfo, fmt.Sprintf("using sidecar %s for remote commands", *sidecarID))
 		return false
 	}
@@ -617,7 +749,7 @@ func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, side
 		return false, &userError{msg: msgCouldNotLoadSidecar, suggestion: configFilePermHint, err: loadErr}
 	}
 	if active != nil {
-		*sidecarID = active.SidecarID
+		*sidecarID = active.ID()
 		return false, nil
 	}
 	streams.ErrPrintf("No active sidecar found, creating a new sandbox...\n")
@@ -637,7 +769,7 @@ func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, side
 			err:        err,
 		}
 	}
-	if saveErr := sidecar.SaveActive(ctx, sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); saveErr != nil {
+	if saveErr := sidecar.SaveActive(ctx, sidecar.ActiveSidecar{SidecarIDs: []string{sc.ID}, Name: sc.Name}); saveErr != nil {
 		streams.ErrPrintf("warning: could not save active sidecar: %v\n", saveErr)
 	}
 	// Persist the org ID so future sandbox creation skips the picker.
@@ -700,6 +832,19 @@ func sidecarAutoName(ctx context.Context, workDir string) string {
 	return base + "-validate"
 }
 
+// wrapHookExec applies Stop hook lifecycle to an execution result.
+// When hook is nil it passes execErr through unchanged.
+func wrapHookExec(hook *hookContext, cfg *config.ProjectConfig, execErr error, w io.Writer) error {
+	if hook == nil {
+		return execErr
+	}
+	maxAttempts := cfg.StopHookMaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = validate.DefaultMaxAttempts
+	}
+	return validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, w)
+}
+
 func mapValidateError(err error) error {
 	if errors.Is(err, validate.ErrNotConfigured) {
 		return &userError{
@@ -709,4 +854,103 @@ func mapValidateError(err error) error {
 		}
 	}
 	return err
+}
+
+// shouldUseSidecarGroup reports whether validate should create a sidecar per remote command
+// and run them in parallel. Group mode activates when at least 2 commands are
+// explicitly marked Remote:true, and the caller is not in allRemote mode
+// (--remote / sidecarImage), which uses a single sidecar for all commands.
+func shouldUseSidecarGroup(name string, opts *validateOpts, cfg *config.ProjectConfig, allRemote bool) bool {
+	if name != "" || opts.inlineCmd != "" || opts.sidecarID != "" || allRemote {
+		return false
+	}
+	remoteCfg, _ := splitByRemote(cfg)
+	return len(remoteCfg.Commands) >= 2
+}
+
+// sidecarAutoNameForCmd extends sidecarAutoName with a sanitised command suffix
+// so each sidecar in a sidecar group is identifiable by the command it runs.
+func sidecarAutoNameForCmd(ctx context.Context, workDir, cmdName string) string {
+	base := sidecarAutoName(ctx, workDir)
+	if cmdName == "" {
+		return base
+	}
+	safe := strings.ToLower(strings.ReplaceAll(cmdName, "/", "-"))
+	safe = branchSanitizer.ReplaceAllString(safe, "")
+	if len(safe) > 12 {
+		safe = safe[:12]
+	}
+	if safe != "" {
+		return base + "-" + safe
+	}
+	return base
+}
+
+// setupSidecarGroup creates one sidecar per remote command (or reuses an existing
+// sidecar group from active state when the count matches) and stores the IDs in
+// opts.sidecarIDs. Returns true when new sidecars were created.
+func setupSidecarGroup(ctx context.Context, client *circleci.Client, opts *validateOpts, image string, cfg *config.ProjectConfig, activeSidecar *sidecar.ActiveSidecar, statusFn iostream.StatusFunc, workDir string, streams iostream.Streams) (bool, error) {
+	remoteCfg, _ := splitByRemote(cfg)
+	remoteCmds := remoteCfg.Commands
+	n := len(remoteCmds)
+
+	// Reuse an existing sidecar group when the sidecar count matches exactly.
+	if activeSidecar != nil && len(activeSidecar.SidecarIDs) == n {
+		opts.sidecarIDs = activeSidecar.SidecarIDs
+		statusFn(iostream.LevelInfo, fmt.Sprintf("using %d sidecars for parallel execution", n))
+		return false, nil
+	}
+
+	statusFn(iostream.LevelStep, fmt.Sprintf("Creating %d sidecars for parallel execution...", n))
+	resolvedOrgID, err := resolveOrgID(opts.orgID, workDir, orgPicker(ctx, client))
+	if err != nil {
+		return false, err
+	}
+
+	type createResult struct {
+		id  string
+		err error
+	}
+	results := make([]createResult, n)
+	var wg sync.WaitGroup
+	for i, cmd := range remoteCmds {
+		wg.Add(1)
+		go func(i int, cmdName string) {
+			defer wg.Done()
+			sc, err := sidecar.Create(ctx, client, resolvedOrgID, sidecarAutoNameForCmd(ctx, workDir, cmdName), image)
+			if err != nil {
+				results[i] = createResult{err: err}
+				return
+			}
+			results[i] = createResult{id: sc.ID}
+		}(i, cmd.Name)
+	}
+	wg.Wait()
+
+	var ids []string
+	var errs []error
+	for _, r := range results {
+		if r.err != nil {
+			errs = append(errs, r.err)
+		} else {
+			ids = append(ids, r.id)
+		}
+	}
+	if len(errs) > 0 {
+		combined := errors.Join(errs...)
+		if authErr := notAuthorized("create sidecars", combined); authErr != nil {
+			return false, authErr
+		}
+		return false, &userError{
+			msg:        "Could not create sandboxes for parallel validation.",
+			suggestion: "Check your network connection or run 'chunk sidecar create' manually.",
+			err:        combined,
+		}
+	}
+
+	opts.sidecarIDs = ids
+	if saveErr := sidecar.SaveActive(ctx, sidecar.ActiveSidecar{SidecarIDs: ids}); saveErr != nil {
+		streams.ErrPrintf("warning: could not save sidecar group state: %v\n", saveErr)
+	}
+	return true, nil
 }

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -937,6 +937,12 @@ func setupSidecarGroup(ctx context.Context, client *circleci.Client, opts *valid
 		}
 	}
 	if len(errs) > 0 {
+		// Save any sidecars that were created successfully so they aren't orphaned.
+		if len(ids) > 0 {
+			if saveErr := sidecar.SaveActive(ctx, sidecar.ActiveSidecar{SidecarIDs: ids}); saveErr != nil {
+				streams.ErrPrintf("warning: could not save partial sidecar group state: %v\n", saveErr)
+			}
+		}
 		combined := errors.Join(errs...)
 		if authErr := notAuthorized("create sidecars", combined); authErr != nil {
 			return false, authErr

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -379,3 +379,31 @@ func TestSidecarAutoNameNoSessionLongBranch(t *testing.T) {
 	// branch truncated to 30 chars
 	assert.Equal(t, got, filepath.Base(dir)+"-"+long[:30]+"-validate")
 }
+
+func TestAssignCommandsToSidecars(t *testing.T) {
+	cmds := []config.Command{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+
+	// One sidecar: every command lands in the single group.
+	single := assignCommandsToSidecars(cmds, 1)
+	assert.Equal(t, len(single), 1)
+	assert.Equal(t, commandNames(single[0]), "a, b, c")
+
+	// One sidecar per command: each command gets its own group.
+	perCmd := assignCommandsToSidecars(cmds, 3)
+	assert.Equal(t, len(perCmd), 3)
+	assert.Equal(t, commandNames(perCmd[0]), "a")
+	assert.Equal(t, commandNames(perCmd[1]), "b")
+	assert.Equal(t, commandNames(perCmd[2]), "c")
+
+	// Fewer sidecars than commands: round-robin wraps.
+	twoBox := assignCommandsToSidecars(cmds, 2)
+	assert.Equal(t, len(twoBox), 2)
+	assert.Equal(t, commandNames(twoBox[0]), "a, c")
+	assert.Equal(t, commandNames(twoBox[1]), "b")
+
+	// More sidecars than commands: trailing groups are empty.
+	extra := assignCommandsToSidecars(cmds, 5)
+	assert.Equal(t, len(extra), 5)
+	assert.Equal(t, len(extra[3]), 0)
+	assert.Equal(t, len(extra[4]), 0)
+}

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -16,12 +16,41 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
 )
 
-// ActiveSidecar holds the currently active sidecar for a project.
+// ActiveSidecar holds the currently active sidecar(s) for a project. A single
+// sidecar is just a group of length one, so every consumer works with the same
+// SidecarIDs slice regardless of how many sidecars are in play.
 type ActiveSidecar struct {
-	SidecarID     string `json:"sidecar_id"`
-	Name          string `json:"name,omitempty"`
-	Workspace     string `json:"workspace,omitempty"`
-	LastSyncedRef string `json:"last_synced_ref,omitempty"`
+	SidecarIDs    []string `json:"sidecar_ids,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	Workspace     string   `json:"workspace,omitempty"`
+	LastSyncedRef string   `json:"last_synced_ref,omitempty"`
+}
+
+// ID returns the primary sidecar ID (the first in the group), or "" when no
+// sidecar is set.
+func (a *ActiveSidecar) ID() string {
+	if a == nil || len(a.SidecarIDs) == 0 {
+		return ""
+	}
+	return a.SidecarIDs[0]
+}
+
+// UnmarshalJSON reads active-sidecar state, folding the legacy single-valued
+// "sidecar_id" field into SidecarIDs so state files written by older versions
+// keep working.
+func (a *ActiveSidecar) UnmarshalJSON(data []byte) error {
+	type alias ActiveSidecar
+	aux := struct {
+		LegacyID string `json:"sidecar_id"`
+		*alias
+	}{alias: (*alias)(a)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if len(a.SidecarIDs) == 0 && aux.LegacyID != "" {
+		a.SidecarIDs = []string{aux.LegacyID}
+	}
+	return nil
 }
 
 // CurrentBranch returns the current git branch for the repo rooted at root.

--- a/internal/sidecar/active_test.go
+++ b/internal/sidecar/active_test.go
@@ -27,7 +27,7 @@ func TestSaveActiveWritesToXDGDataPath(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	assert.NilError(t, SaveActive(context.Background(), ActiveSidecar{SidecarID: "sb-1"}))
+	assert.NilError(t, SaveActive(context.Background(), ActiveSidecar{SidecarIDs: []string{"sb-1"}}))
 
 	// Must not appear inside the project's .chunk directory.
 	_, err := os.Stat(filepath.Join(dir, ".chunk", "sidecar.json"))
@@ -63,15 +63,36 @@ func TestSaveAndLoadActive(t *testing.T) {
 	setupXDGData(t)
 
 	ctx := context.Background()
-	want := ActiveSidecar{SidecarID: "sb-abc", Name: "my-box"}
+	want := ActiveSidecar{SidecarIDs: []string{"sb-abc"}, Name: "my-box"}
 	err := SaveActive(ctx, want)
 	assert.NilError(t, err)
 
 	got, err := LoadActive(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil, "expected non-nil ActiveSidecar")
-	assert.Equal(t, got.SidecarID, want.SidecarID)
+	assert.Equal(t, got.ID(), want.ID())
 	assert.Equal(t, got.Name, want.Name)
+}
+
+func TestLoadActiveReadsLegacySidecarID(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	setupXDGData(t)
+
+	// Write a state file in the legacy single-field format that older CLI
+	// versions produced, then confirm it folds into SidecarIDs on load.
+	dataDir, err := config.ProjectDataDir(dir)
+	assert.NilError(t, err)
+	assert.NilError(t, os.MkdirAll(dataDir, 0o755))
+	legacy := `{"sidecar_id":"sb-legacy","name":"old-box"}`
+	assert.NilError(t, os.WriteFile(filepath.Join(dataDir, "sidecar.json"), []byte(legacy), 0o644))
+
+	got, err := LoadActive(context.Background())
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil, "expected non-nil ActiveSidecar")
+	assert.DeepEqual(t, got.SidecarIDs, []string{"sb-legacy"})
+	assert.Equal(t, got.ID(), "sb-legacy")
+	assert.Equal(t, got.Name, "old-box")
 }
 
 func TestLoadActiveReturnsNilWhenMissing(t *testing.T) {
@@ -96,20 +117,20 @@ func TestLoadActiveUsesGitRootAsKey(t *testing.T) {
 
 	// Save from child — keyed to parent (git root).
 	t.Chdir(child)
-	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarID: "sb-git-root"}))
+	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarIDs: []string{"sb-git-root"}}))
 
 	// Load from child — should find it.
 	got, err := LoadActive(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
-	assert.Equal(t, got.SidecarID, "sb-git-root")
+	assert.Equal(t, got.ID(), "sb-git-root")
 
 	// Load from parent (the git root) — same project, same file.
 	t.Chdir(parent)
 	got, err = LoadActive(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
-	assert.Equal(t, got.SidecarID, "sb-git-root")
+	assert.Equal(t, got.ID(), "sb-git-root")
 }
 
 func TestLoadActiveUsesCwdWhenNoGitRepo(t *testing.T) {
@@ -118,12 +139,12 @@ func TestLoadActiveUsesCwdWhenNoGitRepo(t *testing.T) {
 	setupXDGData(t)
 
 	ctx := context.Background()
-	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarID: "sb-cwd"}))
+	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarIDs: []string{"sb-cwd"}}))
 
 	got, err := LoadActive(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
-	assert.Equal(t, got.SidecarID, "sb-cwd")
+	assert.Equal(t, got.ID(), "sb-cwd")
 }
 
 func TestClearActive(t *testing.T) {
@@ -132,7 +153,7 @@ func TestClearActive(t *testing.T) {
 	setupXDGData(t)
 
 	ctx := context.Background()
-	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarID: "sb-xyz"}))
+	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarIDs: []string{"sb-xyz"}}))
 
 	got, err := LoadActive(ctx)
 	assert.NilError(t, err)
@@ -154,7 +175,7 @@ func TestSessionKeyedSidecar(t *testing.T) {
 	sessCtx := session.WithID(ctx, "sess-abc")
 
 	// Save without a session — generic file.
-	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarID: "sb-generic"}))
+	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarIDs: []string{"sb-generic"}}))
 
 	// Session-keyed load should not see the generic file.
 	got, err := LoadActive(sessCtx)
@@ -162,18 +183,18 @@ func TestSessionKeyedSidecar(t *testing.T) {
 	assert.Assert(t, got == nil, "session-keyed load should not see generic file")
 
 	// Save under the session.
-	assert.NilError(t, SaveActive(sessCtx, ActiveSidecar{SidecarID: "sb-session"}))
+	assert.NilError(t, SaveActive(sessCtx, ActiveSidecar{SidecarIDs: []string{"sb-session"}}))
 
 	got, err = LoadActive(sessCtx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
-	assert.Equal(t, got.SidecarID, "sb-session")
+	assert.Equal(t, got.ID(), "sb-session")
 
 	// Without the session, the original generic file is still intact.
 	got, err = LoadActive(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
-	assert.Equal(t, got.SidecarID, "sb-generic")
+	assert.Equal(t, got.ID(), "sb-generic")
 }
 
 func TestClearActiveNoopWhenMissing(t *testing.T) {
@@ -190,14 +211,14 @@ func TestWorkspaceFieldRoundTrip(t *testing.T) {
 	setupXDGData(t)
 
 	ctx := context.Background()
-	want := ActiveSidecar{SidecarID: "sb-1", Name: "test", Workspace: "/workspace/myrepo"}
+	want := ActiveSidecar{SidecarIDs: []string{"sb-1"}, Name: "test", Workspace: "/workspace/myrepo"}
 	assert.NilError(t, SaveActive(ctx, want))
 
 	got, err := LoadActive(ctx)
 	assert.NilError(t, err)
 	assert.Assert(t, got != nil)
 	assert.Equal(t, got.Workspace, want.Workspace)
-	assert.Equal(t, got.SidecarID, want.SidecarID)
+	assert.Equal(t, got.ID(), want.ID())
 }
 
 func TestWorkspaceOmittedWhenEmpty(t *testing.T) {
@@ -206,7 +227,7 @@ func TestWorkspaceOmittedWhenEmpty(t *testing.T) {
 	setupXDGData(t)
 
 	ctx := context.Background()
-	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarID: "sb-1"}))
+	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarIDs: []string{"sb-1"}}))
 
 	stateDir, err := saveDir()
 	assert.NilError(t, err)
@@ -221,7 +242,7 @@ func TestResolveWorkspaceCLIFlagWins(t *testing.T) {
 	setupXDGData(t)
 
 	ctx := context.Background()
-	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarID: "sb-1", Workspace: "/workspace/saved"}))
+	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarIDs: []string{"sb-1"}, Workspace: "/workspace/saved"}))
 
 	got, err := ResolveWorkspace(ctx, "/workspace/override", "myrepo")
 	assert.NilError(t, err)
@@ -234,7 +255,7 @@ func TestResolveWorkspaceSidecarFallback(t *testing.T) {
 	setupXDGData(t)
 
 	ctx := context.Background()
-	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarID: "sb-1", Workspace: "/workspace/saved"}))
+	assert.NilError(t, SaveActive(ctx, ActiveSidecar{SidecarIDs: []string{"sb-1"}, Workspace: "/workspace/saved"}))
 
 	got, err := ResolveWorkspace(ctx, "", "myrepo")
 	assert.NilError(t, err)

--- a/internal/sidecar/sync.go
+++ b/internal/sidecar/sync.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
@@ -131,9 +132,9 @@ func BundleSync(ctx context.Context,
 		return err
 	}
 
-	_, repo, err := gitremote.DetectOrgAndRepo(cwd)
-	if err != nil {
-		return &NoOriginRemoteError{Err: err}
+	_, repo, repoErr := gitremote.DetectOrgAndRepo(cwd)
+	if repoErr != nil && workdir == "" {
+		return &NoOriginRemoteError{Err: repoErr}
 	}
 
 	repoPath, err := ResolveWorkspace(ctx, workdir, repo)
@@ -149,12 +150,12 @@ func BundleSync(ctx context.Context,
 		return fmt.Errorf("bundle sync: load active sidecar: %w", err)
 	}
 	if active == nil {
-		active = &ActiveSidecar{SidecarID: sidecarID}
+		active = &ActiveSidecar{SidecarIDs: []string{sidecarID}}
 	}
 	lastRef := active.LastSyncedRef
-	if active.SidecarID != sidecarID {
+	if active.ID() != sidecarID {
 		lastRef = "" // sidecar changed; force full bundle
-		active.SidecarID = sidecarID
+		active.SidecarIDs = []string{sidecarID}
 	}
 
 	headRef, err := gitutil.HeadRef(cwd)
@@ -162,65 +163,44 @@ func BundleSync(ctx context.Context,
 		return fmt.Errorf("bundle sync: %w", err)
 	}
 
-	// Ensure the destination directory exists.
-	parentDir := filepath.Dir(repoPath)
-	if result, err := ExecOverSSH(ctx, session, "mkdir -p "+ShellEscape(parentDir), nil, nil); err != nil {
-		return fmt.Errorf("bundle sync: mkdir: %w", err)
-	} else if result.ExitCode != 0 {
-		return fmt.Errorf("bundle sync: mkdir -p %s: %s", parentDir, result.Stderr)
-	}
-
-	// Check whether a git repo already exists at the destination.
-	testResult, err := ExecOverSSH(ctx, session, "test -d "+ShellEscape(repoPath+"/.git"), nil, nil)
+	// Ensure the destination exists and has a git repo; a fresh repo forces a
+	// full bundle.
+	freshRepo, err := ensureRemoteRepo(ctx, session, repoPath)
 	if err != nil {
-		return fmt.Errorf("bundle sync: check repo: %w", err)
+		return fmt.Errorf("bundle sync: %w", err)
 	}
-	if testResult.ExitCode != 0 {
-		if result, err := ExecOverSSH(ctx, session, "git init "+ShellEscape(repoPath), nil, nil); err != nil {
-			return fmt.Errorf("bundle sync: git init: %w", err)
-		} else if result.ExitCode != 0 {
-			return fmt.Errorf("bundle sync: git init: %s", result.Stderr)
-		}
-		lastRef = "" // force full bundle for a fresh repo
+	if freshRepo {
+		lastRef = ""
 	}
 
 	resetRef := "HEAD"
 	if lastRef == headRef {
 		status(iostream.LevelInfo, "No new commits since last sync.")
 	} else {
-		if err := sendBundle(ctx, session, lastRef, cwd, repo, repoPath, status); err != nil {
-			return err
+		bundle, err := gitutil.CreateBundle(lastRef, cwd)
+		if err != nil {
+			return fmt.Errorf("bundle sync: %w", err)
+		}
+		label := "incremental bundle"
+		if lastRef == "" {
+			label = "full bundle"
+		}
+		status(iostream.LevelInfo, fmt.Sprintf("Sending %s (%d bytes)...", label, len(bundle)))
+		if err := sendBundle(ctx, session, repo, repoPath, bundle); err != nil {
+			return fmt.Errorf("bundle sync: %w", err)
 		}
 		resetRef = "FETCH_HEAD"
 	}
 
-	// Always reset and clean so the patch applies cleanly from a known state.
-	resetCmd := fmt.Sprintf("git -C %s reset --hard %s", ShellEscape(repoPath), resetRef)
-	cleanCmd := fmt.Sprintf("git -C %s clean -fd", ShellEscape(repoPath))
-	if result, err := ExecOverSSH(ctx, session, resetCmd, nil, nil); err != nil {
-		return fmt.Errorf("bundle sync: reset: %w", err)
-	} else if result.ExitCode != 0 {
-		return fmt.Errorf("bundle sync: reset: %s", result.Stderr)
-	}
-	if result, err := ExecOverSSH(ctx, session, cleanCmd, nil, nil); err != nil {
-		return fmt.Errorf("bundle sync: clean: %w", err)
-	} else if result.ExitCode != 0 {
-		return fmt.Errorf("bundle sync: clean: %s", result.Stderr)
-	}
-
-	// Apply any uncommitted working-tree changes as a patch on top.
 	patch, err := gitutil.GeneratePatch(headRef)
 	if err != nil {
 		return fmt.Errorf("bundle sync: %w", err)
 	}
 	if patch != "" {
 		status(iostream.LevelInfo, fmt.Sprintf("Applying working-tree changes (%d bytes)...", len(patch)))
-		applyCmd := fmt.Sprintf("git -C %s apply", ShellEscape(repoPath))
-		if result, err := ExecOverSSH(ctx, session, applyCmd, strings.NewReader(patch), nil); err != nil {
-			return fmt.Errorf("bundle sync: apply patch: %w", err)
-		} else if result.ExitCode != 0 {
-			return fmt.Errorf("bundle sync: apply patch: %s", result.Stderr)
-		}
+	}
+	if err := resetCleanApply(ctx, session, repoPath, resetRef, patch); err != nil {
+		return fmt.Errorf("bundle sync: %w", err)
 	}
 
 	// Persist the synced ref.
@@ -233,32 +213,149 @@ func BundleSync(ctx context.Context,
 	return nil
 }
 
-// sendBundle creates and transfers a git bundle (full or incremental) to the
-// sidecar, then fetches it into the remote repo.
-func sendBundle(ctx context.Context, session *Session, lastRef, cwd, repo, repoPath string, status iostream.StatusFunc) error {
-	label := "incremental bundle"
-	if lastRef == "" {
-		label = "full bundle"
+// BundleSyncFanOut synchronises a local working tree to multiple sidecars in
+// parallel. It builds one git bundle and patch, then delivers them to all
+// targets concurrently. Unlike BundleSync, it always sends a full bundle (no
+// incremental optimisation) and does not update any active-sidecar state.
+func BundleSyncFanOut(ctx context.Context, client *circleci.Client, sidecarIDs []string, identityFile, authSock, workdir, cwd string, status iostream.StatusFunc) error {
+	_, repo, repoErr := gitremote.DetectOrgAndRepo(cwd)
+	if repoErr != nil && workdir == "" {
+		return &NoOriginRemoteError{Err: repoErr}
 	}
 
-	bundle, err := gitutil.CreateBundle(lastRef, cwd)
+	repoPath := workdir
+	if repoPath == "" {
+		repoPath = sidecarHome() + "/" + repo
+	}
+
+	headRef, err := gitutil.HeadRef(cwd)
 	if err != nil {
-		return fmt.Errorf("bundle sync: %w", err)
+		return fmt.Errorf("fan-out sync: %w", err)
 	}
-	status(iostream.LevelInfo, fmt.Sprintf("Sending %s (%d bytes)...", label, len(bundle)))
 
-	bundlePath := fmt.Sprintf("/tmp/chunk-sync-%s.bundle", repo)
-	if result, err := ExecOverSSH(ctx, session, "tee "+ShellEscape(bundlePath), bytes.NewReader(bundle), nil); err != nil {
-		return fmt.Errorf("bundle sync: write bundle: %w", err)
+	bundle, err := gitutil.CreateBundle("", cwd)
+	if err != nil {
+		return fmt.Errorf("fan-out sync: %w", err)
+	}
+	status(iostream.LevelInfo, fmt.Sprintf("Bundle ready (%d bytes), syncing to %d sidecars...", len(bundle), len(sidecarIDs)))
+
+	patch, err := gitutil.GeneratePatch(headRef)
+	if err != nil {
+		return fmt.Errorf("fan-out sync: %w", err)
+	}
+
+	errs := make([]error, len(sidecarIDs))
+	var wg sync.WaitGroup
+	for i, id := range sidecarIDs {
+		wg.Add(1)
+		go func(i int, id string) {
+			defer wg.Done()
+			sess, err := OpenSession(ctx, client, id, identityFile, authSock)
+			if err != nil {
+				errs[i] = fmt.Errorf("sidecar %s: open session: %w", id, err)
+				return
+			}
+			if err := applyBundleToSidecar(ctx, sess, repo, repoPath, bundle, patch); err != nil {
+				errs[i] = fmt.Errorf("sidecar %s: %w", id, err)
+			}
+		}(i, id)
+	}
+	wg.Wait()
+
+	if err := errors.Join(errs...); err != nil {
+		return err
+	}
+	status(iostream.LevelDone, fmt.Sprintf("Synced %d sidecars", len(sidecarIDs)))
+	return nil
+}
+
+// applyBundleToSidecar delivers a pre-built full bundle and patch to a single
+// sidecar: it ensures the repo exists, fetches the bundle, then resets, cleans,
+// and applies the working-tree patch. It shares its per-step primitives with
+// BundleSync so the single- and multi-sidecar paths behave identically.
+func applyBundleToSidecar(ctx context.Context, session *Session, repo, repoPath string, bundle []byte, patch string) error {
+	if _, err := ensureRemoteRepo(ctx, session, repoPath); err != nil {
+		return err
+	}
+	if err := sendBundle(ctx, session, repo, repoPath, bundle); err != nil {
+		return err
+	}
+	return resetCleanApply(ctx, session, repoPath, "FETCH_HEAD", patch)
+}
+
+// ensureRemoteRepo makes sure repoPath's parent exists and repoPath holds a git
+// repo, running "git init" when absent. It returns true when the repo was
+// freshly initialised (so callers know to send a full bundle).
+func ensureRemoteRepo(ctx context.Context, session *Session, repoPath string) (bool, error) {
+	parentDir := filepath.Dir(repoPath)
+	if result, err := ExecOverSSH(ctx, session, "mkdir -p "+ShellEscape(parentDir), nil, nil); err != nil {
+		return false, fmt.Errorf("mkdir: %w", err)
 	} else if result.ExitCode != 0 {
-		return fmt.Errorf("bundle sync: write bundle: %s", result.Stderr)
+		return false, fmt.Errorf("mkdir -p %s: %s", parentDir, result.Stderr)
+	}
+
+	testResult, err := ExecOverSSH(ctx, session, "test -d "+ShellEscape(repoPath+"/.git"), nil, nil)
+	if err != nil {
+		return false, fmt.Errorf("check repo: %w", err)
+	}
+	if testResult.ExitCode == 0 {
+		return false, nil
+	}
+	if result, err := ExecOverSSH(ctx, session, "git init "+ShellEscape(repoPath), nil, nil); err != nil {
+		return false, fmt.Errorf("git init: %w", err)
+	} else if result.ExitCode != 0 {
+		return false, fmt.Errorf("git init: %s", result.Stderr)
+	}
+	return true, nil
+}
+
+// sendBundle transfers a pre-built git bundle to the sidecar and fetches it into
+// the remote repo (leaving the fetched tip as FETCH_HEAD).
+func sendBundle(ctx context.Context, session *Session, repo, repoPath string, bundle []byte) error {
+	bundleName := repo
+	if bundleName == "" {
+		bundleName = "chunk"
+	}
+	bundlePath := fmt.Sprintf("/tmp/chunk-sync-%s.bundle", bundleName)
+	if result, err := ExecOverSSH(ctx, session, "tee "+ShellEscape(bundlePath), bytes.NewReader(bundle), nil); err != nil {
+		return fmt.Errorf("write bundle: %w", err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("write bundle: %s", result.Stderr)
 	}
 
 	fetchCmd := fmt.Sprintf("git -C %s fetch %s HEAD", ShellEscape(repoPath), ShellEscape(bundlePath))
 	if result, err := ExecOverSSH(ctx, session, fetchCmd, nil, nil); err != nil {
-		return fmt.Errorf("bundle sync: fetch: %w", err)
+		return fmt.Errorf("fetch: %w", err)
 	} else if result.ExitCode != 0 {
-		return fmt.Errorf("bundle sync: fetch: %s", result.Stderr)
+		return fmt.Errorf("fetch: %s", result.Stderr)
+	}
+	return nil
+}
+
+// resetCleanApply resets repoPath to resetRef, cleans untracked files, then
+// applies patch (when non-empty) as working-tree changes on top.
+func resetCleanApply(ctx context.Context, session *Session, repoPath, resetRef, patch string) error {
+	resetCmd := fmt.Sprintf("git -C %s reset --hard %s", ShellEscape(repoPath), resetRef)
+	if result, err := ExecOverSSH(ctx, session, resetCmd, nil, nil); err != nil {
+		return fmt.Errorf("reset: %w", err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("reset: %s", result.Stderr)
+	}
+
+	cleanCmd := fmt.Sprintf("git -C %s clean -fd", ShellEscape(repoPath))
+	if result, err := ExecOverSSH(ctx, session, cleanCmd, nil, nil); err != nil {
+		return fmt.Errorf("clean: %w", err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("clean: %s", result.Stderr)
+	}
+
+	if patch != "" {
+		applyCmd := fmt.Sprintf("git -C %s apply", ShellEscape(repoPath))
+		if result, err := ExecOverSSH(ctx, session, applyCmd, strings.NewReader(patch), nil); err != nil {
+			return fmt.Errorf("apply patch: %w", err)
+		} else if result.ExitCode != 0 {
+			return fmt.Errorf("apply patch: %s", result.Stderr)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Adds `--count N` to `chunk sidecar create` to spin up multiple sidecars in parallel and set them as the active group
- Updates `chunk sidecar sync` to deliver one bundle to all sidecars in the active group in parallel
- Updates `chunk validate` to automatically provision one sidecar per remote command when two or more remote commands are configured (reuses an existing group of the right size)
- Fixes three bugs discovered during implementation: nil check on `active` in `resolveSidecarID`, missing error path in sync fan-out, and a race in parallel create result collection

## Test plan

- [ ] `chunk sidecar create --count 3` creates three sidecars and sets them as the active group
- [ ] `chunk sidecar sync` delivers the bundle to all sidecars in the active group in parallel
- [ ] `chunk validate` with two or more remote commands creates matching sidecars and runs them in parallel
- [ ] Single-sidecar workflows are unaffected (no `--count`, no group — existing behaviour unchanged)
- [ ] Unit tests pass: `task test`
- [ ] Acceptance tests pass: `task acceptance-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)