### PR TITLE
Update chunk init to suggest sidecar skill instead of Smarter Testing

### DIFF
--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -778,10 +778,10 @@ func TestInitSkipsTestSuitesByDefault(t *testing.T) {
 	_, err := os.Stat(filepath.Join(workDir, ".circleci", "test-suites.yml"))
 	assert.Assert(t, os.IsNotExist(err), "expected default to skip write, err=%v", err)
 
-	assert.Assert(t, strings.Contains(result.Stderr, "Smarter Testing"),
-		"expected hint in stderr, got: %s", result.Stderr)
-	assert.Assert(t, strings.Contains(result.Stderr, "test-suites.yml"),
-		"expected hint to mention test-suites.yml, got: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "chunk-sidecar"),
+		"expected sidecar hint in stderr, got: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "sidecar dev loop"),
+		"expected hint to mention sidecar dev loop, got: %s", result.Stderr)
 }
 
 func TestInitProjectDirNotGitRepo(t *testing.T) {

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -353,19 +353,16 @@ func writeTestSuites(workDir string, streams iostream.Streams) error {
 	return nil
 }
 
-// printTestSuitesHint prints onboarding guidance for scaffolding
-// .circleci/test-suites.yml. Skipped when the file already exists.
-// The schema description is intentionally agent-actionable: an AI agent
-// reading the init output has enough to draft the file for any language.
+// printTestSuitesHint prints onboarding guidance for setting up the sidecar
+// dev loop. Skipped when .circleci/test-suites.yml already exists.
 func printTestSuitesHint(workDir string, streams iostream.Streams) {
 	if _, err := os.Stat(filepath.Join(workDir, ".circleci", "test-suites.yml")); err == nil {
 		return
 	}
 	streams.ErrPrintln("")
-	streams.ErrPrintln(ui.Bold("Next step: scaffold .circleci/test-suites.yml for Smarter Testing"))
-	streams.ErrPrintln(ui.Dim("  Ask your AI coding agent to scaffold .circleci/test-suites.yml — the"))
-	streams.ErrPrintln(ui.Dim("  chunk-sidecar skill covers the file shape and per-language patterns."))
-	streams.ErrPrintln(ui.Dim("  Or rerun with --skip-test-suites=false to use built-in Go/pytest templates."))
+	streams.ErrPrintln(ui.Bold("Next step: set up the sidecar dev loop"))
+	streams.ErrPrintln(ui.Dim("  Ask your AI coding agent to run the chunk-sidecar skill to create"))
+	streams.ErrPrintln(ui.Dim("  a remote sidecar, sync your workspace, and run tests remotely."))
 }
 
 // writeAllHookFiles writes hook config files for all supported agents.


### PR DESCRIPTION
## Summary

- Replaces the post-init hint about scaffolding `.circleci/test-suites.yml` for Smarter Testing with a prompt to run the `chunk-sidecar` skill
- Hint now reads: "Ask your AI coding agent to run the chunk-sidecar skill to create a remote sidecar, sync your workspace, and run tests remotely."
- Updates acceptance test assertions to match the new hint text

## Test plan

- [x] Run `chunk init` in a repo without `.circleci/test-suites.yml` and confirm the new sidecar hint appears
- [x] Confirm `TestInitSkipsTestSuitesByDefault` passes
- [x] Confirm `TestInitNoCircleCINoToken` and `TestInitNoCircleCIWithToken` still pass (hint contains no "CircleCI" text)

<img width="547" height="253" alt="Screenshot 2026-07-29 at 12 22 39 PM" src="https://github.com/user-attachments/assets/6d8bdca7-2daf-487c-a8c9-8556b02cb368" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)