### PR TITLE
Restore newlines in remote command output

### DIFF
--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -227,9 +227,9 @@ func (c *Client) streamCommandOutput(ctx context.Context, commandID string) (*Ex
 			}
 			switch event.Stream {
 			case "stdout":
-				result.Stdout += event.Line
+				result.Stdout += event.Line + "\n"
 			case "stderr":
-				result.Stderr += event.Line
+				result.Stderr += event.Line + "\n"
 			}
 		}
 		return sc.Err()

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/gin-gonic/gin"
@@ -393,17 +394,19 @@ func (f *FakeCircleCI) handleCommandOutput(c *gin.Context) {
 	c.Status(http.StatusOK)
 
 	idx := 0
-	writeEvent := func(stream, line string) {
-		b, _ := json.Marshal(commandOutputLine{Index: idx, Stream: stream, Line: line})
-		_, _ = fmt.Fprintf(c.Writer, "%s\n", b)
-		idx++
+	writeLines := func(stream, output string) {
+		for _, line := range strings.Split(strings.TrimRight(output, "\n"), "\n") {
+			b, _ := json.Marshal(commandOutputLine{Index: idx, Stream: stream, Line: line})
+			_, _ = fmt.Fprintf(c.Writer, "%s\n", b)
+			idx++
+		}
 	}
 
 	if resp.Stdout != "" {
-		writeEvent("stdout", resp.Stdout)
+		writeLines("stdout", resp.Stdout)
 	}
 	if resp.Stderr != "" {
-		writeEvent("stderr", resp.Stderr)
+		writeLines("stderr", resp.Stderr)
 	}
 
 	result, _ := json.Marshal(commandOutputLine{


### PR DESCRIPTION
## Summary

- Each output line from the async exec API arrives as a separate NDJSON event with no trailing newline; `streamCommandOutput` was concatenating `event.Line` directly, stripping all line breaks from remote command output
- Fix appends `\n` after each accumulated line in `streamCommandOutput`
- Fix the fake server to match real API behaviour: split multi-line strings into per-line events rather than emitting the whole string as a single event