### PR TITLE
Improve chunk validate stop hook UX

### DIFF
--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -173,10 +173,10 @@ func TestValidateRunLocal(t *testing.T) {
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "echo installed"),
-		"expected install command output, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "echo tested"),
-		"expected test command output, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "install"),
+		"expected install status in output, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "test"),
+		"expected test status in output, got: %s", combined)
 }
 
 func TestValidateRunLocalFailure(t *testing.T) {
@@ -244,9 +244,9 @@ func TestValidateRunNamed(t *testing.T) {
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "echo tested"),
-		"expected test command in output, got: %s", combined)
-	// Should not run install
+	assert.Assert(t, strings.Contains(combined, "test"),
+		"expected test status in output, got: %s", combined)
+	// Should not run install — its echo output would appear on failure, not on success
 	assert.Assert(t, !strings.Contains(combined, "echo installed"),
 		"should not run install when running named test command, got: %s", combined)
 }
@@ -280,8 +280,9 @@ func TestValidateInlineCmd(t *testing.T) {
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "inline-output"),
-		"expected inline command output, got: %s", combined)
+	// Command output is buffered and discarded on success; check for the status line instead.
+	assert.Assert(t, strings.Contains(combined, "custom"),
+		"expected custom command status in output, got: %s", combined)
 }
 
 func TestValidateInlineCmdDryRun(t *testing.T) {

--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -559,8 +559,8 @@ func TestValidateHookMode_SuccessLine(t *testing.T) {
 		hookStdin(t, "test-session-success-line", false))
 
 	assert.Equal(t, result.ExitCode, 0, "expected exit 0 for passing hook; stderr: %s", result.Stderr)
-	assert.Assert(t, strings.Contains(result.Stderr, "chunk validate passed"),
-		"expected 'chunk validate passed' in stderr; got: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stdout, "chunk validate passed"),
+		"expected 'chunk validate passed' in stdout; got stdout: %s stderr: %s", result.Stdout, result.Stderr)
 }
 
 // TestValidateHookMode_SetupErrorFlushedToStderr verifies that when setup fails

--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -173,10 +173,10 @@ func TestValidateRunLocal(t *testing.T) {
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "install"),
-		"expected install status in output, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "test"),
-		"expected test status in output, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "installed"),
+		"expected install command output in result, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "tested"),
+		"expected test command output in result, got: %s", combined)
 }
 
 func TestValidateRunLocalFailure(t *testing.T) {
@@ -244,11 +244,10 @@ func TestValidateRunNamed(t *testing.T) {
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "test"),
-		"expected test status in output, got: %s", combined)
-	// Should not run install — its echo output would appear on failure, not on success
-	assert.Assert(t, !strings.Contains(combined, "echo installed"),
-		"should not run install when running named test command, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "tested"),
+		"expected test command output in result, got: %s", combined)
+	assert.Assert(t, !strings.Contains(combined, "installed"),
+		"install command must not run when only 'test' is requested, got: %s", combined)
 }
 
 func TestValidateRunNamedNotConfiguredNonTTY(t *testing.T) {
@@ -280,9 +279,8 @@ func TestValidateInlineCmd(t *testing.T) {
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 	combined := result.Stdout + result.Stderr
-	// Command output is buffered and discarded on success; check for the status line instead.
-	assert.Assert(t, strings.Contains(combined, "custom"),
-		"expected custom command status in output, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "inline-output"),
+		"expected command output in result, got: %s", combined)
 }
 
 func TestValidateInlineCmdDryRun(t *testing.T) {
@@ -547,6 +545,59 @@ func writeSidecarState(t *testing.T, e *testenv.TestEnv, projectRoot, sessionID,
 	filename := sidecar.StateFileName(sessionID, branch)
 	data := []byte(`{"sidecar_id":"` + sidecarID + `"}`)
 	assert.NilError(t, os.WriteFile(filepath.Join(dir, filename), data, 0o644))
+}
+
+// TestValidateHookMode_SuccessLine verifies that the "chunk validate passed"
+// success line is written to stderr after a clean hook run.
+func TestValidateHookMode_SuccessLine(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	// writeProjectConfig leaves an untracked file → dirty tree → hook runs.
+	writeProjectConfig(t, workDir, "", "true")
+
+	env := testenv.NewTestEnv(t)
+	result := binary.RunCLIWithStdin(t, []string{"validate"}, env, workDir,
+		hookStdin(t, "test-session-success-line", false))
+
+	assert.Equal(t, result.ExitCode, 0, "expected exit 0 for passing hook; stderr: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "chunk validate passed"),
+		"expected 'chunk validate passed' in stderr; got: %s", result.Stderr)
+}
+
+// TestValidateHookMode_SetupErrorFlushedToStderr verifies that when setup fails
+// in hook mode (e.g. SSH unreachable), the error output is flushed to stderr
+// rather than silently discarded by hookBuf.
+func TestValidateHookMode_SetupErrorFlushedToStderr(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = "127.0.0.1" // no real SSH server — sync will fail
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	chunkDir := filepath.Join(workDir, ".chunk")
+	assert.NilError(t, os.MkdirAll(chunkDir, 0o755))
+	cfg := `{"commands":[{"name":"test","run":"true","remote":true}]}`
+	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), []byte(cfg), 0o644))
+	// Dirty tree ensures the hook actually runs.
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "dirty.txt"), []byte("x"), 0o644))
+
+	sshDir := filepath.Join(t.TempDir(), ".ssh")
+	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
+	identityFile := filepath.Join(sshDir, "chunk_ai")
+	assert.NilError(t, generateTestSSHKey(t, identityFile))
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	env.Extra["CIRCLECI_ORG_ID"] = "org-aaa"
+
+	result := binary.RunCLIWithStdin(t, []string{
+		"validate", "--identity-file", identityFile,
+	}, env, workDir, hookStdin(t, "test-session-setup-err", false))
+
+	assert.Assert(t, result.ExitCode != 0, "expected failure; stderr: %s", result.Stderr)
+	// The hook output (including the setup error) must be flushed to stderr,
+	// not silently swallowed when hookBuf is non-empty on error exit.
+	assert.Assert(t, strings.Contains(result.Stderr, "chunk validate"),
+		"expected hook output in stderr; got: %s", result.Stderr)
 }
 
 // gitCurrentBranch returns the current branch of the git repo at dir, or ""

--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -594,10 +594,9 @@ func TestValidateHookMode_SetupErrorFlushedToStderr(t *testing.T) {
 	}, env, workDir, hookStdin(t, "test-session-setup-err", false))
 
 	assert.Assert(t, result.ExitCode != 0, "expected failure; stderr: %s", result.Stderr)
-	// The hook output (including the setup error) must be flushed to stderr,
-	// not silently swallowed when hookBuf is non-empty on error exit.
-	assert.Assert(t, strings.Contains(result.Stderr, "chunk validate"),
-		"expected hook output in stderr; got: %s", result.Stderr)
+	// Sync status messages must reach stderr — proves setup output is not silently dropped.
+	assert.Assert(t, strings.Contains(result.Stderr, "Assessing"),
+		"expected sync attempt in stderr; got: %s", result.Stderr)
 }
 
 // gitCurrentBranch returns the current branch of the git repo at dir, or ""

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -314,11 +314,11 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			maxAttempts = validate.DefaultMaxAttempts
 		}
 		hookErr := validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
+		_, _ = io.Copy(cmd.ErrOrStderr(), hookBuf)
 		if hookErr == nil && execErr == nil {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.Success(fmt.Sprintf("chunk validate passed (%s)", validate.FormatDuration(time.Since(start)))))
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s\n", ui.ErrSuccess(fmt.Sprintf("chunk validate passed (%s)", validate.FormatDuration(time.Since(start)))))
 			return nil
 		}
-		_, _ = io.Copy(cmd.ErrOrStderr(), hookBuf)
 		return hookErr
 	}
 	return execErr

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -302,10 +302,12 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		}
 		return runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
 	}()
-	if execErr != nil {
-		statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed)", validate.FormatDuration(time.Since(start))))
-	} else {
-		statusFn(iostream.LevelStep, fmt.Sprintf("done in %s", validate.FormatDuration(time.Since(start))))
+	if hook == nil {
+		if execErr != nil {
+			statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed)", validate.FormatDuration(time.Since(start))))
+		} else {
+			statusFn(iostream.LevelStep, fmt.Sprintf("done in %s", validate.FormatDuration(time.Since(start))))
+		}
 	}
 
 	if hook != nil {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -275,19 +274,10 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return err
 	}
 
-	// In hook context, buffer all detailed output. On success we discard it
-	// and show only a brief summary; on failure we flush the full detail.
-	var hookBuf *bytes.Buffer
-	if hook != nil {
-		hookBuf = new(bytes.Buffer)
-		streams = iostream.Streams{Out: hookBuf, Err: hookBuf}
-	}
 	statusFn = newStatusFunc(streams)
 
 	statusFn(iostream.LevelStep, "chunk validate")
 
-	// Wrap setup + run in a closure so all error paths reach the hookBuf
-	// flush below, not just errors from runValidate itself.
 	execErr := func() error {
 		freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, activeSidecar, statusFn, workDir, streams)
 		if err != nil {
@@ -302,12 +292,10 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		}
 		return runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
 	}()
-	if hook == nil {
-		if execErr != nil {
-			statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed)", validate.FormatDuration(time.Since(start))))
-		} else {
-			statusFn(iostream.LevelStep, fmt.Sprintf("done in %s", validate.FormatDuration(time.Since(start))))
-		}
+	if execErr != nil {
+		statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed)", validate.FormatDuration(time.Since(start))))
+	} else if hook == nil {
+		statusFn(iostream.LevelStep, fmt.Sprintf("done in %s", validate.FormatDuration(time.Since(start))))
 	}
 
 	if hook != nil {
@@ -316,9 +304,8 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			maxAttempts = validate.DefaultMaxAttempts
 		}
 		hookErr := validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
-		_, _ = io.Copy(cmd.ErrOrStderr(), hookBuf)
 		if hookErr == nil && execErr == nil {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s\n", ui.ErrSuccess(fmt.Sprintf("chunk validate passed (%s)", validate.FormatDuration(time.Since(start)))))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.Success(fmt.Sprintf("chunk validate passed (%s)", validate.FormatDuration(time.Since(start)))))
 			return nil
 		}
 		return hookErr

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -293,9 +293,9 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
 	}()
 	if execErr != nil {
-		statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed)", validate.FormatDuration(time.Since(start))))
+		statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed)", ui.FormatDuration(time.Since(start))))
 	} else if hook == nil {
-		statusFn(iostream.LevelStep, fmt.Sprintf("done in %s", validate.FormatDuration(time.Since(start))))
+		statusFn(iostream.LevelStep, fmt.Sprintf("done in %s", ui.FormatDuration(time.Since(start))))
 	}
 
 	if hook != nil {
@@ -305,7 +305,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		}
 		hookErr := validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
 		if hookErr == nil && execErr == nil {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.Success(fmt.Sprintf("chunk validate passed (%s)", validate.FormatDuration(time.Since(start)))))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.Success(fmt.Sprintf("chunk validate passed (%s)", ui.FormatDuration(time.Since(start)))))
 			return nil
 		}
 		return hookErr

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -274,23 +275,38 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return err
 	}
 
+	// In hook context, buffer all detailed output. On success we discard it
+	// and show only a brief summary; on failure we flush the full detail.
+	var hookBuf *bytes.Buffer
+	if hook != nil {
+		hookBuf = new(bytes.Buffer)
+		streams = iostream.Streams{Out: hookBuf, Err: hookBuf}
+	}
+	statusFn = newStatusFunc(streams)
+
 	statusFn(iostream.LevelStep, "chunk validate")
 
-	freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, activeSidecar, statusFn, workDir, streams)
-	if err != nil {
-		return err
+	// Wrap setup + run in a closure so all error paths reach the hookBuf
+	// flush below, not just errors from runValidate itself.
+	execErr := func() error {
+		freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, activeSidecar, statusFn, workDir, streams)
+		if err != nil {
+			return err
+		}
+		// Only load env vars and resolve secrets when a sidecar is actually
+		// being used — avoids parsing .env.local or hitting secrets APIs on
+		// purely local runs.
+		envVars, err := loadSidecarEnvVars(ctx, circleCIClient, opts, workDir, statusFn)
+		if err != nil {
+			return err
+		}
+		return runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
+	}()
+	if execErr != nil {
+		statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed)", validate.FormatDuration(time.Since(start))))
+	} else {
+		statusFn(iostream.LevelStep, fmt.Sprintf("done in %s", validate.FormatDuration(time.Since(start))))
 	}
-
-	// Only load env vars and resolve secrets when a sidecar is actually
-	// being used — avoids parsing .env.local or hitting secrets APIs on
-	// purely local runs.
-	envVars, err := loadSidecarEnvVars(ctx, circleCIClient, opts, workDir, statusFn)
-	if err != nil {
-		return err
-	}
-
-	execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
-	statusFn(iostream.LevelStep, fmt.Sprintf("done in %s", validate.FormatDuration(time.Since(start))))
 
 	if hook != nil {
 		maxAttempts := cfg.StopHookMaxAttempts
@@ -299,10 +315,10 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		}
 		hookErr := validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
 		if hookErr == nil && execErr == nil {
-			// On success (exit 0) Claude Code doesn't surface stderr to the user.
-			// Write one line to stdout so the user sees validation passed.
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "✓ chunk validate passed (%s)\n", validate.FormatDuration(time.Since(start)))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.Success(fmt.Sprintf("chunk validate passed (%s)", validate.FormatDuration(time.Since(start)))))
+			return nil
 		}
+		_, _ = io.Copy(cmd.ErrOrStderr(), hookBuf)
 		return hookErr
 	}
 	return execErr

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -38,6 +39,8 @@ func newStatusFunc(streams iostream.Streams) iostream.StatusFunc {
 			streams.ErrPrintf("  %s\n", ui.ErrWarning(msg))
 		case iostream.LevelDone:
 			streams.ErrPrintf("  %s\n", ui.ErrSuccess(msg))
+		case iostream.LevelError:
+			streams.ErrPrintf("  %s\n", ui.ErrError(msg))
 		}
 	}
 }
@@ -181,6 +184,9 @@ func maybeEnsureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc confi
 func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) error {
 	streams := iostream.FromCmd(cmd)
 
+	// Record before git-status check so total captures setup overhead too.
+	start := time.Now()
+
 	workDir := opts.projectDir
 	if workDir == "" {
 		var err error
@@ -268,6 +274,8 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return err
 	}
 
+	statusFn(iostream.LevelStep, "chunk validate")
+
 	freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, activeSidecar, statusFn, workDir, streams)
 	if err != nil {
 		return err
@@ -282,13 +290,20 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	}
 
 	execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
+	statusFn(iostream.LevelStep, fmt.Sprintf("done in %s", validate.FormatDuration(time.Since(start))))
 
 	if hook != nil {
 		maxAttempts := cfg.StopHookMaxAttempts
 		if maxAttempts <= 0 {
 			maxAttempts = validate.DefaultMaxAttempts
 		}
-		return validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
+		hookErr := validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
+		if hookErr == nil && execErr == nil {
+			// On success (exit 0) Claude Code doesn't surface stderr to the user.
+			// Write one line to stdout so the user sees validation passed.
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "✓ chunk validate passed (%s)\n", validate.FormatDuration(time.Since(start)))
+		}
+		return hookErr
 	}
 	return execErr
 }

--- a/internal/iostream/status.go
+++ b/internal/iostream/status.go
@@ -5,10 +5,11 @@ type Level int
 
 // Status levels for progress reporting.
 const (
-	LevelStep Level = iota // numbered step heading (e.g. "Step 1/3: Discovering...")
-	LevelInfo              // dim informational detail
-	LevelWarn              // yellow warning
-	LevelDone              // green success/completion
+	LevelStep  Level = iota // numbered step heading (e.g. "Step 1/3: Discovering...")
+	LevelInfo               // dim informational detail
+	LevelWarn               // yellow warning
+	LevelDone               // green success/completion
+	LevelError              // red ✗ failure
 )
 
 // StatusFunc is a callback for reporting progress from business logic.

--- a/internal/ui/colors.go
+++ b/internal/ui/colors.go
@@ -63,3 +63,6 @@ func ErrBold(text string) string { return wrapErr("1", text) }
 
 // ErrDim applies dim using stderr color detection.
 func ErrDim(text string) string { return wrapErr("2", text) }
+
+// ErrRed applies red color using stderr color detection.
+func ErrRed(text string) string { return wrapErr("31", text) }

--- a/internal/ui/format.go
+++ b/internal/ui/format.go
@@ -25,6 +25,11 @@ func ErrWarning(msg string) string {
 	return ErrYellow("⚠ " + msg)
 }
 
+// ErrError formats a failure message using stderr color detection.
+func ErrError(msg string) string {
+	return ErrRed("✗ " + msg)
+}
+
 // FormatError formats a red error with optional detail and suggestion.
 func FormatError(brief string, detail string, suggestion string) string {
 	var b strings.Builder

--- a/internal/ui/format.go
+++ b/internal/ui/format.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // Success formats a green checkmark success message.
@@ -28,6 +29,17 @@ func ErrWarning(msg string) string {
 // ErrError formats a failure message using stderr color detection.
 func ErrError(msg string) string {
 	return ErrRed("✗ " + msg)
+}
+
+// FormatDuration formats a duration for display in status messages.
+func FormatDuration(d time.Duration) string {
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	return d.Round(time.Second).String()
 }
 
 // FormatError formats a red error with optional detail and suggestion.

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -13,8 +13,17 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
-	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
+
+func formatElapsed(d time.Duration) string {
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	return d.Round(time.Second).String()
+}
 
 // ErrNotConfigured indicates no validate commands are configured.
 var ErrNotConfigured = errors.New("no validate commands configured")
@@ -157,11 +166,11 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 			_, _ = fmt.Fprint(streams.Err, stderr)
 		}
 		if exitCode != 0 {
-			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, ui.FormatDuration(elapsed)))
+			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, formatElapsed(elapsed)))
 			skipRemaining(status, commands[i+1:], maxWidth)
 			return fmt.Errorf("remote %s failed with exit code %d", c.Name, exitCode)
 		}
-		status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, ui.FormatDuration(elapsed)))
+		status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, formatElapsed(elapsed)))
 	}
 	return nil
 }
@@ -185,10 +194,10 @@ func RunRemoteInline(ctx context.Context, execFn func(ctx context.Context, scrip
 		_, _ = fmt.Fprint(streams.Err, stderr)
 	}
 	if exitCode != 0 {
-		status(iostream.LevelError, fmt.Sprintf("%s  %s", name, ui.FormatDuration(elapsed)))
+		status(iostream.LevelError, fmt.Sprintf("%s  %s", name, formatElapsed(elapsed)))
 		return fmt.Errorf("remote %s failed with exit code %d", name, exitCode)
 	}
-	status(iostream.LevelDone, fmt.Sprintf("%s  %s", name, ui.FormatDuration(elapsed)))
+	status(iostream.LevelDone, fmt.Sprintf("%s  %s", name, formatElapsed(elapsed)))
 	return nil
 }
 
@@ -246,17 +255,17 @@ func runCommand(ctx context.Context, workDir, name, command string, timeoutSec, 
 
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			status(iostream.LevelError, fmt.Sprintf("%-*s  timed out after %ds  %s", nameWidth, name, timeoutSec, ui.FormatDuration(elapsed)))
+			status(iostream.LevelError, fmt.Sprintf("%-*s  timed out after %ds  %s", nameWidth, name, timeoutSec, formatElapsed(elapsed)))
 			return fmt.Errorf("%s command timed out after %ds", name, timeoutSec)
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() != 0 {
-			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", nameWidth, name, ui.FormatDuration(elapsed)))
+			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", nameWidth, name, formatElapsed(elapsed)))
 			return fmt.Errorf("%s command failed with exit code %d", name, exitErr.ExitCode())
 		}
 		return fmt.Errorf("%s: %w", name, err)
 	}
-	status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", nameWidth, name, ui.FormatDuration(elapsed)))
+	status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", nameWidth, name, formatElapsed(elapsed)))
 	return nil
 }
 

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -67,7 +67,7 @@ func List(cfg *config.ProjectConfig, status iostream.StatusFunc) error {
 
 // RunInline runs an inline command string.
 func RunInline(ctx context.Context, workDir, name, command string, status iostream.StatusFunc, streams iostream.Streams) error {
-	return runCommand(ctx, workDir, name, command, 0, len(name), status, streams)
+	return runCommand(ctx, workDir, name, command, 0, 0, status, streams)
 }
 
 // RunNamed runs a single named command from config.
@@ -76,7 +76,23 @@ func RunNamed(ctx context.Context, workDir, name string, cfg *config.ProjectConf
 	if c == nil {
 		return fmt.Errorf("command %q not configured", name)
 	}
-	return runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, len(c.Name), status, streams)
+	return runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, 0, status, streams)
+}
+
+func skipRemaining(status iostream.StatusFunc, remaining []config.Command, width int) {
+	for _, c := range remaining {
+		status(iostream.LevelWarn, fmt.Sprintf("%-*s  skipped", width, c.Name))
+	}
+}
+
+func nameWidth(commands []config.Command) int {
+	w := 0
+	for _, c := range commands {
+		if len(c.Name) > w {
+			w = len(c.Name)
+		}
+	}
+	return w
 }
 
 // RunAll runs all configured commands, stopping at the first failure.
@@ -85,24 +101,16 @@ func RunAll(ctx context.Context, workDir string, cfg *config.ProjectConfig, stat
 		return ErrNotConfigured
 	}
 
-	maxWidth := 0
-	for _, c := range cfg.Commands {
-		if len(c.Name) > maxWidth {
-			maxWidth = len(c.Name)
-		}
-	}
-
+	maxWidth := nameWidth(cfg.Commands)
 	start := time.Now()
 	for i, c := range cfg.Commands {
 		if err := runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, maxWidth, status, streams); err != nil {
-			for j := i + 1; j < len(cfg.Commands); j++ {
-				status(iostream.LevelWarn, fmt.Sprintf("%-*s  skipped", maxWidth, cfg.Commands[j].Name))
-			}
+			skipRemaining(status, cfg.Commands[i+1:], maxWidth)
 			return err
 		}
 	}
 	if len(cfg.Commands) > 1 {
-		status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", maxWidth, fmt.Sprintf("%d passed", len(cfg.Commands)), FormatDuration(time.Since(start))))
+		status(iostream.LevelDone, fmt.Sprintf("%d passed  %s", len(cfg.Commands), FormatDuration(time.Since(start))))
 	}
 	return nil
 }
@@ -141,13 +149,8 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 		commands = []config.Command{*c}
 	}
 
-	maxWidth := 0
-	for _, c := range commands {
-		if len(c.Name) > maxWidth {
-			maxWidth = len(c.Name)
-		}
-	}
-
+	maxWidth := nameWidth(commands)
+	overallStart := time.Now()
 	for i, c := range commands {
 		run := expandCommand(workDir, c.Run)
 		script := "cd " + shellEscape(dest) + " && " + run
@@ -155,11 +158,12 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 		stdout, stderr, exitCode, err := execFn(ctx, script)
 		elapsed := time.Since(start)
 		if err != nil {
-			status(iostream.LevelError, fmt.Sprintf("%-*s  exec error: %v", maxWidth, c.Name, err))
-			for j := i + 1; j < len(commands); j++ {
-				status(iostream.LevelWarn, fmt.Sprintf("%-*s  skipped", maxWidth, commands[j].Name))
-			}
+			status(iostream.LevelError, fmt.Sprintf("%-*s  exec error", maxWidth, c.Name))
+			skipRemaining(status, commands[i+1:], maxWidth)
 			return fmt.Errorf("remote %s: %w", c.Name, err)
+		}
+		if exitCode != 0 && (stdout != "" || stderr != "") {
+			status(iostream.LevelInfo, c.Name+":")
 		}
 		if stdout != "" {
 			_, _ = fmt.Fprint(streams.Out, stdout)
@@ -168,16 +172,14 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 			_, _ = fmt.Fprint(streams.Err, stderr)
 		}
 		if exitCode != 0 {
-			if stdout != "" || stderr != "" {
-				status(iostream.LevelInfo, c.Name+":")
-			}
 			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, FormatDuration(elapsed)))
-			for j := i + 1; j < len(commands); j++ {
-				status(iostream.LevelWarn, fmt.Sprintf("%-*s  skipped", maxWidth, commands[j].Name))
-			}
+			skipRemaining(status, commands[i+1:], maxWidth)
 			return fmt.Errorf("remote %s failed with exit code %d", c.Name, exitCode)
 		}
 		status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, FormatDuration(elapsed)))
+	}
+	if len(commands) > 1 {
+		status(iostream.LevelDone, fmt.Sprintf("%d passed  %s", len(commands), FormatDuration(time.Since(overallStart))))
 	}
 	return nil
 }
@@ -191,6 +193,9 @@ func RunRemoteInline(ctx context.Context, execFn func(ctx context.Context, scrip
 	if err != nil {
 		return fmt.Errorf("remote %s: %w", name, err)
 	}
+	if exitCode != 0 && (stdout != "" || stderr != "") {
+		status(iostream.LevelInfo, name+":")
+	}
 	if stdout != "" {
 		_, _ = fmt.Fprint(streams.Out, stdout)
 	}
@@ -198,13 +203,10 @@ func RunRemoteInline(ctx context.Context, execFn func(ctx context.Context, scrip
 		_, _ = fmt.Fprint(streams.Err, stderr)
 	}
 	if exitCode != 0 {
-		if stdout != "" || stderr != "" {
-			status(iostream.LevelInfo, name+":")
-		}
-		status(iostream.LevelError, fmt.Sprintf("%-*s  %s", len(name), name, FormatDuration(elapsed)))
+		status(iostream.LevelError, fmt.Sprintf("%s  %s", name, FormatDuration(elapsed)))
 		return fmt.Errorf("remote %s failed with exit code %d", name, exitCode)
 	}
-	status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", len(name), name, FormatDuration(elapsed)))
+	status(iostream.LevelDone, fmt.Sprintf("%s  %s", name, FormatDuration(elapsed)))
 	return nil
 }
 
@@ -262,7 +264,7 @@ func runCommand(ctx context.Context, workDir, name, command string, timeoutSec, 
 
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			status(iostream.LevelError, fmt.Sprintf("%-*s  timed out after %ds", nameWidth, name, timeoutSec))
+			status(iostream.LevelError, fmt.Sprintf("%-*s  timed out after %ds  %s", nameWidth, name, timeoutSec, FormatDuration(elapsed)))
 			return fmt.Errorf("%s command timed out after %ds", name, timeoutSec)
 		}
 		var exitErr *exec.ExitError

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,7 +1,6 @@
 package validate
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -162,21 +161,21 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 			}
 			return fmt.Errorf("remote %s: %w", c.Name, err)
 		}
+		if stdout != "" {
+			_, _ = fmt.Fprint(streams.Out, stdout)
+		}
+		if stderr != "" {
+			_, _ = fmt.Fprint(streams.Err, stderr)
+		}
 		if exitCode != 0 {
 			if stdout != "" || stderr != "" {
 				status(iostream.LevelInfo, c.Name+":")
-			}
-			if stdout != "" {
-				_, _ = fmt.Fprint(streams.Err, stdout)
-			}
-			if stderr != "" {
-				_, _ = fmt.Fprint(streams.Err, stderr)
 			}
 			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, FormatDuration(elapsed)))
 			for j := i + 1; j < len(commands); j++ {
 				status(iostream.LevelWarn, fmt.Sprintf("%-*s  skipped", maxWidth, commands[j].Name))
 			}
-			return fmt.Errorf("remote %s failed with exit code %d (%s)", c.Name, exitCode, FormatDuration(elapsed))
+			return fmt.Errorf("remote %s failed with exit code %d", c.Name, exitCode)
 		}
 		status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, FormatDuration(elapsed)))
 	}
@@ -192,18 +191,18 @@ func RunRemoteInline(ctx context.Context, execFn func(ctx context.Context, scrip
 	if err != nil {
 		return fmt.Errorf("remote %s: %w", name, err)
 	}
+	if stdout != "" {
+		_, _ = fmt.Fprint(streams.Out, stdout)
+	}
+	if stderr != "" {
+		_, _ = fmt.Fprint(streams.Err, stderr)
+	}
 	if exitCode != 0 {
 		if stdout != "" || stderr != "" {
 			status(iostream.LevelInfo, name+":")
 		}
-		if stdout != "" {
-			_, _ = fmt.Fprint(streams.Err, stdout)
-		}
-		if stderr != "" {
-			_, _ = fmt.Fprint(streams.Err, stderr)
-		}
 		status(iostream.LevelError, fmt.Sprintf("%-*s  %s", len(name), name, FormatDuration(elapsed)))
-		return fmt.Errorf("remote %s failed with exit code %d (%s)", name, exitCode, FormatDuration(elapsed))
+		return fmt.Errorf("remote %s failed with exit code %d", name, exitCode)
 	}
 	status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", len(name), name, FormatDuration(elapsed)))
 	return nil
@@ -252,31 +251,24 @@ func runCommand(ctx context.Context, workDir, name, command string, timeoutSec, 
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
 	defer cancel()
 
-	// Buffer output: flushed to stderr only on failure so success runs stay quiet.
-	var buf bytes.Buffer
-
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.Dir = workDir
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
+	cmd.Stdout = streams.Out
+	cmd.Stderr = streams.Err
 
 	start := time.Now()
 	err := cmd.Run()
 	elapsed := time.Since(start)
 
 	if err != nil {
-		if buf.Len() > 0 {
-			status(iostream.LevelInfo, name+":")
-			_, _ = io.Copy(streams.Err, &buf)
-		}
 		if ctx.Err() == context.DeadlineExceeded {
 			status(iostream.LevelError, fmt.Sprintf("%-*s  timed out after %ds", nameWidth, name, timeoutSec))
-			return fmt.Errorf("%s command timed out after %ds (%s)", name, timeoutSec, FormatDuration(elapsed))
+			return fmt.Errorf("%s command timed out after %ds", name, timeoutSec)
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() != 0 {
 			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", nameWidth, name, FormatDuration(elapsed)))
-			return fmt.Errorf("%s command failed with exit code %d (%s)", name, exitErr.ExitCode(), FormatDuration(elapsed))
+			return fmt.Errorf("%s command failed with exit code %d", name, exitErr.ExitCode())
 		}
 		return fmt.Errorf("%s: %w", name, err)
 	}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,6 +1,7 @@
 package validate
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -41,6 +42,17 @@ func shellEscape(arg string) string {
 // DefaultTimeout is the per-command execution timeout in seconds.
 const DefaultTimeout = 300
 
+// FormatDuration formats a duration for display in status messages.
+func FormatDuration(d time.Duration) string {
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	return d.Round(time.Second).String()
+}
+
 // List prints all configured command names and their run strings.
 func List(cfg *config.ProjectConfig, status iostream.StatusFunc) error {
 	if !cfg.HasCommands() {
@@ -56,7 +68,7 @@ func List(cfg *config.ProjectConfig, status iostream.StatusFunc) error {
 
 // RunInline runs an inline command string.
 func RunInline(ctx context.Context, workDir, name, command string, status iostream.StatusFunc, streams iostream.Streams) error {
-	return runCommand(ctx, workDir, name, command, 0, status, streams)
+	return runCommand(ctx, workDir, name, command, 0, len(name), status, streams)
 }
 
 // RunNamed runs a single named command from config.
@@ -65,7 +77,7 @@ func RunNamed(ctx context.Context, workDir, name string, cfg *config.ProjectConf
 	if c == nil {
 		return fmt.Errorf("command %q not configured", name)
 	}
-	return runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, status, streams)
+	return runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, len(c.Name), status, streams)
 }
 
 // RunAll runs all configured commands, stopping at the first failure.
@@ -74,13 +86,24 @@ func RunAll(ctx context.Context, workDir string, cfg *config.ProjectConfig, stat
 		return ErrNotConfigured
 	}
 
+	maxWidth := 0
+	for _, c := range cfg.Commands {
+		if len(c.Name) > maxWidth {
+			maxWidth = len(c.Name)
+		}
+	}
+
+	start := time.Now()
 	for i, c := range cfg.Commands {
-		if err := runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, status, streams); err != nil {
+		if err := runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, maxWidth, status, streams); err != nil {
 			for j := i + 1; j < len(cfg.Commands); j++ {
-				status(iostream.LevelWarn, fmt.Sprintf("%s: skipped (%s failed)", cfg.Commands[j].Name, c.Name))
+				status(iostream.LevelWarn, fmt.Sprintf("%-*s  skipped", maxWidth, cfg.Commands[j].Name))
 			}
 			return err
 		}
+	}
+	if len(cfg.Commands) > 1 {
+		status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", maxWidth, fmt.Sprintf("%d passed", len(cfg.Commands)), FormatDuration(time.Since(start))))
 	}
 	return nil
 }
@@ -118,23 +141,37 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 		}
 		commands = []config.Command{*c}
 	}
+
+	maxWidth := 0
+	for _, c := range commands {
+		if len(c.Name) > maxWidth {
+			maxWidth = len(c.Name)
+		}
+	}
+
 	for _, c := range commands {
 		run := expandCommand(workDir, c.Run)
 		script := "cd " + shellEscape(dest) + " && " + run
-		status(iostream.LevelInfo, fmt.Sprintf("Running %s (remote): %s", c.Name, c.Run))
+		start := time.Now()
 		stdout, stderr, exitCode, err := execFn(ctx, script)
+		elapsed := time.Since(start)
 		if err != nil {
 			return fmt.Errorf("remote %s: %w", c.Name, err)
 		}
-		if stdout != "" {
-			_, _ = fmt.Fprint(streams.Out, stdout)
-		}
-		if stderr != "" {
-			_, _ = fmt.Fprint(streams.Err, stderr)
-		}
 		if exitCode != 0 {
-			return fmt.Errorf("remote %s failed with exit code %d", c.Name, exitCode)
+			if stdout != "" || stderr != "" {
+				status(iostream.LevelInfo, c.Name+":")
+			}
+			if stdout != "" {
+				_, _ = fmt.Fprint(streams.Err, stdout)
+			}
+			if stderr != "" {
+				_, _ = fmt.Fprint(streams.Err, stderr)
+			}
+			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, FormatDuration(elapsed)))
+			return fmt.Errorf("remote %s failed with exit code %d (%s)", c.Name, exitCode, FormatDuration(elapsed))
 		}
+		status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, FormatDuration(elapsed)))
 	}
 	return nil
 }
@@ -142,20 +179,26 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 // RunRemoteInline runs a single inline command on a remote sidecar via SSH.
 func RunRemoteInline(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), name, command, dest string, status iostream.StatusFunc, streams iostream.Streams) error {
 	script := "cd " + shellEscape(dest) + " && " + command
-	status(iostream.LevelInfo, fmt.Sprintf("Running %s (remote): %s", name, command))
+	start := time.Now()
 	stdout, stderr, exitCode, err := execFn(ctx, script)
+	elapsed := time.Since(start)
 	if err != nil {
 		return fmt.Errorf("remote %s: %w", name, err)
 	}
-	if stdout != "" {
-		_, _ = fmt.Fprint(streams.Out, stdout)
-	}
-	if stderr != "" {
-		_, _ = fmt.Fprint(streams.Err, stderr)
-	}
 	if exitCode != 0 {
-		return fmt.Errorf("remote %s failed with exit code %d", name, exitCode)
+		if stdout != "" || stderr != "" {
+			status(iostream.LevelInfo, name+":")
+		}
+		if stdout != "" {
+			_, _ = fmt.Fprint(streams.Err, stdout)
+		}
+		if stderr != "" {
+			_, _ = fmt.Fprint(streams.Err, stderr)
+		}
+		status(iostream.LevelError, fmt.Sprintf("%-*s  %s", len(name), name, FormatDuration(elapsed)))
+		return fmt.Errorf("remote %s failed with exit code %d (%s)", name, exitCode, FormatDuration(elapsed))
 	}
+	status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", len(name), name, FormatDuration(elapsed)))
 	return nil
 }
 
@@ -193,9 +236,8 @@ func expandCommand(workDir, command string) string {
 	return strings.ReplaceAll(command, "{{CHANGED_PACKAGES}}", expanded)
 }
 
-func runCommand(ctx context.Context, workDir, name, command string, timeoutSec int, status iostream.StatusFunc, streams iostream.Streams) error {
+func runCommand(ctx context.Context, workDir, name, command string, timeoutSec, nameWidth int, status iostream.StatusFunc, streams iostream.Streams) error {
 	command = expandCommand(workDir, command)
-	status(iostream.LevelInfo, fmt.Sprintf("Running %s: %s", name, command))
 
 	if timeoutSec <= 0 {
 		timeoutSec = DefaultTimeout
@@ -203,22 +245,35 @@ func runCommand(ctx context.Context, workDir, name, command string, timeoutSec i
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
 	defer cancel()
 
+	// Buffer output: flushed to stderr only on failure so success runs stay quiet.
+	var buf bytes.Buffer
+
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.Dir = workDir
-	cmd.Stdout = streams.Out
-	cmd.Stderr = streams.Err
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
 
+	start := time.Now()
 	err := cmd.Run()
+	elapsed := time.Since(start)
+
 	if err != nil {
+		if buf.Len() > 0 {
+			status(iostream.LevelInfo, name+":")
+			_, _ = io.Copy(streams.Err, &buf)
+		}
 		if ctx.Err() == context.DeadlineExceeded {
-			return fmt.Errorf("%s command timed out after %ds", name, timeoutSec)
+			status(iostream.LevelError, fmt.Sprintf("%-*s  timed out after %ds", nameWidth, name, timeoutSec))
+			return fmt.Errorf("%s command timed out after %ds (%s)", name, timeoutSec, FormatDuration(elapsed))
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() != 0 {
-			return fmt.Errorf("%s command failed with exit code %d", name, exitErr.ExitCode())
+			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", nameWidth, name, FormatDuration(elapsed)))
+			return fmt.Errorf("%s command failed with exit code %d (%s)", name, exitErr.ExitCode(), FormatDuration(elapsed))
 		}
 		return fmt.Errorf("%s: %w", name, err)
 	}
+	status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", nameWidth, name, FormatDuration(elapsed)))
 	return nil
 }
 

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
 
 // ErrNotConfigured indicates no validate commands are configured.
@@ -40,17 +41,6 @@ func shellEscape(arg string) string {
 
 // DefaultTimeout is the per-command execution timeout in seconds.
 const DefaultTimeout = 300
-
-// FormatDuration formats a duration for display in status messages.
-func FormatDuration(d time.Duration) string {
-	if d < time.Second {
-		return fmt.Sprintf("%dms", d.Milliseconds())
-	}
-	if d < time.Minute {
-		return fmt.Sprintf("%.1fs", d.Seconds())
-	}
-	return d.Round(time.Second).String()
-}
 
 // List prints all configured command names and their run strings.
 func List(cfg *config.ProjectConfig, status iostream.StatusFunc) error {
@@ -102,15 +92,11 @@ func RunAll(ctx context.Context, workDir string, cfg *config.ProjectConfig, stat
 	}
 
 	maxWidth := nameWidth(cfg.Commands)
-	start := time.Now()
 	for i, c := range cfg.Commands {
 		if err := runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, maxWidth, status, streams); err != nil {
 			skipRemaining(status, cfg.Commands[i+1:], maxWidth)
 			return err
 		}
-	}
-	if len(cfg.Commands) > 1 {
-		status(iostream.LevelDone, fmt.Sprintf("%d passed  %s", len(cfg.Commands), FormatDuration(time.Since(start))))
 	}
 	return nil
 }
@@ -150,7 +136,6 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 	}
 
 	maxWidth := nameWidth(commands)
-	overallStart := time.Now()
 	for i, c := range commands {
 		run := expandCommand(workDir, c.Run)
 		script := "cd " + shellEscape(dest) + " && " + run
@@ -172,14 +157,11 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 			_, _ = fmt.Fprint(streams.Err, stderr)
 		}
 		if exitCode != 0 {
-			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, FormatDuration(elapsed)))
+			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, ui.FormatDuration(elapsed)))
 			skipRemaining(status, commands[i+1:], maxWidth)
 			return fmt.Errorf("remote %s failed with exit code %d", c.Name, exitCode)
 		}
-		status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, FormatDuration(elapsed)))
-	}
-	if len(commands) > 1 {
-		status(iostream.LevelDone, fmt.Sprintf("%d passed  %s", len(commands), FormatDuration(time.Since(overallStart))))
+		status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, ui.FormatDuration(elapsed)))
 	}
 	return nil
 }
@@ -203,10 +185,10 @@ func RunRemoteInline(ctx context.Context, execFn func(ctx context.Context, scrip
 		_, _ = fmt.Fprint(streams.Err, stderr)
 	}
 	if exitCode != 0 {
-		status(iostream.LevelError, fmt.Sprintf("%s  %s", name, FormatDuration(elapsed)))
+		status(iostream.LevelError, fmt.Sprintf("%s  %s", name, ui.FormatDuration(elapsed)))
 		return fmt.Errorf("remote %s failed with exit code %d", name, exitCode)
 	}
-	status(iostream.LevelDone, fmt.Sprintf("%s  %s", name, FormatDuration(elapsed)))
+	status(iostream.LevelDone, fmt.Sprintf("%s  %s", name, ui.FormatDuration(elapsed)))
 	return nil
 }
 
@@ -264,17 +246,17 @@ func runCommand(ctx context.Context, workDir, name, command string, timeoutSec, 
 
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			status(iostream.LevelError, fmt.Sprintf("%-*s  timed out after %ds  %s", nameWidth, name, timeoutSec, FormatDuration(elapsed)))
+			status(iostream.LevelError, fmt.Sprintf("%-*s  timed out after %ds  %s", nameWidth, name, timeoutSec, ui.FormatDuration(elapsed)))
 			return fmt.Errorf("%s command timed out after %ds", name, timeoutSec)
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() != 0 {
-			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", nameWidth, name, FormatDuration(elapsed)))
+			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", nameWidth, name, ui.FormatDuration(elapsed)))
 			return fmt.Errorf("%s command failed with exit code %d", name, exitErr.ExitCode())
 		}
 		return fmt.Errorf("%s: %w", name, err)
 	}
-	status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", nameWidth, name, FormatDuration(elapsed)))
+	status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", nameWidth, name, ui.FormatDuration(elapsed)))
 	return nil
 }
 

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -149,13 +149,17 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 		}
 	}
 
-	for _, c := range commands {
+	for i, c := range commands {
 		run := expandCommand(workDir, c.Run)
 		script := "cd " + shellEscape(dest) + " && " + run
 		start := time.Now()
 		stdout, stderr, exitCode, err := execFn(ctx, script)
 		elapsed := time.Since(start)
 		if err != nil {
+			status(iostream.LevelError, fmt.Sprintf("%-*s  exec error: %v", maxWidth, c.Name, err))
+			for j := i + 1; j < len(commands); j++ {
+				status(iostream.LevelWarn, fmt.Sprintf("%-*s  skipped", maxWidth, commands[j].Name))
+			}
 			return fmt.Errorf("remote %s: %w", c.Name, err)
 		}
 		if exitCode != 0 {
@@ -169,6 +173,9 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 				_, _ = fmt.Fprint(streams.Err, stderr)
 			}
 			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, FormatDuration(elapsed)))
+			for j := i + 1; j < len(commands); j++ {
+				status(iostream.LevelWarn, fmt.Sprintf("%-*s  skipped", maxWidth, commands[j].Name))
+			}
 			return fmt.Errorf("remote %s failed with exit code %d (%s)", c.Name, exitCode, FormatDuration(elapsed))
 		}
 		status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, FormatDuration(elapsed)))

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -319,7 +319,8 @@ func TestRunRemote(t *testing.T) {
 
 		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), testStatus(&statusBuf), streams))
 		assert.Assert(t, strings.Contains(out.String(), "remote output"), "got: %s", out.String())
-		assert.Assert(t, strings.Contains(statusBuf.String(), "install"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "[done] install"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "[done] test"), "got: %s", statusBuf.String())
 		assert.Equal(t, execCount, 2)
 	})
 
@@ -444,7 +445,7 @@ func TestRunRemoteSSH(t *testing.T) {
 		var statusBuf bytes.Buffer
 		assert.NilError(t, RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), testStatus(&statusBuf), streams))
 		assert.Assert(t, strings.Contains(out.String(), "hello from remote"), "got: %s", out.String())
-		assert.Assert(t, strings.Contains(statusBuf.String(), "test"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "[done] test"), "got: %s", statusBuf.String())
 		assert.Equal(t, len(sshSrv.Commands()), 1)
 	})
 
@@ -511,7 +512,7 @@ func TestRunRemoteInline(t *testing.T) {
 
 		assert.NilError(t, RunRemoteInline(context.Background(), execFn, "custom", "echo hello", "/workspace/repo", testStatus(&statusBuf), streams))
 		assert.Assert(t, strings.Contains(out.String(), "inline output"), "got: %s", out.String())
-		assert.Assert(t, strings.Contains(statusBuf.String(), "custom"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "[done] custom"), "got: %s", statusBuf.String())
 		assert.Assert(t, strings.HasPrefix(capturedScript, "cd '/workspace/repo' &&"), "got: %s", capturedScript)
 	})
 

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -172,9 +172,10 @@ func TestRunAll(t *testing.T) {
 		var statusBuf bytes.Buffer
 
 		assert.NilError(t, RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams))
-		assert.Assert(t, strings.Contains(out.String(), "installed"), "got: %s", out.String())
-		assert.Assert(t, strings.Contains(out.String(), "tested"), "got: %s", out.String())
-		assert.Assert(t, strings.Contains(statusBuf.String(), "Running install"), "got: %s", statusBuf.String())
+		// Output is buffered and discarded on success — only status messages remain.
+		assert.Equal(t, out.Len(), 0)
+		assert.Assert(t, strings.Contains(statusBuf.String(), "install"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "test"), "got: %s", statusBuf.String())
 	})
 
 	t.Run("no commands", func(t *testing.T) {
@@ -209,8 +210,9 @@ func TestRunAll(t *testing.T) {
 		err := RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams)
 		assert.Assert(t, err != nil, "expected error")
 		assert.Assert(t, !strings.Contains(out.String(), "should-not-run"), "skipped command should not produce output, got: %s", out.String())
-		assert.Assert(t, strings.Contains(statusBuf.String(), "test: skipped"), "got: %s", statusBuf.String())
-		assert.Assert(t, strings.Contains(statusBuf.String(), "lint: skipped"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "test"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "lint"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "skipped"), "got: %s", statusBuf.String())
 	})
 
 	t.Run("single command success", func(t *testing.T) {
@@ -221,7 +223,8 @@ func TestRunAll(t *testing.T) {
 		var statusBuf bytes.Buffer
 
 		assert.NilError(t, RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams))
-		assert.Assert(t, strings.Contains(out.String(), "ok"), "got: %s", out.String())
+		assert.Equal(t, out.Len(), 0)
+		assert.Assert(t, strings.Contains(statusBuf.String(), "test"), "got: %s", statusBuf.String())
 	})
 }
 
@@ -280,9 +283,12 @@ func TestRunRemote(t *testing.T) {
 			{Name: "test", Run: "echo test"},
 		}}
 		streams, out, _ := newStreams()
+		var statusBuf bytes.Buffer
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams))
-		assert.Assert(t, strings.Contains(out.String(), "remote output"), "got: %s", out.String())
+		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), testStatus(&statusBuf), streams))
+		// Output is suppressed on success — only status messages remain.
+		assert.Equal(t, out.Len(), 0)
+		assert.Assert(t, strings.Contains(statusBuf.String(), "install"), "got: %s", statusBuf.String())
 		assert.Equal(t, execCount, 2)
 	})
 
@@ -404,8 +410,11 @@ func TestRunRemoteSSH(t *testing.T) {
 		}}
 		streams, out, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), func(iostream.Level, string) {}, streams))
-		assert.Assert(t, strings.Contains(out.String(), "hello from remote"), "got: %s", out.String())
+		var statusBuf bytes.Buffer
+		assert.NilError(t, RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), testStatus(&statusBuf), streams))
+		// Output suppressed on success; verified via status message instead.
+		assert.Equal(t, out.Len(), 0)
+		assert.Assert(t, strings.Contains(statusBuf.String(), "test"), "got: %s", statusBuf.String())
 		assert.Equal(t, len(sshSrv.Commands()), 1)
 	})
 
@@ -468,9 +477,12 @@ func TestRunRemoteInline(t *testing.T) {
 			return "inline output\n", "", 0, nil
 		}
 		streams, out, _ := newStreams()
+		var statusBuf bytes.Buffer
 
-		assert.NilError(t, RunRemoteInline(context.Background(), execFn, "custom", "echo hello", "/workspace/repo", func(iostream.Level, string) {}, streams))
-		assert.Assert(t, strings.Contains(out.String(), "inline output"), "got: %s", out.String())
+		assert.NilError(t, RunRemoteInline(context.Background(), execFn, "custom", "echo hello", "/workspace/repo", testStatus(&statusBuf), streams))
+		// Output suppressed on success.
+		assert.Equal(t, out.Len(), 0)
+		assert.Assert(t, strings.Contains(statusBuf.String(), "custom"), "got: %s", statusBuf.String())
 		assert.Assert(t, strings.HasPrefix(capturedScript, "cd '/workspace/repo' &&"), "got: %s", capturedScript)
 	})
 

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
-	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
 
 func TestShellEscape(t *testing.T) {
@@ -187,7 +186,7 @@ func TestFormatDuration(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {
-			assert.Equal(t, ui.FormatDuration(tt.d), tt.want)
+			assert.Equal(t, formatElapsed(tt.d), tt.want)
 		})
 	}
 }

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 
@@ -62,9 +63,17 @@ func newStreams() (iostream.Streams, *bytes.Buffer, *bytes.Buffer) {
 	return iostream.Streams{Out: &out, Err: &errBuf}, &out, &errBuf
 }
 
+var levelTag = map[iostream.Level]string{
+	iostream.LevelStep:  "step",
+	iostream.LevelInfo:  "info",
+	iostream.LevelWarn:  "warn",
+	iostream.LevelDone:  "done",
+	iostream.LevelError: "error",
+}
+
 func testStatus(buf *bytes.Buffer) iostream.StatusFunc {
-	return func(_ iostream.Level, msg string) {
-		fmt.Fprintln(buf, msg)
+	return func(level iostream.Level, msg string) {
+		fmt.Fprintf(buf, "[%s] %s\n", levelTag[level], msg)
 	}
 }
 
@@ -160,6 +169,28 @@ func TestRunDryRun(t *testing.T) {
 	})
 }
 
+// --- FormatDuration tests ---
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{500 * time.Millisecond, "500ms"},
+		{999 * time.Millisecond, "999ms"},
+		{time.Second, "1.0s"}, // boundary: exactly 1s → seconds branch
+		{1500 * time.Millisecond, "1.5s"},
+		{59*time.Second + 900*time.Millisecond, "59.9s"},
+		{time.Minute, "1m0s"}, // boundary: exactly 1m → minutes branch
+		{90 * time.Second, "1m30s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, FormatDuration(tt.d), tt.want)
+		})
+	}
+}
+
 // --- RunAll tests ---
 
 func TestRunAll(t *testing.T) {
@@ -172,10 +203,10 @@ func TestRunAll(t *testing.T) {
 		var statusBuf bytes.Buffer
 
 		assert.NilError(t, RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams))
-		// Output is buffered and discarded on success — only status messages remain.
-		assert.Equal(t, out.Len(), 0)
-		assert.Assert(t, strings.Contains(statusBuf.String(), "install"), "got: %s", statusBuf.String())
-		assert.Assert(t, strings.Contains(statusBuf.String(), "test"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(out.String(), "installed"), "got: %s", out.String())
+		assert.Assert(t, strings.Contains(out.String(), "tested"), "got: %s", out.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "[done] install"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "[done] test"), "got: %s", statusBuf.String())
 	})
 
 	t.Run("no commands", func(t *testing.T) {
@@ -210,8 +241,9 @@ func TestRunAll(t *testing.T) {
 		err := RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams)
 		assert.Assert(t, err != nil, "expected error")
 		assert.Assert(t, !strings.Contains(out.String(), "should-not-run"), "skipped command should not produce output, got: %s", out.String())
-		assert.Assert(t, strings.Contains(statusBuf.String(), "test"), "got: %s", statusBuf.String())
-		assert.Assert(t, strings.Contains(statusBuf.String(), "lint"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "[error] install"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "[warn] test"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "[warn] lint"), "got: %s", statusBuf.String())
 		assert.Assert(t, strings.Contains(statusBuf.String(), "skipped"), "got: %s", statusBuf.String())
 	})
 
@@ -223,8 +255,8 @@ func TestRunAll(t *testing.T) {
 		var statusBuf bytes.Buffer
 
 		assert.NilError(t, RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams))
-		assert.Equal(t, out.Len(), 0)
-		assert.Assert(t, strings.Contains(statusBuf.String(), "test"), "got: %s", statusBuf.String())
+		assert.Assert(t, strings.Contains(out.String(), "ok"), "got: %s", out.String())
+		assert.Assert(t, strings.Contains(statusBuf.String(), "[done] test"), "got: %s", statusBuf.String())
 	})
 }
 
@@ -286,8 +318,7 @@ func TestRunRemote(t *testing.T) {
 		var statusBuf bytes.Buffer
 
 		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), testStatus(&statusBuf), streams))
-		// Output is suppressed on success — only status messages remain.
-		assert.Equal(t, out.Len(), 0)
+		assert.Assert(t, strings.Contains(out.String(), "remote output"), "got: %s", out.String())
 		assert.Assert(t, strings.Contains(statusBuf.String(), "install"), "got: %s", statusBuf.String())
 		assert.Equal(t, execCount, 2)
 	})
@@ -412,8 +443,7 @@ func TestRunRemoteSSH(t *testing.T) {
 
 		var statusBuf bytes.Buffer
 		assert.NilError(t, RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), testStatus(&statusBuf), streams))
-		// Output suppressed on success; verified via status message instead.
-		assert.Equal(t, out.Len(), 0)
+		assert.Assert(t, strings.Contains(out.String(), "hello from remote"), "got: %s", out.String())
 		assert.Assert(t, strings.Contains(statusBuf.String(), "test"), "got: %s", statusBuf.String())
 		assert.Equal(t, len(sshSrv.Commands()), 1)
 	})
@@ -480,8 +510,7 @@ func TestRunRemoteInline(t *testing.T) {
 		var statusBuf bytes.Buffer
 
 		assert.NilError(t, RunRemoteInline(context.Background(), execFn, "custom", "echo hello", "/workspace/repo", testStatus(&statusBuf), streams))
-		// Output suppressed on success.
-		assert.Equal(t, out.Len(), 0)
+		assert.Assert(t, strings.Contains(out.String(), "inline output"), "got: %s", out.String())
 		assert.Assert(t, strings.Contains(statusBuf.String(), "custom"), "got: %s", statusBuf.String())
 		assert.Assert(t, strings.HasPrefix(capturedScript, "cd '/workspace/repo' &&"), "got: %s", capturedScript)
 	})

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
 
 func TestShellEscape(t *testing.T) {
@@ -186,7 +187,7 @@ func TestFormatDuration(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {
-			assert.Equal(t, FormatDuration(tt.d), tt.want)
+			assert.Equal(t, ui.FormatDuration(tt.d), tt.want)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Reworks `chunk validate` output in stop hook mode to be structured and timing-aware on both success and failure.

**Before:** every command printed its run string as it started, output streamed live regardless of outcome, no per-command timing, no indication of which commands were skipped.

**After:**
- Commands show in aligned columns with elapsed time: `✓ test  3.7s`, `✓ lint  0.4s`
- On **success**: full progress output shown, then `✓ chunk validate passed (9.4s)`
- On **failure**: full buffered output flushed to stderr, failed command shows `✗ test  9.6s`, remaining commands show `⚠ lint  skipped`
- Total elapsed shown at the end: `✗ done in 12.8s (failed)` or `done in 9.4s`
<img width="672" height="48" alt="Screenshot 2026-07-28 at 3 03 17 PM" src="https://github.com/user-attachments/assets/96ad98ee-9ff4-4c26-bfda-d74eaa7d9a96" />
<img width="636" height="866" alt="Screenshot 2026-07-28 at 3 41 43 PM" src="https://github.com/user-attachments/assets/ac54c412-45f4-4ab6-97e8-75db5bb92da0" />

**Known limitation:** Claude Code shows a "Stop hook error: Failed with non-blocking status code: ✓ chunk validate passed (Xs)" prefix on success. This is a Claude Code behavior — any stderr output on exit 0 from a stop hook gets wrapped in that message. The success info is still surfaced; it's just noisier than ideal.

Also fixes a bug where a setup error (e.g. sync failure) would silently swallow the "using sidecar X" message, breaking `TestValidateHookMode_SessionIsolation`.

**Failure example:**
```
  ✗ test          9.6s
  ⚠ test-changed  skipped
  ⚠ lint          skipped
  ⚠ format        skipped
  ✗ done in 12.8s (failed)
```

## Implementation

- Add `LevelError` to `iostream.Status` and `ErrError`/`ErrRed` formatting helpers
- Add `FormatDuration` to `internal/validate` for consistent ms/s/m output
- Hook mode buffers all output into `hookBuf`; flushed to stderr on both success and failure
- Wrap `setupRemote` + `loadSidecarEnvVars` + `runValidate` in a closure so all error paths reach the `io.Copy` flush
- Local commands buffer stdout/stderr and flush only on failure
- Exit 0 on hook success to avoid double "non-blocking" message

## Test plan

- [ ] `task test` passes
- [ ] Stop hook with passing validate shows full output + `✓ chunk validate passed`
- [ ] Stop hook with failing validate shows full output, `✗ done in Xs (failed)`, exits 2 to re-signal Claude