### PR TITLE
Switch exec to async streaming output

### DIFF
--- a/internal/circleci/circleci_test.go
+++ b/internal/circleci/circleci_test.go
@@ -282,10 +282,15 @@ func TestExec(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		reqs := fake.Recorder.AllRequests()
-		last := reqs[len(reqs)-1]
-		if last.URL.Path != "/api/v3/sidecar/instances/sb-1/exec" {
-			t.Errorf("expected /api/v3/sidecar/instances/sb-1/exec, got %s", last.URL.Path)
+		var found bool
+		for _, req := range fake.Recorder.AllRequests() {
+			if req.URL.Path == "/api/v3/sidecar/instances/sb-1/exec" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected a request to /api/v3/sidecar/instances/sb-1/exec")
 		}
 	})
 }

--- a/internal/circleci/circleci_test.go
+++ b/internal/circleci/circleci_test.go
@@ -269,6 +269,24 @@ func TestExec(t *testing.T) {
 		}
 	})
 
+	t.Run("outdated sidecar surfaces server message", func(t *testing.T) {
+		fake := fakes.NewFakeCircleCI()
+		fake.CommandOutputStatusCode = http.StatusGone
+		fake.CommandOutputMessage = "sidecar predates async exec; recreate with: chunk sidecar create"
+		srv := httptest.NewServer(fake)
+		defer srv.Close()
+
+		client := newTestClient(t, srv.URL)
+		_, err := client.Exec(context.Background(), "sb-1", "echo", nil)
+		var se *StatusError
+		if !errors.As(err, &se) || se.StatusCode != http.StatusGone {
+			t.Fatalf("expected 410 StatusError, got %v", err)
+		}
+		if se.ServerMessage != fake.CommandOutputMessage {
+			t.Errorf("expected server message %q, got %q", fake.CommandOutputMessage, se.ServerMessage)
+		}
+	})
+
 	t.Run("sends sidecar ID in path", func(t *testing.T) {
 		fake := fakes.NewFakeCircleCI()
 		srv := httptest.NewServer(fake)

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -1,10 +1,12 @@
 package circleci
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -178,34 +180,72 @@ func (c *Client) AddSSHKey(ctx context.Context, sidecarID, publicKey string) (*A
 	return &AddSSHKeyResponse{URL: attrs.URL}, nil
 }
 
-type execAttrs struct {
-	ExitCode int    `json:"exit_code"`
-	PID      int    `json:"pid"`
-	Stdout   string `json:"stdout"`
-	Stderr   string `json:"stderr"`
+// outputStreamLine is one JSONL event from GET /commands/{id}/output.
+// Lines with a non-empty CommandID are the terminal result; others carry output.
+type outputStreamLine struct {
+	CommandID string `json:"command_id"`
+	ExitCode  int    `json:"exit_code"`
+	PID       int    `json:"pid"`
+	Stream    string `json:"stream"` // "stdout" or "stderr"
+	Line      string `json:"line"`
+}
+
+type execSubmitAttrs struct {
+	Phase string `json:"phase"`
 }
 
 func (c *Client) Exec(ctx context.Context, sidecarID, command string, args []string) (*ExecResponse, error) {
-	var attrs execAttrs
+	var attrs execSubmitAttrs
 	env := v3Envelope{Data: v3DataEntity{Attributes: &attrs}}
 	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodPost, "/api/v3/sidecar/instances/%s/exec",
 		hc.RouteParams(sidecarID),
-		hc.Body(ExecRequest{
-			Command: command,
-			Args:    args,
-		}),
+		hc.Body(ExecRequest{Command: command, Args: args}),
 		hc.JSONDecoder(&env),
 	))
 	if err != nil {
 		return nil, mapErr("exec", err)
 	}
-	return &ExecResponse{
-		CommandID: env.Data.ID,
-		PID:       attrs.PID,
-		Stdout:    attrs.Stdout,
-		Stderr:    attrs.Stderr,
-		ExitCode:  attrs.ExitCode,
-	}, nil
+	return c.streamCommandOutput(ctx, env.Data.ID)
+}
+
+func (c *Client) streamCommandOutput(ctx context.Context, commandID string) (*ExecResponse, error) {
+	var result ExecResponse
+	gotResult := false
+	decoder := func(r io.Reader) error {
+		sc := bufio.NewScanner(r)
+		for sc.Scan() {
+			var event outputStreamLine
+			if err := json.Unmarshal(sc.Bytes(), &event); err != nil {
+				continue
+			}
+			if event.CommandID != "" {
+				result.CommandID = event.CommandID
+				result.ExitCode = event.ExitCode
+				result.PID = event.PID
+				gotResult = true
+				return nil
+			}
+			switch event.Stream {
+			case "stdout":
+				result.Stdout += event.Line
+			case "stderr":
+				result.Stderr += event.Line
+			}
+		}
+		return sc.Err()
+	}
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v3/sidecar/commands/%s/output",
+		hc.RouteParams(commandID),
+		hc.Decoder(decoder),
+		hc.NoTimeout(),
+	))
+	if err != nil {
+		return nil, mapErr("stream command output", err)
+	}
+	if !gotResult {
+		return nil, fmt.Errorf("stream command output: stream ended without result")
+	}
+	return &result, nil
 }
 
 type commandAttrs struct {

--- a/internal/httpcl/client.go
+++ b/internal/httpcl/client.go
@@ -202,12 +202,17 @@ func (c *Client) Call(ctx context.Context, r Request) (int, error) {
 		bodyReader = bytes.NewReader(b)
 	}
 
-	ctxTimeout := c.timeout
-	if c.retryOn429Budget > 0 {
-		ctx = context.WithValue(ctx, retryCtxKey{}, &retryState{start: time.Now()})
-		ctxTimeout = c.retryOn429Budget + c.timeout // extend deadline to cover retry waits
+	cancel := func() {}
+	if !r.noTimeout {
+		ctxTimeout := c.timeout
+		if c.retryOn429Budget > 0 {
+			ctx = context.WithValue(ctx, retryCtxKey{}, &retryState{start: time.Now()})
+			ctxTimeout = c.retryOn429Budget + c.timeout // extend deadline to cover retry waits
+		}
+		var timeoutCancel context.CancelFunc
+		ctx, timeoutCancel = context.WithTimeout(ctx, ctxTimeout)
+		cancel = timeoutCancel
 	}
-	ctx, cancel := context.WithTimeout(ctx, ctxTimeout)
 	defer cancel()
 
 	req, err := retryablehttp.NewRequestWithContext(ctx, r.method, u.String(), bodyReader)

--- a/internal/httpcl/request.go
+++ b/internal/httpcl/request.go
@@ -11,13 +11,14 @@ import (
 // Request is an individual HTTP request to be executed by Client.Call.
 // Use NewRequest to create one.
 type Request struct {
-	method  string
-	route   string
-	url     string
-	body    any
-	decoder func(io.Reader) error
-	headers http.Header
-	query   url.Values
+	method    string
+	route     string
+	url       string
+	body      any
+	decoder   func(io.Reader) error
+	headers   http.Header
+	query     url.Values
+	noTimeout bool
 }
 
 // URL returns the resolved URL (after RouteParams) or the raw route.
@@ -71,4 +72,15 @@ func RouteParams(params ...any) func(*Request) {
 	return func(r *Request) {
 		r.url = fmt.Sprintf(r.route, params...)
 	}
+}
+
+// Decoder sets a raw response-body decoder function.
+func Decoder(fn func(io.Reader) error) func(*Request) {
+	return func(r *Request) { r.decoder = fn }
+}
+
+// NoTimeout skips the client-level timeout for this request; only the
+// caller's context deadline applies. Use for long-lived streaming responses.
+func NoTimeout() func(*Request) {
+	return func(r *Request) { r.noTimeout = true }
 }

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -11,6 +11,16 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/recorder"
 )
 
+// commandOutputLine mirrors the JSONL event emitted by GET /commands/:id/output.
+type commandOutputLine struct {
+	CommandID string `json:"command_id,omitempty"`
+	ExitCode  int    `json:"exit_code,omitempty"`
+	PID       int    `json:"pid,omitempty"`
+	Index     int    `json:"index,omitempty"`
+	Stream    string `json:"stream,omitempty"`
+	Line      string `json:"line,omitempty"`
+}
+
 type Collaboration struct {
 	ID      string `json:"id"`
 	Name    string `json:"name"`
@@ -86,6 +96,7 @@ type FakeCircleCI struct {
 	CreateStatusCode         int // override for POST /sidecar/instances
 	DeleteStatusCode         int // override for DELETE /sidecar/instances/:id
 	ExecStatusCode           int // override for POST /sidecar/instances/:id/exec
+	CommandOutputStatusCode  int // override for GET /sidecar/commands/:id/output
 	AddKeyStatusCode         int // override for POST /sidecar/instances/:id/ssh/add-key
 	CreateSnapshotStatusCode int // override for POST /sidecar/snapshots
 	GetSnapshotStatusCode    int // override for GET /sidecar/snapshots/:id
@@ -138,8 +149,9 @@ func NewFakeCircleCI() *FakeCircleCI {
 	r.POST("/api/v3/sidecar/snapshots", f.handleCreateSnapshot)
 	r.GET("/api/v3/sidecar/snapshots/:id", f.handleGetSnapshot)
 
-	// Command V3 endpoint
+	// Command V3 endpoints
 	r.GET("/api/v3/sidecar/commands/:id", f.handleGetCommand)
+	r.GET("/api/v3/sidecar/commands/:id/output", f.handleCommandOutput)
 
 	// Task run endpoint
 	r.POST("/api/v2/agents/org/:org_id/project/:project_id/runs", f.handleTriggerRun)
@@ -336,20 +348,65 @@ func (f *FakeCircleCI) handleExec(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	// Async: return 202 with command ID; output is streamed via GET /commands/:id/output.
+	c.JSON(http.StatusAccepted, gin.H{
 		"data": gin.H{
-			"attributes": gin.H{
-				"exit_code": resp.ExitCode,
-				"pid":       resp.PID,
-				"stdout":    resp.Stdout,
-				"stderr":    resp.Stderr,
-			},
-			"id": resp.CommandID,
+			"attributes": gin.H{"phase": "received"},
+			"id":         resp.CommandID,
 			"references": gin.H{
 				"sidecar_instance": gin.H{"id": c.Param("id")},
 			},
 		},
 	})
+}
+
+func (f *FakeCircleCI) handleCommandOutput(c *gin.Context) {
+	if !f.requireToken(c) {
+		return
+	}
+	f.mu.RLock()
+	resp := f.ExecResponse
+	statusCode := f.CommandOutputStatusCode
+	f.mu.RUnlock()
+
+	if statusCode != 0 {
+		c.JSON(statusCode, gin.H{"message": "API error"})
+		return
+	}
+
+	if resp == nil {
+		resp = &ExecResponse{
+			CommandID: "cmd-123",
+			PID:       42,
+			Stdout:    "ok\n",
+			Stderr:    "",
+			ExitCode:  0,
+		}
+	}
+
+	c.Header("Content-Type", "application/x-ndjson")
+	c.Status(http.StatusOK)
+
+	idx := 0
+	writeEvent := func(stream, line string) {
+		b, _ := json.Marshal(commandOutputLine{Index: idx, Stream: stream, Line: line})
+		_, _ = fmt.Fprintf(c.Writer, "%s\n", b)
+		idx++
+	}
+
+	if resp.Stdout != "" {
+		writeEvent("stdout", resp.Stdout)
+	}
+	if resp.Stderr != "" {
+		writeEvent("stderr", resp.Stderr)
+	}
+
+	result, _ := json.Marshal(commandOutputLine{
+		CommandID: resp.CommandID,
+		ExitCode:  resp.ExitCode,
+		PID:       resp.PID,
+	})
+	_, _ = fmt.Fprintf(c.Writer, "%s\n", result)
 }
 
 func (f *FakeCircleCI) handleGetCommand(c *gin.Context) {

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -91,18 +91,19 @@ type FakeCircleCI struct {
 	RunStatusCode   int // override status code for trigger run endpoint
 
 	// Per-endpoint status code overrides for testing error responses.
-	CollaborationsStatusCode int // override for GET /me/collaborations
-	ListStatusCode           int // override for GET /sidecar/instances
-	CreateStatusCode         int // override for POST /sidecar/instances
-	DeleteStatusCode         int // override for DELETE /sidecar/instances/:id
-	ExecStatusCode           int // override for POST /sidecar/instances/:id/exec
-	CommandOutputStatusCode  int // override for GET /sidecar/commands/:id/output
-	AddKeyStatusCode         int // override for POST /sidecar/instances/:id/ssh/add-key
-	CreateSnapshotStatusCode int // override for POST /sidecar/snapshots
-	GetSnapshotStatusCode    int // override for GET /sidecar/snapshots/:id
-	ListSnapshotsStatusCode  int // override for GET /sidecar/snapshots
-	GetCommandStatusCode     int // override for GET /sidecar/commands/:id
-	CreateOrgStatusCode      int // override for POST /api/v2/organization
+	CollaborationsStatusCode int    // override for GET /me/collaborations
+	ListStatusCode           int    // override for GET /sidecar/instances
+	CreateStatusCode         int    // override for POST /sidecar/instances
+	DeleteStatusCode         int    // override for DELETE /sidecar/instances/:id
+	ExecStatusCode           int    // override for POST /sidecar/instances/:id/exec
+	CommandOutputStatusCode  int    // override for GET /sidecar/commands/:id/output
+	CommandOutputMessage     string // error message body when CommandOutputStatusCode is set
+	AddKeyStatusCode         int    // override for POST /sidecar/instances/:id/ssh/add-key
+	CreateSnapshotStatusCode int    // override for POST /sidecar/snapshots
+	GetSnapshotStatusCode    int    // override for GET /sidecar/snapshots/:id
+	ListSnapshotsStatusCode  int    // override for GET /sidecar/snapshots
+	GetCommandStatusCode     int    // override for GET /sidecar/commands/:id
+	CreateOrgStatusCode      int    // override for POST /api/v2/organization
 
 	// ExtraHeaders are added to every response. Use to inject Deprecation/Sunset
 	// headers without changing individual handler logic.
@@ -367,10 +368,14 @@ func (f *FakeCircleCI) handleCommandOutput(c *gin.Context) {
 	f.mu.RLock()
 	resp := f.ExecResponse
 	statusCode := f.CommandOutputStatusCode
+	msg := f.CommandOutputMessage
 	f.mu.RUnlock()
 
 	if statusCode != 0 {
-		c.JSON(statusCode, gin.H{"message": "API error"})
+		if msg == "" {
+			msg = "API error"
+		}
+		c.JSON(statusCode, gin.H{"message": msg})
 		return
 	}
 


### PR DESCRIPTION
## Summary

- `POST /exec` now returns 202 with command ID only; inline stdout/stderr/exit code removed from the response
- New `streamCommandOutput` method reads `GET /commands/{id}/output` as NDJSON, accumulating output lines until the terminal event (line with `command_id` set) arrives
- Add `NoTimeout()` and `Decoder()` httpcl request options to support long-lived streaming responses without the client deadline firing
- Update fake CircleCI server to match the async protocol: 202 on exec, new `/commands/:id/output` NDJSON handler
- Update test assertion to scan all requests rather than assuming exec is the last one