### PR TITLE
Add git pre-commit hook installation to chunk init

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -145,7 +145,7 @@ linters:
         # Cobra command Use names and step name comparisons are not constants.
       - linters: [goconst]
         path: internal/cmd/
-        text: 'string `(install|test)`'
+        text: 'string `(config|install|test)`'
 
     paths:
       - third_party$

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -12,6 +12,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/closer"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
 
@@ -125,6 +126,27 @@ func installCompletion(streams iostream.Streams) (err error) {
 
 	streams.ErrPrintln(ui.Success("Completion installed."))
 	return nil
+}
+
+func maybeInstallCompletions(streams iostream.Streams) {
+	installed, err := completionInstalled()
+	if err != nil {
+		streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Skipping shell completions: %v", err)))
+		return
+	}
+	if installed {
+		return
+	}
+	yes, confirmErr := tui.Confirm("Install shell completions?", true)
+	if confirmErr != nil {
+		streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not confirm: %v", confirmErr)))
+		return
+	}
+	if yes {
+		if installErr := installCompletion(streams); installErr != nil {
+			streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not install completions: %v", installErr)))
+		}
+	}
 }
 
 func newCompletionInstallCmd() *cobra.Command {

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -383,32 +383,18 @@ func writeAllHookFiles(workDir string, commands []config.Command, streams iostre
 			return err
 		}
 	}
-	if err := writeGitHook(workDir, streams); err != nil {
-		return err
-	}
 	return nil
 }
 
 const gitHookContent = "#!/bin/sh\nchunk validate\n"
 
 // writeGitHook writes a pre-commit hook to the repository's git hooks
-// directory. It uses --git-common-dir so it targets the shared hooks directory
-// even when workDir is a worktree. If a pre-commit hook already exists and
-// calls chunk validate it is left as-is; if it exists but does not call chunk
-// validate, the call is appended.
-func writeGitHook(workDir string, streams iostream.Streams) error {
-	gitCmd := exec.Command("git", "rev-parse", "--git-common-dir")
-	gitCmd.Dir = workDir
-	out, err := gitCmd.Output()
-	if err != nil {
-		return &userError{msg: "Could not determine git directory.", err: fmt.Errorf("git rev-parse --git-common-dir: %w", err)}
-	}
-
-	gitCommonDir := strings.TrimSpace(string(out))
-	if !filepath.IsAbs(gitCommonDir) {
-		gitCommonDir = filepath.Join(workDir, gitCommonDir)
-	}
-
+// directory. gitCommonDir must be the resolved path returned by
+// `git rev-parse --git-common-dir`, so the hook lands in the shared hooks
+// directory even when running from a worktree. If a pre-commit hook already
+// exists and calls chunk validate it is left as-is; if it exists but does not
+// call chunk validate, the call is appended preserving the existing permissions.
+func writeGitHook(gitCommonDir string, streams iostream.Streams) error {
 	hooksDir := filepath.Join(gitCommonDir, "hooks")
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
 		return &userError{
@@ -449,7 +435,11 @@ func writeGitHook(workDir string, streams iostream.Streams) error {
 		content += "\n"
 	}
 	content += "chunk validate\n"
-	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		return &userError{msg: "Could not stat .git/hooks/pre-commit.", suggestion: suggestionCheckPerms, err: fmt.Errorf("stat pre-commit hook: %w", statErr)}
+	}
+	if err := os.WriteFile(path, []byte(content), info.Mode()); err != nil {
 		return &userError{
 			msg:        "Could not update .git/hooks/pre-commit.",
 			suggestion: suggestionCheckPerms,
@@ -461,7 +451,7 @@ func writeGitHook(workDir string, streams iostream.Streams) error {
 }
 
 func newInitCmd() *cobra.Command {
-	var force, skipHooks, skipValidate, skipCompletions, skipSkills, skipTestSuites bool
+	var force, skipHooks, skipGitHook, skipValidate, skipCompletions, skipSkills, skipTestSuites bool
 	var projectDir string
 
 	cmd := &cobra.Command{
@@ -489,6 +479,17 @@ hook config files.`,
 			gitCmd.Dir = workDir
 			if err := gitCmd.Run(); err != nil {
 				return &userError{msg: "Not a git repository.", suggestion: suggestionGitRepo, err: err}
+			}
+
+			gitCommonDirCmd := exec.Command("git", "rev-parse", "--git-common-dir")
+			gitCommonDirCmd.Dir = workDir
+			commonDirOut, err := gitCommonDirCmd.Output()
+			if err != nil {
+				return &userError{msg: "Could not determine git directory.", err: fmt.Errorf("git rev-parse --git-common-dir: %w", err)}
+			}
+			gitCommonDir := strings.TrimSpace(string(commonDirOut))
+			if !filepath.IsAbs(gitCommonDir) {
+				gitCommonDir = filepath.Join(workDir, gitCommonDir)
 			}
 
 			// Guard: exit cleanly if config exists and --force not set
@@ -558,23 +559,16 @@ hook config files.`,
 				if err := writeAllHookFiles(workDir, cfg.Commands, streams); err != nil {
 					return err
 				}
+				if !skipGitHook {
+					if err := writeGitHook(gitCommonDir, streams); err != nil {
+						return err
+					}
+				}
 			}
 
 			// Step 4: Shell completions
 			if !skipCompletions {
-				installed, err := completionInstalled()
-				if err != nil {
-					streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Skipping shell completions: %v", err)))
-				} else if !installed {
-					yes, confirmErr := tui.Confirm("Install shell completions?", true)
-					if confirmErr != nil {
-						streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not confirm: %v", confirmErr)))
-					} else if yes {
-						if installErr := installCompletion(streams); installErr != nil {
-							streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not install completions: %v", installErr)))
-						}
-					}
-				}
+				maybeInstallCompletions(streams)
 			}
 
 			// Step 5: CircleCI Smarter Testing test-suites.yml
@@ -598,6 +592,7 @@ hook config files.`,
 
 	cmd.Flags().BoolVar(&force, "force", false, "Overwrite existing config")
 	cmd.Flags().BoolVar(&skipHooks, "skip-hooks", false, "Skip hook file generation")
+	cmd.Flags().BoolVar(&skipGitHook, "skip-git-hook", false, "Skip git pre-commit hook installation")
 	cmd.Flags().BoolVar(&skipValidate, "skip-validate", false, "Skip validate command detection")
 	cmd.Flags().BoolVar(&skipCompletions, "skip-completions", false, "Skip shell completion installation")
 	cmd.Flags().BoolVar(&skipSkills, "skip-skills", false, "Skip agent skill installation")

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -383,6 +383,80 @@ func writeAllHookFiles(workDir string, commands []config.Command, streams iostre
 			return err
 		}
 	}
+	if err := writeGitHook(workDir, streams); err != nil {
+		return err
+	}
+	return nil
+}
+
+const gitHookContent = "#!/bin/sh\nchunk validate\n"
+
+// writeGitHook writes a pre-commit hook to the repository's git hooks
+// directory. It uses --git-common-dir so it targets the shared hooks directory
+// even when workDir is a worktree. If a pre-commit hook already exists and
+// calls chunk validate it is left as-is; if it exists but does not call chunk
+// validate, the call is appended.
+func writeGitHook(workDir string, streams iostream.Streams) error {
+	gitCmd := exec.Command("git", "rev-parse", "--git-common-dir")
+	gitCmd.Dir = workDir
+	out, err := gitCmd.Output()
+	if err != nil {
+		return &userError{msg: "Could not determine git directory.", err: fmt.Errorf("git rev-parse --git-common-dir: %w", err)}
+	}
+
+	gitCommonDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitCommonDir) {
+		gitCommonDir = filepath.Join(workDir, gitCommonDir)
+	}
+
+	hooksDir := filepath.Join(gitCommonDir, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		return &userError{
+			msg:        "Could not create git hooks directory.",
+			suggestion: suggestionCheckPerms,
+			err:        fmt.Errorf("create hooks dir: %w", err),
+		}
+	}
+
+	path := filepath.Join(hooksDir, "pre-commit")
+	existing, readErr := os.ReadFile(path)
+	if readErr != nil {
+		if !errors.Is(readErr, fs.ErrNotExist) {
+			return &userError{
+				msg:        "Could not read .git/hooks/pre-commit.",
+				suggestion: suggestionCheckPerms,
+				err:        fmt.Errorf("read pre-commit hook: %w", readErr),
+			}
+		}
+		if err := os.WriteFile(path, []byte(gitHookContent), 0o755); err != nil {
+			return &userError{
+				msg:        "Could not write .git/hooks/pre-commit.",
+				suggestion: suggestionCheckPerms,
+				err:        fmt.Errorf("write pre-commit hook: %w", err),
+			}
+		}
+		streams.ErrPrintln(ui.Success("Wrote .git/hooks/pre-commit"))
+		return nil
+	}
+
+	if strings.Contains(string(existing), "chunk validate") {
+		streams.ErrPrintln(ui.Success("Git pre-commit hook already up to date"))
+		return nil
+	}
+
+	content := string(existing)
+	if len(content) > 0 && content[len(content)-1] != '\n' {
+		content += "\n"
+	}
+	content += "chunk validate\n"
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		return &userError{
+			msg:        "Could not update .git/hooks/pre-commit.",
+			suggestion: suggestionCheckPerms,
+			err:        fmt.Errorf("write pre-commit hook: %w", err),
+		}
+	}
+	streams.ErrPrintln(ui.Success("Updated .git/hooks/pre-commit"))
 	return nil
 }
 

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -359,7 +359,7 @@ func TestWriteGitHookNewFile(t *testing.T) {
 	dir := initGitRepo(t)
 	streams, _, errOut := testStreams()
 
-	err := writeGitHook(dir, streams)
+	err := writeGitHook(filepath.Join(dir, ".git"), streams)
 	assert.NilError(t, err)
 
 	data, err := os.ReadFile(filepath.Join(dir, ".git", "hooks", "pre-commit"))
@@ -377,10 +377,10 @@ func TestWriteGitHookAlreadyUpToDate(t *testing.T) {
 	dir := initGitRepo(t)
 	streams, _, _ := testStreams()
 
-	assert.NilError(t, writeGitHook(dir, streams))
+	assert.NilError(t, writeGitHook(filepath.Join(dir, ".git"), streams))
 
 	streams2, _, errOut := testStreams()
-	assert.NilError(t, writeGitHook(dir, streams2))
+	assert.NilError(t, writeGitHook(filepath.Join(dir, ".git"), streams2))
 	assert.Assert(t, bytes.Contains(errOut.Bytes(), []byte("already up to date")))
 
 	data, err := os.ReadFile(filepath.Join(dir, ".git", "hooks", "pre-commit"))
@@ -397,7 +397,7 @@ func TestWriteGitHookAppendsToExisting(t *testing.T) {
 	assert.NilError(t, os.WriteFile(filepath.Join(hooksDir, "pre-commit"), []byte(existing), 0o755))
 
 	streams, _, errOut := testStreams()
-	err := writeGitHook(dir, streams)
+	err := writeGitHook(filepath.Join(dir, ".git"), streams)
 	assert.NilError(t, err)
 
 	data, err := os.ReadFile(filepath.Join(hooksDir, "pre-commit"))
@@ -405,6 +405,10 @@ func TestWriteGitHookAppendsToExisting(t *testing.T) {
 	content := string(data)
 	assert.Assert(t, strings.HasPrefix(content, existing))
 	assert.Assert(t, strings.Contains(content, "chunk validate"))
+
+	info, err := os.Stat(filepath.Join(hooksDir, "pre-commit"))
+	assert.NilError(t, err)
+	assert.Assert(t, info.Mode()&0o111 != 0, "pre-commit hook must be executable")
 
 	assert.Assert(t, bytes.Contains(errOut.Bytes(), []byte("Updated .git/hooks/pre-commit")))
 }

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -334,6 +335,78 @@ func TestInstallCompletionSkipsWhenAlreadyInstalled(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, string(data), existing)
 	assert.Assert(t, bytes.Contains(errOut.Bytes(), []byte("already installed")))
+}
+
+func initGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	gitCmds := [][]string{
+		{"init"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+	}
+	for _, args := range gitCmds {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	return dir
+}
+
+func TestWriteGitHookNewFile(t *testing.T) {
+	dir := initGitRepo(t)
+	streams, _, errOut := testStreams()
+
+	err := writeGitHook(dir, streams)
+	assert.NilError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, ".git", "hooks", "pre-commit"))
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), gitHookContent)
+
+	info, err := os.Stat(filepath.Join(dir, ".git", "hooks", "pre-commit"))
+	assert.NilError(t, err)
+	assert.Assert(t, info.Mode()&0o111 != 0, "pre-commit hook must be executable")
+
+	assert.Assert(t, bytes.Contains(errOut.Bytes(), []byte("Wrote .git/hooks/pre-commit")))
+}
+
+func TestWriteGitHookAlreadyUpToDate(t *testing.T) {
+	dir := initGitRepo(t)
+	streams, _, _ := testStreams()
+
+	assert.NilError(t, writeGitHook(dir, streams))
+
+	streams2, _, errOut := testStreams()
+	assert.NilError(t, writeGitHook(dir, streams2))
+	assert.Assert(t, bytes.Contains(errOut.Bytes(), []byte("already up to date")))
+
+	data, err := os.ReadFile(filepath.Join(dir, ".git", "hooks", "pre-commit"))
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), gitHookContent)
+}
+
+func TestWriteGitHookAppendsToExisting(t *testing.T) {
+	dir := initGitRepo(t)
+	hooksDir := filepath.Join(dir, ".git", "hooks")
+	assert.NilError(t, os.MkdirAll(hooksDir, 0o755))
+
+	existing := "#!/bin/sh\nnpm test\n"
+	assert.NilError(t, os.WriteFile(filepath.Join(hooksDir, "pre-commit"), []byte(existing), 0o755))
+
+	streams, _, errOut := testStreams()
+	err := writeGitHook(dir, streams)
+	assert.NilError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(hooksDir, "pre-commit"))
+	assert.NilError(t, err)
+	content := string(data)
+	assert.Assert(t, strings.HasPrefix(content, existing))
+	assert.Assert(t, strings.Contains(content, "chunk validate"))
+
+	assert.Assert(t, bytes.Contains(errOut.Bytes(), []byte("Updated .git/hooks/pre-commit")))
 }
 
 func TestEnsureGitignoreEntriesCreatesNew(t *testing.T) {


### PR DESCRIPTION
## Summary

- `chunk init` now writes `.git/hooks/pre-commit` (mode `0755`) containing `chunk validate`, alongside the existing agent hook files (`.claude/settings.json`, `.codex/hooks.json`)
- Uses `git rev-parse --git-common-dir` so the hook lands in the shared hooks directory even when running from a worktree
- Idempotent: no-op if the hook already calls `chunk validate`; appends if a hook exists but doesn't call it

## Motivation

The `.claude/settings.json` Stop hook runs after every agent turn, not just ones where files were edited. A git pre-commit hook covers the commit path for all clients (human, any agent, any git tool) at the git layer, without the per-turn overhead.

## Test plan

- [ ] `TestWriteGitHookNewFile` — new hook written with correct content and executable bit
- [ ] `TestWriteGitHookAlreadyUpToDate` — idempotent on second call
- [ ] `TestWriteGitHookAppendsToExisting` — appends to a pre-existing hook that doesn't call `chunk validate`
- [ ] Full test suite passes locally and on sidecar

🤖 Generated with [Claude Code](https://claude.com/claude-code)