### PR TITLE
Wire chunk validate remote execution to the async HTTP exec API

### DIFF
--- a/internal/circleci/circleci_test.go
+++ b/internal/circleci/circleci_test.go
@@ -224,7 +224,7 @@ func TestExec(t *testing.T) {
 		client := newTestClient(t, srv.URL)
 		ctx := context.Background()
 
-		resp, err := client.Exec(ctx, "sb-1", "ls", []string{"-la"})
+		resp, err := client.Exec(ctx, "sb-1", "ls", []string{"-la"}, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -254,7 +254,7 @@ func TestExec(t *testing.T) {
 		client := newTestClient(t, srv.URL)
 		ctx := context.Background()
 
-		resp, err := client.Exec(ctx, "sb-1", "echo", []string{"hello"})
+		resp, err := client.Exec(ctx, "sb-1", "echo", []string{"hello"}, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -277,7 +277,7 @@ func TestExec(t *testing.T) {
 		defer srv.Close()
 
 		client := newTestClient(t, srv.URL)
-		_, err := client.Exec(context.Background(), "sb-1", "echo", nil)
+		_, err := client.Exec(context.Background(), "sb-1", "echo", nil, nil)
 		var se *StatusError
 		if !errors.As(err, &se) || se.StatusCode != http.StatusGone {
 			t.Fatalf("expected 410 StatusError, got %v", err)
@@ -295,7 +295,7 @@ func TestExec(t *testing.T) {
 		client := newTestClient(t, srv.URL)
 		ctx := context.Background()
 
-		_, err := client.Exec(ctx, "sb-1", "pwd", nil)
+		_, err := client.Exec(ctx, "sb-1", "pwd", nil, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -476,7 +476,7 @@ func TestAuthRequired(t *testing.T) {
 	})
 
 	t.Run("Exec", func(t *testing.T) {
-		_, err := client.Exec(ctx, "sb-1", "ls", nil)
+		_, err := client.Exec(ctx, "sb-1", "ls", nil, nil)
 		if err == nil {
 			t.Fatal("expected error")
 		}

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -194,18 +194,18 @@ type execSubmitAttrs struct {
 	Phase string `json:"phase"`
 }
 
-func (c *Client) Exec(ctx context.Context, sidecarID, command string, args []string) (*ExecResponse, error) {
+func (c *Client) Exec(ctx context.Context, sidecarID, command string, args []string, env map[string]string) (*ExecResponse, error) {
 	var attrs execSubmitAttrs
-	env := v3Envelope{Data: v3DataEntity{Attributes: &attrs}}
+	envelope := v3Envelope{Data: v3DataEntity{Attributes: &attrs}}
 	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodPost, "/api/v3/sidecar/instances/%s/exec",
 		hc.RouteParams(sidecarID),
-		hc.Body(ExecRequest{Command: command, Args: args}),
-		hc.JSONDecoder(&env),
+		hc.Body(ExecRequest{Command: command, Args: args, Env: env}),
+		hc.JSONDecoder(&envelope),
 	))
 	if err != nil {
 		return nil, mapErr("exec", err)
 	}
-	return c.streamCommandOutput(ctx, env.Data.ID)
+	return c.streamCommandOutput(ctx, envelope.Data.ID)
 }
 
 func (c *Client) streamCommandOutput(ctx context.Context, commandID string) (*ExecResponse, error) {

--- a/internal/circleci/types.go
+++ b/internal/circleci/types.go
@@ -8,8 +8,9 @@ type Sidecar struct {
 }
 
 type ExecRequest struct {
-	Command string   `json:"command"`
-	Args    []string `json:"args,omitempty"`
+	Command string            `json:"command"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
 }
 
 type ExecResponse struct {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -281,7 +281,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return err
 	}
 
-	execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.identityFile, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
+	execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
 
 	if hook != nil {
 		maxAttempts := cfg.StopHookMaxAttempts
@@ -316,7 +316,7 @@ func runValidateDryRun(name, inlineCmd string, cfg *config.ProjectConfig, status
 // provided options. It is shared by both direct and hook invocations.
 // allRemote is true when --remote is passed explicitly (all commands run on the
 // sidecar); false means only commands with Remote:true are routed to the sidecar.
-func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, freshlyCreated bool, identityFile, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, freshlyCreated bool, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	// --cmd: inline command (always local in per-command mode)
 	if inlineCmd != "" {
 		cmdName := name
@@ -330,7 +330,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 			streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", cmdName)))
 		}
 		if sidecarID != "" && allRemote {
-			execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc, streams)
+			execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc)
 			if err != nil {
 				return err
 			}
@@ -341,7 +341,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 
 	// All-remote execution (--remote flag): send everything to the sidecar.
 	if sidecarID != "" && allRemote {
-		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc, streams)
+		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc)
 		if err != nil {
 			return err
 		}
@@ -354,7 +354,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 		if name != "" {
 			if cmd := cfg.FindCommand(name); cmd != nil && cmd.Remote {
 				statusFn(iostream.LevelInfo, fmt.Sprintf("running %s on sidecar %s", name, sidecarID))
-				execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc, streams)
+				execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc)
 				if err != nil {
 					return err
 				}
@@ -363,7 +363,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 			statusFn(iostream.LevelInfo, fmt.Sprintf("running %s locally (not marked remote)", name))
 			// Named command is not marked remote; fall through to local execution.
 		} else {
-			return runSplitCommands(ctx, client, sidecarID, freshlyCreated, identityFile, workdir, workDir, envVars, rc, cfg, statusFn, streams)
+			return runSplitCommands(ctx, client, sidecarID, freshlyCreated, workdir, workDir, envVars, rc, cfg, statusFn, streams)
 		}
 	}
 
@@ -440,24 +440,9 @@ func syncToSidecar(ctx context.Context, client *circleci.Client, sidecarID, iden
 	return &userError{msg: "Could not sync to sidecar.", err: err}
 }
 
-// openSSHSession establishes an SSH session to the sidecar and returns an
-// exec function and the resolved remote working directory.
-func openSSHSession(ctx context.Context, client *circleci.Client, sidecarID, identityFile, workdir string, envVars map[string]string, rc config.ResolvedConfig, streams iostream.Streams) (func(context.Context, string) (string, string, int, error), string, error) {
-	if identityFile == "" && rc.UseSSHIdentityFile {
-		var keyErr error
-		identityFile, keyErr = sidecar.DefaultKeyPath()
-		if keyErr != nil {
-			streams.ErrPrintf("warning: could not resolve SSH identity file: %v\n", keyErr)
-		}
-	}
-	var authSock string
-	if identityFile == "" {
-		authSock = os.Getenv(config.EnvSSHAuthSock)
-	}
-	session, err := sidecar.OpenSession(ctx, client, sidecarID, identityFile, authSock)
-	if err != nil {
-		return nil, "", &userError{msg: "Could not open SSH session to sidecar.", err: err}
-	}
+// newExecFn builds a function that runs shell scripts on a remote sidecar via
+// the async HTTP exec API, along with the resolved remote working directory.
+func newExecFn(ctx context.Context, client *circleci.Client, sidecarID, workdir string, envVars map[string]string, rc config.ResolvedConfig) (func(context.Context, string) (string, string, int, error), string, error) {
 	cwd, _ := os.Getwd()
 	_, repo, _ := gitremote.DetectOrgAndRepo(cwd)
 	dest, err := sidecar.ResolveWorkspace(ctx, workdir, repo)
@@ -472,7 +457,7 @@ func openSSHSession(ctx context.Context, client *circleci.Client, sidecarID, ide
 		merged[k] = v
 	}
 	execFn := func(ctx context.Context, script string) (string, string, int, error) {
-		result, err := sidecar.ExecOverSSH(ctx, session, "sh -c "+sidecar.ShellEscape(script), nil, merged)
+		result, err := client.Exec(ctx, sidecarID, "sh", []string{"-c", script}, merged)
 		if err != nil {
 			return "", "", 0, err
 		}
@@ -496,10 +481,10 @@ func hostForwardEnv(token string) map[string]string {
 
 // runSplitCommands handles per-command remote routing when no specific command
 // name is given: remote-tagged commands go to the sidecar, the rest run locally.
-// When freshlyCreated is true, SSH failures are hard errors rather than
+// When freshlyCreated is true, exec failures are hard errors rather than
 // silent local fallbacks (a newly provisioned sidecar that can't be reached
 // indicates a real problem, not temporary unavailability).
-func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, identityFile, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	remoteCfg, localCfg := splitByRemote(cfg)
 	if len(remoteCfg.Commands) > 0 {
 		statusFn(iostream.LevelInfo, fmt.Sprintf("running on sidecar %s: %s", sidecarID, commandNames(remoteCfg.Commands)))
@@ -509,7 +494,7 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 	}
 	var runErr error
 	if len(remoteCfg.Commands) > 0 {
-		execFn, dest, err := openSSHSession(ctx, client, sidecarID, identityFile, workdir, envVars, rc, streams)
+		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc)
 		if err != nil {
 			if freshlyCreated {
 				return newUserError(fmt.Sprintf("Could not reach newly created sidecar %s.", sidecarID)).

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http/httptest"
@@ -132,88 +133,35 @@ func TestHostForwardEnv(t *testing.T) {
 	})
 }
 
-// setupSSHSession starts fake CCI + SSH servers and sets env vars so
-// ensureCircleCIClient resolves to the fake. Returns the SSH server and the
-// identity key file path.
-func setupSSHSession(t *testing.T) (*fakes.SSHServer, string) {
-	t.Helper()
+func TestOpenAPIExecPassesEnvVars(t *testing.T) {
 	isolateConfig(t)
 
-	keyFile, pubKey := fakes.GenerateSSHKeypair(t)
-	sshSrv := fakes.NewSSHServer(t, pubKey)
-	sshSrv.SetResult("hello\n", 0)
-
 	cci := fakes.NewFakeCircleCI()
-	cci.AddKeyURL = sshSrv.Addr()
-	cciSrv := httptest.NewServer(cci)
-	t.Cleanup(cciSrv.Close)
+	srv := httptest.NewServer(cci)
+	t.Cleanup(srv.Close)
 
-	t.Setenv(config.EnvCircleToken, "test-token")
-	t.Setenv(config.EnvCircleCIBaseURL, cciSrv.URL)
-
-	return sshSrv, keyFile
-}
-
-func TestOpenSSHSessionPassesEnvVars(t *testing.T) {
-	sshSrv, keyFile := setupSSHSession(t)
-
-	client, err := circleci.NewClient(circleci.Config{
-		Token:   "test-token",
-		BaseURL: os.Getenv(config.EnvCircleCIBaseURL),
-	})
+	client, err := circleci.NewClient(circleci.Config{Token: "test-token", BaseURL: srv.URL})
 	assert.NilError(t, err)
 
 	envVars := map[string]string{"FOO": "bar", "BAZ": "qux"}
-	execFn, _, err := openSSHSession(context.Background(), client, "sidecar-123", keyFile, "", envVars, config.ResolvedConfig{}, discardStreams())
+	execFn, _, err := newExecFn(context.Background(), client, "sidecar-123", "", envVars, config.ResolvedConfig{})
 	assert.NilError(t, err)
 
 	_, _, _, err = execFn(context.Background(), "echo hello")
 	assert.NilError(t, err)
 
-	got := sshSrv.EnvVars()
-	assert.Equal(t, got["FOO"], "bar")
-	assert.Equal(t, got["BAZ"], "qux")
-}
-
-func TestOpenSSHSessionUsesIdentityFileWhenUseSSHIdentityFile(t *testing.T) {
-	sshSrv, keyFile := setupSSHSession(t)
-
-	client, err := circleci.NewClient(circleci.Config{
-		Token:   "test-token",
-		BaseURL: os.Getenv(config.EnvCircleCIBaseURL),
-	})
-	assert.NilError(t, err)
-
-	// Write the key to the path that sidecar.DefaultKeyPath() would return so
-	// we can pass it explicitly as the identity file — verifying the UseSSHIdentityFile
-	// path uses the provided key rather than SSH_AUTH_SOCK.
-	rc := config.ResolvedConfig{UseSSHIdentityFile: true}
-	execFn, _, err := openSSHSession(context.Background(), client, "sidecar-123", keyFile, "", nil, rc, discardStreams())
-	assert.NilError(t, err)
-
-	sshSrv.SetResult("ok\n", 0)
-	_, _, code, err := execFn(context.Background(), "true")
-	assert.NilError(t, err)
-	assert.Equal(t, code, 0)
-}
-
-func TestOpenSSHSessionFallsBackToAuthSockWhenNoIdentityFile(t *testing.T) {
-	_, keyFile := setupSSHSession(t)
-	t.Setenv(config.EnvSSHAuthSock, "")
-
-	client, err := circleci.NewClient(circleci.Config{
-		Token:   "test-token",
-		BaseURL: os.Getenv(config.EnvCircleCIBaseURL),
-	})
-	assert.NilError(t, err)
-
-	// No identity file provided and UseSSHIdentityFile=false: the session open
-	// attempt will use an empty authSock, which should fail gracefully.
-	rc := config.ResolvedConfig{UseSSHIdentityFile: false}
-	_, _, err = openSSHSession(context.Background(), client, "sidecar-123", keyFile, "", nil, rc, discardStreams())
-	// With a key file explicitly provided the session opens; the important thing
-	// is that UseSSHIdentityFile=false does not attempt DefaultKeyPath resolution.
-	assert.NilError(t, err)
+	// Find the exec request and verify env vars were included in the body.
+	var execReq struct {
+		Env map[string]string `json:"env"`
+	}
+	for _, req := range cci.Recorder.AllRequests() {
+		if strings.Contains(req.URL.Path, "/exec") {
+			assert.NilError(t, json.NewDecoder(bytes.NewReader(req.Body)).Decode(&execReq))
+			break
+		}
+	}
+	assert.Equal(t, execReq.Env["FOO"], "bar")
+	assert.Equal(t, execReq.Env["BAZ"], "qux")
 }
 
 func TestValidateEnvFlagBadValue(t *testing.T) {

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -16,7 +16,7 @@ func Create(ctx context.Context, client *circleci.Client, orgID, name, image str
 }
 
 func Exec(ctx context.Context, client *circleci.Client, sidecarID, command string, args []string) (*circleci.ExecResponse, error) {
-	return client.Exec(ctx, sidecarID, command, args)
+	return client.Exec(ctx, sidecarID, command, args, nil)
 }
 
 func AddSSHKey(ctx context.Context, client *circleci.Client, sidecarID, publicKey, publicKeyFile string) (*circleci.AddSSHKeyResponse, error) {


### PR DESCRIPTION
## Summary

- Adds `Env map[string]string` to `ExecRequest` so env vars are forwarded in the HTTP request body
- Replaces `openSSHSession` with `newExecFn`, which builds a remote exec function using `client.Exec()` instead of an SSH session
- Removes `identityFile` from the exec path in `runValidate` and `runSplitCommands` (SSH is still used for the sync step)
- Replaces three SSH-specific unit tests with a single test verifying env vars reach the HTTP request body

## Notes

Depends on #452. Base branch should be updated to `main` once that merges.

## Test plan

- [ ] All existing tests pass (`go test -race ./...`)
- [ ] `TestOpenAPIExecPassesEnvVars` → `TestNewExecFnPassesEnvVars` verifies env vars in request body
- [ ] Manual: `chunk validate --remote` runs commands on sidecar without SSH session

🤖 Generated with [Claude Code](https://claude.com/claude-code)