### PR TITLE
Auto-create sidecar when remote execution is configured

### DIFF
--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -397,11 +397,11 @@ func TestValidateRunRemoteUsesSSH(t *testing.T) {
 	assert.Equal(t, len(execReqs), 0, "expected 0 HTTP exec requests (SSH should be used)")
 }
 
-func TestValidateSidecarImageNoActiveSidecarRunsLocally(t *testing.T) {
+func TestValidateSidecarImageNoActiveSidecarAutoCreates(t *testing.T) {
 	// Plain chunk validate with sidecarImage configured but no active sidecar must
-	// NOT auto-create a sandbox — it runs commands locally instead. Auto-create is
-	// reserved for the Stop hook path (TestValidateHookAutoCreatesSidecarFromSidecarImage).
+	// auto-create a sandbox — the configured image signals intent to run remotely.
 	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = "127.0.0.1"
 	srv := httptest.NewServer(cci)
 	defer srv.Close()
 
@@ -421,19 +421,33 @@ func TestValidateSidecarImageNoActiveSidecarRunsLocally(t *testing.T) {
 	assert.NilError(t, err)
 	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), data, 0o644))
 
+	sshDir := filepath.Join(t.TempDir(), ".ssh")
+	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
+	identityFile := filepath.Join(sshDir, "chunk_ai")
+	assert.NilError(t, generateTestSSHKey(t, identityFile))
+
 	env := testenv.NewTestEnv(t)
 	env.CircleCIURL = srv.URL
 	env.Extra["CIRCLECI_ORG_ID"] = "org-aaa"
 
-	result := binary.RunCLI(t, []string{"validate"}, env, workDir)
+	result := binary.RunCLI(t, []string{"validate", "--identity-file", identityFile}, env, workDir)
 
-	// Command runs locally (echo test-output) — must succeed.
-	assert.Equal(t, result.ExitCode, 0, "expected local fallback to succeed, stderr: %s", result.Stderr)
+	// No real SSH server is running so sync will fail — that's expected.
+	assert.Assert(t, result.ExitCode != 0, "expected failure because no SSH server is running")
 
-	// No sidecar must have been created.
 	reqs := cci.Recorder.AllRequests()
-	createReqs := filterByPath(reqs, "/api/v2/sidecar/instances")
-	assert.Equal(t, len(createReqs), 0, "expected no create-sidecar request when no active sidecar exists; got: %v", reqs)
+
+	// A sidecar must have been created with the configured image.
+	createReqs := filterByPath(reqs, "/api/v3/sidecar/instances")
+	assert.Equal(t, len(createReqs), 1, "expected 1 create-sidecar request; got: %v", reqs)
+
+	var body map[string]any
+	assert.NilError(t, json.Unmarshal(createReqs[0].Body, &body))
+	envelope := body["data"].(map[string]any)
+	attrs := envelope["attributes"].(map[string]any)
+	refs := envelope["references"].(map[string]any)
+	assert.Equal(t, attrs["image"], "my-snapshot-abc123", "expected sidecar image from config")
+	assert.Equal(t, refs["org"].(map[string]any)["id"], "org-aaa", "expected org from CIRCLECI_ORG_ID")
 }
 
 func TestValidateHookAutoCreatesSidecarFromSidecarImage(t *testing.T) {

--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -443,11 +443,16 @@ func TestValidateSidecarImageNoActiveSidecarAutoCreates(t *testing.T) {
 
 	var body map[string]any
 	assert.NilError(t, json.Unmarshal(createReqs[0].Body, &body))
-	envelope := body["data"].(map[string]any)
-	attrs := envelope["attributes"].(map[string]any)
-	refs := envelope["references"].(map[string]any)
+	envelope, ok := body["data"].(map[string]any)
+	assert.Assert(t, ok, "expected data envelope in response body")
+	attrs, ok := envelope["attributes"].(map[string]any)
+	assert.Assert(t, ok, "expected attributes in data envelope")
+	refs, ok := envelope["references"].(map[string]any)
+	assert.Assert(t, ok, "expected references in data envelope")
 	assert.Equal(t, attrs["image"], "my-snapshot-abc123", "expected sidecar image from config")
-	assert.Equal(t, refs["org"].(map[string]any)["id"], "org-aaa", "expected org from CIRCLECI_ORG_ID")
+	org, ok := refs["org"].(map[string]any)
+	assert.Assert(t, ok, "expected org in references")
+	assert.Equal(t, org["id"], "org-aaa", "expected org from CIRCLECI_ORG_ID")
 }
 
 func TestValidateHookAutoCreatesSidecarFromSidecarImage(t *testing.T) {
@@ -498,11 +503,16 @@ func TestValidateHookAutoCreatesSidecarFromSidecarImage(t *testing.T) {
 
 	var body map[string]any
 	assert.NilError(t, json.Unmarshal(createReqs[0].Body, &body))
-	envelope := body["data"].(map[string]any)
-	attrs := envelope["attributes"].(map[string]any)
-	refs := envelope["references"].(map[string]any)
+	envelope, ok := body["data"].(map[string]any)
+	assert.Assert(t, ok, "expected data envelope in response body")
+	attrs, ok := envelope["attributes"].(map[string]any)
+	assert.Assert(t, ok, "expected attributes in data envelope")
+	refs, ok := envelope["references"].(map[string]any)
+	assert.Assert(t, ok, "expected references in data envelope")
 	assert.Equal(t, attrs["image"], "my-snapshot-abc123", "expected sidecar image from config")
-	assert.Equal(t, refs["org"].(map[string]any)["id"], "org-aaa", "expected org from CIRCLECI_ORG_ID")
+	org, ok := refs["org"].(map[string]any)
+	assert.Assert(t, ok, "expected org in references")
+	assert.Equal(t, org["id"], "org-aaa", "expected org from CIRCLECI_ORG_ID")
 
 	// AddSSHKey must be called on the newly created sidecar — proves it was used.
 	addKeyReqs := filterByPath(reqs, "/api/v3/sidecar/instances/sidecar-new-123/ssh/add-key")

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -150,11 +150,11 @@ func initHook(ctx context.Context, hook *hookContext, workDir string, streams io
 	return ctx, streams, false, nil
 }
 
-func validateNeedsSidecar(explicitRemote bool, cfg *config.ProjectConfig, hook *hookContext, hasActiveSidecar bool) bool {
+func validateNeedsSidecar(explicitRemote bool, cfg *config.ProjectConfig, hasActiveSidecar bool) bool {
 	if explicitRemote || cfg.HasRemoteCommands() {
 		return true
 	}
-	return cfg.HasSidecarImage() && (hook != nil || hasActiveSidecar)
+	return cfg.HasSidecarImage()
 }
 
 func loadSidecarEnvVars(ctx context.Context, client *circleci.Client, opts *validateOpts, workDir string, statusFn iostream.StatusFunc) (map[string]string, error) {
@@ -245,7 +245,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 
 	explicitRemote := opts.remote || opts.sidecarID != ""
 	activeSidecar, _ := sidecar.LoadActive(ctx)
-	needsSidecar := validateNeedsSidecar(explicitRemote, cfg, hook, activeSidecar != nil)
+	needsSidecar := validateNeedsSidecar(explicitRemote, cfg, activeSidecar != nil)
 	if hook != nil && needsSidecar && rc.CircleCIToken == "" {
 		streams.ErrPrintln("CircleCI auth is not configured.")
 		streams.ErrPrintln("Suggestion: " + suggestionCircleCIAuth)
@@ -409,7 +409,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 // setupRemote resolves (or creates) the sidecar ID based on the validate flags
 // and config, then returns whether a new sidecar was provisioned.
 func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpts, image string, cfg *config.ProjectConfig, hook *hookContext, activeSidecar *sidecar.ActiveSidecar, statusFn iostream.StatusFunc, workDir string, streams iostream.Streams) (bool, error) {
-	if validateNeedsSidecar(opts.remote || opts.sidecarID != "", cfg, hook, activeSidecar != nil) {
+	if validateNeedsSidecar(opts.remote || opts.sidecarID != "", cfg, activeSidecar != nil) {
 		if opts.remote {
 			created, err := resolveOrCreateSidecarID(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, streams)
 			if err != nil {
@@ -418,7 +418,7 @@ func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpt
 			statusFn(iostream.LevelInfo, fmt.Sprintf("running all commands on sidecar %s", opts.sidecarID))
 			return created, nil
 		}
-		return resolveSidecar(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, hook, activeSidecar, streams), nil
+		return resolveSidecar(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, activeSidecar, streams), nil
 	}
 	return false, nil
 }
@@ -581,28 +581,22 @@ func resolveImage(name string, cfg *config.ProjectConfig) string {
 }
 
 // resolveSidecar fills sidecarID for per-command remote routing
-// (i.e. when --remote is not set but some commands have Remote:true).
-// It uses the active sidecar when available, auto-creates one when the
-// caller is a Stop hook, and warns otherwise.
+// (i.e. when --remote is not set but some commands have Remote:true or a
+// sidecarImage is configured). It uses the active sidecar when available,
+// and auto-creates one otherwise.
 // Returns true when a brand-new sidecar was provisioned in this call.
-func resolveSidecar(ctx context.Context, client *circleci.Client, sidecarID *string, orgID, image, workDir string, hook *hookContext, active *sidecar.ActiveSidecar, streams iostream.Streams) bool {
+func resolveSidecar(ctx context.Context, client *circleci.Client, sidecarID *string, orgID, image, workDir string, active *sidecar.ActiveSidecar, streams iostream.Streams) bool {
 	statusFn := newStatusFunc(streams)
 	if active != nil {
 		*sidecarID = active.SidecarID
 		statusFn(iostream.LevelInfo, fmt.Sprintf("using sidecar %s for remote commands", *sidecarID))
 		return false
 	}
-	if hook != nil {
-		// In Stop hook context: auto-create from the stored snapshot so remote
-		// commands get the prepared environment.
-		created, err := resolveOrCreateSidecarID(ctx, client, sidecarID, orgID, image, workDir, streams)
-		if err != nil {
-			streams.ErrPrintf("warning: no sandbox available (%v); run 'chunk config set orgID <id>' to enable remote validation, running locally instead\n", err)
-		}
-		return created
+	created, err := resolveOrCreateSidecarID(ctx, client, sidecarID, orgID, image, workDir, streams)
+	if err != nil {
+		streams.ErrPrintf("warning: no sandbox available (%v); run 'chunk config set orgID <id>' to enable remote validation, running locally instead\n", err)
 	}
-	statusFn(iostream.LevelWarn, "no active sidecar found — remote commands will run locally")
-	return false
+	return created
 }
 
 // resolveOrCreateSidecarID fills sidecarID from the active sidecar, or creates

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -150,7 +150,7 @@ func initHook(ctx context.Context, hook *hookContext, workDir string, streams io
 	return ctx, streams, false, nil
 }
 
-func validateNeedsSidecar(explicitRemote bool, cfg *config.ProjectConfig, hasActiveSidecar bool) bool {
+func validateNeedsSidecar(explicitRemote bool, cfg *config.ProjectConfig) bool {
 	if explicitRemote || cfg.HasRemoteCommands() {
 		return true
 	}
@@ -245,7 +245,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 
 	explicitRemote := opts.remote || opts.sidecarID != ""
 	activeSidecar, _ := sidecar.LoadActive(ctx)
-	needsSidecar := validateNeedsSidecar(explicitRemote, cfg, activeSidecar != nil)
+	needsSidecar := validateNeedsSidecar(explicitRemote, cfg)
 	if hook != nil && needsSidecar && rc.CircleCIToken == "" {
 		streams.ErrPrintln("CircleCI auth is not configured.")
 		streams.ErrPrintln("Suggestion: " + suggestionCircleCIAuth)
@@ -268,7 +268,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return err
 	}
 
-	freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, hook, activeSidecar, statusFn, workDir, streams)
+	freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, activeSidecar, statusFn, workDir, streams)
 	if err != nil {
 		return err
 	}
@@ -408,8 +408,8 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 
 // setupRemote resolves (or creates) the sidecar ID based on the validate flags
 // and config, then returns whether a new sidecar was provisioned.
-func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpts, image string, cfg *config.ProjectConfig, hook *hookContext, activeSidecar *sidecar.ActiveSidecar, statusFn iostream.StatusFunc, workDir string, streams iostream.Streams) (bool, error) {
-	if validateNeedsSidecar(opts.remote || opts.sidecarID != "", cfg, activeSidecar != nil) {
+func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpts, image string, cfg *config.ProjectConfig, activeSidecar *sidecar.ActiveSidecar, statusFn iostream.StatusFunc, workDir string, streams iostream.Streams) (bool, error) {
+	if validateNeedsSidecar(opts.remote || opts.sidecarID != "", cfg) {
 		if opts.remote {
 			created, err := resolveOrCreateSidecarID(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, streams)
 			if err != nil {
@@ -594,7 +594,7 @@ func resolveSidecar(ctx context.Context, client *circleci.Client, sidecarID *str
 	}
 	created, err := resolveOrCreateSidecarID(ctx, client, sidecarID, orgID, image, workDir, streams)
 	if err != nil {
-		streams.ErrPrintf("warning: no sandbox available (%v); run 'chunk config set orgID <id>' to enable remote validation, running locally instead\n", err)
+		streams.ErrPrintf("warning: could not create sandbox (%v); running commands locally instead\n", err)
 	}
 	return created
 }

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -566,7 +566,7 @@ func commandNames(cmds []config.Command) string {
 	return strings.Join(names, ", ")
 }
 
-// resolveImage returns the sidecar image to use for sandbox creation.
+// resolveImage returns the sidecar image to use for sidecar creation.
 // A per-command sidecarImage takes precedence over the project-level default.
 func resolveImage(name string, cfg *config.ProjectConfig) string {
 	if name != "" && cfg != nil {
@@ -594,13 +594,13 @@ func resolveSidecar(ctx context.Context, client *circleci.Client, sidecarID *str
 	}
 	created, err := resolveOrCreateSidecarID(ctx, client, sidecarID, orgID, image, workDir, streams)
 	if err != nil {
-		streams.ErrPrintf("warning: could not create sandbox (%v); running commands locally instead\n", err)
+		streams.ErrPrintf("warning: could not create sidecar (%v); running commands locally instead\n", err)
 	}
 	return created
 }
 
 // resolveOrCreateSidecarID fills sidecarID from the active sidecar, or creates
-// a new sandbox when none is configured. Returns true when a new sidecar was
+// a new sidecar when none is configured. Returns true when a new sidecar was
 // provisioned (as opposed to loaded from the active state file).
 func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, sidecarID *string, orgID, image, workDir string, streams iostream.Streams) (created bool, err error) {
 	if *sidecarID != "" {
@@ -614,7 +614,7 @@ func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, side
 		*sidecarID = active.SidecarID
 		return false, nil
 	}
-	streams.ErrPrintf("No active sidecar found, creating a new sandbox...\n")
+	streams.ErrPrintf("No active sidecar found, creating a new sidecar...\n")
 	resolvedOrgID, err := resolveOrgID(orgID, workDir, orgPicker(ctx, client))
 	if err != nil {
 		return false, err
@@ -626,7 +626,7 @@ func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, side
 			return false, authErr
 		}
 		return false, &userError{
-			msg:        "Could not create a sandbox.",
+			msg:        "Could not create a sidecar.",
 			suggestion: "Check your network connection or run 'chunk sidecar create' manually.",
 			err:        err,
 		}
@@ -634,7 +634,7 @@ func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, side
 	if saveErr := sidecar.SaveActive(ctx, sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); saveErr != nil {
 		streams.ErrPrintf("warning: could not save active sidecar: %v\n", saveErr)
 	}
-	// Persist the org ID so future sandbox creation skips the picker.
+	// Persist the org ID so future sidecar creation skips the picker.
 	projCfg, loadErr := config.LoadProjectConfig(workDir)
 	if loadErr != nil {
 		projCfg = &config.ProjectConfig{}
@@ -645,7 +645,7 @@ func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, side
 			streams.ErrPrintf("warning: could not save org ID to project config: %v\n", saveErr)
 		}
 	}
-	streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Created sandbox %s (%s)", sc.Name, sc.ID)))
+	streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Created sidecar %s (%s)", sc.Name, sc.ID)))
 	*sidecarID = sc.ID
 	return true, nil
 }

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -111,21 +111,12 @@ func TestValidateHookSkipsAuthCheckWhenNoRemoteCommands(t *testing.T) {
 	_ = err
 }
 
-func TestValidateNeedsSidecarSidecarImageWithActiveSidecar(t *testing.T) {
+func TestValidateNeedsSidecarSidecarImage(t *testing.T) {
 	cfg := &config.ProjectConfig{
 		Validation: &config.ValidationConfig{SidecarImage: "my-snapshot-abc123"},
 	}
-	got := validateNeedsSidecar(false, cfg, true)
-	assert.Assert(t, got, "expected validateNeedsSidecar=true with sidecarImage and active sidecar")
-}
-
-func TestValidateNeedsSidecarSidecarImageNoActiveSidecar(t *testing.T) {
-	cfg := &config.ProjectConfig{
-		Validation: &config.ValidationConfig{SidecarImage: "my-snapshot-abc123"},
-	}
-	// sidecarImage alone → should use sidecar (auto-creates if none active)
-	got := validateNeedsSidecar(false, cfg, false)
-	assert.Assert(t, got, "expected validateNeedsSidecar=true with sidecarImage and no active sidecar")
+	got := validateNeedsSidecar(false, cfg)
+	assert.Assert(t, got, "expected validateNeedsSidecar=true with sidecarImage configured")
 }
 
 func TestHostForwardEnv(t *testing.T) {

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -115,8 +115,7 @@ func TestValidateNeedsSidecarSidecarImageWithActiveSidecar(t *testing.T) {
 	cfg := &config.ProjectConfig{
 		Validation: &config.ValidationConfig{SidecarImage: "my-snapshot-abc123"},
 	}
-	// sidecarImage + active sidecar, no hook → should use sidecar
-	got := validateNeedsSidecar(false, cfg, nil, true)
+	got := validateNeedsSidecar(false, cfg, true)
 	assert.Assert(t, got, "expected validateNeedsSidecar=true with sidecarImage and active sidecar")
 }
 
@@ -124,9 +123,9 @@ func TestValidateNeedsSidecarSidecarImageNoActiveSidecar(t *testing.T) {
 	cfg := &config.ProjectConfig{
 		Validation: &config.ValidationConfig{SidecarImage: "my-snapshot-abc123"},
 	}
-	// sidecarImage but no active sidecar, no hook → must not use sidecar (avoids auto-create)
-	got := validateNeedsSidecar(false, cfg, nil, false)
-	assert.Assert(t, !got, "expected validateNeedsSidecar=false with sidecarImage but no active sidecar")
+	// sidecarImage alone → should use sidecar (auto-creates if none active)
+	got := validateNeedsSidecar(false, cfg, false)
+	assert.Assert(t, got, "expected validateNeedsSidecar=true with sidecarImage and no active sidecar")
 }
 
 func TestHostForwardEnv(t *testing.T) {


### PR DESCRIPTION
## Summary

- `chunk validate` previously warned "no active sidecar found — remote commands will run locally" and fell back to local execution when `sidecarImage` or `Remote:true` commands were configured but no active sidecar existed
- Configuring `sidecarImage` or `Remote:true` commands now signals intent to run remotely, so a sidecar is created automatically rather than silently falling back to local
- `hook` and `hasActiveSidecar` parameters are removed from `validateNeedsSidecar`, `setupRemote`, and `resolveSidecar` since auto-creation is no longer gated on hook context or active sidecar state
- Fallback warning updated from a stale `chunk config set orgID` suggestion to the actual error reason
- "sandbox" renamed to "sidecar" in all user-facing messages

## Test plan

- [x] Run `chunk validate` with `sidecarImage` configured and no active sidecar — confirm a sidecar is created automatically
- [ ] Run `chunk validate` with `Remote:true` commands and no active sidecar — confirm a sidecar is created automatically
- [x] Run `chunk validate` with no remote config — confirm it still runs locally without attempting sidecar creation
- [x] Acceptance test `TestValidateSidecarImageNoActiveSidecarAutoCreates` verifies a create-sidecar request is made

🤖 Generated with [Claude Code](https://claude.com/claude-code)
