### PR TITLE
Cache successful validate results in hook mode

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,7 +30,7 @@ chunk-cli/
     ├── filecache/             # Generic JSON-on-disk cache (FileCache[T])
     ├── github/                # GitHub GraphQL client (reviews, repos)
     ├── gitremote/             # Git remote URL parsing for org/repo detection
-    ├── gitutil/               # Git utility helpers
+    ├── gitutil/               # Git utility helpers, working-tree fingerprints
     ├── httpcl/                # HTTP client library (JSON + retries)
     ├── iostream/              # I/O stream abstraction
     ├── sidecar/               # CircleCI sidecar operations
@@ -258,12 +258,14 @@ runs configured validation commands before the AI agent commits code. See
 **[docs/HOOKS.md](HOOKS.md)** for details.
 
 `chunk validate` runs those same commands manually. In hook mode it additionally
-caches successful runs: `validate.BuildCacheKey` hashes the command config, the
-HEAD SHA, and the contents of every changed file into a key, and a repeat hook
-invocation that hits an entry skips execution. The unit of caching is the whole
-run, not individual files. Manual runs never cache, and the key builder refuses
-to produce a key at all when git state is untrustworthy, since a config-only key
-would stay stable across code changes. See
+caches successful runs. Both tree-dependent hook decisions read one
+`gitutil.Fingerprint` call: it returns the HEAD SHA, a digest of the contents of
+every changed file, and whether the tree is clean at all. A clean tree skips the
+run outright; otherwise `validate.BuildCacheKey` combines the fingerprint with
+the command config and execution target into a key, and a repeat hook invocation
+that hits an entry skips execution. The unit of caching is the whole run, not
+individual files. Manual runs never cache, and an unusable fingerprint is refused
+as a key, since a config-only key would stay stable across code changes. See
 **[docs/HOOKS.md](HOOKS.md#result-caching)** for the user-facing behaviour.
 
 ## HTTP Client (`internal/httpcl/`)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,6 +27,7 @@ chunk-cli/
     ├── buildprompt/           # Three-step pipeline: discover → analyze → generate
     ├── circleci/              # CircleCI REST API client
     ├── config/                # User config (XDG_CONFIG_HOME/chunk/config.json)
+    ├── filecache/             # Generic JSON-on-disk cache (FileCache[T])
     ├── github/                # GitHub GraphQL client (reviews, repos)
     ├── gitremote/             # Git remote URL parsing for org/repo detection
     ├── gitutil/               # Git utility helpers
@@ -198,7 +199,7 @@ in `config.Resolve` and makes clients testable.
 | `CLAUDE_WORKING_DIR` | validate | Active worktree directory (Stop hook context) |
 | `CHUNK_HOOKS_DISABLED` | validate, hook | Disable Stop-hook validation when set (any non-empty value) |
 | `XDG_CONFIG_HOME` | config | User config directory (default: `~/.config`) |
-| `XDG_DATA_HOME` | sidecar | Per-project state directory (default: `~/.local/share`) |
+| `XDG_DATA_HOME` | sidecar, validate | Per-project state directory, including the hook-mode validate result cache (default: `~/.local/share`) |
 | `CHUNK_NO_TELEMETRY` | telemetry | Disable anonymous usage telemetry (any non-empty value) |
 | `NO_ANALYTICS` | telemetry | Disable anonymous usage telemetry (any non-empty value) |
 | `DO_NOT_TRACK` | telemetry | Disable anonymous usage telemetry (any non-empty value) |
@@ -256,8 +257,14 @@ known agent is found, the common case for a human running `chunk` directly.
 runs configured validation commands before the AI agent commits code. See
 **[docs/HOOKS.md](HOOKS.md)** for details.
 
-`chunk validate` runs those same commands manually, with SHA256-based content
-caching so unchanged files skip re-execution.
+`chunk validate` runs those same commands manually. In hook mode it additionally
+caches successful runs: `validate.BuildCacheKey` hashes the command config, the
+HEAD SHA, and the contents of every changed file into a key, and a repeat hook
+invocation that hits an entry skips execution. The unit of caching is the whole
+run, not individual files. Manual runs never cache, and the key builder refuses
+to produce a key at all when git state is untrustworthy, since a config-only key
+would stay stable across code changes. See
+**[docs/HOOKS.md](HOOKS.md#result-caching)** for the user-facing behaviour.
 
 ## HTTP Client (`internal/httpcl/`)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,6 +31,7 @@ chunk-cli/
     ├── github/                # GitHub GraphQL client (reviews, repos)
     ├── gitremote/             # Git remote URL parsing for org/repo detection
     ├── gitutil/               # Git utility helpers, working-tree fingerprints
+    ├── hashutil/              # Collision-free digests of string parts (cache keys)
     ├── httpcl/                # HTTP client library (JSON + retries)
     ├── iostream/              # I/O stream abstraction
     ├── sidecar/               # CircleCI sidecar operations
@@ -61,6 +62,8 @@ main.go → internal/cmd/ → internal/{business packages} → internal/httpcl/
 - Business packages (`buildprompt/`, `task/`, etc.) contain the logic
 - `internal/httpcl/` is an independent library — no imports are allowed to other `internal/` packages
 - `config/` is a leaf — no imports from other `internal/` packages
+- `hashutil/` is a leaf too: stdlib only, so any package can share its digest
+  primitive rather than re-deriving one
 
 No upward or lateral imports between business packages, except where a
 package naturally composes another (e.g. `task/` uses `circleci/`).
@@ -261,11 +264,14 @@ runs configured validation commands before the AI agent commits code. See
 caches successful runs. Both tree-dependent hook decisions read one
 `gitutil.Fingerprint` call: it returns the HEAD SHA, a digest of the contents of
 every changed file, and whether the tree is clean at all. A clean tree skips the
-run outright; otherwise `validate.BuildCacheKey` combines the fingerprint with
-the command config and execution target into a key, and a repeat hook invocation
-that hits an entry skips execution. The unit of caching is the whole run, not
-individual files. Manual runs never cache, and an unusable fingerprint is refused
-as a key, since a config-only key would stay stable across code changes. See
+run outright; otherwise `validate.BuildCacheKey` combines the fingerprint with the
+project config and execution target into a key, and a repeat hook invocation that
+hits an entry skips execution — going through the same `finishValidate` path as a
+real success, so hook bookkeeping has one home. The unit of caching is the whole
+run, not individual files. Manual runs never cache, and an unusable fingerprint is
+refused as a key, since a config-only key would stay stable across code changes;
+`Fingerprint` returns an error saying which condition it hit, and hook mode prints
+it, because a repo that never caches is otherwise silent about why. See
 **[docs/HOOKS.md](HOOKS.md#result-caching)** for the user-facing behaviour.
 
 ## HTTP Client (`internal/httpcl/`)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -186,11 +186,12 @@ chunk
 - `chunk auth set github` stores a GitHub token in the config file; previously
   only the `GITHUB_TOKEN` environment variable was supported.
 - `chunk hook disable` creates a `.chunk/hooks-disabled` sentinel file inspected by the `chunk validate` Stop hook; `hook enable` removes it. Stop-hook validation is also disabled when `CHUNK_HOOKS_DISABLED` is set in the environment.
-- `chunk validate` caches successful runs in hook mode only, keyed by the command
-  config, HEAD SHA, and the contents of all changed files; a repeat hook
-  invocation with nothing changed prints `skipped` instead of re-running. Manual
-  runs, `--cmd` inline commands, and repos whose state cannot be hashed never
-  cache. See [HOOKS.md](HOOKS.md#result-caching).
+- `chunk validate` caches successful runs in hook mode only, keyed by
+  `.chunk/config.json`, the execution target, the HEAD SHA, and the contents of
+  all changed files; a repeat hook invocation with nothing changed prints
+  `skipped` instead of re-running. Manual runs, `--cmd` inline commands, and
+  repos whose state cannot be hashed never cache. Entries expire after 7 days.
+  See [HOOKS.md](HOOKS.md#result-caching).
 
 ## Config keys
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -186,6 +186,11 @@ chunk
 - `chunk auth set github` stores a GitHub token in the config file; previously
   only the `GITHUB_TOKEN` environment variable was supported.
 - `chunk hook disable` creates a `.chunk/hooks-disabled` sentinel file inspected by the `chunk validate` Stop hook; `hook enable` removes it. Stop-hook validation is also disabled when `CHUNK_HOOKS_DISABLED` is set in the environment.
+- `chunk validate` caches successful runs in hook mode only, keyed by the command
+  config, HEAD SHA, and the contents of all changed files; a repeat hook
+  invocation with nothing changed prints `skipped` instead of re-running. Manual
+  runs, `--cmd` inline commands, and repos whose state cannot be hashed never
+  cache. See [HOOKS.md](HOOKS.md#result-caching).
 
 ## Config keys
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -430,7 +430,9 @@ After `chunk init`, two hooks run automatically in Claude Code and Cursor:
 
 The Stop hook retries up to `stopHookMaxAttempts` times (default: 3) before giving up and letting the session end.
 
-See [docs/HOOKS.md](HOOKS.md) for configuration details.
+A successful Stop-hook run is cached, so if the hook fires again with nothing changed it prints `skipped (no changes since last successful run)` rather than re-running your commands. Failures are never cached. Running `chunk validate` yourself always executes the commands.
+
+See [docs/HOOKS.md](HOOKS.md) for configuration details and [Result Caching](HOOKS.md#result-caching) for what invalidates the cache.
 
 ---
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -25,9 +25,12 @@ chunk validate: skipped (no changes since last successful run)
 Only successes are cached. A failing run is never stored, so the agent always
 gets a real re-run after a fix attempt.
 
-The cache key covers everything that can change the outcome:
+The cache key covers:
 
 - the `commands` block of `.chunk/config.json`
+- the execution target — the configured sidecar snapshot image and the active
+  sidecar's ID, so a result validated against one sidecar is never reused for
+  another
 - the HEAD commit SHA
 - the contents of every file git reports as changed — tracked, staged, and
   untracked alike
@@ -36,6 +39,17 @@ Because contents are hashed rather than just the `git status` output, editing a
 file that was already dirty invalidates the entry. Any edit that could change a
 command's result produces a new key.
 
+Two things deliberately stay out of the key:
+
+- **Gitignored files.** `git status` does not report ignored paths, so nothing
+  under `.gitignore` participates in the digest — `.env.local`, generated code,
+  vendored dependencies, local tooling config. Hashing them would mean walking
+  trees like `node_modules` on every hook invocation. A command whose result
+  depends on an ignored file can therefore report a hit after that file changes;
+  touch a tracked file, or delete the cache directory, to force a re-run.
+- **Environment variables** passed with `--env` or loaded from `.env.local`,
+  for the same reason.
+
 Caching is skipped, and commands always run, when:
 
 - the run is not a hook invocation (a manual `chunk validate` never caches)
@@ -43,9 +57,11 @@ Caching is skipped, and commands always run, when:
 - the working-tree state cannot be hashed reliably — not a git repo, a repo with
   no commits yet, or a changed path that cannot be read (an unreadable file, or a
   non-regular path such as a dirty submodule)
+- the changed files total more than 64 MiB, the point past which hashing the tree
+  costs more than re-running the commands
 
-That last case fails closed: without trustworthy git state the key would depend
-on the config alone and would stay stable across code changes, so no cache is
+Those last two fail closed: without a trustworthy digest the key would depend on
+the config alone and would stay stable across code changes, so no cache is
 consulted at all.
 
 Entries live outside the repo, under the per-project data directory:

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -30,7 +30,9 @@ fingerprint, taken once per hook invocation.
 
 The cache key covers:
 
-- the `commands` block of `.chunk/config.json`
+- all of `.chunk/config.json` — the `commands` block, and the `environment` block
+  that decides what those commands run against. A project that gitignores
+  `.chunk/` still gets a re-run when either changes
 - the execution target — the configured sidecar snapshot image and the active
   sidecar's ID, so a result validated against one sidecar is never reused for
   another
@@ -65,7 +67,15 @@ Caching is skipped, and commands always run, when:
 
 Those last two fail closed: without a trustworthy digest the key would depend on
 the config alone and would stay stable across code changes, so no cache is
-consulted at all.
+consulted at all. When the working tree cannot be hashed, the hook says so:
+
+```
+chunk validate: working tree state unavailable (hash sub: changed path is not a
+regular file); running everything, caching nothing
+```
+
+That line is the only signal that a repo is getting no benefit from the cache, so
+a repo that never prints `skipped` is not left unexplained.
 
 Entries live outside the repo, under the per-project data directory:
 
@@ -73,9 +83,11 @@ Entries live outside the repo, under the per-project data directory:
 $XDG_DATA_HOME/chunk/<sha256-of-project-path>/validate-cache/
 ```
 
-Each entry is a small JSON file. Superseded entries (older commits, earlier
-working-tree states) are not pruned automatically; delete the directory to clear
-the cache.
+Each entry is a small JSON file. Keys are content-addressed, so a superseded
+entry (an older commit, an earlier working-tree state) is never read again; each
+write sweeps entries older than 7 days, along with any partial file left behind by
+an interrupted run. Nothing needs cleaning by hand, though deleting the directory
+is always safe and forces a re-run.
 
 ## Worktree Support
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -25,6 +25,9 @@ chunk validate: skipped (no changes since last successful run)
 Only successes are cached. A failing run is never stored, so the agent always
 gets a real re-run after a fix attempt.
 
+The clean-tree skip above and the cache below read the same working-tree
+fingerprint, taken once per hook invocation.
+
 The cache key covers:
 
 - the `commands` block of `.chunk/config.json`

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -13,6 +13,51 @@ before a commit. If any command fails, the commit is blocked.
 when the working tree is clean. When there are changes, it runs all configured
 commands so problems are surfaced before the agent stops working.
 
+## Result Caching
+
+In hook mode only, a successful `chunk validate` run is cached. If the hook
+fires again with nothing changed, the commands are skipped entirely:
+
+```
+chunk validate: skipped (no changes since last successful run)
+```
+
+Only successes are cached. A failing run is never stored, so the agent always
+gets a real re-run after a fix attempt.
+
+The cache key covers everything that can change the outcome:
+
+- the `commands` block of `.chunk/config.json`
+- the HEAD commit SHA
+- the contents of every file git reports as changed — tracked, staged, and
+  untracked alike
+
+Because contents are hashed rather than just the `git status` output, editing a
+file that was already dirty invalidates the entry. Any edit that could change a
+command's result produces a new key.
+
+Caching is skipped, and commands always run, when:
+
+- the run is not a hook invocation (a manual `chunk validate` never caches)
+- `--cmd` supplied an inline command
+- the working-tree state cannot be hashed reliably — not a git repo, a repo with
+  no commits yet, or a changed path that cannot be read (an unreadable file, or a
+  non-regular path such as a dirty submodule)
+
+That last case fails closed: without trustworthy git state the key would depend
+on the config alone and would stay stable across code changes, so no cache is
+consulted at all.
+
+Entries live outside the repo, under the per-project data directory:
+
+```
+$XDG_DATA_HOME/chunk/<sha256-of-project-path>/validate-cache/
+```
+
+Each entry is a small JSON file. Superseded entries (older commits, earlier
+working-tree states) are not pruned automatically; delete the directory to clear
+the cache.
+
 ## Worktree Support
 
 The Stop hook uses `CLAUDE_WORKING_DIR` (the actual session working directory)

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -791,8 +791,9 @@ func validateCacheDir(workDir string) (string, error) {
 	return filepath.Join(projectDir, "validate-cache"), nil
 }
 
-// hookResultCache returns a ResultCache and cache key for hook-mode runs,
-// or (nil, "") when caching does not apply (non-hook or inline cmd).
+// hookResultCache returns a ResultCache and cache key for hook-mode runs, or
+// (nil, "") when caching does not apply: non-hook runs, inline commands, or a
+// working tree whose state cannot be hashed reliably.
 func hookResultCache(hook *hookContext, inlineCmd, workDir, commandName string, cfg *config.ProjectConfig) (validate.ResultCache, string) {
 	if hook == nil || inlineCmd != "" {
 		return nil, ""
@@ -801,7 +802,10 @@ func hookResultCache(hook *hookContext, inlineCmd, workDir, commandName string, 
 	if err != nil {
 		return nil, ""
 	}
-	key := validate.BuildCacheKey(workDir, commandName, cfg.Commands)
+	key, ok := validate.BuildCacheKey(workDir, commandName, cfg.Commands)
+	if !ok {
+		return nil, ""
+	}
 	return filecache.FileCache[validate.CachedResult]{Dir: cacheDir}, key
 }
 

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
 	"github.com/CircleCI-Public/chunk-cli/internal/filecache"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
+	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
 	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
@@ -140,9 +141,12 @@ func newValidateCmd() *cobra.Command {
 }
 
 // initHook applies hook-specific context, stream, and early-exit logic.
+// tree is the working-tree fingerprint for this run; the zero value means it
+// could not be established, and reports the tree as not clean so validation
+// still runs in ambiguous cases.
 // Returns updated ctx and streams, a skip flag (true = return nil immediately),
 // and a non-nil error when the hook should exit with a non-zero code.
-func initHook(ctx context.Context, hook *hookContext, workDir string, streams iostream.Streams) (context.Context, iostream.Streams, bool, error) {
+func initHook(ctx context.Context, hook *hookContext, workDir string, tree gitutil.Worktree, streams iostream.Streams) (context.Context, iostream.Streams, bool, error) {
 	if hook == nil {
 		return ctx, streams, false, nil
 	}
@@ -157,7 +161,7 @@ func initHook(ctx context.Context, hook *hookContext, workDir string, streams io
 		streams.ErrPrintln("chunk validate: hooks are disabled — skipping validation")
 		return ctx, streams, false, validate.NewHookExitError(1)
 	}
-	if !validate.HasGitChanges(workDir) {
+	if tree.Clean {
 		return ctx, streams, true, nil
 	}
 	return ctx, streams, false, nil
@@ -209,9 +213,20 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	hook := detectHook(cmd.InOrStdin())
 	ctx := cmd.Context()
 
+	// The working-tree fingerprint answers both hook-only questions about the
+	// tree: whether there is anything to validate at all, and whether this exact
+	// tree already validated successfully. Computing it once keeps the two
+	// consistent and costs a single pass over the changed files. On failure it is
+	// the zero Worktree, which reads as "not clean" and is refused as a cache
+	// key, so both questions fall back to running the commands.
+	var tree gitutil.Worktree
+	if hook != nil {
+		tree, _ = gitutil.Fingerprint(workDir)
+	}
+
 	var skip bool
 	var hookErr error
-	ctx, streams, skip, hookErr = initHook(ctx, hook, workDir, streams)
+	ctx, streams, skip, hookErr = initHook(ctx, hook, workDir, tree, streams)
 	if hookErr != nil {
 		return hookErr
 	}
@@ -270,7 +285,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return errSilentExit
 	}
 
-	resultCache, cacheKey := hookResultCache(hook, opts.inlineCmd, workDir, name, cfg, execTarget(opts, cfg, activeSidecar))
+	resultCache, cacheKey := hookResultCache(hook, opts.inlineCmd, workDir, tree, name, cfg, execTarget(opts, cfg, activeSidecar))
 	if resultCache != nil {
 		if _, ok := resultCache.Get(cacheKey); ok {
 			streams.ErrPrintln("chunk validate: skipped (no changes since last successful run)")
@@ -798,8 +813,8 @@ func validateCacheDir(workDir string) (string, error) {
 
 // hookResultCache returns a ResultCache and cache key for hook-mode runs, or
 // (nil, "") when caching does not apply: non-hook runs, inline commands, or a
-// working tree whose state cannot be hashed reliably.
-func hookResultCache(hook *hookContext, inlineCmd, workDir, commandName string, cfg *config.ProjectConfig, target string) (validate.ResultCache, string) {
+// working tree whose state could not be fingerprinted.
+func hookResultCache(hook *hookContext, inlineCmd, workDir string, tree gitutil.Worktree, commandName string, cfg *config.ProjectConfig, target string) (validate.ResultCache, string) {
 	if hook == nil || inlineCmd != "" {
 		return nil, ""
 	}
@@ -808,7 +823,7 @@ func hookResultCache(hook *hookContext, inlineCmd, workDir, commandName string, 
 		return nil, ""
 	}
 	key, ok := validate.BuildCacheKey(validate.CacheKeyInputs{
-		WorkDir:     workDir,
+		Worktree:    tree,
 		CommandName: commandName,
 		Commands:    cfg.Commands,
 		Target:      target,

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -339,7 +339,9 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 
 	execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
 	if execErr == nil && resultCache != nil {
-		_ = resultCache.Put(cacheKey, validate.CachedResult{CachedAt: time.Now()})
+		if err := resultCache.Put(cacheKey, validate.CachedResult{CachedAt: time.Now()}); err != nil {
+			streams.ErrPrintf("  %s\n", ui.ErrDim(fmt.Sprintf("chunk validate: cache write failed: %v", err)))
+		}
 	}
 	return finishValidate(cmd, hook, execErr, start, opts.sidecarID, cfg, statusFn, streams)
 }
@@ -811,10 +813,10 @@ func validateCacheDir(workDir string) (string, error) {
 	return filepath.Join(projectDir, "validate-cache"), nil
 }
 
-// hookResultCache returns a ResultCache and cache key for hook-mode runs, or
+// hookResultCache returns a cache and cache key for hook-mode runs, or
 // (nil, "") when caching does not apply: non-hook runs, inline commands, or a
 // working tree whose state could not be fingerprinted.
-func hookResultCache(hook *hookContext, inlineCmd, workDir string, tree gitutil.Worktree, commandName string, cfg *config.ProjectConfig, target string) (validate.ResultCache, string) {
+func hookResultCache(hook *hookContext, inlineCmd, workDir string, tree gitutil.Worktree, commandName string, cfg *config.ProjectConfig, target string) (*filecache.FileCache[validate.CachedResult], string) {
 	if hook == nil || inlineCmd != "" {
 		return nil, ""
 	}
@@ -831,7 +833,7 @@ func hookResultCache(hook *hookContext, inlineCmd, workDir string, tree gitutil.
 	if !ok {
 		return nil, ""
 	}
-	return filecache.FileCache[validate.CachedResult]{Dir: cacheDir}, key
+	return &filecache.FileCache[validate.CachedResult]{Dir: cacheDir}, key
 }
 
 // execTarget describes where this run's commands will execute, for inclusion in

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -270,10 +270,15 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return errSilentExit
 	}
 
-	resultCache, cacheKey := hookResultCache(hook, opts.inlineCmd, workDir, name, cfg)
+	resultCache, cacheKey := hookResultCache(hook, opts.inlineCmd, workDir, name, cfg, execTarget(opts, cfg, activeSidecar))
 	if resultCache != nil {
 		if _, ok := resultCache.Get(cacheKey); ok {
 			streams.ErrPrintln("chunk validate: skipped (no changes since last successful run)")
+			// A cache hit is a success, so it clears the failure counter just as
+			// WrapHookResult does for a real one. Leaving a stale count behind
+			// would bring the "ask the user for guidance" bail-out forward by a
+			// turn. resultCache is only non-nil in hook mode, so hook is set.
+			validate.ResetAttempts(hook.sessionID)
 			return nil
 		}
 	}
@@ -794,7 +799,7 @@ func validateCacheDir(workDir string) (string, error) {
 // hookResultCache returns a ResultCache and cache key for hook-mode runs, or
 // (nil, "") when caching does not apply: non-hook runs, inline commands, or a
 // working tree whose state cannot be hashed reliably.
-func hookResultCache(hook *hookContext, inlineCmd, workDir, commandName string, cfg *config.ProjectConfig) (validate.ResultCache, string) {
+func hookResultCache(hook *hookContext, inlineCmd, workDir, commandName string, cfg *config.ProjectConfig, target string) (validate.ResultCache, string) {
 	if hook == nil || inlineCmd != "" {
 		return nil, ""
 	}
@@ -802,11 +807,40 @@ func hookResultCache(hook *hookContext, inlineCmd, workDir, commandName string, 
 	if err != nil {
 		return nil, ""
 	}
-	key, ok := validate.BuildCacheKey(workDir, commandName, cfg.Commands)
+	key, ok := validate.BuildCacheKey(validate.CacheKeyInputs{
+		WorkDir:     workDir,
+		CommandName: commandName,
+		Commands:    cfg.Commands,
+		Target:      target,
+	})
 	if !ok {
 		return nil, ""
 	}
 	return filecache.FileCache[validate.CachedResult]{Dir: cacheDir}, key
+}
+
+// execTarget describes where this run's commands will execute, for inclusion in
+// the cache key. Which sidecar is used depends on the configured snapshot image
+// and on the active sidecar — mutable state that lives outside the repo, so
+// neither shows up in the working-tree digest. Without it, switching the active
+// sidecar between runs leaves the key unchanged and the second sidecar is never
+// validated against.
+//
+// Returns "" for a purely local run. The sidecar ID is empty when one will be
+// created during this run; the image still distinguishes those from local runs.
+func execTarget(opts *validateOpts, cfg *config.ProjectConfig, active *sidecar.ActiveSidecar) string {
+	id := opts.sidecarID
+	if id == "" && active != nil {
+		id = active.SidecarID
+	}
+	var image string
+	if cfg.HasSidecarImage() {
+		image = cfg.Validation.SidecarImage
+	}
+	if id == "" && image == "" {
+		return ""
+	}
+	return id + "\x00" + image
 }
 
 func mapValidateError(err error) error {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -141,12 +141,12 @@ func newValidateCmd() *cobra.Command {
 }
 
 // initHook applies hook-specific context, stream, and early-exit logic.
-// tree is the working-tree fingerprint for this run; the zero value means it
-// could not be established, and reports the tree as not clean so validation
-// still runs in ambiguous cases.
+// tree is the working-tree fingerprint for this run, and treeErr the reason it
+// could not be taken. A zero tree reports as not clean, so validation still runs
+// in ambiguous cases.
 // Returns updated ctx and streams, a skip flag (true = return nil immediately),
 // and a non-nil error when the hook should exit with a non-zero code.
-func initHook(ctx context.Context, hook *hookContext, workDir string, tree gitutil.Worktree, streams iostream.Streams) (context.Context, iostream.Streams, bool, error) {
+func initHook(ctx context.Context, hook *hookContext, workDir string, tree gitutil.Worktree, treeErr error, streams iostream.Streams) (context.Context, iostream.Streams, bool, error) {
 	if hook == nil {
 		return ctx, streams, false, nil
 	}
@@ -160,6 +160,14 @@ func initHook(ctx context.Context, hook *hookContext, workDir string, tree gitut
 	if validate.HooksDisabled(workDir, os.Getenv(config.EnvChunkHooksDisabled) != "") {
 		streams.ErrPrintln("chunk validate: hooks are disabled — skipping validation")
 		return ctx, streams, false, validate.NewHookExitError(1)
+	}
+	// Say so when the tree could not be fingerprinted. Everything below degrades
+	// silently on a zero tree — the clean-tree skip and the result cache both just
+	// run the commands — so a repo that never once prints "skipped" (one with a
+	// dirty submodule, say) is otherwise indistinguishable from one where the
+	// cache is working and nothing is ever unchanged.
+	if treeErr != nil {
+		streams.ErrPrintf("  %s\n", ui.ErrDim(fmt.Sprintf("chunk validate: working tree state unavailable (%v); running everything, caching nothing", treeErr)))
 	}
 	if tree.Clean {
 		return ctx, streams, true, nil
@@ -220,13 +228,14 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	// the zero Worktree, which reads as "not clean" and is refused as a cache
 	// key, so both questions fall back to running the commands.
 	var tree gitutil.Worktree
+	var treeErr error
 	if hook != nil {
-		tree, _ = gitutil.Fingerprint(workDir)
+		tree, treeErr = gitutil.Fingerprint(workDir)
 	}
 
 	var skip bool
 	var hookErr error
-	ctx, streams, skip, hookErr = initHook(ctx, hook, workDir, tree, streams)
+	ctx, streams, skip, hookErr = initHook(ctx, hook, workDir, tree, treeErr, streams)
 	if hookErr != nil {
 		return hookErr
 	}
@@ -289,12 +298,10 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	if resultCache != nil {
 		if _, ok := resultCache.Get(cacheKey); ok {
 			streams.ErrPrintln("chunk validate: skipped (no changes since last successful run)")
-			// A cache hit is a success, so it clears the failure counter just as
-			// WrapHookResult does for a real one. Leaving a stale count behind
-			// would bring the "ask the user for guidance" bail-out forward by a
-			// turn. resultCache is only non-nil in hook mode, so hook is set.
-			validate.ResetAttempts(hook.sessionID)
-			return nil
+			// A hit is a success, so it finishes the same way a real successful run
+			// does rather than repeating that bookkeeping here: clearing the failure
+			// counter, and whatever else the success branch grows later.
+			return finishValidate(cmd, hook, nil, start, opts.sidecarID, cfg, statusFn, streams)
 		}
 	}
 
@@ -816,6 +823,9 @@ func validateCacheDir(workDir string) (string, error) {
 // hookResultCache returns a cache and cache key for hook-mode runs, or
 // (nil, "") when caching does not apply: non-hook runs, inline commands, or a
 // working tree whose state could not be fingerprinted.
+//
+// The cache keeps itself to a bounded size as it is written to; entries live for
+// filecache.DefaultMaxAge.
 func hookResultCache(hook *hookContext, inlineCmd, workDir string, tree gitutil.Worktree, commandName string, cfg *config.ProjectConfig, target string) (*filecache.FileCache[validate.CachedResult], string) {
 	if hook == nil || inlineCmd != "" {
 		return nil, ""
@@ -827,7 +837,7 @@ func hookResultCache(hook *hookContext, inlineCmd, workDir string, tree gitutil.
 	key, ok := validate.BuildCacheKey(validate.CacheKeyInputs{
 		Worktree:    tree,
 		CommandName: commandName,
-		Commands:    cfg.Commands,
+		Config:      cfg,
 		Target:      target,
 	})
 	if !ok {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
+	"github.com/CircleCI-Public/chunk-cli/internal/filecache"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
@@ -269,6 +270,14 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return errSilentExit
 	}
 
+	resultCache, cacheKey := hookResultCache(hook, opts.inlineCmd, workDir, name, cfg)
+	if resultCache != nil {
+		if _, ok := resultCache.Get(cacheKey); ok {
+			streams.ErrPrintln("chunk validate: skipped (no changes since last successful run)")
+			return nil
+		}
+	}
+
 	// allRemote is true when the caller explicitly targets the sidecar
 	// (--remote or --sidecar-id), meaning every command runs there.
 	// Per-command routing only applies when the sidecar is resolved implicitly.
@@ -309,6 +318,9 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	}
 
 	execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
+	if execErr == nil && resultCache != nil {
+		_ = resultCache.Put(cacheKey, validate.CachedResult{CachedAt: time.Now()})
+	}
 	return finishValidate(cmd, hook, execErr, start, opts.sidecarID, cfg, statusFn, streams)
 }
 
@@ -768,6 +780,30 @@ func sidecarAutoName(ctx context.Context, workDir string) string {
 
 const suggestionValidateNotConfigured = "Run 'chunk init' to detect and configure validation commands.\n" +
 	"This also installs the /chunk-sidecar skill so your AI coding agent can help you set up remote validation on a sidecar."
+
+// validateCacheDir returns the directory used to store validate result cache
+// entries for the given project root.
+func validateCacheDir(workDir string) (string, error) {
+	projectDir, err := config.ProjectDataDir(workDir)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(projectDir, "validate-cache"), nil
+}
+
+// hookResultCache returns a ResultCache and cache key for hook-mode runs,
+// or (nil, "") when caching does not apply (non-hook or inline cmd).
+func hookResultCache(hook *hookContext, inlineCmd, workDir, commandName string, cfg *config.ProjectConfig) (validate.ResultCache, string) {
+	if hook == nil || inlineCmd != "" {
+		return nil, ""
+	}
+	cacheDir, err := validateCacheDir(workDir)
+	if err != nil {
+		return nil, ""
+	}
+	key := validate.BuildCacheKey(workDir, commandName, cfg.Commands)
+	return filecache.FileCache[validate.CachedResult]{Dir: cacheDir}, key
+}
 
 func mapValidateError(err error) error {
 	if errors.Is(err, validate.ErrNotConfigured) {

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
 	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
@@ -46,8 +47,9 @@ func TestValidateHookExitsOneWhenCircleCITokenMissingAndRemoteCommands(t *testin
 	t.Setenv(config.EnvCircleToken, "")
 	t.Setenv(config.EnvCircleCIToken, "")
 
-	// Set up a project dir with a remote command. HasGitChanges returns true in
-	// a non-git dir, so the hook won't short-circuit on a clean-tree check.
+	// Set up a project dir with a remote command. A non-git dir cannot be
+	// fingerprinted, and an unusable fingerprint reads as not clean, so the hook
+	// won't short-circuit on the clean-tree check.
 	dir := t.TempDir()
 	projCfg := &config.ProjectConfig{
 		Commands: []config.Command{
@@ -230,7 +232,7 @@ func TestValidateHookCacheHitResetsAttempts(t *testing.T) {
 
 	dir := t.TempDir()
 	gitSetup(t, dir, "main")
-	// Saving the config leaves .chunk/ untracked, so HasGitChanges stays true and
+	// Saving the config leaves .chunk/ untracked, so the tree is never clean and
 	// the hook reaches the cache instead of short-circuiting on a clean tree.
 	assert.NilError(t, config.SaveProjectConfig(dir, &config.ProjectConfig{
 		Commands: []config.Command{{Name: "test", Run: "exit 0"}},
@@ -265,6 +267,10 @@ func TestValidateHookCacheHitResetsAttempts(t *testing.T) {
 
 // --- hookResultCache ---
 
+// hookTree stands in for the fingerprint the hook computes once per run; gitutil
+// owns the tests that prove a digest tracks the working tree.
+var hookTree = gitutil.Worktree{Head: "abc123", Digest: "deadbeef"}
+
 // hookResultCache is the boundary between "these runs are cacheable" and
 // "these are not"; each guard below must return no cache so the run always
 // executes.
@@ -276,20 +282,16 @@ func TestHookResultCacheDisabledCases(t *testing.T) {
 		name      string
 		hook      *hookContext
 		inlineCmd string
-		gitInit   bool
+		tree      gitutil.Worktree
 	}{
-		{name: "not a hook run", hook: nil, gitInit: true},
-		{name: "inline command", hook: hook, inlineCmd: "go test ./foo", gitInit: true},
-		{name: "unusable git state", hook: hook, gitInit: false},
+		{name: "not a hook run", hook: nil, tree: hookTree},
+		{name: "inline command", hook: hook, inlineCmd: "go test ./foo", tree: hookTree},
+		{name: "unusable git state", hook: hook, tree: gitutil.Worktree{}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir := t.TempDir()
-			if tt.gitInit {
-				gitSetup(t, dir, "main")
-			}
-			cache, key := hookResultCache(tt.hook, tt.inlineCmd, dir, "", cfg, "")
+			cache, key := hookResultCache(tt.hook, tt.inlineCmd, t.TempDir(), tt.tree, "", cfg, "")
 			assert.Assert(t, cache == nil, "expected no cache")
 			assert.Equal(t, key, "")
 		})
@@ -297,11 +299,9 @@ func TestHookResultCacheDisabledCases(t *testing.T) {
 }
 
 func TestHookResultCacheEnabledForNamedCommand(t *testing.T) {
-	dir := t.TempDir()
-	gitSetup(t, dir, "main")
 	cfg := &config.ProjectConfig{Commands: []config.Command{{Name: "test", Run: "go test ./..."}}}
 
-	cache, key := hookResultCache(&hookContext{sessionID: "s1"}, "", dir, "test", cfg, "")
+	cache, key := hookResultCache(&hookContext{sessionID: "s1"}, "", t.TempDir(), hookTree, "test", cfg, "")
 	assert.Assert(t, cache != nil, "expected a cache for a named command in hook mode")
 	assert.Assert(t, key != "")
 }
@@ -311,12 +311,11 @@ func TestHookResultCacheEnabledForNamedCommand(t *testing.T) {
 // for another.
 func TestHookResultCacheTargetAffectsKey(t *testing.T) {
 	dir := t.TempDir()
-	gitSetup(t, dir, "main")
 	cfg := &config.ProjectConfig{Commands: []config.Command{{Name: "test", Run: "go test ./..."}}}
 	hook := &hookContext{sessionID: "s1"}
 
-	_, local := hookResultCache(hook, "", dir, "test", cfg, "")
-	_, remote := hookResultCache(hook, "", dir, "test", cfg, "sidecar-a\x00")
+	_, local := hookResultCache(hook, "", dir, hookTree, "test", cfg, "")
+	_, remote := hookResultCache(hook, "", dir, hookTree, "test", cfg, "sidecar-a\x00")
 	assert.Assert(t, local != remote, "target must participate in the cache key")
 }
 

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -21,7 +21,9 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
+	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+	"github.com/CircleCI-Public/chunk-cli/internal/validate"
 )
 
 // hookPayload is the JSON Claude Code sends to Stop hooks via stdin.
@@ -210,6 +212,57 @@ func TestValidateEnvFlagBadValue(t *testing.T) {
 	assert.Assert(t, strings.Contains(err.Error(), "BADVALUE"), "got: %v", err)
 }
 
+// activeStopHookPayload is a re-signalled Stop hook: stop_hook_active is true,
+// so initHook leaves the failure counter alone and the counter's fate is decided
+// by how the run itself ends.
+const activeStopHookPayload = `{"session_id":"test-session-001","stop_hook_active":true}`
+
+// TestValidateHookCacheHitResetsAttempts covers a Stop hook firing again on a
+// tree that already validated. The commands are skipped, and because a cache hit
+// is a success it must clear the failure counter — otherwise a stale count
+// brings the "ask the user for guidance" bail-out forward by a turn.
+func TestValidateHookCacheHitResetsAttempts(t *testing.T) {
+	isolateConfig(t)
+	// The attempt counter lives under os.TempDir(); isolate it from other tests
+	// sharing this session ID.
+	t.Setenv("TMPDIR", t.TempDir())
+	const sessionID = "test-session-001"
+
+	dir := t.TempDir()
+	gitSetup(t, dir, "main")
+	// Saving the config leaves .chunk/ untracked, so HasGitChanges stays true and
+	// the hook reaches the cache instead of short-circuiting on a clean tree.
+	assert.NilError(t, config.SaveProjectConfig(dir, &config.ProjectConfig{
+		Commands: []config.Command{{Name: "test", Run: "exit 0"}},
+	}))
+
+	run := func() string {
+		t.Helper()
+		var outBuf, errBuf bytes.Buffer
+		root := NewRootCmd("test")
+		root.SetOut(&outBuf)
+		root.SetErr(&errBuf)
+		root.SetIn(strings.NewReader(activeStopHookPayload))
+		root.SetArgs([]string{"validate", "--project", dir})
+		assert.NilError(t, root.Execute())
+		return errBuf.String()
+	}
+
+	const skipMsg = "skipped (no changes since last successful run)"
+
+	first := run()
+	assert.Assert(t, !strings.Contains(first, skipMsg), "first run must execute, got: %q", first)
+
+	// A failure at some other tree state leaves a count of 1 behind.
+	assert.Equal(t, validate.TrackFailedAttempt(sessionID, nil), 1)
+
+	second := run()
+	assert.Assert(t, strings.Contains(second, skipMsg), "second run must hit the cache, got: %q", second)
+
+	// The hit cleared the counter, so the next failure is attempt 1 again.
+	assert.Equal(t, validate.TrackFailedAttempt(sessionID, nil), 1)
+}
+
 // --- hookResultCache ---
 
 // hookResultCache is the boundary between "these runs are cacheable" and
@@ -236,7 +289,7 @@ func TestHookResultCacheDisabledCases(t *testing.T) {
 			if tt.gitInit {
 				gitSetup(t, dir, "main")
 			}
-			cache, key := hookResultCache(tt.hook, tt.inlineCmd, dir, "", cfg)
+			cache, key := hookResultCache(tt.hook, tt.inlineCmd, dir, "", cfg, "")
 			assert.Assert(t, cache == nil, "expected no cache")
 			assert.Equal(t, key, "")
 		})
@@ -248,9 +301,79 @@ func TestHookResultCacheEnabledForNamedCommand(t *testing.T) {
 	gitSetup(t, dir, "main")
 	cfg := &config.ProjectConfig{Commands: []config.Command{{Name: "test", Run: "go test ./..."}}}
 
-	cache, key := hookResultCache(&hookContext{sessionID: "s1"}, "", dir, "test", cfg)
+	cache, key := hookResultCache(&hookContext{sessionID: "s1"}, "", dir, "test", cfg, "")
 	assert.Assert(t, cache != nil, "expected a cache for a named command in hook mode")
 	assert.Assert(t, key != "")
+}
+
+// TestHookResultCacheTargetAffectsKey pins the wiring: a different execution
+// target has to reach the key, or a run validated on one sidecar reports a hit
+// for another.
+func TestHookResultCacheTargetAffectsKey(t *testing.T) {
+	dir := t.TempDir()
+	gitSetup(t, dir, "main")
+	cfg := &config.ProjectConfig{Commands: []config.Command{{Name: "test", Run: "go test ./..."}}}
+	hook := &hookContext{sessionID: "s1"}
+
+	_, local := hookResultCache(hook, "", dir, "test", cfg, "")
+	_, remote := hookResultCache(hook, "", dir, "test", cfg, "sidecar-a\x00")
+	assert.Assert(t, local != remote, "target must participate in the cache key")
+}
+
+// --- execTarget ---
+
+func TestExecTarget(t *testing.T) {
+	withImage := &config.ProjectConfig{Validation: &config.ValidationConfig{SidecarImage: "snap-1"}}
+
+	tests := []struct {
+		name   string
+		opts   *validateOpts
+		cfg    *config.ProjectConfig
+		active *sidecar.ActiveSidecar
+		want   string
+	}{
+		{name: "local run", opts: &validateOpts{}, cfg: &config.ProjectConfig{}, want: ""},
+		{
+			name: "explicit sidecar id",
+			opts: &validateOpts{sidecarID: "sc-1"},
+			cfg:  &config.ProjectConfig{},
+			want: "sc-1\x00",
+		},
+		{
+			name:   "active sidecar",
+			opts:   &validateOpts{},
+			cfg:    &config.ProjectConfig{},
+			active: &sidecar.ActiveSidecar{SidecarID: "sc-2"},
+			want:   "sc-2\x00",
+		},
+		{
+			name:   "explicit id wins over active",
+			opts:   &validateOpts{sidecarID: "sc-1"},
+			cfg:    &config.ProjectConfig{},
+			active: &sidecar.ActiveSidecar{SidecarID: "sc-2"},
+			want:   "sc-1\x00",
+		},
+		{
+			name: "configured image with no sidecar yet",
+			opts: &validateOpts{},
+			cfg:  withImage,
+			want: "\x00snap-1",
+		},
+		{
+			name:   "image and active sidecar",
+			opts:   &validateOpts{},
+			cfg:    withImage,
+			active: &sidecar.ActiveSidecar{SidecarID: "sc-2"},
+			want:   "sc-2\x00snap-1",
+		},
+		{name: "nil config", opts: &validateOpts{}, cfg: nil, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, execTarget(tt.opts, tt.cfg, tt.active), tt.want)
+		})
+	}
 }
 
 // gitSetup initialises a minimal git repo at dir on the given branch name.

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -210,6 +210,49 @@ func TestValidateEnvFlagBadValue(t *testing.T) {
 	assert.Assert(t, strings.Contains(err.Error(), "BADVALUE"), "got: %v", err)
 }
 
+// --- hookResultCache ---
+
+// hookResultCache is the boundary between "these runs are cacheable" and
+// "these are not"; each guard below must return no cache so the run always
+// executes.
+func TestHookResultCacheDisabledCases(t *testing.T) {
+	cfg := &config.ProjectConfig{Commands: []config.Command{{Name: "test", Run: "go test ./..."}}}
+	hook := &hookContext{sessionID: "s1"}
+
+	tests := []struct {
+		name      string
+		hook      *hookContext
+		inlineCmd string
+		gitInit   bool
+	}{
+		{name: "not a hook run", hook: nil, gitInit: true},
+		{name: "inline command", hook: hook, inlineCmd: "go test ./foo", gitInit: true},
+		{name: "unusable git state", hook: hook, gitInit: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.gitInit {
+				gitSetup(t, dir, "main")
+			}
+			cache, key := hookResultCache(tt.hook, tt.inlineCmd, dir, "", cfg)
+			assert.Assert(t, cache == nil, "expected no cache")
+			assert.Equal(t, key, "")
+		})
+	}
+}
+
+func TestHookResultCacheEnabledForNamedCommand(t *testing.T) {
+	dir := t.TempDir()
+	gitSetup(t, dir, "main")
+	cfg := &config.ProjectConfig{Commands: []config.Command{{Name: "test", Run: "go test ./..."}}}
+
+	cache, key := hookResultCache(&hookContext{sessionID: "s1"}, "", dir, "test", cfg)
+	assert.Assert(t, cache != nil, "expected a cache for a named command in hook mode")
+	assert.Assert(t, key != "")
+}
+
 // gitSetup initialises a minimal git repo at dir on the given branch name.
 func gitSetup(t *testing.T, dir, branch string) {
 	t.Helper()

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -219,38 +219,74 @@ func TestValidateEnvFlagBadValue(t *testing.T) {
 // by how the run itself ends.
 const activeStopHookPayload = `{"session_id":"test-session-001","stop_hook_active":true}`
 
+// skipMsg is the one line that tells the agent no commands ran.
+const skipMsg = "skipped (no changes since last successful run)"
+
+// runActiveStopHook fires a re-signalled Stop hook against dir and returns what
+// the agent would see, along with the exit error. Unlike runValidateHook it does
+// not assert on the error, so failing runs can be exercised too.
+func runActiveStopHook(t *testing.T, dir string) (stderr string, err error) {
+	t.Helper()
+	var outBuf, errBuf bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetIn(strings.NewReader(activeStopHookPayload))
+	root.SetArgs([]string{"validate", "--project", dir})
+	err = root.Execute()
+	return errBuf.String(), err
+}
+
+// countingCommand returns a command that appends a line to a marker file each
+// time it runs and then exits with code, plus a func reporting how many times it
+// has run. The marker lives outside the repo on purpose: written inside it, every
+// run would change the working-tree digest and a re-run would prove nothing about
+// the cache.
+func countingCommand(t *testing.T, code int) (run string, runs func() int) {
+	t.Helper()
+	marker := filepath.Join(t.TempDir(), "runs")
+	return fmt.Sprintf("echo x >> %s; exit %d", marker, code), func() int {
+		t.Helper()
+		data, err := os.ReadFile(marker)
+		if errors.Is(err, os.ErrNotExist) {
+			return 0
+		}
+		assert.NilError(t, err)
+		return len(strings.Fields(string(data)))
+	}
+}
+
+// hookProject sets up a git repo with one configured command. Saving the config
+// leaves .chunk/ untracked, so the tree is never clean and the hook reaches the
+// cache instead of short-circuiting on the clean-tree check.
+func hookProject(t *testing.T, run string) string {
+	t.Helper()
+	// The attempt counter lives under os.TempDir(); isolate it from other tests
+	// sharing this session ID.
+	t.Setenv("TMPDIR", t.TempDir())
+	dir := t.TempDir()
+	gitSetup(t, dir, "main")
+	assert.NilError(t, config.SaveProjectConfig(dir, &config.ProjectConfig{
+		Commands: []config.Command{{Name: "test", Run: run}},
+	}))
+	return dir
+}
+
 // TestValidateHookCacheHitResetsAttempts covers a Stop hook firing again on a
 // tree that already validated. The commands are skipped, and because a cache hit
 // is a success it must clear the failure counter — otherwise a stale count
 // brings the "ask the user for guidance" bail-out forward by a turn.
 func TestValidateHookCacheHitResetsAttempts(t *testing.T) {
 	isolateConfig(t)
-	// The attempt counter lives under os.TempDir(); isolate it from other tests
-	// sharing this session ID.
-	t.Setenv("TMPDIR", t.TempDir())
 	const sessionID = "test-session-001"
-
-	dir := t.TempDir()
-	gitSetup(t, dir, "main")
-	// Saving the config leaves .chunk/ untracked, so the tree is never clean and
-	// the hook reaches the cache instead of short-circuiting on a clean tree.
-	assert.NilError(t, config.SaveProjectConfig(dir, &config.ProjectConfig{
-		Commands: []config.Command{{Name: "test", Run: "exit 0"}},
-	}))
+	dir := hookProject(t, "exit 0")
 
 	run := func() string {
 		t.Helper()
-		var outBuf, errBuf bytes.Buffer
-		root := NewRootCmd("test")
-		root.SetOut(&outBuf)
-		root.SetErr(&errBuf)
-		root.SetIn(strings.NewReader(activeStopHookPayload))
-		root.SetArgs([]string{"validate", "--project", dir})
-		assert.NilError(t, root.Execute())
-		return errBuf.String()
+		stderr, err := runActiveStopHook(t, dir)
+		assert.NilError(t, err)
+		return stderr
 	}
-
-	const skipMsg = "skipped (no changes since last successful run)"
 
 	first := run()
 	assert.Assert(t, !strings.Contains(first, skipMsg), "first run must execute, got: %q", first)
@@ -263,6 +299,52 @@ func TestValidateHookCacheHitResetsAttempts(t *testing.T) {
 
 	// The hit cleared the counter, so the next failure is attempt 1 again.
 	assert.Equal(t, validate.TrackFailedAttempt(sessionID, nil), 1)
+}
+
+// TestValidateHookFailureIsNotCached is the guarantee the whole cache rests on.
+// If a failing run were ever stored, every later hook invocation on the same tree
+// would print "skipped" and return nil, so the agent would stop with the build
+// broken — and nothing else in the suite would notice.
+func TestValidateHookFailureIsNotCached(t *testing.T) {
+	isolateConfig(t)
+	run, runs := countingCommand(t, 1)
+	dir := hookProject(t, run)
+
+	_, err := runActiveStopHook(t, dir)
+	assert.Assert(t, err != nil, "a failing command must fail the hook")
+	assert.Equal(t, runs(), 1)
+
+	second, err := runActiveStopHook(t, dir)
+	assert.Assert(t, err != nil, "the second run must fail too, not report a hit")
+	assert.Assert(t, !strings.Contains(second, skipMsg),
+		"a failed run must not be cached, got: %q", second)
+	assert.Equal(t, runs(), 2, "the commands must run again after a failure")
+}
+
+// TestValidateHookCacheMissAfterEdit is the other half of the contract: a hit is
+// only correct while the tree is untouched, so an edit between runs has to reach
+// the key and put the commands back on.
+func TestValidateHookCacheMissAfterEdit(t *testing.T) {
+	isolateConfig(t)
+	run, runs := countingCommand(t, 0)
+	dir := hookProject(t, run)
+
+	_, err := runActiveStopHook(t, dir)
+	assert.NilError(t, err)
+	assert.Equal(t, runs(), 1)
+
+	second, err := runActiveStopHook(t, dir)
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(second, skipMsg), "unchanged tree must hit, got: %q", second)
+	assert.Equal(t, runs(), 1, "a cache hit must not execute the commands")
+
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0o644))
+
+	third, err := runActiveStopHook(t, dir)
+	assert.NilError(t, err)
+	assert.Assert(t, !strings.Contains(third, skipMsg),
+		"an edited tree must miss the cache, got: %q", third)
+	assert.Equal(t, runs(), 2, "the commands must run again after an edit")
 }
 
 // --- hookResultCache ---

--- a/internal/filecache/filecache.go
+++ b/internal/filecache/filecache.go
@@ -10,8 +10,11 @@ import (
 
 // FileCache is a generic JSON-on-disk cache keyed by arbitrary strings.
 // Each entry is stored as a single file whose name is the hex-encoded SHA-256
-// of the raw key string. Concurrent writes to the same key are safe: the
-// content-hash naming makes them idempotent (same bytes, same filename).
+// of the raw key string. Concurrent writes to the same key are safe: Put stages
+// the entry in its own temporary file and renames it into place, so a reader
+// sees either the previous entry or a complete new one, never a mixture. Two
+// writers racing on one key both produce valid entries and the last rename
+// wins.
 type FileCache[T any] struct {
 	Dir string
 }
@@ -33,7 +36,9 @@ func (c FileCache[T]) Get(key string) (T, bool) {
 }
 
 // Put writes v to the cache under key, creating Dir and any parent directories
-// as needed. Files are written with mode 0600.
+// as needed. The entry is staged in a temporary file alongside its final path
+// and renamed into place, which is atomic within a single directory. Entries
+// have mode 0600, the mode os.CreateTemp applies and the rename preserves.
 func (c FileCache[T]) Put(key string, v T) error {
 	if err := os.MkdirAll(c.Dir, 0o755); err != nil {
 		return err
@@ -42,7 +47,31 @@ func (c FileCache[T]) Put(key string, v T) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(c.entryPath(key), data, 0o600)
+	f, err := os.CreateTemp(c.Dir, ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	if err := writeAndClose(f, data); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, c.entryPath(key)); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// writeAndClose writes data to f and closes it, returning the first error. The
+// close error matters here: on some filesystems a deferred write only surfaces
+// then, and renaming a short file into place would publish a corrupt entry.
+func writeAndClose(f *os.File, data []byte) error {
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 func (c FileCache[T]) entryPath(key string) string {

--- a/internal/filecache/filecache.go
+++ b/internal/filecache/filecache.go
@@ -1,0 +1,51 @@
+package filecache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// FileCache is a generic JSON-on-disk cache keyed by arbitrary strings.
+// Each entry is stored as a single file whose name is the hex-encoded SHA-256
+// of the raw key string. Concurrent writes to the same key are safe: the
+// content-hash naming makes them idempotent (same bytes, same filename).
+type FileCache[T any] struct {
+	Dir string
+}
+
+// Get returns the cached value for key. Returns the zero value and false on a
+// cache miss or any read/unmarshal error; errors are treated as misses so a
+// corrupt entry never blocks execution.
+func (c FileCache[T]) Get(key string) (T, bool) {
+	var zero T
+	data, err := os.ReadFile(c.entryPath(key))
+	if err != nil {
+		return zero, false
+	}
+	var v T
+	if err := json.Unmarshal(data, &v); err != nil {
+		return zero, false
+	}
+	return v, true
+}
+
+// Put writes v to the cache under key, creating Dir and any parent directories
+// as needed. Files are written with mode 0600.
+func (c FileCache[T]) Put(key string, v T) error {
+	if err := os.MkdirAll(c.Dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(c.entryPath(key), data, 0o600)
+}
+
+func (c FileCache[T]) entryPath(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return filepath.Join(c.Dir, hex.EncodeToString(sum[:])+".json")
+}

--- a/internal/filecache/filecache.go
+++ b/internal/filecache/filecache.go
@@ -6,7 +6,28 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 )
+
+// DefaultMaxAge is how long an entry survives when MaxAge is unset. Keys are
+// content-addressed, so a superseded entry is never read again — it only has to
+// outlive the chance of the caller returning to that exact state.
+const DefaultMaxAge = 7 * 24 * time.Hour
+
+// tmpPrefix marks a staged entry that has not been renamed into place yet, and
+// entrySuffix a published one. Only files matching one of the two are swept, so
+// anything else sharing the directory is left alone.
+const (
+	tmpPrefix   = ".tmp-"
+	entrySuffix = ".json"
+)
+
+// tmpGrace is how long a staged file is left alone before the sweep treats it as
+// orphaned. A staged file whose writer is still running is seconds old, so this
+// only ever collects leftovers from a process that died mid-write. Unlike an
+// entry, an orphan has no value at all, hence the much shorter window.
+const tmpGrace = time.Hour
 
 // FileCache is a generic JSON-on-disk cache keyed by arbitrary strings.
 // Each entry is stored as a single file whose name is the hex-encoded SHA-256
@@ -15,8 +36,16 @@ import (
 // sees either the previous entry or a complete new one, never a mixture. Two
 // writers racing on one key both produce valid entries and the last rename
 // wins.
+//
+// A new key means a new file, and nothing supersedes the entries it replaces, so
+// with content-addressed keys the directory would grow one file per write forever.
+// Put sweeps it; see MaxAge.
 type FileCache[T any] struct {
 	Dir string
+	// MaxAge bounds how long an entry survives after it was written. Zero means
+	// DefaultMaxAge. Nothing switches the sweep off: an unbounded cache
+	// directory is a leak rather than a feature.
+	MaxAge time.Duration
 }
 
 // Get returns the cached value for key. Returns the zero value and false on a
@@ -39,6 +68,9 @@ func (c FileCache[T]) Get(key string) (T, bool) {
 // as needed. The entry is staged in a temporary file alongside its final path
 // and renamed into place, which is atomic within a single directory. Entries
 // have mode 0600, the mode os.CreateTemp applies and the rename preserves.
+//
+// Put then sweeps Dir, so the cache is bounded by writes to it rather than by
+// anyone remembering to clean it out.
 func (c FileCache[T]) Put(key string, v T) error {
 	if err := os.MkdirAll(c.Dir, 0o755); err != nil {
 		return err
@@ -47,7 +79,7 @@ func (c FileCache[T]) Put(key string, v T) error {
 	if err != nil {
 		return err
 	}
-	f, err := os.CreateTemp(c.Dir, ".tmp-*")
+	f, err := os.CreateTemp(c.Dir, tmpPrefix+"*")
 	if err != nil {
 		return err
 	}
@@ -60,7 +92,47 @@ func (c FileCache[T]) Put(key string, v T) error {
 		_ = os.Remove(tmp)
 		return err
 	}
+	c.sweep()
 	return nil
+}
+
+// sweep removes entries older than MaxAge, along with staged files orphaned by a
+// process that died between staging and rename — which is what happens when a
+// Stop hook is interrupted mid-write.
+//
+// Best effort throughout: a failed sweep is not a failed Put, since the entry the
+// caller asked for is already in place. The entry just written is the newest file
+// in the directory, so it always survives.
+func (c FileCache[T]) sweep() {
+	maxAge := c.MaxAge
+	if maxAge <= 0 {
+		maxAge = DefaultMaxAge
+	}
+	entries, err := os.ReadDir(c.Dir)
+	if err != nil {
+		return
+	}
+	now := time.Now()
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() {
+			continue
+		}
+		var cutoff time.Time
+		switch {
+		case strings.HasPrefix(name, tmpPrefix):
+			cutoff = now.Add(-tmpGrace)
+		case strings.HasSuffix(name, entrySuffix):
+			cutoff = now.Add(-maxAge)
+		default:
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(c.Dir, name))
+	}
 }
 
 // writeAndClose writes data to f and closes it, returning the first error. The
@@ -76,5 +148,5 @@ func writeAndClose(f *os.File, data []byte) error {
 
 func (c FileCache[T]) entryPath(key string) string {
 	sum := sha256.Sum256([]byte(key))
-	return filepath.Join(c.Dir, hex.EncodeToString(sum[:])+".json")
+	return filepath.Join(c.Dir, hex.EncodeToString(sum[:])+entrySuffix)
 }

--- a/internal/filecache/filecache_test.go
+++ b/internal/filecache/filecache_test.go
@@ -1,0 +1,73 @@
+package filecache_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/filecache"
+)
+
+type entry struct {
+	Value string `json:"value"`
+}
+
+func TestFileCache_PutAndGet(t *testing.T) {
+	c := filecache.FileCache[entry]{Dir: t.TempDir()}
+
+	assert.NilError(t, c.Put("key1", entry{Value: "hello"}))
+
+	got, ok := c.Get("key1")
+	assert.Assert(t, ok)
+	assert.Equal(t, got.Value, "hello")
+}
+
+func TestFileCache_Miss(t *testing.T) {
+	c := filecache.FileCache[entry]{Dir: t.TempDir()}
+
+	_, ok := c.Get("nonexistent")
+	assert.Assert(t, !ok)
+}
+
+func TestFileCache_CorruptFile_ReportsMiss(t *testing.T) {
+	dir := t.TempDir()
+	c := filecache.FileCache[entry]{Dir: dir}
+
+	assert.NilError(t, c.Put("key1", entry{Value: "ok"}))
+
+	// Find and corrupt the entry file.
+	entries, err := os.ReadDir(dir)
+	assert.NilError(t, err)
+	assert.Equal(t, len(entries), 1)
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, entries[0].Name()), []byte("{bad json"), 0o600))
+
+	_, ok := c.Get("key1")
+	assert.Assert(t, !ok, "corrupt entry should be treated as a miss")
+}
+
+func TestFileCache_DifferentKeys_DifferentEntries(t *testing.T) {
+	c := filecache.FileCache[entry]{Dir: t.TempDir()}
+
+	assert.NilError(t, c.Put("keyA", entry{Value: "a"}))
+	assert.NilError(t, c.Put("keyB", entry{Value: "b"}))
+
+	a, ok := c.Get("keyA")
+	assert.Assert(t, ok)
+	assert.Equal(t, a.Value, "a")
+
+	b, ok := c.Get("keyB")
+	assert.Assert(t, ok)
+	assert.Equal(t, b.Value, "b")
+}
+
+func TestFileCache_CreatesDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "cache")
+	c := filecache.FileCache[entry]{Dir: dir}
+
+	assert.NilError(t, c.Put("k", entry{Value: "v"}))
+
+	_, ok := c.Get("k")
+	assert.Assert(t, ok)
+}

--- a/internal/filecache/filecache_test.go
+++ b/internal/filecache/filecache_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 
@@ -60,6 +61,90 @@ func TestFileCache_DifferentKeys_DifferentEntries(t *testing.T) {
 	b, ok := c.Get("keyB")
 	assert.Assert(t, ok)
 	assert.Equal(t, b.Value, "b")
+}
+
+// backdate rewrites a file's modification time, standing in for an entry written
+// on an earlier day.
+func backdate(t *testing.T, path string, age time.Duration) {
+	t.Helper()
+	when := time.Now().Add(-age)
+	assert.NilError(t, os.Chtimes(path, when, when))
+}
+
+// TestFileCache_Put_SweepsStaleEntries covers the growth that content-addressed
+// keys cause: every new key writes a new file and nothing ever supersedes an old
+// one in place, so without a sweep the directory accumulates one entry per write
+// forever.
+func TestFileCache_Put_SweepsStaleEntries(t *testing.T) {
+	dir := t.TempDir()
+	c := filecache.FileCache[entry]{Dir: dir, MaxAge: 24 * time.Hour}
+
+	assert.NilError(t, c.Put("old", entry{Value: "old"}))
+	entries, err := os.ReadDir(dir)
+	assert.NilError(t, err)
+	assert.Equal(t, len(entries), 1)
+	backdate(t, filepath.Join(dir, entries[0].Name()), 48*time.Hour)
+
+	// The write that follows is what collects it.
+	assert.NilError(t, c.Put("new", entry{Value: "new"}))
+
+	_, ok := c.Get("old")
+	assert.Assert(t, !ok, "an entry past MaxAge must be swept")
+	got, ok := c.Get("new")
+	assert.Assert(t, ok, "the entry just written must survive its own sweep")
+	assert.Equal(t, got.Value, "new")
+}
+
+func TestFileCache_Put_KeepsFreshEntries(t *testing.T) {
+	dir := t.TempDir()
+	c := filecache.FileCache[entry]{Dir: dir, MaxAge: 24 * time.Hour}
+
+	assert.NilError(t, c.Put("keep", entry{Value: "keep"}))
+	assert.NilError(t, c.Put("other", entry{Value: "other"}))
+
+	_, ok := c.Get("keep")
+	assert.Assert(t, ok, "an entry within MaxAge must not be swept")
+}
+
+// TestFileCache_Put_SweepsOrphanedTempFiles covers a write interrupted between
+// staging and rename — an interrupted Stop hook. The staged file is never named
+// as an entry, so nothing would ever look at it again.
+func TestFileCache_Put_SweepsOrphanedTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	c := filecache.FileCache[entry]{Dir: dir}
+
+	orphan := filepath.Join(dir, ".tmp-abandoned")
+	assert.NilError(t, os.WriteFile(orphan, []byte(`{"value":"partial`), 0o600))
+	backdate(t, orphan, 2*time.Hour)
+
+	fresh := filepath.Join(dir, ".tmp-inflight")
+	assert.NilError(t, os.WriteFile(fresh, []byte(`{"value":"partial`), 0o600))
+
+	assert.NilError(t, c.Put("k", entry{Value: "v"}))
+
+	_, err := os.Stat(orphan)
+	assert.Assert(t, os.IsNotExist(err), "an orphaned staged file must be swept")
+	// A staged file from a writer still running is seconds old; sweeping it would
+	// break that concurrent Put.
+	_, err = os.Stat(fresh)
+	assert.NilError(t, err, "a staged file still being written must be left alone")
+}
+
+// TestFileCache_Put_LeavesForeignFilesAlone keeps the sweep to files it owns: the
+// cache directory is shared with nothing today, but deleting an unrecognised file
+// is not a cache's business.
+func TestFileCache_Put_LeavesForeignFilesAlone(t *testing.T) {
+	dir := t.TempDir()
+	c := filecache.FileCache[entry]{Dir: dir, MaxAge: time.Hour}
+
+	foreign := filepath.Join(dir, "README.txt")
+	assert.NilError(t, os.WriteFile(foreign, []byte("notes"), 0o600))
+	backdate(t, foreign, 30*24*time.Hour)
+
+	assert.NilError(t, c.Put("k", entry{Value: "v"}))
+
+	_, err := os.Stat(foreign)
+	assert.NilError(t, err, "a file the cache did not write must be left alone")
 }
 
 func TestFileCache_CreatesDir(t *testing.T) {

--- a/internal/gitutil/fingerprint.go
+++ b/internal/gitutil/fingerprint.go
@@ -1,0 +1,163 @@
+package gitutil
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// maxDigestBytes caps the total file content hashed into one fingerprint.
+// Because the digest enumerates untracked files individually (see Fingerprint),
+// a large un-gitignored tree — a build directory nobody remembered to ignore —
+// would otherwise be re-read on every call. Past the budget fingerprinting
+// fails, and callers fall back to doing the work they would have skipped.
+// A var rather than a const so tests can shrink it.
+var maxDigestBytes int64 = 64 << 20
+
+// Worktree fingerprints the state of a git working tree at a point in time.
+// Two Worktrees with equal Head and Digest describe trees with identical
+// content, so callers can compare one against a previously recorded value to
+// decide whether anything has changed since.
+//
+// The zero Worktree describes no tree at all. It reports the tree as not clean
+// and is refused as a cache key, so a caller holding one falls back to doing
+// whatever work it might otherwise have skipped.
+type Worktree struct {
+	// Head is the SHA of the current HEAD commit.
+	Head string
+	// Digest hashes every path git reports as changed, contents included.
+	Digest string
+	// Clean reports whether git sees no change at all relative to HEAD: nothing
+	// modified, staged, or untracked.
+	Clean bool
+}
+
+// Fingerprint captures the state of the working tree at dir: the HEAD commit
+// plus a digest of the porcelain status entries — which record adds, deletions,
+// renames and mode changes — and the current contents of every changed path.
+//
+// Hashing contents is what makes the fingerprint sensitive to repeated edits.
+// Porcelain output for a modified file is byte-identical before and after a
+// further edit (both report " M path"), so status alone would call the tree
+// unchanged across that edit — exactly the loop a Stop hook runs in.
+//
+// The second return value is false when the tree's state cannot be established:
+// dir is not a repo, the repo has no commits yet, a changed path cannot be read,
+// or the tree exceeds the digest budget. The returned Worktree is then the zero
+// value, which is safe to pass on: no caller can mistake it for a real tree.
+func Fingerprint(dir string) (Worktree, bool) {
+	head, err := HeadRef(dir)
+	if err != nil {
+		return Worktree{}, false
+	}
+	out, ok := gitOut(dir, "rev-parse", "--show-toplevel")
+	if !ok {
+		return Worktree{}, false
+	}
+	root := strings.TrimSpace(out)
+
+	// Porcelain paths are relative to the repo root regardless of dir. -z leaves
+	// exotic paths unquoted so they can be opened, and -uall lists untracked
+	// files individually rather than collapsing them into a single "dir/" entry,
+	// so their contents are hashed too.
+	status, ok := gitOut(dir, "status", "--porcelain", "-z", "-uall")
+	if !ok {
+		return Worktree{}, false
+	}
+
+	digest, ok := digestTree(root, status)
+	if !ok {
+		return Worktree{}, false
+	}
+	return Worktree{Head: head, Digest: digest, Clean: status == ""}, true
+}
+
+// digestTree hashes the porcelain status and the contents of each path it names.
+func digestTree(root, status string) (string, bool) {
+	h := sha256.New()
+	writePart(h, status)
+	remaining := maxDigestBytes
+	for _, rel := range changedPaths(status) {
+		writePart(h, rel)
+		n, ok := hashFile(h, filepath.Join(root, rel), remaining)
+		if !ok {
+			return "", false
+		}
+		remaining -= n
+	}
+	return hex.EncodeToString(h.Sum(nil)), true
+}
+
+// changedPaths extracts the paths from -z porcelain status output. Entries are
+// "XY <path>\x00"; rename and copy entries carry an extra "<origPath>\x00"
+// field that is skipped, since nothing exists under the original name.
+func changedPaths(status string) []string {
+	fields := strings.Split(status, "\x00")
+	var paths []string
+	for i := 0; i < len(fields); i++ {
+		f := fields[i]
+		// Every entry is at least "XY " plus one path character; anything
+		// shorter is the empty string trailing the final separator.
+		if len(f) < 4 {
+			continue
+		}
+		paths = append(paths, f[3:])
+		if f[0] == 'R' || f[0] == 'C' || f[1] == 'R' || f[1] == 'C' {
+			i++
+		}
+	}
+	return paths
+}
+
+// hashFile mixes the contents of path into h as a fixed-width digest, keeping
+// part boundaries unambiguous, and reports how many bytes it read. A missing
+// file is not a failure: deletions and renames are already recorded in the
+// status entry. Anything else — an unreadable file, or a non-regular path such
+// as a dirty submodule — means the digest would not reflect that path's state,
+// so it reports false.
+//
+// A file larger than remaining is refused without being read, so exceeding the
+// digest budget costs a stat rather than a full pass over the file.
+func hashFile(h io.Writer, path string, remaining int64) (int64, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, errors.Is(err, os.ErrNotExist)
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return 0, false
+	}
+	if info.Size() > remaining {
+		return 0, false
+	}
+	fh := sha256.New()
+	n, err := io.Copy(fh, f)
+	if err != nil {
+		return 0, false
+	}
+	_, _ = h.Write(fh.Sum(nil))
+	return n, true
+}
+
+// writePart mixes s into h length-prefixed, so that concatenations of different
+// parts cannot collide (["ab","c"] and ["a","bc"] hash differently).
+func writePart(h io.Writer, s string) {
+	_, _ = fmt.Fprintf(h, "%d:", len(s))
+	_, _ = io.WriteString(h, s)
+}
+
+func gitOut(dir string, args ...string) (string, bool) {
+	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).Output()
+	if err != nil {
+		return "", false
+	}
+	return string(out), true
+}

--- a/internal/gitutil/fingerprint.go
+++ b/internal/gitutil/fingerprint.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/hashutil"
 )
 
 // maxDigestBytes caps the total file content hashed into one fingerprint.
@@ -20,6 +22,21 @@ import (
 // A var rather than a const so tests can shrink it.
 var maxDigestBytes int64 = 64 << 20
 
+// Errors reported by Fingerprint. They name the condition that stopped it,
+// because a caller that silently stops caching for one repo and not another is
+// otherwise impossible to explain: each of these means "this tree cannot be
+// fingerprinted at all", not "nothing has changed".
+var (
+	// ErrNotRegularFile reports a changed path that is neither a regular file
+	// nor absent — most often a dirty submodule, whose state lives in another
+	// repository and so cannot be hashed from here.
+	ErrNotRegularFile = errors.New("changed path is not a regular file")
+	// ErrDigestBudget reports that the changed files total more than the digest
+	// budget, the point past which hashing them costs more than whatever the
+	// caller would have skipped.
+	ErrDigestBudget = errors.New("changed files exceed the digest budget")
+)
+
 // Worktree fingerprints the state of a git working tree at a point in time.
 // Two Worktrees with equal Head and Digest describe trees with identical
 // content, so callers can compare one against a previously recorded value to
@@ -27,7 +44,8 @@ var maxDigestBytes int64 = 64 << 20
 //
 // The zero Worktree describes no tree at all. It reports the tree as not clean
 // and is refused as a cache key, so a caller holding one falls back to doing
-// whatever work it might otherwise have skipped.
+// whatever work it might otherwise have skipped. Fingerprint returns it
+// alongside an error saying which condition made the tree unfingerprintable.
 type Worktree struct {
 	// Head is the SHA of the current HEAD commit.
 	Head string
@@ -47,18 +65,18 @@ type Worktree struct {
 // further edit (both report " M path"), so status alone would call the tree
 // unchanged across that edit — exactly the loop a Stop hook runs in.
 //
-// The second return value is false when the tree's state cannot be established:
-// dir is not a repo, the repo has no commits yet, a changed path cannot be read,
-// or the tree exceeds the digest budget. The returned Worktree is then the zero
-// value, which is safe to pass on: no caller can mistake it for a real tree.
-func Fingerprint(dir string) (Worktree, bool) {
+// The error is non-nil when the tree's state cannot be established: dir is not a
+// repo, the repo has no commits yet, a changed path cannot be read, or the tree
+// exceeds the digest budget. The returned Worktree is then the zero value, which
+// is safe to pass on: no caller can mistake it for a real tree.
+func Fingerprint(dir string) (Worktree, error) {
 	head, err := HeadRef(dir)
 	if err != nil {
-		return Worktree{}, false
+		return Worktree{}, fmt.Errorf("resolve HEAD: %w", err)
 	}
-	out, ok := gitOut(dir, "rev-parse", "--show-toplevel")
-	if !ok {
-		return Worktree{}, false
+	out, err := gitOut(dir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return Worktree{}, fmt.Errorf("resolve repo root: %w", err)
 	}
 	root := strings.TrimSpace(out)
 
@@ -66,32 +84,32 @@ func Fingerprint(dir string) (Worktree, bool) {
 	// exotic paths unquoted so they can be opened, and -uall lists untracked
 	// files individually rather than collapsing them into a single "dir/" entry,
 	// so their contents are hashed too.
-	status, ok := gitOut(dir, "status", "--porcelain", "-z", "-uall")
-	if !ok {
-		return Worktree{}, false
+	status, err := gitOut(dir, "status", "--porcelain", "-z", "-uall")
+	if err != nil {
+		return Worktree{}, fmt.Errorf("read git status: %w", err)
 	}
 
-	digest, ok := digestTree(root, status)
-	if !ok {
-		return Worktree{}, false
+	digest, err := digestTree(root, status)
+	if err != nil {
+		return Worktree{}, err
 	}
-	return Worktree{Head: head, Digest: digest, Clean: status == ""}, true
+	return Worktree{Head: head, Digest: digest, Clean: status == ""}, nil
 }
 
 // digestTree hashes the porcelain status and the contents of each path it names.
-func digestTree(root, status string) (string, bool) {
+func digestTree(root, status string) (string, error) {
 	h := sha256.New()
-	writePart(h, status)
+	hashutil.WritePart(h, status)
 	remaining := maxDigestBytes
 	for _, rel := range changedPaths(status) {
-		writePart(h, rel)
-		n, ok := hashFile(h, filepath.Join(root, rel), remaining)
-		if !ok {
-			return "", false
+		hashutil.WritePart(h, rel)
+		n, err := hashFile(h, filepath.Join(root, rel), remaining)
+		if err != nil {
+			return "", fmt.Errorf("hash %s: %w", rel, err)
 		}
 		remaining -= n
 	}
-	return hex.EncodeToString(h.Sum(nil)), true
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // changedPaths extracts the paths from -z porcelain status output. Entries are
@@ -120,44 +138,43 @@ func changedPaths(status string) []string {
 // file is not a failure: deletions and renames are already recorded in the
 // status entry. Anything else — an unreadable file, or a non-regular path such
 // as a dirty submodule — means the digest would not reflect that path's state,
-// so it reports false.
+// so it reports an error naming the condition.
 //
 // A file larger than remaining is refused without being read, so exceeding the
 // digest budget costs a stat rather than a full pass over the file.
-func hashFile(h io.Writer, path string, remaining int64) (int64, bool) {
+func hashFile(h io.Writer, path string, remaining int64) (int64, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return 0, errors.Is(err, os.ErrNotExist)
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
 	}
 	defer func() { _ = f.Close() }()
 
 	info, err := f.Stat()
-	if err != nil || !info.Mode().IsRegular() {
-		return 0, false
+	if err != nil {
+		return 0, err
+	}
+	if !info.Mode().IsRegular() {
+		return 0, ErrNotRegularFile
 	}
 	if info.Size() > remaining {
-		return 0, false
+		return 0, ErrDigestBudget
 	}
 	fh := sha256.New()
 	n, err := io.Copy(fh, f)
 	if err != nil {
-		return 0, false
+		return 0, err
 	}
 	_, _ = h.Write(fh.Sum(nil))
-	return n, true
+	return n, nil
 }
 
-// writePart mixes s into h length-prefixed, so that concatenations of different
-// parts cannot collide (["ab","c"] and ["a","bc"] hash differently).
-func writePart(h io.Writer, s string) {
-	_, _ = fmt.Fprintf(h, "%d:", len(s))
-	_, _ = io.WriteString(h, s)
-}
-
-func gitOut(dir string, args ...string) (string, bool) {
+func gitOut(dir string, args ...string) (string, error) {
 	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).Output()
 	if err != nil {
-		return "", false
+		return "", err
 	}
-	return string(out), true
+	return string(out), nil
 }

--- a/internal/gitutil/fingerprint_test.go
+++ b/internal/gitutil/fingerprint_test.go
@@ -1,6 +1,7 @@
 package gitutil
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,8 +13,8 @@ import (
 // fingerprint asserts the tree could be fingerprinted and returns it.
 func fingerprint(t *testing.T, dir string) Worktree {
 	t.Helper()
-	wt, ok := Fingerprint(dir)
-	assert.Assert(t, ok, "expected a usable fingerprint for %s", dir)
+	wt, err := Fingerprint(dir)
+	assert.NilError(t, err)
 	return wt
 }
 
@@ -45,8 +46,8 @@ func TestFingerprintUntrackedFileIsNotClean(t *testing.T) {
 // open: a directory with no git state yields the zero Worktree, which reports
 // the tree as not clean rather than claiming there is nothing to do.
 func TestFingerprintNotARepoIsUnusable(t *testing.T) {
-	wt, ok := Fingerprint(t.TempDir())
-	assert.Assert(t, !ok, "a non-repo dir must not produce a fingerprint")
+	wt, err := Fingerprint(t.TempDir())
+	assert.Assert(t, err != nil, "a non-repo dir must not produce a fingerprint")
 	assert.Equal(t, wt, Worktree{})
 	assert.Equal(t, wt.Clean, false)
 }
@@ -55,8 +56,8 @@ func TestFingerprintRepoWithoutCommitsIsUnusable(t *testing.T) {
 	dir := t.TempDir()
 	gitRun(t, dir, "init")
 
-	wt, ok := Fingerprint(dir)
-	assert.Assert(t, !ok, "a repo with no HEAD must not produce a fingerprint")
+	wt, err := Fingerprint(dir)
+	assert.Assert(t, err != nil, "a repo with no HEAD must not produce a fingerprint")
 	assert.Equal(t, wt, Worktree{})
 }
 
@@ -162,7 +163,8 @@ func TestFingerprintFromSubDirMatchesRepoRoot(t *testing.T) {
 
 // TestFingerprintOversizedWorktreeIsUnusable guards the digest budget: hashing
 // an unbounded amount of content on every call is worse than not fingerprinting
-// at all, so an oversized tree fails like any other unusable state.
+// at all, so an oversized tree fails like any other unusable state. The error
+// has to name the budget, or a repo that silently never caches is undiagnosable.
 func TestFingerprintOversizedWorktreeIsUnusable(t *testing.T) {
 	dir := setupRepo(t)
 
@@ -171,12 +173,52 @@ func TestFingerprintOversizedWorktreeIsUnusable(t *testing.T) {
 	t.Cleanup(func() { maxDigestBytes = original })
 
 	writeFile(t, dir, "small.go", "package p")
-	_, ok := Fingerprint(dir)
-	assert.Assert(t, ok, "a tree within budget must still produce a fingerprint")
+	_, err := Fingerprint(dir)
+	assert.NilError(t, err, "a tree within budget must still produce a fingerprint")
 
 	writeFile(t, dir, "big.go", strings.Repeat("x", 64))
-	_, ok = Fingerprint(dir)
-	assert.Assert(t, !ok, "a tree over the digest budget must not produce a fingerprint")
+	_, err = Fingerprint(dir)
+	assert.Assert(t, errors.Is(err, ErrDigestBudget), "want ErrDigestBudget, got %v", err)
+	assert.Assert(t, strings.Contains(err.Error(), "big.go"),
+		"the error must name the offending path, got %v", err)
+}
+
+// TestFingerprintNonRegularChangedPathIsUnusable covers the condition a repo with
+// a dirty submodule hits: git reports the path as changed, but its state lives in
+// another repository, so hashing it here would produce a digest that does not
+// track it. A directory standing in for the submodule reaches the same branch.
+func TestFingerprintNonRegularChangedPathIsUnusable(t *testing.T) {
+	dir := setupRepo(t)
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
+	// An empty untracked directory is invisible to git status, so give the
+	// submodule stand-in a nested file. With -uall git reports the file, not the
+	// directory, so also stage the directory name as a path git must open.
+	writeFile(t, dir, "sub/.gitkeep", "")
+	gitRun(t, dir, "add", "sub/.gitkeep")
+	gitRun(t, dir, "commit", "-m", "add sub")
+	assert.NilError(t, os.Remove(filepath.Join(dir, "sub", ".gitkeep")))
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "sub", ".gitkeep"), 0o755))
+
+	_, err := Fingerprint(dir)
+	assert.Assert(t, errors.Is(err, ErrNotRegularFile), "want ErrNotRegularFile, got %v", err)
+}
+
+// TestFingerprintUnreadableChangedPathIsUnusable is the other half: a changed
+// file whose contents cannot be read leaves the digest blind to it, so the whole
+// fingerprint fails rather than silently omitting the path.
+func TestFingerprintUnreadableChangedPathIsUnusable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores file permissions")
+	}
+	dir := setupRepo(t)
+	writeFile(t, dir, "secret.go", "package p\n")
+	assert.NilError(t, os.Chmod(filepath.Join(dir, "secret.go"), 0o000))
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(dir, "secret.go"), 0o644) })
+
+	_, err := Fingerprint(dir)
+	assert.Assert(t, err != nil, "an unreadable changed file must not produce a fingerprint")
+	assert.Assert(t, strings.Contains(err.Error(), "secret.go"),
+		"the error must name the offending path, got %v", err)
 }
 
 func TestFingerprintDeletedFileChangesDigest(t *testing.T) {

--- a/internal/gitutil/fingerprint_test.go
+++ b/internal/gitutil/fingerprint_test.go
@@ -1,0 +1,210 @@
+package gitutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// fingerprint asserts the tree could be fingerprinted and returns it.
+func fingerprint(t *testing.T, dir string) Worktree {
+	t.Helper()
+	wt, ok := Fingerprint(dir)
+	assert.Assert(t, ok, "expected a usable fingerprint for %s", dir)
+	return wt
+}
+
+// writeFile writes content to dir/rel, failing the test on error.
+func writeFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, rel), []byte(content), 0o644))
+}
+
+func TestFingerprintSameTreeIsStable(t *testing.T) {
+	dir := setupRepo(t)
+	assert.Equal(t, fingerprint(t, dir), fingerprint(t, dir))
+}
+
+func TestFingerprintCleanRepoIsClean(t *testing.T) {
+	wt := fingerprint(t, setupRepo(t))
+	assert.Equal(t, wt.Clean, true)
+}
+
+func TestFingerprintUntrackedFileIsNotClean(t *testing.T) {
+	dir := setupRepo(t)
+	writeFile(t, dir, "dirty.txt", "change")
+
+	wt := fingerprint(t, dir)
+	assert.Equal(t, wt.Clean, false)
+}
+
+// TestFingerprintNotARepoIsUnusable pins the contract callers depend on to fail
+// open: a directory with no git state yields the zero Worktree, which reports
+// the tree as not clean rather than claiming there is nothing to do.
+func TestFingerprintNotARepoIsUnusable(t *testing.T) {
+	wt, ok := Fingerprint(t.TempDir())
+	assert.Assert(t, !ok, "a non-repo dir must not produce a fingerprint")
+	assert.Equal(t, wt, Worktree{})
+	assert.Equal(t, wt.Clean, false)
+}
+
+func TestFingerprintRepoWithoutCommitsIsUnusable(t *testing.T) {
+	dir := t.TempDir()
+	gitRun(t, dir, "init")
+
+	wt, ok := Fingerprint(dir)
+	assert.Assert(t, !ok, "a repo with no HEAD must not produce a fingerprint")
+	assert.Equal(t, wt, Worktree{})
+}
+
+func TestFingerprintUncommittedChangeChangesDigest(t *testing.T) {
+	dir := setupRepo(t)
+	before := fingerprint(t, dir)
+
+	writeFile(t, dir, "new.go", "package p")
+
+	assert.Assert(t, before.Digest != fingerprint(t, dir).Digest,
+		"working tree change must change the digest")
+}
+
+func TestFingerprintNewCommitChangesHead(t *testing.T) {
+	dir := setupRepo(t)
+	before := fingerprint(t, dir)
+
+	writeFile(t, dir, "x.go", "package p")
+	gitRun(t, dir, "add", "x.go")
+	gitRun(t, dir, "commit", "-m", "add x")
+
+	after := fingerprint(t, dir)
+	assert.Assert(t, before.Head != after.Head, "new commit must change HEAD")
+	assert.Equal(t, after.Clean, true)
+}
+
+// TestFingerprintEditAlreadyDirtyFileChangesDigest covers the agent edit loop:
+// "git status --porcelain" reports " M tracked.go" identically before and after
+// a further edit, so a status-only digest would call the tree unchanged and let
+// a caller skip work on the new content.
+func TestFingerprintEditAlreadyDirtyFileChangesDigest(t *testing.T) {
+	dir := setupRepo(t)
+	writeFile(t, dir, "tracked.go", "package p\n")
+	gitRun(t, dir, "add", "tracked.go")
+	gitRun(t, dir, "commit", "-m", "add tracked")
+
+	writeFile(t, dir, "tracked.go", "package p // first edit\n")
+	first := fingerprint(t, dir)
+
+	writeFile(t, dir, "tracked.go", "package p // second edit\n")
+	second := fingerprint(t, dir)
+
+	assert.Assert(t, first.Digest != second.Digest,
+		"editing an already-modified file must change the digest")
+}
+
+// TestFingerprintEditUntrackedFileChangesDigest is the untracked counterpart:
+// "?? new.go" is also stable across edits to that file.
+func TestFingerprintEditUntrackedFileChangesDigest(t *testing.T) {
+	dir := setupRepo(t)
+
+	writeFile(t, dir, "new.go", "package p\n")
+	first := fingerprint(t, dir)
+
+	writeFile(t, dir, "new.go", "package p // edited\n")
+	second := fingerprint(t, dir)
+
+	assert.Assert(t, first.Digest != second.Digest,
+		"editing an untracked file must change the digest")
+}
+
+// TestFingerprintEditFileInUntrackedDirChangesDigest guards the -uall flag:
+// without it git collapses an untracked directory to a single "dir/" entry and
+// the contents of files inside it are never hashed.
+func TestFingerprintEditFileInUntrackedDirChangesDigest(t *testing.T) {
+	dir := setupRepo(t)
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "pkg"), 0o755))
+
+	writeFile(t, dir, "pkg/new.go", "package pkg\n")
+	first := fingerprint(t, dir)
+
+	writeFile(t, dir, "pkg/new.go", "package pkg // edited\n")
+	second := fingerprint(t, dir)
+
+	assert.Assert(t, first.Digest != second.Digest,
+		"editing a file in an untracked dir must change the digest")
+}
+
+func TestFingerprintStagedChangeChangesDigest(t *testing.T) {
+	dir := setupRepo(t)
+	writeFile(t, dir, "tracked.go", "package p\n")
+	gitRun(t, dir, "add", "tracked.go")
+	gitRun(t, dir, "commit", "-m", "add tracked")
+
+	before := fingerprint(t, dir)
+
+	writeFile(t, dir, "tracked.go", "package p // edited\n")
+	gitRun(t, dir, "add", "tracked.go")
+
+	assert.Assert(t, before.Digest != fingerprint(t, dir).Digest,
+		"staged change must change the digest")
+}
+
+func TestFingerprintFromSubDirMatchesRepoRoot(t *testing.T) {
+	// Porcelain paths are repo-root-relative, so a run from a subdirectory must
+	// still hash the same working tree rather than failing to open any path.
+	dir := setupRepo(t)
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
+	writeFile(t, dir, "dirty.go", "package p\n")
+
+	assert.Equal(t, fingerprint(t, dir), fingerprint(t, filepath.Join(dir, "sub")))
+}
+
+// TestFingerprintOversizedWorktreeIsUnusable guards the digest budget: hashing
+// an unbounded amount of content on every call is worse than not fingerprinting
+// at all, so an oversized tree fails like any other unusable state.
+func TestFingerprintOversizedWorktreeIsUnusable(t *testing.T) {
+	dir := setupRepo(t)
+
+	original := maxDigestBytes
+	maxDigestBytes = 16
+	t.Cleanup(func() { maxDigestBytes = original })
+
+	writeFile(t, dir, "small.go", "package p")
+	_, ok := Fingerprint(dir)
+	assert.Assert(t, ok, "a tree within budget must still produce a fingerprint")
+
+	writeFile(t, dir, "big.go", strings.Repeat("x", 64))
+	_, ok = Fingerprint(dir)
+	assert.Assert(t, !ok, "a tree over the digest budget must not produce a fingerprint")
+}
+
+func TestFingerprintDeletedFileChangesDigest(t *testing.T) {
+	dir := setupRepo(t)
+	writeFile(t, dir, "tracked.go", "package p\n")
+	gitRun(t, dir, "add", "tracked.go")
+	gitRun(t, dir, "commit", "-m", "add tracked")
+
+	before := fingerprint(t, dir)
+
+	assert.NilError(t, os.Remove(filepath.Join(dir, "tracked.go")))
+
+	// A deletion is recorded by the status entry; the missing file must not be
+	// treated as an error that makes the whole tree unusable.
+	assert.Assert(t, before.Digest != fingerprint(t, dir).Digest,
+		"deletion must change the digest")
+}
+
+func TestFingerprintRenamedFileChangesDigest(t *testing.T) {
+	dir := setupRepo(t)
+	writeFile(t, dir, "old.go", "package p\n")
+	gitRun(t, dir, "add", "old.go")
+	gitRun(t, dir, "commit", "-m", "add old")
+
+	before := fingerprint(t, dir)
+
+	gitRun(t, dir, "mv", "old.go", "new.go")
+
+	assert.Assert(t, before.Digest != fingerprint(t, dir).Digest,
+		"rename must change the digest")
+}

--- a/internal/hashutil/hashutil.go
+++ b/internal/hashutil/hashutil.go
@@ -1,0 +1,28 @@
+// Package hashutil builds digests out of string parts without boundary
+// collisions. Cache keys are assembled from several independent values, so the
+// hash has to distinguish where one value ends and the next begins.
+package hashutil
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+)
+
+// WritePart mixes s into h length-prefixed, so that concatenations of different
+// parts cannot collide (["ab","c"] and ["a","bc"] hash differently).
+func WritePart(h io.Writer, s string) {
+	_, _ = fmt.Fprintf(h, "%d:", len(s))
+	_, _ = io.WriteString(h, s)
+}
+
+// SumParts returns the hex-encoded SHA-256 of parts, each mixed in with
+// WritePart so the split between them is part of the digest.
+func SumParts(parts ...string) string {
+	h := sha256.New()
+	for _, p := range parts {
+		WritePart(h, p)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/hashutil/hashutil_test.go
+++ b/internal/hashutil/hashutil_test.go
@@ -1,0 +1,26 @@
+package hashutil_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/hashutil"
+)
+
+func TestSumPartsSameInputsEqual(t *testing.T) {
+	assert.Equal(t, hashutil.SumParts("a", "b"), hashutil.SumParts("a", "b"))
+}
+
+// TestSumPartsBoundaryCollision is the property the length prefix exists for:
+// without it these two splits would concatenate to the same bytes, so two
+// different cache keys would share an entry.
+func TestSumPartsBoundaryCollision(t *testing.T) {
+	assert.Assert(t, hashutil.SumParts("ab", "c") != hashutil.SumParts("a", "bc"),
+		"different part splits must produce different digests")
+}
+
+func TestSumPartsEmptyPartCounts(t *testing.T) {
+	assert.Assert(t, hashutil.SumParts("", "a") != hashutil.SumParts("a"),
+		"an empty part must still change the digest")
+}

--- a/internal/validate/cache.go
+++ b/internal/validate/cache.go
@@ -4,26 +4,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 )
-
-// maxDigestBytes caps the total file content hashed into one working-tree
-// digest. Because the digest enumerates untracked files individually (see
-// worktreeDigest), a large un-gitignored tree — a build directory nobody
-// remembered to ignore — would otherwise be re-read on every hook invocation.
-// Past the budget the digest fails closed: no key, no cache, commands run.
-// A var rather than a const so tests can shrink it.
-var maxDigestBytes int64 = 64 << 20
 
 // ResultCache is a read/write store for validate run outcomes.
 type ResultCache interface {
@@ -53,12 +40,11 @@ func CacheKey(name string, parts ...string) string {
 	return name + "\x00" + hex.EncodeToString(h.Sum(nil))
 }
 
-// CacheKeyInputs collects everything outside the working tree that can change
-// the outcome of a validate run.
+// CacheKeyInputs collects the working-tree fingerprint plus everything outside
+// the tree that can change the outcome of a validate run.
 type CacheKeyInputs struct {
-	// WorkDir is the directory the run was invoked from; git state is resolved
-	// relative to it.
-	WorkDir string
+	// Worktree fingerprints the tree the run will validate.
+	Worktree gitutil.Worktree
 	// CommandName is the single command being run, or "" when all commands run.
 	CommandName string
 	// Commands is the configured command set.
@@ -70,123 +56,28 @@ type CacheKeyInputs struct {
 	Target string
 }
 
-// BuildCacheKey constructs the cache key for a validate run from the serialized
-// commands, the execution target, the HEAD commit SHA, and a digest of the
-// working tree.
+// BuildCacheKey constructs the cache key for a validate run from the working-tree
+// fingerprint, the serialized commands, and the execution target.
 //
-// The second return value is false when the git state cannot be established
-// (not a repo, no commits yet, a changed path that cannot be read, or a working
-// tree too large to hash within maxDigestBytes). Callers must not read or write
-// the cache in that case: with no trustworthy git state the key would depend
-// only on the config and would therefore stay stable across code changes,
-// turning every subsequent run into a false cache hit.
+// The second return value is false when the fingerprint is the zero Worktree —
+// gitutil.Fingerprint could not establish the tree's state — or the commands
+// cannot be serialized. Callers must not read or write the cache in that case:
+// with no trustworthy git state the key would depend only on the config and
+// would therefore stay stable across code changes, turning every subsequent run
+// into a false cache hit.
 func BuildCacheKey(in CacheKeyInputs) (string, bool) {
-	head, err := gitutil.HeadRef(in.WorkDir)
-	if err != nil {
-		return "", false
-	}
-	tree, ok := worktreeDigest(in.WorkDir)
-	if !ok {
+	if in.Worktree.Head == "" || in.Worktree.Digest == "" {
 		return "", false
 	}
 	cfgBytes, err := json.Marshal(in.Commands)
 	if err != nil {
 		return "", false
 	}
-	return CacheKey(in.CommandName, sha256hex(cfgBytes), in.Target, head, tree), true
+	return CacheKey(in.CommandName, sha256hex(cfgBytes), in.Target, in.Worktree.Head, in.Worktree.Digest), true
 }
 
-// worktreeDigest hashes the state of every path git reports as changed: the
-// porcelain status entries, which record adds, deletions, renames and mode
-// changes, plus the current contents of each changed path.
-//
-// Hashing contents is what makes the key sensitive to repeated edits. Porcelain
-// output for a modified file is byte-identical before and after a further edit
-// (both report " M path"), so status alone would let the second edit reuse the
-// first run's result — exactly the loop a Stop hook runs in.
-func worktreeDigest(workDir string) (string, bool) {
-	out, ok := gitOut(workDir, "rev-parse", "--show-toplevel")
-	if !ok {
-		return "", false
-	}
-	root := strings.TrimSpace(out)
-
-	// Porcelain paths are relative to the repo root regardless of workDir. -z
-	// leaves exotic paths unquoted so they can be opened, and -uall lists
-	// untracked files individually rather than collapsing them into a single
-	// "dir/" entry, so their contents are hashed too.
-	status, ok := gitOut(workDir, "status", "--porcelain", "-z", "-uall")
-	if !ok {
-		return "", false
-	}
-
-	h := sha256.New()
-	writePart(h, status)
-	remaining := maxDigestBytes
-	for _, rel := range changedPaths(status) {
-		writePart(h, rel)
-		n, ok := hashFile(h, filepath.Join(root, rel), remaining)
-		if !ok {
-			return "", false
-		}
-		remaining -= n
-	}
-	return hex.EncodeToString(h.Sum(nil)), true
-}
-
-// changedPaths extracts the paths from -z porcelain status output. Entries are
-// "XY <path>\x00"; rename and copy entries carry an extra "<origPath>\x00"
-// field that is skipped, since nothing exists under the original name.
-func changedPaths(status string) []string {
-	fields := strings.Split(status, "\x00")
-	var paths []string
-	for i := 0; i < len(fields); i++ {
-		f := fields[i]
-		// Every entry is at least "XY " plus one path character; anything
-		// shorter is the empty string trailing the final separator.
-		if len(f) < 4 {
-			continue
-		}
-		paths = append(paths, f[3:])
-		if f[0] == 'R' || f[0] == 'C' || f[1] == 'R' || f[1] == 'C' {
-			i++
-		}
-	}
-	return paths
-}
-
-// hashFile mixes the contents of path into h as a fixed-width digest, keeping
-// part boundaries unambiguous, and reports how many bytes it read. A missing
-// file is not a failure: deletions and renames are already recorded in the
-// status entry. Anything else — an unreadable file, or a non-regular path such
-// as a dirty submodule — means the digest would not reflect that path's state,
-// so it reports false.
-//
-// A file larger than remaining is refused without being read, so exceeding the
-// digest budget costs a stat rather than a full pass over the file.
-func hashFile(h io.Writer, path string, remaining int64) (int64, bool) {
-	f, err := os.Open(path)
-	if err != nil {
-		return 0, errors.Is(err, os.ErrNotExist)
-	}
-	defer func() { _ = f.Close() }()
-
-	info, err := f.Stat()
-	if err != nil || !info.Mode().IsRegular() {
-		return 0, false
-	}
-	if info.Size() > remaining {
-		return 0, false
-	}
-	fh := sha256.New()
-	n, err := io.Copy(fh, f)
-	if err != nil {
-		return 0, false
-	}
-	_, _ = h.Write(fh.Sum(nil))
-	return n, true
-}
-
+// writePart mixes s into h length-prefixed, so that concatenations of different
+// parts cannot collide.
 func writePart(h io.Writer, s string) {
 	_, _ = fmt.Fprintf(h, "%d:", len(s))
 	_, _ = io.WriteString(h, s)
@@ -195,13 +86,4 @@ func writePart(h io.Writer, s string) {
 func sha256hex(b []byte) string {
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:])
-}
-
-func gitOut(workDir string, args ...string) (string, bool) {
-	cmdArgs := append([]string{"-C", workDir}, args...)
-	out, err := exec.Command("git", cmdArgs...).Output()
-	if err != nil {
-		return "", false
-	}
-	return string(out), true
 }

--- a/internal/validate/cache.go
+++ b/internal/validate/cache.go
@@ -4,11 +4,16 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
 )
 
 // ResultCache is a read/write store for validate run outcomes.
@@ -30,24 +35,118 @@ type CachedResult struct {
 func CacheKey(name string, parts ...string) string {
 	h := sha256.New()
 	for _, p := range parts {
-		_, _ = fmt.Fprintf(h, "%d:", len(p))
-		_, _ = io.WriteString(h, p)
+		writePart(h, p)
 	}
 	return name + "\x00" + hex.EncodeToString(h.Sum(nil))
 }
 
-// BuildCacheKey constructs the cache key for a validate run. It hashes the
-// serialized commands, the HEAD commit SHA, and the working-tree status so
-// the key changes whenever code or configuration changes.
+// BuildCacheKey constructs the cache key for a validate run from the
+// serialized commands, the HEAD commit SHA, and a digest of the working tree.
 // commandName is "" when all commands are run.
-func BuildCacheKey(workDir, commandName string, commands any) string {
-	cfgBytes, _ := json.Marshal(commands)
-	return CacheKey(
-		commandName,
-		sha256hex(cfgBytes),
-		strings.TrimSpace(gitOut(workDir, "rev-parse", "HEAD")),
-		sha256hex([]byte(gitOut(workDir, "status", "--porcelain"))),
-	)
+//
+// The second return value is false when the git state cannot be established
+// (not a repo, no commits yet, or a changed path that cannot be read). Callers
+// must not read or write the cache in that case: with no trustworthy git state
+// the key would depend only on the config and would therefore stay stable
+// across code changes, turning every subsequent run into a false cache hit.
+func BuildCacheKey(workDir, commandName string, commands []config.Command) (string, bool) {
+	head, ok := gitOut(workDir, "rev-parse", "HEAD")
+	if !ok {
+		return "", false
+	}
+	tree, ok := worktreeDigest(workDir)
+	if !ok {
+		return "", false
+	}
+	cfgBytes, err := json.Marshal(commands)
+	if err != nil {
+		return "", false
+	}
+	return CacheKey(commandName, sha256hex(cfgBytes), strings.TrimSpace(head), tree), true
+}
+
+// worktreeDigest hashes the state of every path git reports as changed: the
+// porcelain status entries, which record adds, deletions, renames and mode
+// changes, plus the current contents of each changed path.
+//
+// Hashing contents is what makes the key sensitive to repeated edits. Porcelain
+// output for a modified file is byte-identical before and after a further edit
+// (both report " M path"), so status alone would let the second edit reuse the
+// first run's result — exactly the loop a Stop hook runs in.
+func worktreeDigest(workDir string) (string, bool) {
+	root, ok := gitOut(workDir, "rev-parse", "--show-toplevel")
+	if !ok {
+		return "", false
+	}
+
+	// Porcelain paths are relative to the repo root regardless of workDir. -z
+	// leaves exotic paths unquoted so they can be opened, and -uall lists
+	// untracked files individually rather than collapsing them into a single
+	// "dir/" entry, so their contents are hashed too.
+	status, ok := gitOut(workDir, "status", "--porcelain", "-z", "-uall")
+	if !ok {
+		return "", false
+	}
+
+	h := sha256.New()
+	writePart(h, status)
+	for _, rel := range changedPaths(status) {
+		writePart(h, rel)
+		if !hashFile(h, filepath.Join(strings.TrimSpace(root), rel)) {
+			return "", false
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil)), true
+}
+
+// changedPaths extracts the paths from -z porcelain status output. Entries are
+// "XY <path>\x00"; rename and copy entries carry an extra "<origPath>\x00"
+// field that is skipped, since nothing exists under the original name.
+func changedPaths(status string) []string {
+	fields := strings.Split(status, "\x00")
+	var paths []string
+	for i := 0; i < len(fields); i++ {
+		f := fields[i]
+		// Every entry is at least "XY " plus one path character; anything
+		// shorter is the empty string trailing the final separator.
+		if len(f) < 4 {
+			continue
+		}
+		paths = append(paths, f[3:])
+		if f[0] == 'R' || f[0] == 'C' || f[1] == 'R' || f[1] == 'C' {
+			i++
+		}
+	}
+	return paths
+}
+
+// hashFile mixes the contents of path into h as a fixed-width digest, keeping
+// part boundaries unambiguous. A missing file is not a failure: deletions and
+// renames are already recorded in the status entry. Anything else — an
+// unreadable file, or a non-regular path such as a dirty submodule — means the
+// digest would not reflect that path's state, so it reports false.
+func hashFile(h io.Writer, path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return errors.Is(err, os.ErrNotExist)
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	fh := sha256.New()
+	if _, err := io.Copy(fh, f); err != nil {
+		return false
+	}
+	_, _ = h.Write(fh.Sum(nil))
+	return true
+}
+
+func writePart(h io.Writer, s string) {
+	_, _ = fmt.Fprintf(h, "%d:", len(s))
+	_, _ = io.WriteString(h, s)
 }
 
 func sha256hex(b []byte) string {
@@ -55,11 +154,11 @@ func sha256hex(b []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func gitOut(workDir string, args ...string) string {
+func gitOut(workDir string, args ...string) (string, bool) {
 	cmdArgs := append([]string{"-C", workDir}, args...)
 	out, err := exec.Command("git", cmdArgs...).Output()
 	if err != nil {
-		return ""
+		return "", false
 	}
-	return string(out)
+	return string(out), true
 }

--- a/internal/validate/cache.go
+++ b/internal/validate/cache.go
@@ -1,37 +1,30 @@
 package validate
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
-	"fmt"
-	"io"
 	"time"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
+	"github.com/CircleCI-Public/chunk-cli/internal/hashutil"
 )
 
 // CachedResult records the timestamp of a successful validate run. Only
 // successful runs are cached; failures are never stored so the agent always
 // retries after a fix, even when the working tree has not changed.
 //
-// CachedAt is informational: presence of the entry is what marks a run as
-// successful, and nothing currently reads the timestamp. It exists as a
-// debugging breadcrumb and a hook for a future TTL.
+// CachedAt is a debugging breadcrumb: presence of the entry is what marks a run
+// as successful, and expiry works off the entry file's modification time, which
+// records the same instant. It is here so a cache directory can be read by eye.
 type CachedResult struct {
 	CachedAt time.Time `json:"cached_at"`
 }
 
-// CacheKey builds a content-addressed key from a name and ordered content
-// parts. Parts are length-prefixed before hashing to prevent boundary
-// collisions (["ab","c"] and ["a","bc"] produce different keys).
-func CacheKey(name string, parts ...string) string {
-	h := sha256.New()
-	for _, p := range parts {
-		writePart(h, p)
-	}
-	return name + "\x00" + hex.EncodeToString(h.Sum(nil))
+// cacheKey builds a content-addressed key from a name and ordered content parts.
+// The name stays in the clear so entries can be told apart by eye; everything
+// else is hashed.
+func cacheKey(name string, parts ...string) string {
+	return name + "\x00" + hashutil.SumParts(parts...)
 }
 
 // CacheKeyInputs collects the working-tree fingerprint plus everything outside
@@ -41,8 +34,11 @@ type CacheKeyInputs struct {
 	Worktree gitutil.Worktree
 	// CommandName is the single command being run, or "" when all commands run.
 	CommandName string
-	// Commands is the configured command set.
-	Commands []config.Command
+	// Config is the project config driving the run, hashed whole. The commands
+	// are the obvious input, but the environment block decides what those
+	// commands run against, and a project that gitignores .chunk/ gets no
+	// invalidation from the working-tree digest when any of it changes.
+	Config *config.ProjectConfig
 	// Target identifies where the commands execute: "" for a local run,
 	// otherwise an opaque description of the sidecar. Sidecar routing depends on
 	// mutable state outside the repo, so it has to participate in the key — a
@@ -51,33 +47,21 @@ type CacheKeyInputs struct {
 }
 
 // BuildCacheKey constructs the cache key for a validate run from the working-tree
-// fingerprint, the serialized commands, and the execution target.
+// fingerprint, the serialized project config, and the execution target.
 //
 // The second return value is false when the fingerprint is the zero Worktree —
-// gitutil.Fingerprint could not establish the tree's state — or the commands
-// cannot be serialized. Callers must not read or write the cache in that case:
-// with no trustworthy git state the key would depend only on the config and
-// would therefore stay stable across code changes, turning every subsequent run
-// into a false cache hit.
+// gitutil.Fingerprint could not establish the tree's state — or the config cannot
+// be serialized. Callers must not read or write the cache in that case: with no
+// trustworthy git state the key would depend only on the config and would
+// therefore stay stable across code changes, turning every subsequent run into a
+// false cache hit.
 func BuildCacheKey(in CacheKeyInputs) (string, bool) {
 	if in.Worktree.Head == "" || in.Worktree.Digest == "" {
 		return "", false
 	}
-	cfgBytes, err := json.Marshal(in.Commands)
+	cfgBytes, err := json.Marshal(in.Config)
 	if err != nil {
 		return "", false
 	}
-	return CacheKey(in.CommandName, sha256hex(cfgBytes), in.Target, in.Worktree.Head, in.Worktree.Digest), true
-}
-
-// writePart mixes s into h length-prefixed, so that concatenations of different
-// parts cannot collide.
-func writePart(h io.Writer, s string) {
-	_, _ = fmt.Fprintf(h, "%d:", len(s))
-	_, _ = io.WriteString(h, s)
-}
-
-func sha256hex(b []byte) string {
-	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:])
+	return cacheKey(in.CommandName, string(cfgBytes), in.Target, in.Worktree.Head, in.Worktree.Digest), true
 }

--- a/internal/validate/cache.go
+++ b/internal/validate/cache.go
@@ -1,0 +1,65 @@
+package validate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// ResultCache is a read/write store for validate run outcomes.
+type ResultCache interface {
+	Get(key string) (CachedResult, bool)
+	Put(key string, r CachedResult) error
+}
+
+// CachedResult records the timestamp of a successful validate run. Only
+// successful runs are cached; failures are never stored so the agent always
+// retries after a fix, even when the working tree has not changed.
+type CachedResult struct {
+	CachedAt time.Time `json:"cached_at"`
+}
+
+// CacheKey builds a content-addressed key from a name and ordered content
+// parts. Parts are length-prefixed before hashing to prevent boundary
+// collisions (["ab","c"] and ["a","bc"] produce different keys).
+func CacheKey(name string, parts ...string) string {
+	h := sha256.New()
+	for _, p := range parts {
+		_, _ = fmt.Fprintf(h, "%d:", len(p))
+		_, _ = io.WriteString(h, p)
+	}
+	return name + "\x00" + hex.EncodeToString(h.Sum(nil))
+}
+
+// BuildCacheKey constructs the cache key for a validate run. It hashes the
+// serialized commands, the HEAD commit SHA, and the working-tree status so
+// the key changes whenever code or configuration changes.
+// commandName is "" when all commands are run.
+func BuildCacheKey(workDir, commandName string, commands any) string {
+	cfgBytes, _ := json.Marshal(commands)
+	return CacheKey(
+		commandName,
+		sha256hex(cfgBytes),
+		strings.TrimSpace(gitOut(workDir, "rev-parse", "HEAD")),
+		sha256hex([]byte(gitOut(workDir, "status", "--porcelain"))),
+	)
+}
+
+func sha256hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func gitOut(workDir string, args ...string) string {
+	cmdArgs := append([]string{"-C", workDir}, args...)
+	out, err := exec.Command("git", cmdArgs...).Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}

--- a/internal/validate/cache.go
+++ b/internal/validate/cache.go
@@ -14,7 +14,16 @@ import (
 	"time"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 )
+
+// maxDigestBytes caps the total file content hashed into one working-tree
+// digest. Because the digest enumerates untracked files individually (see
+// worktreeDigest), a large un-gitignored tree — a build directory nobody
+// remembered to ignore — would otherwise be re-read on every hook invocation.
+// Past the budget the digest fails closed: no key, no cache, commands run.
+// A var rather than a const so tests can shrink it.
+var maxDigestBytes int64 = 64 << 20
 
 // ResultCache is a read/write store for validate run outcomes.
 type ResultCache interface {
@@ -25,6 +34,10 @@ type ResultCache interface {
 // CachedResult records the timestamp of a successful validate run. Only
 // successful runs are cached; failures are never stored so the agent always
 // retries after a fix, even when the working tree has not changed.
+//
+// CachedAt is informational: presence of the entry is what marks a run as
+// successful, and nothing currently reads the timestamp. It exists as a
+// debugging breadcrumb and a hook for a future TTL.
 type CachedResult struct {
 	CachedAt time.Time `json:"cached_at"`
 }
@@ -40,29 +53,47 @@ func CacheKey(name string, parts ...string) string {
 	return name + "\x00" + hex.EncodeToString(h.Sum(nil))
 }
 
-// BuildCacheKey constructs the cache key for a validate run from the
-// serialized commands, the HEAD commit SHA, and a digest of the working tree.
-// commandName is "" when all commands are run.
+// CacheKeyInputs collects everything outside the working tree that can change
+// the outcome of a validate run.
+type CacheKeyInputs struct {
+	// WorkDir is the directory the run was invoked from; git state is resolved
+	// relative to it.
+	WorkDir string
+	// CommandName is the single command being run, or "" when all commands run.
+	CommandName string
+	// Commands is the configured command set.
+	Commands []config.Command
+	// Target identifies where the commands execute: "" for a local run,
+	// otherwise an opaque description of the sidecar. Sidecar routing depends on
+	// mutable state outside the repo, so it has to participate in the key — a
+	// working tree validated against one sidecar says nothing about another.
+	Target string
+}
+
+// BuildCacheKey constructs the cache key for a validate run from the serialized
+// commands, the execution target, the HEAD commit SHA, and a digest of the
+// working tree.
 //
 // The second return value is false when the git state cannot be established
-// (not a repo, no commits yet, or a changed path that cannot be read). Callers
-// must not read or write the cache in that case: with no trustworthy git state
-// the key would depend only on the config and would therefore stay stable
-// across code changes, turning every subsequent run into a false cache hit.
-func BuildCacheKey(workDir, commandName string, commands []config.Command) (string, bool) {
-	head, ok := gitOut(workDir, "rev-parse", "HEAD")
-	if !ok {
-		return "", false
-	}
-	tree, ok := worktreeDigest(workDir)
-	if !ok {
-		return "", false
-	}
-	cfgBytes, err := json.Marshal(commands)
+// (not a repo, no commits yet, a changed path that cannot be read, or a working
+// tree too large to hash within maxDigestBytes). Callers must not read or write
+// the cache in that case: with no trustworthy git state the key would depend
+// only on the config and would therefore stay stable across code changes,
+// turning every subsequent run into a false cache hit.
+func BuildCacheKey(in CacheKeyInputs) (string, bool) {
+	head, err := gitutil.HeadRef(in.WorkDir)
 	if err != nil {
 		return "", false
 	}
-	return CacheKey(commandName, sha256hex(cfgBytes), strings.TrimSpace(head), tree), true
+	tree, ok := worktreeDigest(in.WorkDir)
+	if !ok {
+		return "", false
+	}
+	cfgBytes, err := json.Marshal(in.Commands)
+	if err != nil {
+		return "", false
+	}
+	return CacheKey(in.CommandName, sha256hex(cfgBytes), in.Target, head, tree), true
 }
 
 // worktreeDigest hashes the state of every path git reports as changed: the
@@ -74,10 +105,11 @@ func BuildCacheKey(workDir, commandName string, commands []config.Command) (stri
 // (both report " M path"), so status alone would let the second edit reuse the
 // first run's result — exactly the loop a Stop hook runs in.
 func worktreeDigest(workDir string) (string, bool) {
-	root, ok := gitOut(workDir, "rev-parse", "--show-toplevel")
+	out, ok := gitOut(workDir, "rev-parse", "--show-toplevel")
 	if !ok {
 		return "", false
 	}
+	root := strings.TrimSpace(out)
 
 	// Porcelain paths are relative to the repo root regardless of workDir. -z
 	// leaves exotic paths unquoted so they can be opened, and -uall lists
@@ -90,11 +122,14 @@ func worktreeDigest(workDir string) (string, bool) {
 
 	h := sha256.New()
 	writePart(h, status)
+	remaining := maxDigestBytes
 	for _, rel := range changedPaths(status) {
 		writePart(h, rel)
-		if !hashFile(h, filepath.Join(strings.TrimSpace(root), rel)) {
+		n, ok := hashFile(h, filepath.Join(root, rel), remaining)
+		if !ok {
 			return "", false
 		}
+		remaining -= n
 	}
 	return hex.EncodeToString(h.Sum(nil)), true
 }
@@ -121,27 +156,35 @@ func changedPaths(status string) []string {
 }
 
 // hashFile mixes the contents of path into h as a fixed-width digest, keeping
-// part boundaries unambiguous. A missing file is not a failure: deletions and
-// renames are already recorded in the status entry. Anything else — an
-// unreadable file, or a non-regular path such as a dirty submodule — means the
-// digest would not reflect that path's state, so it reports false.
-func hashFile(h io.Writer, path string) bool {
+// part boundaries unambiguous, and reports how many bytes it read. A missing
+// file is not a failure: deletions and renames are already recorded in the
+// status entry. Anything else — an unreadable file, or a non-regular path such
+// as a dirty submodule — means the digest would not reflect that path's state,
+// so it reports false.
+//
+// A file larger than remaining is refused without being read, so exceeding the
+// digest budget costs a stat rather than a full pass over the file.
+func hashFile(h io.Writer, path string, remaining int64) (int64, bool) {
 	f, err := os.Open(path)
 	if err != nil {
-		return errors.Is(err, os.ErrNotExist)
+		return 0, errors.Is(err, os.ErrNotExist)
 	}
 	defer func() { _ = f.Close() }()
 
 	info, err := f.Stat()
 	if err != nil || !info.Mode().IsRegular() {
-		return false
+		return 0, false
+	}
+	if info.Size() > remaining {
+		return 0, false
 	}
 	fh := sha256.New()
-	if _, err := io.Copy(fh, f); err != nil {
-		return false
+	n, err := io.Copy(fh, f)
+	if err != nil {
+		return 0, false
 	}
 	_, _ = h.Write(fh.Sum(nil))
-	return true
+	return n, true
 }
 
 func writePart(h io.Writer, s string) {

--- a/internal/validate/cache.go
+++ b/internal/validate/cache.go
@@ -12,12 +12,6 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 )
 
-// ResultCache is a read/write store for validate run outcomes.
-type ResultCache interface {
-	Get(key string) (CachedResult, bool)
-	Put(key string, r CachedResult) error
-}
-
 // CachedResult records the timestamp of a successful validate run. Only
 // successful runs are cached; failures are never stored so the agent always
 // retries after a fix, even when the working tree has not changed.

--- a/internal/validate/cache_test.go
+++ b/internal/validate/cache_test.go
@@ -41,13 +41,22 @@ func TestCacheKey_EmptyName(t *testing.T) {
 
 // --- BuildCacheKey ---
 
+var testCommands = []config.Command{{Name: "test", Run: "go test ./..."}}
+
+// buildKey asserts the key could be built and returns it.
+func buildKey(t *testing.T, dir, commandName string, cmds []config.Command) string {
+	t.Helper()
+	key, ok := BuildCacheKey(dir, commandName, cmds)
+	assert.Assert(t, ok, "expected a usable cache key")
+	return key
+}
+
 func TestBuildCacheKey_SameInputs_Equal(t *testing.T) {
 	dir := t.TempDir()
 	initGitRepo(t, dir)
 
-	cmds := []config.Command{{Name: "test", Run: "go test ./..."}}
-	a := BuildCacheKey(dir, "", cmds)
-	b := BuildCacheKey(dir, "", cmds)
+	a := buildKey(t, dir, "", testCommands)
+	b := buildKey(t, dir, "", testCommands)
 	assert.Equal(t, a, b)
 }
 
@@ -55,9 +64,8 @@ func TestBuildCacheKey_DifferentCommandName_NotEqual(t *testing.T) {
 	dir := t.TempDir()
 	initGitRepo(t, dir)
 
-	cmds := []config.Command{{Name: "test", Run: "go test ./..."}}
-	all := BuildCacheKey(dir, "", cmds)
-	named := BuildCacheKey(dir, "test", cmds)
+	all := buildKey(t, dir, "", testCommands)
+	named := buildKey(t, dir, "test", testCommands)
 	assert.Assert(t, all != named)
 }
 
@@ -65,37 +73,161 @@ func TestBuildCacheKey_DifferentCommands_NotEqual(t *testing.T) {
 	dir := t.TempDir()
 	initGitRepo(t, dir)
 
-	a := BuildCacheKey(dir, "", []config.Command{{Name: "test", Run: "go test ./..."}})
-	b := BuildCacheKey(dir, "", []config.Command{{Name: "test", Run: "go test -race ./..."}})
+	a := buildKey(t, dir, "", testCommands)
+	b := buildKey(t, dir, "", []config.Command{{Name: "test", Run: "go test -race ./..."}})
 	assert.Assert(t, a != b)
 }
 
 func TestBuildCacheKey_UncommittedChange_NotEqual(t *testing.T) {
 	dir := t.TempDir()
 	initGitRepo(t, dir)
-	cmds := []config.Command{{Name: "test", Run: "go test ./..."}}
 
-	before := BuildCacheKey(dir, "", cmds)
+	before := buildKey(t, dir, "", testCommands)
 
-	assert.NilError(t, os.WriteFile(filepath.Join(dir, "new.go"), []byte("package p"), 0o644))
+	writeFile(t, dir, "new.go", "package p")
 
-	after := BuildCacheKey(dir, "", cmds)
+	after := buildKey(t, dir, "", testCommands)
 	assert.Assert(t, before != after, "working tree change must invalidate key")
 }
 
 func TestBuildCacheKey_NewCommit_NotEqual(t *testing.T) {
 	dir := t.TempDir()
 	initGitRepo(t, dir)
-	cmds := []config.Command{{Name: "test", Run: "go test ./..."}}
 
-	before := BuildCacheKey(dir, "", cmds)
+	before := buildKey(t, dir, "", testCommands)
 
-	assert.NilError(t, os.WriteFile(filepath.Join(dir, "x.go"), []byte("package p"), 0o644))
+	writeFile(t, dir, "x.go", "package p")
 	runCmd(t, dir, "git", "add", "x.go")
 	runCmd(t, dir, "git", "commit", "-m", "add x")
 
-	after := BuildCacheKey(dir, "", cmds)
+	after := buildKey(t, dir, "", testCommands)
 	assert.Assert(t, before != after, "new commit must invalidate key")
+}
+
+// TestBuildCacheKey_EditAlreadyDirtyFile_NotEqual covers the agent edit loop:
+// "git status --porcelain" reports " M tracked.go" identically before and
+// after a further edit, so a status-only key would report a false cache hit and
+// skip validation of the new content.
+func TestBuildCacheKey_EditAlreadyDirtyFile_NotEqual(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "tracked.go", "package p\n")
+	initGitRepo(t, dir)
+
+	writeFile(t, dir, "tracked.go", "package p // first edit\n")
+	first := buildKey(t, dir, "", testCommands)
+
+	writeFile(t, dir, "tracked.go", "package p // second edit\n")
+	second := buildKey(t, dir, "", testCommands)
+
+	assert.Assert(t, first != second, "editing an already-modified file must invalidate key")
+}
+
+// TestBuildCacheKey_EditUntrackedFile_NotEqual is the untracked counterpart:
+// "?? new.go" is also stable across edits to that file.
+func TestBuildCacheKey_EditUntrackedFile_NotEqual(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	writeFile(t, dir, "new.go", "package p\n")
+	first := buildKey(t, dir, "", testCommands)
+
+	writeFile(t, dir, "new.go", "package p // edited\n")
+	second := buildKey(t, dir, "", testCommands)
+
+	assert.Assert(t, first != second, "editing an untracked file must invalidate key")
+}
+
+// TestBuildCacheKey_EditFileInUntrackedDir_NotEqual guards the -uall flag:
+// without it git collapses an untracked directory to a single "dir/" entry and
+// the contents of files inside it are never hashed.
+func TestBuildCacheKey_EditFileInUntrackedDir_NotEqual(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "pkg"), 0o755))
+
+	writeFile(t, dir, "pkg/new.go", "package pkg\n")
+	first := buildKey(t, dir, "", testCommands)
+
+	writeFile(t, dir, "pkg/new.go", "package pkg // edited\n")
+	second := buildKey(t, dir, "", testCommands)
+
+	assert.Assert(t, first != second, "editing a file in an untracked dir must invalidate key")
+}
+
+func TestBuildCacheKey_StagedChange_NotEqual(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "tracked.go", "package p\n")
+	initGitRepo(t, dir)
+
+	before := buildKey(t, dir, "", testCommands)
+
+	writeFile(t, dir, "tracked.go", "package p // edited\n")
+	runCmd(t, dir, "git", "add", "tracked.go")
+
+	after := buildKey(t, dir, "", testCommands)
+	assert.Assert(t, before != after, "staged change must invalidate key")
+}
+
+func TestBuildCacheKey_SubDir_MatchesRepoRoot(t *testing.T) {
+	// Porcelain paths are repo-root-relative, so a run from a subdirectory must
+	// still hash the same working tree rather than failing to open any path.
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
+	writeFile(t, dir, "dirty.go", "package p\n")
+
+	root := buildKey(t, dir, "", testCommands)
+	sub := buildKey(t, filepath.Join(dir, "sub"), "", testCommands)
+	assert.Equal(t, root, sub)
+}
+
+func TestBuildCacheKey_NotARepo_NotOK(t *testing.T) {
+	// No git state means the key would depend only on the config, so it must be
+	// refused rather than returned as a stable key.
+	_, ok := BuildCacheKey(t.TempDir(), "", testCommands)
+	assert.Assert(t, !ok, "non-repo dir must not produce a cache key")
+}
+
+func TestBuildCacheKey_RepoWithoutCommits_NotOK(t *testing.T) {
+	dir := t.TempDir()
+	runCmd(t, dir, "git", "init")
+
+	_, ok := BuildCacheKey(dir, "", testCommands)
+	assert.Assert(t, !ok, "repo with no HEAD must not produce a cache key")
+}
+
+func TestBuildCacheKey_DeletedFile_NotEqual(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "tracked.go", "package p\n")
+	initGitRepo(t, dir)
+
+	before := buildKey(t, dir, "", testCommands)
+
+	assert.NilError(t, os.Remove(filepath.Join(dir, "tracked.go")))
+
+	// A deletion is recorded by the status entry; the missing file must not be
+	// treated as an error that disables caching.
+	after := buildKey(t, dir, "", testCommands)
+	assert.Assert(t, before != after, "deletion must invalidate key")
+}
+
+func TestBuildCacheKey_RenamedFile_NotEqual(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "old.go", "package p\n")
+	initGitRepo(t, dir)
+
+	before := buildKey(t, dir, "", testCommands)
+
+	runCmd(t, dir, "git", "mv", "old.go", "new.go")
+
+	after := buildKey(t, dir, "", testCommands)
+	assert.Assert(t, before != after, "rename must invalidate key")
+}
+
+// writeFile writes content to dir/rel, failing the test on error.
+func writeFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, rel), []byte(content), 0o644))
 }
 
 // runCmd executes a command in dir with git env set, failing the test on error.

--- a/internal/validate/cache_test.go
+++ b/internal/validate/cache_test.go
@@ -1,15 +1,12 @@
 package validate
 
 import (
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 )
 
 // --- CacheKey ---
@@ -44,171 +41,83 @@ func TestCacheKey_EmptyName(t *testing.T) {
 
 var testCommands = []config.Command{{Name: "test", Run: "go test ./..."}}
 
+// testTree is a stand-in for a real fingerprint; gitutil owns the tests that
+// prove a digest actually tracks the working tree.
+var testTree = gitutil.Worktree{Head: "abc123", Digest: "deadbeef"}
+
 // buildKey asserts the key could be built and returns it.
-func buildKey(t *testing.T, dir, commandName string, cmds []config.Command) string {
+func buildKey(t *testing.T, in CacheKeyInputs) string {
 	t.Helper()
-	key, ok := BuildCacheKey(CacheKeyInputs{WorkDir: dir, CommandName: commandName, Commands: cmds})
+	key, ok := BuildCacheKey(in)
 	assert.Assert(t, ok, "expected a usable cache key")
 	return key
 }
 
 func TestBuildCacheKey_SameInputs_Equal(t *testing.T) {
-	dir := t.TempDir()
-	initGitRepo(t, dir)
-
-	a := buildKey(t, dir, "", testCommands)
-	b := buildKey(t, dir, "", testCommands)
-	assert.Equal(t, a, b)
+	in := CacheKeyInputs{Worktree: testTree, Commands: testCommands}
+	assert.Equal(t, buildKey(t, in), buildKey(t, in))
 }
 
 func TestBuildCacheKey_DifferentCommandName_NotEqual(t *testing.T) {
-	dir := t.TempDir()
-	initGitRepo(t, dir)
-
-	all := buildKey(t, dir, "", testCommands)
-	named := buildKey(t, dir, "test", testCommands)
+	all := buildKey(t, CacheKeyInputs{Worktree: testTree, Commands: testCommands})
+	named := buildKey(t, CacheKeyInputs{Worktree: testTree, CommandName: "test", Commands: testCommands})
 	assert.Assert(t, all != named)
 }
 
 func TestBuildCacheKey_DifferentCommands_NotEqual(t *testing.T) {
-	dir := t.TempDir()
-	initGitRepo(t, dir)
-
-	a := buildKey(t, dir, "", testCommands)
-	b := buildKey(t, dir, "", []config.Command{{Name: "test", Run: "go test -race ./..."}})
+	a := buildKey(t, CacheKeyInputs{Worktree: testTree, Commands: testCommands})
+	b := buildKey(t, CacheKeyInputs{
+		Worktree: testTree,
+		Commands: []config.Command{{Name: "test", Run: "go test -race ./..."}},
+	})
 	assert.Assert(t, a != b)
 }
 
-func TestBuildCacheKey_UncommittedChange_NotEqual(t *testing.T) {
-	dir := t.TempDir()
-	initGitRepo(t, dir)
+// TestBuildCacheKey_DifferentWorktree_NotEqual pins the wiring that makes the
+// cache safe: both halves of the fingerprint have to reach the key, or a tree
+// that has moved on reports a hit for the run that validated the old one.
+func TestBuildCacheKey_DifferentWorktree_NotEqual(t *testing.T) {
+	base := buildKey(t, CacheKeyInputs{Worktree: testTree, Commands: testCommands})
 
-	before := buildKey(t, dir, "", testCommands)
+	newCommit := testTree
+	newCommit.Head = "def456"
+	edited := testTree
+	edited.Digest = "cafebabe"
 
-	writeFile(t, dir, "new.go", "package p")
-
-	after := buildKey(t, dir, "", testCommands)
-	assert.Assert(t, before != after, "working tree change must invalidate key")
+	assert.Assert(t, base != buildKey(t, CacheKeyInputs{Worktree: newCommit, Commands: testCommands}),
+		"a new HEAD must invalidate the key")
+	assert.Assert(t, base != buildKey(t, CacheKeyInputs{Worktree: edited, Commands: testCommands}),
+		"a changed working tree must invalidate the key")
 }
 
-func TestBuildCacheKey_NewCommit_NotEqual(t *testing.T) {
-	dir := t.TempDir()
-	initGitRepo(t, dir)
+// TestBuildCacheKey_UnusableWorktree_NotOK covers the fail-closed contract: with
+// no trustworthy git state the key would depend only on the config, so it would
+// stay stable across code changes and turn every later run into a false hit.
+func TestBuildCacheKey_UnusableWorktree_NotOK(t *testing.T) {
+	tests := []struct {
+		name string
+		tree gitutil.Worktree
+	}{
+		{name: "zero fingerprint", tree: gitutil.Worktree{}},
+		{name: "no head", tree: gitutil.Worktree{Digest: "deadbeef"}},
+		{name: "no digest", tree: gitutil.Worktree{Head: "abc123"}},
+	}
 
-	before := buildKey(t, dir, "", testCommands)
-
-	writeFile(t, dir, "x.go", "package p")
-	runCmd(t, dir, "git", "add", "x.go")
-	runCmd(t, dir, "git", "commit", "-m", "add x")
-
-	after := buildKey(t, dir, "", testCommands)
-	assert.Assert(t, before != after, "new commit must invalidate key")
-}
-
-// TestBuildCacheKey_EditAlreadyDirtyFile_NotEqual covers the agent edit loop:
-// "git status --porcelain" reports " M tracked.go" identically before and
-// after a further edit, so a status-only key would report a false cache hit and
-// skip validation of the new content.
-func TestBuildCacheKey_EditAlreadyDirtyFile_NotEqual(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, dir, "tracked.go", "package p\n")
-	initGitRepo(t, dir)
-
-	writeFile(t, dir, "tracked.go", "package p // first edit\n")
-	first := buildKey(t, dir, "", testCommands)
-
-	writeFile(t, dir, "tracked.go", "package p // second edit\n")
-	second := buildKey(t, dir, "", testCommands)
-
-	assert.Assert(t, first != second, "editing an already-modified file must invalidate key")
-}
-
-// TestBuildCacheKey_EditUntrackedFile_NotEqual is the untracked counterpart:
-// "?? new.go" is also stable across edits to that file.
-func TestBuildCacheKey_EditUntrackedFile_NotEqual(t *testing.T) {
-	dir := t.TempDir()
-	initGitRepo(t, dir)
-
-	writeFile(t, dir, "new.go", "package p\n")
-	first := buildKey(t, dir, "", testCommands)
-
-	writeFile(t, dir, "new.go", "package p // edited\n")
-	second := buildKey(t, dir, "", testCommands)
-
-	assert.Assert(t, first != second, "editing an untracked file must invalidate key")
-}
-
-// TestBuildCacheKey_EditFileInUntrackedDir_NotEqual guards the -uall flag:
-// without it git collapses an untracked directory to a single "dir/" entry and
-// the contents of files inside it are never hashed.
-func TestBuildCacheKey_EditFileInUntrackedDir_NotEqual(t *testing.T) {
-	dir := t.TempDir()
-	initGitRepo(t, dir)
-	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "pkg"), 0o755))
-
-	writeFile(t, dir, "pkg/new.go", "package pkg\n")
-	first := buildKey(t, dir, "", testCommands)
-
-	writeFile(t, dir, "pkg/new.go", "package pkg // edited\n")
-	second := buildKey(t, dir, "", testCommands)
-
-	assert.Assert(t, first != second, "editing a file in an untracked dir must invalidate key")
-}
-
-func TestBuildCacheKey_StagedChange_NotEqual(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, dir, "tracked.go", "package p\n")
-	initGitRepo(t, dir)
-
-	before := buildKey(t, dir, "", testCommands)
-
-	writeFile(t, dir, "tracked.go", "package p // edited\n")
-	runCmd(t, dir, "git", "add", "tracked.go")
-
-	after := buildKey(t, dir, "", testCommands)
-	assert.Assert(t, before != after, "staged change must invalidate key")
-}
-
-func TestBuildCacheKey_SubDir_MatchesRepoRoot(t *testing.T) {
-	// Porcelain paths are repo-root-relative, so a run from a subdirectory must
-	// still hash the same working tree rather than failing to open any path.
-	dir := t.TempDir()
-	initGitRepo(t, dir)
-	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
-	writeFile(t, dir, "dirty.go", "package p\n")
-
-	root := buildKey(t, dir, "", testCommands)
-	sub := buildKey(t, filepath.Join(dir, "sub"), "", testCommands)
-	assert.Equal(t, root, sub)
-}
-
-func TestBuildCacheKey_NotARepo_NotOK(t *testing.T) {
-	// No git state means the key would depend only on the config, so it must be
-	// refused rather than returned as a stable key.
-	_, ok := BuildCacheKey(CacheKeyInputs{WorkDir: t.TempDir(), Commands: testCommands})
-	assert.Assert(t, !ok, "non-repo dir must not produce a cache key")
-}
-
-func TestBuildCacheKey_RepoWithoutCommits_NotOK(t *testing.T) {
-	dir := t.TempDir()
-	runCmd(t, dir, "git", "init")
-
-	_, ok := BuildCacheKey(CacheKeyInputs{WorkDir: dir, Commands: testCommands})
-	assert.Assert(t, !ok, "repo with no HEAD must not produce a cache key")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := BuildCacheKey(CacheKeyInputs{Worktree: tt.tree, Commands: testCommands})
+			assert.Assert(t, !ok, "an unusable fingerprint must not produce a cache key")
+		})
+	}
 }
 
 // TestBuildCacheKey_DifferentTarget_NotEqual covers switching the active
 // sidecar: the working tree is untouched, so only the target distinguishes a
 // run validated on one sidecar from one that must still be validated on another.
 func TestBuildCacheKey_DifferentTarget_NotEqual(t *testing.T) {
-	dir := t.TempDir()
-	initGitRepo(t, dir)
-
 	key := func(target string) string {
 		t.Helper()
-		k, ok := BuildCacheKey(CacheKeyInputs{WorkDir: dir, Commands: testCommands, Target: target})
-		assert.Assert(t, ok, "expected a usable cache key")
-		return k
+		return buildKey(t, CacheKeyInputs{Worktree: testTree, Commands: testCommands, Target: target})
 	}
 
 	local := key("")
@@ -218,71 +127,4 @@ func TestBuildCacheKey_DifferentTarget_NotEqual(t *testing.T) {
 	assert.Assert(t, local != sidecarA, "local and sidecar runs must not share a key")
 	assert.Assert(t, sidecarA != sidecarB, "different sidecars must not share a key")
 	assert.Equal(t, sidecarA, key("sidecar-a\x00img"))
-}
-
-// TestBuildCacheKey_OversizedWorktree_NotOK guards the digest budget: hashing an
-// unbounded amount of content on every hook invocation is worse than not
-// caching, so an oversized tree fails closed like any other unusable state.
-func TestBuildCacheKey_OversizedWorktree_NotOK(t *testing.T) {
-	dir := t.TempDir()
-	initGitRepo(t, dir)
-
-	original := maxDigestBytes
-	maxDigestBytes = 16
-	t.Cleanup(func() { maxDigestBytes = original })
-
-	writeFile(t, dir, "small.go", "package p")
-	_, ok := BuildCacheKey(CacheKeyInputs{WorkDir: dir, Commands: testCommands})
-	assert.Assert(t, ok, "a tree within budget must still produce a key")
-
-	writeFile(t, dir, "big.go", strings.Repeat("x", 64))
-	_, ok = BuildCacheKey(CacheKeyInputs{WorkDir: dir, Commands: testCommands})
-	assert.Assert(t, !ok, "a tree over the digest budget must not produce a cache key")
-}
-
-func TestBuildCacheKey_DeletedFile_NotEqual(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, dir, "tracked.go", "package p\n")
-	initGitRepo(t, dir)
-
-	before := buildKey(t, dir, "", testCommands)
-
-	assert.NilError(t, os.Remove(filepath.Join(dir, "tracked.go")))
-
-	// A deletion is recorded by the status entry; the missing file must not be
-	// treated as an error that disables caching.
-	after := buildKey(t, dir, "", testCommands)
-	assert.Assert(t, before != after, "deletion must invalidate key")
-}
-
-func TestBuildCacheKey_RenamedFile_NotEqual(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, dir, "old.go", "package p\n")
-	initGitRepo(t, dir)
-
-	before := buildKey(t, dir, "", testCommands)
-
-	runCmd(t, dir, "git", "mv", "old.go", "new.go")
-
-	after := buildKey(t, dir, "", testCommands)
-	assert.Assert(t, before != after, "rename must invalidate key")
-}
-
-// writeFile writes content to dir/rel, failing the test on error.
-func writeFile(t *testing.T, dir, rel, content string) {
-	t.Helper()
-	assert.NilError(t, os.WriteFile(filepath.Join(dir, rel), []byte(content), 0o644))
-}
-
-// runCmd executes a command in dir with git env set, failing the test on error.
-func runCmd(t *testing.T, dir string, name string, args ...string) {
-	t.Helper()
-	cmd := exec.Command(name, args...)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
-		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
-		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
-	)
-	out, err := cmd.CombinedOutput()
-	assert.NilError(t, err, "%s %v: %s", name, args, out)
 }

--- a/internal/validate/cache_test.go
+++ b/internal/validate/cache_test.go
@@ -1,0 +1,112 @@
+package validate
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+)
+
+// --- CacheKey ---
+
+func TestCacheKey_SameName_SameParts_Equal(t *testing.T) {
+	a := CacheKey("cmd", "part1", "part2")
+	b := CacheKey("cmd", "part1", "part2")
+	assert.Equal(t, a, b)
+}
+
+func TestCacheKey_DifferentName_NotEqual(t *testing.T) {
+	a := CacheKey("cmdA", "part1")
+	b := CacheKey("cmdB", "part1")
+	assert.Assert(t, a != b)
+}
+
+func TestCacheKey_BoundaryCollision_NotEqual(t *testing.T) {
+	// Without length-prefixing ["ab","c"] and ["a","bc"] would hash identically.
+	a := CacheKey("cmd", "ab", "c")
+	b := CacheKey("cmd", "a", "bc")
+	assert.Assert(t, a != b, "boundary collision: different part splits must produce different keys")
+}
+
+func TestCacheKey_EmptyName(t *testing.T) {
+	// "" is the commandName for "run all"; must still produce a stable key.
+	a := CacheKey("", "hash1", "sha", "status")
+	b := CacheKey("", "hash1", "sha", "status")
+	assert.Equal(t, a, b)
+}
+
+// --- BuildCacheKey ---
+
+func TestBuildCacheKey_SameInputs_Equal(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	cmds := []config.Command{{Name: "test", Run: "go test ./..."}}
+	a := BuildCacheKey(dir, "", cmds)
+	b := BuildCacheKey(dir, "", cmds)
+	assert.Equal(t, a, b)
+}
+
+func TestBuildCacheKey_DifferentCommandName_NotEqual(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	cmds := []config.Command{{Name: "test", Run: "go test ./..."}}
+	all := BuildCacheKey(dir, "", cmds)
+	named := BuildCacheKey(dir, "test", cmds)
+	assert.Assert(t, all != named)
+}
+
+func TestBuildCacheKey_DifferentCommands_NotEqual(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	a := BuildCacheKey(dir, "", []config.Command{{Name: "test", Run: "go test ./..."}})
+	b := BuildCacheKey(dir, "", []config.Command{{Name: "test", Run: "go test -race ./..."}})
+	assert.Assert(t, a != b)
+}
+
+func TestBuildCacheKey_UncommittedChange_NotEqual(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	cmds := []config.Command{{Name: "test", Run: "go test ./..."}}
+
+	before := BuildCacheKey(dir, "", cmds)
+
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "new.go"), []byte("package p"), 0o644))
+
+	after := BuildCacheKey(dir, "", cmds)
+	assert.Assert(t, before != after, "working tree change must invalidate key")
+}
+
+func TestBuildCacheKey_NewCommit_NotEqual(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	cmds := []config.Command{{Name: "test", Run: "go test ./..."}}
+
+	before := BuildCacheKey(dir, "", cmds)
+
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "x.go"), []byte("package p"), 0o644))
+	runCmd(t, dir, "git", "add", "x.go")
+	runCmd(t, dir, "git", "commit", "-m", "add x")
+
+	after := BuildCacheKey(dir, "", cmds)
+	assert.Assert(t, before != after, "new commit must invalidate key")
+}
+
+// runCmd executes a command in dir with git env set, failing the test on error.
+func runCmd(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	assert.NilError(t, err, "%s %v: %s", name, args, out)
+}

--- a/internal/validate/cache_test.go
+++ b/internal/validate/cache_test.go
@@ -6,40 +6,45 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/envspec"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 )
 
-// --- CacheKey ---
+// --- cacheKey ---
 
 func TestCacheKey_SameName_SameParts_Equal(t *testing.T) {
-	a := CacheKey("cmd", "part1", "part2")
-	b := CacheKey("cmd", "part1", "part2")
+	a := cacheKey("cmd", "part1", "part2")
+	b := cacheKey("cmd", "part1", "part2")
 	assert.Equal(t, a, b)
 }
 
 func TestCacheKey_DifferentName_NotEqual(t *testing.T) {
-	a := CacheKey("cmdA", "part1")
-	b := CacheKey("cmdB", "part1")
+	a := cacheKey("cmdA", "part1")
+	b := cacheKey("cmdB", "part1")
 	assert.Assert(t, a != b)
 }
 
 func TestCacheKey_BoundaryCollision_NotEqual(t *testing.T) {
 	// Without length-prefixing ["ab","c"] and ["a","bc"] would hash identically.
-	a := CacheKey("cmd", "ab", "c")
-	b := CacheKey("cmd", "a", "bc")
+	a := cacheKey("cmd", "ab", "c")
+	b := cacheKey("cmd", "a", "bc")
 	assert.Assert(t, a != b, "boundary collision: different part splits must produce different keys")
 }
 
 func TestCacheKey_EmptyName(t *testing.T) {
 	// "" is the commandName for "run all"; must still produce a stable key.
-	a := CacheKey("", "hash1", "sha", "status")
-	b := CacheKey("", "hash1", "sha", "status")
+	a := cacheKey("", "hash1", "sha", "status")
+	b := cacheKey("", "hash1", "sha", "status")
 	assert.Equal(t, a, b)
 }
 
 // --- BuildCacheKey ---
 
-var testCommands = []config.Command{{Name: "test", Run: "go test ./..."}}
+func testConfig() *config.ProjectConfig {
+	return &config.ProjectConfig{
+		Commands: []config.Command{{Name: "test", Run: "go test ./..."}},
+	}
+}
 
 // testTree is a stand-in for a real fingerprint; gitutil owns the tests that
 // prove a digest actually tracks the working tree.
@@ -54,39 +59,63 @@ func buildKey(t *testing.T, in CacheKeyInputs) string {
 }
 
 func TestBuildCacheKey_SameInputs_Equal(t *testing.T) {
-	in := CacheKeyInputs{Worktree: testTree, Commands: testCommands}
+	in := CacheKeyInputs{Worktree: testTree, Config: testConfig()}
 	assert.Equal(t, buildKey(t, in), buildKey(t, in))
 }
 
 func TestBuildCacheKey_DifferentCommandName_NotEqual(t *testing.T) {
-	all := buildKey(t, CacheKeyInputs{Worktree: testTree, Commands: testCommands})
-	named := buildKey(t, CacheKeyInputs{Worktree: testTree, CommandName: "test", Commands: testCommands})
+	all := buildKey(t, CacheKeyInputs{Worktree: testTree, Config: testConfig()})
+	named := buildKey(t, CacheKeyInputs{Worktree: testTree, CommandName: "test", Config: testConfig()})
 	assert.Assert(t, all != named)
 }
 
 func TestBuildCacheKey_DifferentCommands_NotEqual(t *testing.T) {
-	a := buildKey(t, CacheKeyInputs{Worktree: testTree, Commands: testCommands})
-	b := buildKey(t, CacheKeyInputs{
-		Worktree: testTree,
-		Commands: []config.Command{{Name: "test", Run: "go test -race ./..."}},
-	})
+	edited := testConfig()
+	edited.Commands[0].Run = "go test -race ./..."
+
+	a := buildKey(t, CacheKeyInputs{Worktree: testTree, Config: testConfig()})
+	b := buildKey(t, CacheKeyInputs{Worktree: testTree, Config: edited})
 	assert.Assert(t, a != b)
+}
+
+// TestBuildCacheKey_DifferentEnvironment_NotEqual covers a project that gitignores
+// .chunk/: editing the environment block changes what the commands run against
+// without touching the working tree, so the config has to reach the key whole or
+// the next run reports a hit and never re-runs against the new environment.
+func TestBuildCacheKey_DifferentEnvironment_NotEqual(t *testing.T) {
+	withEnv := testConfig()
+	withEnv.Environment = &envspec.Environment{
+		Stack: "go",
+		Setup: []envspec.Step{{Name: "install", Command: "go mod download"}},
+	}
+	changedEnv := testConfig()
+	changedEnv.Environment = &envspec.Environment{
+		Stack: "go",
+		Setup: []envspec.Step{{Name: "install", Command: "go mod download && apt-get install -y libpcap-dev"}},
+	}
+
+	base := buildKey(t, CacheKeyInputs{Worktree: testTree, Config: testConfig()})
+	a := buildKey(t, CacheKeyInputs{Worktree: testTree, Config: withEnv})
+	b := buildKey(t, CacheKeyInputs{Worktree: testTree, Config: changedEnv})
+
+	assert.Assert(t, base != a, "adding an environment must invalidate the key")
+	assert.Assert(t, a != b, "changing a setup step must invalidate the key")
 }
 
 // TestBuildCacheKey_DifferentWorktree_NotEqual pins the wiring that makes the
 // cache safe: both halves of the fingerprint have to reach the key, or a tree
 // that has moved on reports a hit for the run that validated the old one.
 func TestBuildCacheKey_DifferentWorktree_NotEqual(t *testing.T) {
-	base := buildKey(t, CacheKeyInputs{Worktree: testTree, Commands: testCommands})
+	base := buildKey(t, CacheKeyInputs{Worktree: testTree, Config: testConfig()})
 
 	newCommit := testTree
 	newCommit.Head = "def456"
 	edited := testTree
 	edited.Digest = "cafebabe"
 
-	assert.Assert(t, base != buildKey(t, CacheKeyInputs{Worktree: newCommit, Commands: testCommands}),
+	assert.Assert(t, base != buildKey(t, CacheKeyInputs{Worktree: newCommit, Config: testConfig()}),
 		"a new HEAD must invalidate the key")
-	assert.Assert(t, base != buildKey(t, CacheKeyInputs{Worktree: edited, Commands: testCommands}),
+	assert.Assert(t, base != buildKey(t, CacheKeyInputs{Worktree: edited, Config: testConfig()}),
 		"a changed working tree must invalidate the key")
 }
 
@@ -105,7 +134,7 @@ func TestBuildCacheKey_UnusableWorktree_NotOK(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, ok := BuildCacheKey(CacheKeyInputs{Worktree: tt.tree, Commands: testCommands})
+			_, ok := BuildCacheKey(CacheKeyInputs{Worktree: tt.tree, Config: testConfig()})
 			assert.Assert(t, !ok, "an unusable fingerprint must not produce a cache key")
 		})
 	}
@@ -117,7 +146,7 @@ func TestBuildCacheKey_UnusableWorktree_NotOK(t *testing.T) {
 func TestBuildCacheKey_DifferentTarget_NotEqual(t *testing.T) {
 	key := func(target string) string {
 		t.Helper()
-		return buildKey(t, CacheKeyInputs{Worktree: testTree, Commands: testCommands, Target: target})
+		return buildKey(t, CacheKeyInputs{Worktree: testTree, Config: testConfig(), Target: target})
 	}
 
 	local := key("")

--- a/internal/validate/cache_test.go
+++ b/internal/validate/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -46,7 +47,7 @@ var testCommands = []config.Command{{Name: "test", Run: "go test ./..."}}
 // buildKey asserts the key could be built and returns it.
 func buildKey(t *testing.T, dir, commandName string, cmds []config.Command) string {
 	t.Helper()
-	key, ok := BuildCacheKey(dir, commandName, cmds)
+	key, ok := BuildCacheKey(CacheKeyInputs{WorkDir: dir, CommandName: commandName, Commands: cmds})
 	assert.Assert(t, ok, "expected a usable cache key")
 	return key
 }
@@ -184,7 +185,7 @@ func TestBuildCacheKey_SubDir_MatchesRepoRoot(t *testing.T) {
 func TestBuildCacheKey_NotARepo_NotOK(t *testing.T) {
 	// No git state means the key would depend only on the config, so it must be
 	// refused rather than returned as a stable key.
-	_, ok := BuildCacheKey(t.TempDir(), "", testCommands)
+	_, ok := BuildCacheKey(CacheKeyInputs{WorkDir: t.TempDir(), Commands: testCommands})
 	assert.Assert(t, !ok, "non-repo dir must not produce a cache key")
 }
 
@@ -192,8 +193,51 @@ func TestBuildCacheKey_RepoWithoutCommits_NotOK(t *testing.T) {
 	dir := t.TempDir()
 	runCmd(t, dir, "git", "init")
 
-	_, ok := BuildCacheKey(dir, "", testCommands)
+	_, ok := BuildCacheKey(CacheKeyInputs{WorkDir: dir, Commands: testCommands})
 	assert.Assert(t, !ok, "repo with no HEAD must not produce a cache key")
+}
+
+// TestBuildCacheKey_DifferentTarget_NotEqual covers switching the active
+// sidecar: the working tree is untouched, so only the target distinguishes a
+// run validated on one sidecar from one that must still be validated on another.
+func TestBuildCacheKey_DifferentTarget_NotEqual(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	key := func(target string) string {
+		t.Helper()
+		k, ok := BuildCacheKey(CacheKeyInputs{WorkDir: dir, Commands: testCommands, Target: target})
+		assert.Assert(t, ok, "expected a usable cache key")
+		return k
+	}
+
+	local := key("")
+	sidecarA := key("sidecar-a\x00img")
+	sidecarB := key("sidecar-b\x00img")
+
+	assert.Assert(t, local != sidecarA, "local and sidecar runs must not share a key")
+	assert.Assert(t, sidecarA != sidecarB, "different sidecars must not share a key")
+	assert.Equal(t, sidecarA, key("sidecar-a\x00img"))
+}
+
+// TestBuildCacheKey_OversizedWorktree_NotOK guards the digest budget: hashing an
+// unbounded amount of content on every hook invocation is worse than not
+// caching, so an oversized tree fails closed like any other unusable state.
+func TestBuildCacheKey_OversizedWorktree_NotOK(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	original := maxDigestBytes
+	maxDigestBytes = 16
+	t.Cleanup(func() { maxDigestBytes = original })
+
+	writeFile(t, dir, "small.go", "package p")
+	_, ok := BuildCacheKey(CacheKeyInputs{WorkDir: dir, Commands: testCommands})
+	assert.Assert(t, ok, "a tree within budget must still produce a key")
+
+	writeFile(t, dir, "big.go", strings.Repeat("x", 64))
+	_, ok = BuildCacheKey(CacheKeyInputs{WorkDir: dir, Commands: testCommands})
+	assert.Assert(t, !ok, "a tree over the digest budget must not produce a cache key")
 }
 
 func TestBuildCacheKey_DeletedFile_NotEqual(t *testing.T) {

--- a/internal/validate/hook_test.go
+++ b/internal/validate/hook_test.go
@@ -5,14 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
-
-	"github.com/CircleCI-Public/chunk-cli/internal/config"
 )
 
 // sessionID returns a unique session ID for each test to prevent state leakage.
@@ -21,27 +18,6 @@ func sessionID(t *testing.T) string {
 	id := fmt.Sprintf("test-%s", t.Name())
 	t.Cleanup(func() { ResetAttempts(id) })
 	return id
-}
-
-// initGitRepo creates a git repo in dir, stages any existing files, and
-// creates an initial commit so that git status works correctly and the
-// working tree starts clean.
-func initGitRepo(t *testing.T, dir string) {
-	t.Helper()
-	run := func(args ...string) {
-		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
-			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
-		)
-		out, err := cmd.CombinedOutput()
-		assert.NilError(t, err, "git %v: %s", args, out)
-	}
-	run("init")
-	run("add", "-A")
-	run("commit", "--allow-empty", "-m", "init")
 }
 
 // --- TrackFailedAttempt / ResetAttempts ---
@@ -132,25 +108,4 @@ func TestHooksDisabled_SentinelFile(t *testing.T) {
 
 func TestHooksDisabled_Neither(t *testing.T) {
 	assert.Equal(t, HooksDisabled(t.TempDir(), false), false)
-}
-
-// --- HasGitChanges ---
-
-func TestHasGitChanges_CleanRepo_ReturnsFalse(t *testing.T) {
-	dir := t.TempDir()
-	writeConfig(t, dir, []config.Command{{Name: "test", Run: "true"}})
-	initGitRepo(t, dir)
-	assert.Equal(t, HasGitChanges(dir), false)
-}
-
-func TestHasGitChanges_UntrackedFile_ReturnsTrue(t *testing.T) {
-	dir := t.TempDir()
-	initGitRepo(t, dir)
-	assert.NilError(t, os.WriteFile(dir+"/dirty.txt", []byte("change"), 0o644))
-	assert.Equal(t, HasGitChanges(dir), true)
-}
-
-func TestHasGitChanges_NotARepo_ReturnsTrue(t *testing.T) {
-	// Non-repo dir: git fails, should fail open
-	assert.Equal(t, HasGitChanges(t.TempDir()), true)
 }

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -295,18 +295,6 @@ func HooksDisabled(workDir string, envDisabled bool) bool {
 	return err == nil
 }
 
-// HasGitChanges reports whether the working tree at workDir has any
-// uncommitted modifications (staged or unstaged). Returns true when git
-// is unavailable or the directory is not a repository so that validation
-// still runs in ambiguous cases.
-func HasGitChanges(workDir string) bool {
-	out, err := exec.Command("git", "-C", workDir, "status", "--porcelain").Output()
-	if err != nil {
-		return true // fail open: run validation when git is unavailable
-	}
-	return strings.TrimSpace(string(out)) != ""
-}
-
 // WrapHookResult applies Stop hook lifecycle to the result of running validate
 // commands. On success it resets the attempt counter. On failure it increments
 // the counter and returns a HookExitError with code 2 to re-signal the agent,


### PR DESCRIPTION
## Summary

- Adds a generic `FileCache[T]` (`internal/filecache`) — one JSON file per entry, filename is `sha256(key)`, silent miss on corrupt entries. Each write sweeps entries older than 7 days plus any staged file an interrupted run left behind, so the directory stays bounded
- Adds `CachedResult` and `BuildCacheKey` to `internal/validate`, `gitutil.Fingerprint` for the working-tree half of the key, and `internal/hashutil` for the length-prefixed digest primitive both of those rest on
- Replaces `validate.HasGitChanges` with that same fingerprint, so the Stop hook's existing clean-tree skip and the new cache read one pass over the tree instead of disagreeing about what changed
- Wires the cache into `chunk validate`'s Stop hook path: on a successful run the outcome is stored, and subsequent hook invocations with identical inputs skip execution and print a one-line "skipped" message

## Motivation

In hook mode `chunk validate` fires on every Claude Code Stop turn. Re-running `go test ./...` (or an SSH exec to a sidecar) when nothing has changed since the last successful run is pure waste.

Invalidation is by content hash. The key is the command name plus a SHA-256 over:

- **`.chunk/config.json` whole** — commands and the environment block that decides what they run against, so a project that gitignores `.chunk/` still re-runs when either changes
- **the execution target** — a result validated against one sidecar is never reused for another
- **the HEAD SHA**
- **the porcelain status and the contents of every changed file** — the status entries record deletions, renames and mode changes; hashing contents on top is what catches a second edit to an already-dirty file, which `git status` output alone reports identically

Failures are never cached, so the agent always retries after applying a fix.

Entries also expire 7 days after they were written, swept on the next write. That is not the invalidation mechanism — a stale key simply never matches again — it just stops a content-addressed directory from growing one file per Stop turn forever.

When the tree cannot be fingerprinted at all (a dirty submodule, an unreadable changed file, more than 64 MiB of changed files) no cache is consulted, and hook mode prints the reason — otherwise a repo that gets no benefit from this has no way to find out why.

## Test plan

- [x] `go test -race ./...` and `task acceptance-test` pass
- [x] `TestValidateHookCacheMissAfterEdit` — second run on an untouched tree skips; editing a file puts the commands back on
- [x] `TestValidateHookFailureIsNotCached` — a failing command is never stored, so the next invocation re-runs rather than reporting a hit
- [x] Both verified by mutation: caching failures reddens the first, dropping the working-tree digest from the key reddens the second
- [x] `TestFileCache_Put_Sweeps*` — stale entries and orphaned staged files are collected; a staged file still being written, and any file the cache did not write, are left alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
