### PR TITLE
Disable telemetry in e2e sidecar test helpers

### DIFF
--- a/acceptance/sidecars_build_e2e_test.go
+++ b/acceptance/sidecars_build_e2e_test.go
@@ -201,6 +201,7 @@ func e2eRunEnv(t *testing.T, dir string) (stdout, stderr string, exitCode int) {
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 		fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
 		"NO_COLOR=1",
+		"CHUNK_NO_TELEMETRY=1",
 	}
 
 	var outBuf, errBuf bytes.Buffer
@@ -227,6 +228,7 @@ func e2eRunBuild(t *testing.T, dir, tag, envJSON string) (output string, exitCod
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 		fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
 		"NO_COLOR=1",
+		"CHUNK_NO_TELEMETRY=1",
 	}
 	cmd.Stdin = strings.NewReader(envJSON)
 	var outBuf bytes.Buffer


### PR DESCRIPTION
## Summary

- Add `CHUNK_NO_TELEMETRY=1` to the hardcoded env slices in `e2eRunEnv` and `e2eRunBuild` in `acceptance/sidecars_build_e2e_test.go`, which bypassed `TestEnv` and could fire real Segment events if the developer had telemetry opted in