### PR TITLE
Pass environment image to sidecar on setup

### DIFF
--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -960,7 +960,7 @@ Example:
 			// Step 2: Resolve or create sidecar.
 			if sidecarID == "" {
 				var resolveErr error
-				sidecarID, _, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, name, dir, status, streams)
+				sidecarID, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, name, dir, env.TemplateName(), status, streams)
 				if resolveErr != nil {
 					return resolveErr
 				}
@@ -1031,32 +1031,32 @@ Example:
 func sidecarSetupResolveSidecar(
 	ctx context.Context,
 	client *circleci.Client,
-	orgID, name, workDir string,
+	orgID, name, workDir, image string,
 	status iostream.StatusFunc,
 	streams iostream.Streams,
-) (id, displayName string, err error) {
+) (id string, err error) {
 	active, err := sidecar.LoadActive(ctx)
 	if err != nil {
-		return "", "", &userError{msg: msgCouldNotLoadSidecar, suggestion: configFilePermHint, err: err}
+		return "", &userError{msg: msgCouldNotLoadSidecar, suggestion: configFilePermHint, err: err}
 	}
 	if active != nil {
 		status(iostream.LevelInfo, fmt.Sprintf("using active sidecar %s", active.SidecarID))
-		return active.SidecarID, active.Name, nil
+		return active.SidecarID, nil
 	}
 	if name == "" {
 		name = randomSidecarName()
 	}
 	resolvedOrgID, err := resolveOrgID(orgID, workDir, orgPicker(ctx, client))
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 	status(iostream.LevelStep, fmt.Sprintf("Creating sidecar %q...", name))
-	sc, err := sidecar.Create(ctx, client, resolvedOrgID, name, "")
+	sc, err := sidecar.Create(ctx, client, resolvedOrgID, name, image)
 	if err != nil {
 		if authErr := notAuthorized("create sidecars", err); authErr != nil {
-			return "", "", authErr
+			return "", authErr
 		}
-		return "", "", &userError{
+		return "", &userError{
 			msg:        "Could not create the sidecar.",
 			suggestion: suggestionNetworkRetry,
 			err:        err,
@@ -1066,7 +1066,7 @@ func sidecarSetupResolveSidecar(
 		streams.ErrPrintf("warning: could not save active sidecar: %v\n", saveErr)
 	}
 	status(iostream.LevelDone, fmt.Sprintf("Created sidecar %s (%s)", sc.Name, sc.ID))
-	return sc.ID, sc.Name, nil
+	return sc.ID, nil
 }
 
 func sidecarSetupEnsureSSHKey(identityFile string, status iostream.StatusFunc) error {

--- a/internal/cmd/sidecar_test.go
+++ b/internal/cmd/sidecar_test.go
@@ -1,13 +1,17 @@
 package cmd
 
 import (
+	"context"
+	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 )
 
@@ -40,6 +44,30 @@ func TestSidecarCreateUsesImageFromConfig(t *testing.T) {
 
 	assert.Equal(t, len(cci.Sidecars), 1)
 	assert.Equal(t, cci.Sidecars[0].Image, "snap-from-config")
+}
+
+func TestSidecarSetupPassesEnvImageToCreate(t *testing.T) {
+	isolateConfig(t)
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	t.Cleanup(srv.Close)
+
+	client, err := circleci.NewClient(circleci.Config{Token: "test-token", BaseURL: srv.URL})
+	assert.NilError(t, err)
+
+	noop := iostream.StatusFunc(func(_ iostream.Level, _ string) {})
+	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
+
+	id, err := sidecarSetupResolveSidecar(
+		context.Background(), client,
+		"org-abc", "my-sidecar", t.TempDir(),
+		"cimg-go:1.26.5",
+		noop, streams,
+	)
+	assert.NilError(t, err)
+	assert.Assert(t, id != "")
+	assert.Equal(t, len(cci.Sidecars), 1)
+	assert.Equal(t, cci.Sidecars[0].Image, "cimg-go:1.26.5")
 }
 
 func TestSnapshotCreateNameTooLong(t *testing.T) {

--- a/internal/envspec/envspec.go
+++ b/internal/envspec/envspec.go
@@ -1,5 +1,7 @@
 package envspec
 
+import "strings"
+
 // Step is a single named provisioning command in the sidecar setup sequence.
 type Step struct {
 	Name    string `json:"name"`
@@ -22,6 +24,16 @@ func (e *Environment) SetupStep(name string) string {
 		}
 	}
 	return ""
+}
+
+// TemplateName returns the provisioner template name for this environment,
+// e.g. "cimg-go:1.26.5" for image "cimg/go" and version "1.26.5".
+// Returns "" when Image or ImageVersion is not set.
+func (e *Environment) TemplateName() string {
+	if e.Image == "" || e.ImageVersion == "" {
+		return ""
+	}
+	return strings.ReplaceAll(e.Image, "/", "-") + ":" + e.ImageVersion
 }
 
 // BinaryPaths returns colon-separated PATH prefixes needed for the detected stack.


### PR DESCRIPTION
`sidecar setup` was creating sidecars with an empty image, defaulting
to the base Ubuntu template. The env image configured in
`.chunk/config.json` was resolved but never passed through to
`sidecar.Create`.

This was working at some point — `ca6dffe` added the `image` param to
`sidecarSetupResolveSidecar`, but the call site always passed `""`.
`d1063b8` ("Add parallel sidecars") then removed the dead parameter
entirely. This restores the intent.

## Changes

- Add `TemplateName()` on `envspec.Environment` — converts the stored
  `image`/`image_version` fields (e.g. `cimg/go` + `1.26.5`) to the
  provisioner format (`cimg-go:1.26.5`)
- Restore `image` parameter on `sidecarSetupResolveSidecar` and pass
  `env.TemplateName()` from the call site
- Drop the now-unused `displayName` return value from
  `sidecarSetupResolveSidecar` (was always discarded by callers)
- Test: `TestSidecarSetupPassesEnvImageToCreate` verifies the image
  reaches the API when creating a new sidecar during setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)