### PR TITLE
Reduce org ID friction: add chunk org list and auto-detect org ID in init

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -88,9 +88,11 @@ Run this once per project. It auto-detects your test and lint commands (using Cl
 chunk init
 ```
 
+Run this after authenticating — init uses your CircleCI credentials to detect your org ID and save it to the project config. If you belong to one org it's selected automatically; if you belong to several, init shows a picker. Org ID is needed for sidecar commands, so capturing it here means you won't be prompted later.
+
 What it creates:
 
-- **`.chunk/config.json`** — list of validation commands (test, lint, format); tracked in git
+- **`.chunk/config.json`** — list of validation commands (test, lint, format) and your CircleCI org ID; tracked in git
 - **`.claude/settings.json`** — hooks that run validation before commits and after each agent session; tracked in git
 - **`.codex/hooks.json`** — the same hooks, for Codex sessions (only written if Codex is installed); tracked in git
 - **`.git/hooks/pre-commit`** — runs `chunk validate` locally before every commit; not tracked in git
@@ -182,13 +184,16 @@ The agent loads your team's prompt, diffs the changes, and returns filtered find
 
 ### First-time sidecar setup
 
-Before creating a sidecar in a non-interactive session (AI agents, scripts), set
-your CircleCI org ID once per project:
+Sidecar commands need a CircleCI org ID. The recommended path is to authenticate and run `chunk init` before using sidecars — init captures the org ID automatically and saves it to `.chunk/config.json`. After that, `chunk sidecar create` just works.
+
+If you skipped that or need to set the org ID manually:
 
 ```bash
-chunk auth set circleci
+# List your orgs — single-org users can skip this, init auto-selected it
+chunk org list
+
+# Persist the ID to the project config
 chunk config set orgID <your-org-id>
-chunk sidecar create
 ```
 
 `chunk config show` displays the resolved `orgID` when set. One-off overrides:

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -110,7 +110,7 @@ func newAuthSetCmd() *cobra.Command {
 		Use:       "set <provider>",
 		Short:     "Store credentials for a provider",
 		Args:      cobra.ExactArgs(1),
-		ValidArgs: []string{"circleci", "anthropic", "github"},
+		ValidArgs: []string{providerCircleCI, providerAnthropic, providerGitHub},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
 			rc, _ := config.Resolve("", "", insecureStorage)
@@ -407,7 +407,7 @@ func newAuthRemoveCmd() *cobra.Command {
 		Use:       "remove <provider>",
 		Short:     "Remove stored credentials",
 		Args:      cobra.ExactArgs(1),
-		ValidArgs: []string{"circleci", "anthropic", "github"},
+		ValidArgs: []string{providerCircleCI, providerAnthropic, providerGitHub},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
 			rc, _ := config.Resolve("", "", insecureStorage)

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -12,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/anthropic"
+	"github.com/CircleCI-Public/chunk-cli/internal/authprompt"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
@@ -427,8 +429,31 @@ func printInitSummary(commands []config.Command, streams iostream.Streams) {
 	}
 }
 
+// detectOrgID attempts to resolve a CircleCI org ID without prompting for auth.
+// Auto-selects when the user belongs to exactly one org; shows a picker when
+// interactive with multiple orgs. Skipped gracefully on auth failure, no TTY,
+// or cancellation — none of these are fatal for chunk init.
+func detectOrgID(ctx context.Context, rc config.ResolvedConfig, streams iostream.Streams, cfg *config.ProjectConfig) {
+	client, err := authprompt.ResolveCircleCIClient(rc, nil)
+	if err != nil {
+		if !errors.Is(err, authprompt.ErrNeedsAuth) {
+			streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not detect org ID: %v", err)))
+		}
+		return
+	}
+	orgID, err := orgPicker(ctx, client)()
+	if err != nil {
+		if !errors.Is(err, tui.ErrNoTTY) && !errors.Is(err, tui.ErrCancelled) {
+			streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not detect org ID: %v", err)))
+		}
+		return
+	}
+	cfg.OrgID = orgID
+	streams.ErrPrintf("Org ID: %s\n", ui.Bold(orgID))
+}
+
 func newInitCmd() *cobra.Command {
-	var force, skipHooks, skipGitHook, skipValidate, skipCompletions, skipSkills, skipTestSuites bool
+	var force, skipHooks, skipGitHook, skipValidate, skipCompletions, skipSkills, skipTestSuites, skipOrgID bool
 	var projectDir string
 
 	cmd := &cobra.Command{
@@ -495,9 +520,13 @@ hook config files.`,
 				streams.ErrPrintf("Detected repository: %s\n", ui.Bold(fmt.Sprintf("%s/%s", org, repo)))
 			}
 
+			rc, rcErr := config.Resolve("", "", insecureStorage)
+			if rcErr != nil {
+				streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not load config: %v", rcErr)))
+			}
+
 			// Step 2: Validate command detection
 			if !skipValidate {
-				rc, _ := config.Resolve("", "", insecureStorage)
 				claude, _ := anthropic.New(anthropic.Config{APIKey: rc.AnthropicAPIKey, BaseURL: rc.AnthropicBaseURL})
 				commands, detectErr := validate.DetectCommands(ctx, claude, workDir)
 				if detectErr != nil {
@@ -517,6 +546,11 @@ hook config files.`,
 				}
 			}
 
+			// Step 3: CircleCI org ID
+			if !skipOrgID && cfg.OrgID == "" {
+				detectOrgID(ctx, rc, streams, cfg)
+			}
+
 			// Save config
 			if err := config.SaveProjectConfig(workDir, cfg); err != nil {
 				return &userError{
@@ -527,7 +561,7 @@ hook config files.`,
 			}
 			streams.ErrPrintln(ui.Success("Wrote .chunk/config.json"))
 
-			// Step 3: Write hook config files for supported agents.
+			// Step 4: Write hook config files for supported agents.
 			if !skipHooks {
 				if err := writeAllHookFiles(workDir, cfg.Commands, streams); err != nil {
 					return err
@@ -539,12 +573,12 @@ hook config files.`,
 				}
 			}
 
-			// Step 4: Shell completions
+			// Step 5: Shell completions
 			if !skipCompletions {
 				maybeInstallCompletions(streams)
 			}
 
-			// Step 5: CircleCI Smarter Testing test-suites.yml
+			// Step 6: CircleCI Smarter Testing test-suites.yml
 			if skipTestSuites {
 				printTestSuitesHint(workDir, streams)
 			} else {
@@ -553,7 +587,7 @@ hook config files.`,
 				}
 			}
 
-			// Step 6: Agent skills
+			// Step 7: Agent skills
 			if !skipSkills {
 				installSkillsStep(workDir, streams)
 			}
@@ -571,6 +605,7 @@ hook config files.`,
 	cmd.Flags().BoolVar(&skipCompletions, "skip-completions", false, "Skip shell completion installation")
 	cmd.Flags().BoolVar(&skipSkills, "skip-skills", false, "Skip agent skill installation")
 	cmd.Flags().BoolVar(&skipTestSuites, "skip-test-suites", true, "Skip CircleCI test-suites.yml generation (default: skip; pass =false to use built-in Go/pytest templates)")
+	cmd.Flags().BoolVar(&skipOrgID, "skip-org-id", false, "Skip CircleCI org ID detection")
 	cmd.Flags().StringVar(&projectDir, "project-dir", "", "Project directory (defaults to current directory)")
 
 	return cmd

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io/fs"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,6 +18,7 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
 
@@ -472,6 +475,59 @@ func TestPrintInitSummaryNoCommands(t *testing.T) {
 	assert.Assert(t, !strings.Contains(out, "Validation commands:"), "should not show command table when none configured")
 	assert.Assert(t, strings.Contains(out, ".chunk/config.json"), "missing config path")
 	assert.Assert(t, strings.Contains(out, "chunk validate"), "missing validate hint")
+}
+
+func newDetectOrgIDFake(t *testing.T) (*fakes.FakeCircleCI, config.ResolvedConfig) {
+	t.Helper()
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	t.Cleanup(srv.Close)
+	rc := config.ResolvedConfig{CircleCIToken: "test-token", CircleCIBaseURL: srv.URL}
+	return cci, rc
+}
+
+func TestDetectOrgID_NoAuth(t *testing.T) {
+	cfg := &config.ProjectConfig{}
+	streams, _, errOut := testStreams()
+	detectOrgID(context.Background(), config.ResolvedConfig{}, streams, cfg)
+	assert.Equal(t, cfg.OrgID, "")
+	assert.Equal(t, errOut.Len(), 0)
+}
+
+func TestDetectOrgID_SingleOrg(t *testing.T) {
+	cci, rc := newDetectOrgIDFake(t)
+	cci.Collaborations = []fakes.Collaboration{{ID: "org-xyz", Name: "myorg"}}
+
+	cfg := &config.ProjectConfig{}
+	streams, _, errOut := testStreams()
+	detectOrgID(context.Background(), rc, streams, cfg)
+	assert.Equal(t, cfg.OrgID, "org-xyz")
+	assert.Assert(t, strings.Contains(errOut.String(), "org-xyz"))
+}
+
+func TestDetectOrgID_MultipleOrgs_NoTTY(t *testing.T) {
+	cci, rc := newDetectOrgIDFake(t)
+	cci.Collaborations = []fakes.Collaboration{
+		{ID: "org-1", Name: "first"},
+		{ID: "org-2", Name: "second"},
+	}
+
+	cfg := &config.ProjectConfig{}
+	streams, _, errOut := testStreams()
+	detectOrgID(context.Background(), rc, streams, cfg)
+	assert.Equal(t, cfg.OrgID, "")
+	assert.Equal(t, errOut.Len(), 0, "ErrNoTTY should be suppressed silently")
+}
+
+func TestDetectOrgID_APIError(t *testing.T) {
+	cci, rc := newDetectOrgIDFake(t)
+	cci.CollaborationsStatusCode = 500
+
+	cfg := &config.ProjectConfig{}
+	streams, _, errOut := testStreams()
+	detectOrgID(context.Background(), rc, streams, cfg)
+	assert.Equal(t, cfg.OrgID, "")
+	assert.Assert(t, strings.Contains(errOut.String(), "Could not detect org ID"))
 }
 
 func TestInstallCompletionBashWritesRCFile(t *testing.T) {

--- a/internal/cmd/org.go
+++ b/internal/cmd/org.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/tui"
@@ -15,11 +16,61 @@ func newOrgCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                "org",
 		Short:              "Manage CircleCI organizations",
-		Hidden:             true,
 		RunE:               groupRunE,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
 	cmd.AddCommand(newOrgCreateCmd())
+	cmd.AddCommand(newOrgListCmd())
+	return cmd
+}
+
+func newOrgListCmd() *cobra.Command {
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List CircleCI organizations",
+		Long:  "List CircleCI organizations the authenticated user belongs to.\n\nUseful for finding your org ID to pass as --org-id or store with 'chunk config set orgID <id>'.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			insecureStorage, _ := cmd.Flags().GetBool("insecure-storage")
+			rc, _ := config.Resolve("", "", insecureStorage)
+			io := iostream.FromCmd(cmd)
+
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, tui.PromptHidden)
+			if err != nil {
+				return err
+			}
+
+			collabs, err := client.ListCollaborations(cmd.Context())
+			if err != nil {
+				return &userError{
+					msg:        "Could not list organizations.",
+					suggestion: "Check your network connection.",
+					err:        fmt.Errorf("list collaborations: %w", err),
+				}
+			}
+
+			if jsonOut {
+				if collabs == nil {
+					collabs = []circleci.Collaboration{}
+				}
+				return iostream.PrintJSON(io.Out, collabs)
+			}
+
+			if len(collabs) == 0 {
+				io.ErrPrintln(ui.Warning("No organizations found."))
+				return nil
+			}
+
+			io.Printf("%-40s  %s\n", "ID", "NAME")
+			for _, c := range collabs {
+				io.Printf("%-40s  %s/%s\n", c.ID, c.VcsType, c.Name)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 	return cmd
 }
 

--- a/internal/cmd/org_test.go
+++ b/internal/cmd/org_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"net/http/httptest"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 )
@@ -101,4 +103,116 @@ func TestOrgCreateRequiresName(t *testing.T) {
 
 	err := cmd.Execute()
 	assert.Assert(t, err != nil, "expected error when no name argument given")
+}
+
+func setupOrgListFake(t *testing.T) *fakes.FakeCircleCI {
+	t.Helper()
+	isolateConfig(t)
+	fake := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+	t.Setenv(config.EnvCircleToken, "test-token")
+	t.Setenv(config.EnvCircleCIBaseURL, srv.URL)
+	return fake
+}
+
+func TestOrgListTableOutput(t *testing.T) {
+	fake := setupOrgListFake(t)
+	fake.Collaborations = []fakes.Collaboration{
+		{ID: "org-abc", Name: "myorg", VCSType: "github"},
+		{ID: "org-def", Name: "otherorg", VCSType: "circleci"},
+	}
+
+	cmd := newOrgListCmd()
+	cmd.Flags().Bool("insecure-storage", false, "")
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+
+	err := cmd.Execute()
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(out.String(), "org-abc"), "expected org ID in output: %s", out.String())
+	assert.Assert(t, strings.Contains(out.String(), "myorg"), "expected org name in output: %s", out.String())
+	assert.Assert(t, strings.Contains(out.String(), "org-def"), "expected second org ID in output: %s", out.String())
+}
+
+func TestOrgListJSONOutput(t *testing.T) {
+	fake := setupOrgListFake(t)
+	fake.Collaborations = []fakes.Collaboration{
+		{ID: "org-abc", Name: "myorg", VCSType: "github"},
+	}
+
+	cmd := newOrgListCmd()
+	cmd.Flags().Bool("insecure-storage", false, "")
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--json"})
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	err := cmd.Execute()
+	assert.NilError(t, err)
+
+	var collabs []circleci.Collaboration
+	assert.NilError(t, json.Unmarshal(out.Bytes(), &collabs))
+	assert.Equal(t, len(collabs), 1)
+	assert.Equal(t, collabs[0].ID, "org-abc")
+}
+
+func TestOrgListJSONEmpty(t *testing.T) {
+	setupOrgListFake(t)
+
+	cmd := newOrgListCmd()
+	cmd.Flags().Bool("insecure-storage", false, "")
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--json"})
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	err := cmd.Execute()
+	assert.NilError(t, err)
+
+	var collabs []circleci.Collaboration
+	assert.NilError(t, json.Unmarshal(out.Bytes(), &collabs), "empty list should decode as [], not null")
+	assert.Equal(t, len(collabs), 0)
+}
+
+func TestOrgListEmpty(t *testing.T) {
+	setupOrgListFake(t)
+
+	cmd := newOrgListCmd()
+	cmd.Flags().Bool("insecure-storage", false, "")
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+
+	err := cmd.Execute()
+	assert.NilError(t, err)
+	assert.Equal(t, out.Len(), 0, "no table output expected for empty list")
+	assert.Assert(t, strings.Contains(errOut.String(), "No organizations found"), "expected warning: %s", errOut.String())
+}
+
+func TestOrgListRequiresAuth(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv(config.EnvCircleToken, "")
+	t.Setenv(config.EnvCircleCIToken, "")
+
+	cmd := newOrgListCmd()
+	cmd.Flags().Bool("insecure-storage", false, "")
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	assert.Assert(t, err != nil)
 }

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -111,12 +111,22 @@ func orgPicker(ctx context.Context, client *circleci.Client) func() (string, err
 				err:        fmt.Errorf("no organizations found for current user"),
 			}
 		}
+		if len(collabs) == 1 {
+			return collabs[0].ID, nil
+		}
 		labels := make([]string, len(collabs))
 		for i, c := range collabs {
 			labels[i] = fmt.Sprintf("%s/%s", c.VcsType, c.Name)
 		}
 		idx, err := tui.SelectFromList("Select an organization:", labels)
 		if err != nil {
+			if errors.Is(err, tui.ErrNoTTY) {
+				return "", &userError{
+					msg:        "No interactive terminal available to select an organization.",
+					suggestion: "Run 'chunk org list' to find your org ID, then set it with 'chunk config set orgID <id>' or pass --org-id.",
+					err:        err,
+				}
+			}
 			return "", &userError{msg: "Could not select an organization.", suggestion: "Pass --org-id instead.", err: err}
 		}
 		return collabs[idx].ID, nil

--- a/internal/cmd/sidecar_test.go
+++ b/internal/cmd/sidecar_test.go
@@ -1,14 +1,18 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+	"github.com/CircleCI-Public/chunk-cli/internal/tui"
 )
 
 func setupSidecarCreateFake(t *testing.T) *fakes.FakeCircleCI {
@@ -53,6 +57,109 @@ func TestSnapshotCreateNameTooLong(t *testing.T) {
 	err := cmd.Execute()
 	assert.ErrorContains(t, err, "255 characters or fewer")
 	assert.ErrorContains(t, err, "256")
+}
+
+func TestResolveOrgID_FlagTakesPrecedence(t *testing.T) {
+	called := false
+	got, err := resolveOrgID("from-flag", t.TempDir(), func() (string, error) {
+		called = true
+		return "picker-org", nil
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, got, "from-flag")
+	assert.Assert(t, !called, "pickOrg should not be called when flag is set")
+}
+
+func TestResolveOrgID_EnvVar(t *testing.T) {
+	t.Setenv(config.EnvCircleCIOrgID, "env-org")
+	called := false
+	got, err := resolveOrgID("", t.TempDir(), func() (string, error) {
+		called = true
+		return "picker-org", nil
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, got, "env-org")
+	assert.Assert(t, !called, "pickOrg should not be called when env var is set")
+}
+
+func TestResolveOrgID_ProjectConfig(t *testing.T) {
+	t.Setenv(config.EnvCircleCIOrgID, "")
+	dir := t.TempDir()
+	assert.NilError(t, config.SaveProjectConfig(dir, &config.ProjectConfig{OrgID: "config-org"}))
+	called := false
+	got, err := resolveOrgID("", dir, func() (string, error) {
+		called = true
+		return "picker-org", nil
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, got, "config-org")
+	assert.Assert(t, !called, "pickOrg should not be called when project config has org ID")
+}
+
+func TestResolveOrgID_FallsBackToPickOrg(t *testing.T) {
+	t.Setenv(config.EnvCircleCIOrgID, "")
+	got, err := resolveOrgID("", t.TempDir(), func() (string, error) {
+		return "picker-org", nil
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, got, "picker-org")
+}
+
+func TestResolveOrgID_PickOrgError(t *testing.T) {
+	t.Setenv(config.EnvCircleCIOrgID, "")
+	pickErr := errors.New("network failure")
+	_, err := resolveOrgID("", t.TempDir(), func() (string, error) {
+		return "", pickErr
+	})
+	assert.ErrorIs(t, err, pickErr)
+}
+
+func newOrgPickerClient(t *testing.T, cci *fakes.FakeCircleCI) *circleci.Client {
+	t.Helper()
+	srv := httptest.NewServer(cci)
+	t.Cleanup(srv.Close)
+	client, err := circleci.NewClient(circleci.Config{Token: "test-token", BaseURL: srv.URL})
+	assert.NilError(t, err)
+	return client
+}
+
+func TestOrgPicker_APIError(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.CollaborationsStatusCode = 500
+	client := newOrgPickerClient(t, cci)
+
+	_, err := orgPicker(context.Background(), client)()
+	assert.Assert(t, err != nil)
+}
+
+func TestOrgPicker_NoOrgs(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	client := newOrgPickerClient(t, cci)
+
+	_, err := orgPicker(context.Background(), client)()
+	assert.ErrorContains(t, err, "no organizations found")
+}
+
+func TestOrgPicker_SingleOrg(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.Collaborations = []fakes.Collaboration{{ID: "org-abc", Name: "myorg"}}
+	client := newOrgPickerClient(t, cci)
+
+	got, err := orgPicker(context.Background(), client)()
+	assert.NilError(t, err)
+	assert.Equal(t, got, "org-abc")
+}
+
+func TestOrgPicker_MultipleOrgs_NoTTY(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.Collaborations = []fakes.Collaboration{
+		{ID: "org-1", Name: "first"},
+		{ID: "org-2", Name: "second"},
+	}
+	client := newOrgPickerClient(t, cci)
+
+	_, err := orgPicker(context.Background(), client)()
+	assert.Assert(t, errors.Is(err, tui.ErrNoTTY), "expected ErrNoTTY, got: %v", err)
 }
 
 func TestSnapshotCreateNameAtLimit(t *testing.T) {

--- a/skills/chunk-sidecar/SKILL.md
+++ b/skills/chunk-sidecar/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: chunk-sidecar
 description: Use when the user says "validate on the sidecar", "run tests on the sidecar", "sync to sidecar", "sidecar dev loop", "check this on the sidecar", "validate remotely", "scaffold test-suites.yml", "set up smarter testing", "write .circleci/test-suites.yml", "run smarter testing doctor", or "diagnose smarter testing", or when you have made edits and want to verify them on a remote `chunk` sidecar instead of running locally. Also covers creating sidecars, snapshotting a configured environment, customizing the sidecar image via `chunk sidecar`, and scaffolding `.circleci/test-suites.yml` for CircleCI Smarter Testing.
-version: 2.0.0
+version: 2.1.0
 allowed-tools:
   - Bash(chunk --version)
   - Bash(chunk auth status)
   - Bash(chunk config set:*)
+  - Bash(chunk org list:*)
   - Bash(chunk sidecar:*)
   - Bash(chunk validate:*)
   - Bash(cat .chunk/config.json)
@@ -111,7 +112,7 @@ Before any `chunk sidecar` command, confirm:
 
 1. `chunk --version` — CLI is installed and on PATH.
 2. `chunk auth status` — exit code 0, CircleCI shows "Configured". If not, run `chunk auth set circleci`.
-3. **OrgID** — read `cat .chunk/config.json` and check `orgID`. If missing, run `test -n "${CIRCLECI_ORG_ID:-}"`. If **both** are unset, ask the user for their org ID **exactly once** and persist with `chunk config set orgID <id>`.
+3. **OrgID** — read `cat .chunk/config.json` and check `orgID`. If missing, run `test -n "${CIRCLECI_ORG_ID:-}"`. If **both** are unset, run `chunk org list --json`: one org, use it automatically; several, show the list and ask **exactly once**; error or empty, stop and ask the user to run `chunk auth set circleci`. Persist with `chunk config set orgID <id>`.
 
 Never run `echo $CIRCLE_TOKEN`, `env`, `printenv`, or any command that exposes credential env vars.
 
@@ -192,7 +193,7 @@ If `circleci-testsuite` is not installed, fall back to manual validation (see v1
 
 ## Troubleshooting
 
-- **`Could not select an organization` / `no interactive terminal`** — orgID missing. Ask user once, then `chunk config set orgID <id>`.
+- **`Could not select an organization` / `no interactive terminal`** — orgID missing. Run `chunk org list --json`, auto-select if there is one org, otherwise ask once, then `chunk config set orgID <id>`.
 - **Auth errors (401/403, "token invalid")** — run `chunk auth status`, follow its printed remediation.
 - **Sidecar 404 on `current` / `sync` / `validate`** — sidecar was deleted externally. Run `chunk sidecar forget`, return to Step 0.
 - **`permission denied (publickey)`** — run `chunk sidecar add-ssh-key --public-key-file ~/.ssh/chunk_ai.pub`. If it persists, tell user to remove `~/.ssh/chunk_ai*` to regenerate the keypair.


### PR DESCRIPTION
## Summary

Sidecar commands need a CircleCI org ID, but there was no way to discover or capture it through the CLI — users either knew it already or got blocked. This PR closes that gap.

`chunk init` now auto-detects the org ID after writing the project config. Single-org users get it picked silently; multi-org users see a picker. The ID is saved to `.chunk/config.json` so sidecar commands just work from that point on.

For cases where init isn't an option, `chunk org list` provides a discovery command. The `orgPicker` error message now points to it, and the sidecar skill uses it instead of stopping to ask the user.

## Test plan

- [ ] `chunk init` while authenticated to one org — org ID auto-selected and written to `.chunk/config.json`
- [ ] `chunk init` while authenticated to multiple orgs — picker appears, selected ID written
- [ ] `chunk init` while not authenticated — completes without error, no org ID written
- [ ] `chunk init` in a non-interactive environment (no TTY) — completes without error or spurious warning
- [ ] `chunk init --skip-org-id` — org ID detection step skipped
- [ ] `chunk org list` — orgs printed in table form; `--json` returns JSON
- [ ] `chunk sidecar create` with single-org account and no orgID in config — org auto-selected, no picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)