### PR TITLE
Read sidecar output as resumable byte-exact SSE

### DIFF
--- a/internal/circleci/circleci_test.go
+++ b/internal/circleci/circleci_test.go
@@ -224,7 +224,7 @@ func TestExec(t *testing.T) {
 		client := newTestClient(t, srv.URL)
 		ctx := context.Background()
 
-		resp, err := client.Exec(ctx, "sb-1", "ls", []string{"-la"}, nil)
+		resp, err := client.Exec(ctx, "sb-1", "ls", []string{"-la"}, nil, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -254,7 +254,7 @@ func TestExec(t *testing.T) {
 		client := newTestClient(t, srv.URL)
 		ctx := context.Background()
 
-		resp, err := client.Exec(ctx, "sb-1", "echo", []string{"hello"}, nil)
+		resp, err := client.Exec(ctx, "sb-1", "echo", []string{"hello"}, nil, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -277,7 +277,7 @@ func TestExec(t *testing.T) {
 		defer srv.Close()
 
 		client := newTestClient(t, srv.URL)
-		_, err := client.Exec(context.Background(), "sb-1", "echo", nil, nil)
+		_, err := client.Exec(context.Background(), "sb-1", "echo", nil, nil, nil)
 		var se *StatusError
 		if !errors.As(err, &se) || se.StatusCode != http.StatusGone {
 			t.Fatalf("expected 410 StatusError, got %v", err)
@@ -295,7 +295,7 @@ func TestExec(t *testing.T) {
 		client := newTestClient(t, srv.URL)
 		ctx := context.Background()
 
-		_, err := client.Exec(ctx, "sb-1", "pwd", nil, nil)
+		_, err := client.Exec(ctx, "sb-1", "pwd", nil, nil, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -476,7 +476,7 @@ func TestAuthRequired(t *testing.T) {
 	})
 
 	t.Run("Exec", func(t *testing.T) {
-		_, err := client.Exec(ctx, "sb-1", "ls", nil, nil)
+		_, err := client.Exec(ctx, "sb-1", "ls", nil, nil, nil)
 		if err == nil {
 			t.Fatal("expected error")
 		}

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -1,8 +1,8 @@
 package circleci
 
 import (
-	"bufio"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	hc "github.com/CircleCI-Public/chunk-cli/internal/httpcl"
+	"github.com/CircleCI-Public/chunk-cli/internal/sse"
 	"github.com/CircleCI-Public/chunk-cli/internal/version"
 )
 
@@ -19,6 +20,16 @@ var ErrTokenNotFound = errors.New("api token not found")
 
 // ErrNotAuthorized indicates the request was rejected (401/403).
 var ErrNotAuthorized = errors.New("not authorized")
+
+// ErrOutputFormatUnsupported indicates the output stream contained no events this
+// build understands.
+//
+// It means the API is *older* than this binary, not newer: the frame vocabulary
+// is designed so a newer API only ever adds event types while still emitting
+// stdout, stderr and exit. Receiving none of those therefore places the API
+// behind the client, which is the opposite of what a naive "upgrade" hint would
+// imply.
+var ErrOutputFormatUnsupported = errors.New("sidecar output format not supported")
 
 // StatusError is an alias for the shared httpcl.StatusError type.
 type StatusError = hc.StatusError
@@ -180,21 +191,50 @@ func (c *Client) AddSSHKey(ctx context.Context, sidecarID, publicKey string) (*A
 	return &AddSSHKeyResponse{URL: attrs.URL}, nil
 }
 
-// outputStreamLine is one JSONL event from GET /commands/{id}/output.
-// Lines with a non-empty CommandID are the terminal result; others carry output.
-type outputStreamLine struct {
-	CommandID string `json:"command_id"`
-	ExitCode  int    `json:"exit_code"`
-	PID       int    `json:"pid"`
-	Stream    string `json:"stream"` // "stdout" or "stderr"
-	Line      string `json:"line"`
-}
+// Stream names, matching the wire event names.
+const (
+	StreamStdout = "stdout"
+	StreamStderr = "stderr"
+)
+
+// OutputFn receives a run of raw output bytes from one stream, exactly as the
+// remote command wrote them. data is only valid for the duration of the call.
+type OutputFn func(stream string, data []byte)
+
+// maxOutputFrame caps a single SSE frame. The API batches output at 64KiB, which
+// base64-encodes to ~87KiB, so this is generous.
+const maxOutputFrame = 1 << 20
+
+// maxStreamStalls bounds consecutive attempts that deliver nothing at all —
+// connection refused, a 5xx, an instant close. Those are the only attempts worth
+// counting: reconnecting is the normal way this API serves a long command, since
+// the server caps each connection by design.
+const maxStreamStalls = 5
+
+// maxStreamAttempts is a runaway guard, not a real limit. With connections capped
+// at around fifteen seconds a legitimate stream reconnects roughly four times a
+// minute, so this allows many hours of output while still bounding a server that
+// talks but never terminates the stream.
+// A var only so tests can shrink it.
+var maxStreamAttempts = 2000
+
+// streamRetryBase is the first delay after a stalled attempt, scaled up per
+// consecutive stall. A healthy reconnect does not wait at all.
+// A var only so tests can shrink it; not intended to vary in normal use.
+var streamRetryBase = 500 * time.Millisecond
 
 type execSubmitAttrs struct {
 	Phase string `json:"phase"`
 }
 
-func (c *Client) Exec(ctx context.Context, sidecarID, command string, args []string, env map[string]string) (*ExecResponse, error) {
+// Exec submits a command and collects its output.
+//
+// When onOutput is non-nil it receives each run of output bytes as it arrives
+// and Stdout/Stderr are left empty — accumulating is then the caller's choice,
+// which matters because output can be arbitrarily large.
+func (c *Client) Exec(
+	ctx context.Context, sidecarID, command string, args []string, env map[string]string, onOutput OutputFn,
+) (*ExecResponse, error) {
 	var attrs execSubmitAttrs
 	envelope := v3Envelope{Data: v3DataEntity{Attributes: &attrs}}
 	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodPost, "/api/v3/sidecar/instances/%s/exec",
@@ -205,47 +245,207 @@ func (c *Client) Exec(ctx context.Context, sidecarID, command string, args []str
 	if err != nil {
 		return nil, mapErr("exec", err)
 	}
-	return c.streamCommandOutput(ctx, envelope.Data.ID)
+	return c.streamCommandOutput(ctx, envelope.Data.ID, onOutput)
 }
 
-func (c *Client) streamCommandOutput(ctx context.Context, commandID string) (*ExecResponse, error) {
-	var result ExecResponse
-	gotResult := false
-	decoder := func(r io.Reader) error {
-		sc := bufio.NewScanner(r)
-		for sc.Scan() {
-			var event outputStreamLine
-			if err := json.Unmarshal(sc.Bytes(), &event); err != nil {
-				continue
+// exitEvent is the payload of a terminal `exit` frame.
+type exitEvent struct {
+	ExitCode int    `json:"exit_code"`
+	Signal   string `json:"signal"`
+	PID      int    `json:"pid"`
+}
+
+// errorEvent is the payload of a terminal `error` frame.
+type errorEvent struct {
+	Code      string `json:"code"`
+	Message   string `json:"message"`
+	Retryable bool   `json:"retryable"`
+}
+
+// streamCommandOutput reads a command's output stream to its end, reconnecting
+// from the last cursor whenever the connection drops before a terminal event.
+//
+// The API ends a stream with exactly one exit or error event, or with nothing at
+// all; nothing at all means the connection was interrupted, which is precisely
+// what makes resuming safe rather than a guess.
+func (c *Client) streamCommandOutput(ctx context.Context, commandID string, onOutput OutputFn) (*ExecResponse, error) {
+	result := &ExecResponse{CommandID: commandID}
+
+	var (
+		cursor   string
+		attempts int
+		stalls   int
+	)
+
+	for {
+		outcome, err := c.streamOnce(ctx, commandID, cursor, onOutput, result)
+		attempts++
+
+		// Frames arrived but none were intelligible. Retrying cannot help, and
+		// reporting it as a stalled stream would send someone hunting a network
+		// fault that does not exist.
+		if err == nil && outcome.frames > 0 && outcome.known == 0 {
+			return nil, ErrOutputFormatUnsupported
+		}
+
+		if outcome.cursor != "" {
+			cursor = outcome.cursor
+		}
+
+		switch {
+		case outcome.exited:
+			return result, nil
+		case outcome.failed != nil:
+			if !outcome.failed.Retryable {
+				return nil, fmt.Errorf("remote command: %s", outcome.failed.Message)
 			}
-			if event.CommandID != "" {
-				result.CommandID = event.CommandID
-				result.ExitCode = event.ExitCode
-				result.PID = event.PID
-				gotResult = true
-				return nil
+		case err != nil:
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
 			}
-			switch event.Stream {
-			case "stdout":
-				result.Stdout += event.Line + "\n"
-			case "stderr":
-				result.Stderr += event.Line + "\n"
+			if !isRetryable(err) {
+				return nil, mapErr("stream command output", err)
 			}
 		}
-		return sc.Err()
+
+		// A connection that delivered any frame proves the far end is alive and
+		// talking, so it resets the stall count even when the command produced no
+		// new output — a command can legitimately be silent for minutes while it
+		// compiles, and the server closes each connection on a timer regardless.
+		// Counting those as failures would abandon a healthy but quiet command.
+		if outcome.frames > 0 {
+			stalls = 0
+		} else {
+			stalls++
+			if stalls > maxStreamStalls {
+				return nil, fmt.Errorf(
+					"stream command output: gave up after %d attempts that returned nothing", stalls-1)
+			}
+		}
+
+		if attempts >= maxStreamAttempts {
+			return nil, fmt.Errorf(
+				"stream command output: gave up after %d reconnects without the command finishing", attempts)
+		}
+
+		// A stream cut short by the server's timeout is routine, so resume at
+		// once — inserting a delay every few seconds would make output stutter
+		// for no reason. Only back off when an attempt yielded nothing.
+		if stalls == 0 {
+			continue
+		}
+		delay := min(time.Duration(stalls)*streamRetryBase, 10*streamRetryBase)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+		}
 	}
-	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v3/sidecar/commands/%s/output",
+}
+
+// streamOutcome is how a single connection to the output stream ended.
+type streamOutcome struct {
+	// cursor is the last event id seen, for resuming.
+	cursor string
+	// exited is true if a terminal exit event arrived.
+	exited bool
+	// failed is set if a terminal error event arrived.
+	failed *errorEvent
+	// frames counts every frame received, recognised or not.
+	frames int
+	// known counts frames this client understood. Frames without known means the
+	// server is speaking a format this version does not, which is worth saying
+	// plainly rather than reporting as a stalled stream.
+	known int
+}
+
+// streamOnce consumes one connection's worth of the output stream.
+func (c *Client) streamOnce(
+	ctx context.Context, commandID, cursor string, onOutput OutputFn, result *ExecResponse,
+) (streamOutcome, error) {
+	var outcome streamOutcome
+
+	decoder := func(r io.Reader) error {
+		last, err := sse.Scan(r, maxOutputFrame, func(f sse.Frame) error {
+			if !f.Comment {
+				outcome.frames++
+			}
+			switch f.Event {
+			case StreamStdout, StreamStderr:
+				outcome.known++
+				raw, decErr := base64.StdEncoding.DecodeString(string(f.Data))
+				if decErr != nil {
+					return fmt.Errorf("decoding %s payload: %w", f.Event, decErr)
+				}
+				if onOutput != nil {
+					onOutput(f.Event, raw)
+					return nil
+				}
+				if f.Event == StreamStdout {
+					result.Stdout += string(raw)
+				} else {
+					result.Stderr += string(raw)
+				}
+			case "exit":
+				outcome.known++
+				var e exitEvent
+				if jsonErr := json.Unmarshal(f.Data, &e); jsonErr != nil {
+					return fmt.Errorf("decoding exit event: %w", jsonErr)
+				}
+				result.ExitCode = e.ExitCode
+				result.PID = e.PID
+				result.Signal = e.Signal
+				outcome.exited = true
+			case "error":
+				outcome.known++
+				var e errorEvent
+				if jsonErr := json.Unmarshal(f.Data, &e); jsonErr != nil {
+					return fmt.Errorf("decoding error event: %w", jsonErr)
+				}
+				outcome.failed = &e
+			case "start":
+				outcome.known++
+			default:
+				// A future event type: ignored, which is what keeps the wire
+				// format extensible.
+			}
+			return nil
+		})
+		if last != "" {
+			outcome.cursor = last
+		}
+		return err
+	}
+
+	opts := []func(*hc.Request){
 		hc.RouteParams(commandID),
+		hc.Header("Accept", "text/event-stream"),
 		hc.Decoder(decoder),
 		hc.NoTimeout(),
-	))
-	if err != nil {
-		return nil, mapErr("stream command output", err)
 	}
-	if !gotResult {
-		return nil, fmt.Errorf("stream command output: stream ended without result")
+	if cursor != "" {
+		opts = append(opts, hc.Header("Last-Event-ID", cursor))
 	}
-	return &result, nil
+
+	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v3/sidecar/commands/%s/output", opts...))
+	return outcome, err
+}
+
+// isRetryable reports whether a failed stream attempt is worth resuming. A
+// transport error is; a definitive rejection from the API is not, since
+// reconnecting would only repeat it.
+func isRetryable(err error) bool {
+	var se *StatusError
+	if errors.As(err, &se) {
+		return se.StatusCode >= 500 && se.StatusCode != http.StatusNotImplemented
+	}
+	var he *hc.HTTPError
+	if errors.As(err, &he) {
+		return he.StatusCode >= 500
+	}
+	// Anything that is not an HTTP status is a transport or decode failure, which
+	// resuming from the last cursor is exactly the remedy for.
+	return true
 }
 
 type commandAttrs struct {
@@ -388,23 +588,39 @@ func mapErr(op string, err error) error {
 	return se
 }
 
-// extractServerMessage tries to pull a human-readable message from a JSON
-// error body. Falls back to the raw body string if JSON parsing fails.
+// extractServerMessage pulls the human-readable message out of a JSON error
+// body, falling back to the raw body only when there is nothing better.
+//
+// Three shapes are in play. V3 nests the text in an object,
+// {"error":{"title":"..."}}, while older endpoints return a bare string as
+// either "error" or "message". Decoding "error" as a string — as this used to —
+// fails outright on the V3 shape, so every V3 error surfaced to users as a raw
+// JSON envelope complete with trace id.
 func extractServerMessage(body []byte) string {
 	if len(body) == 0 {
 		return ""
 	}
 	var payload struct {
-		Error   string `json:"error"`
-		Message string `json:"message"`
+		Error   json.RawMessage `json:"error"`
+		Message string          `json:"message"`
 	}
-	if err := json.Unmarshal(body, &payload); err == nil {
-		if payload.Error != "" {
-			return payload.Error
-		}
-		if payload.Message != "" {
-			return payload.Message
-		}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return string(body)
+	}
+
+	var v3 struct {
+		Title string `json:"title"`
+	}
+	if json.Unmarshal(payload.Error, &v3) == nil && v3.Title != "" {
+		return v3.Title
+	}
+
+	var bare string
+	if json.Unmarshal(payload.Error, &bare) == nil && bare != "" {
+		return bare
+	}
+	if payload.Message != "" {
+		return payload.Message
 	}
 	return string(body)
 }

--- a/internal/circleci/exec_stream_test.go
+++ b/internal/circleci/exec_stream_test.go
@@ -1,0 +1,293 @@
+package circleci
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+)
+
+// execWith runs a command against a fake configured with the given canned
+// result, returning the streamed bytes alongside the response.
+func execWith(t *testing.T, resp *fakes.ExecResponse, tweak func(*fakes.FakeCircleCI)) (*ExecResponse, []byte, []byte, error) {
+	t.Helper()
+	out, stdout, stderr, _, err := execCounting(t, resp, tweak)
+	return out, stdout, stderr, err
+}
+
+// execCounting also reports how many times the output stream was requested, so a
+// resume test cannot pass without the reconnect actually happening.
+func execCounting(
+	t *testing.T, resp *fakes.ExecResponse, tweak func(*fakes.FakeCircleCI),
+) (*ExecResponse, []byte, []byte, int, error) {
+	t.Helper()
+
+	// Keep reconnect backoff out of the test's wall clock; the delay logic itself
+	// is not what these tests are about.
+	previous := streamRetryBase
+	streamRetryBase = time.Millisecond
+	t.Cleanup(func() { streamRetryBase = previous })
+
+	fake := fakes.NewFakeCircleCI()
+	fake.ExecResponse = resp
+	if tweak != nil {
+		tweak(fake)
+	}
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+
+	client := newTestClient(t, srv.URL)
+
+	var stdout, stderr bytes.Buffer
+	onOutput := func(stream string, data []byte) {
+		if stream == StreamStderr {
+			stderr.Write(data)
+		} else {
+			stdout.Write(data)
+		}
+	}
+
+	out, err := client.Exec(context.Background(), "sb-1", "sh", nil, nil, onOutput)
+
+	attempts := 0
+	for _, req := range fake.Recorder.AllRequests() {
+		if strings.HasSuffix(req.URL.Path, "/output") {
+			attempts++
+		}
+	}
+	return out, stdout.Bytes(), stderr.Bytes(), attempts, err
+}
+
+// Bytes must reach the caller exactly as the remote command wrote them. Every
+// payload here was corrupted by the previous line-oriented format: carriage
+// returns were destroyed by line splitting, and invalid UTF-8 was silently
+// replaced with U+FFFD by JSON encoding.
+func TestExecPreservesBytesExactly(t *testing.T) {
+	payloads := []struct {
+		name string
+		data string
+	}{
+		{"carriage return redraw", "a\rb\rc"},
+		{"no trailing newline", "Continue? [y/N] "},
+		{"ansi escapes", "\x1b[32mok\x1b[0m\n"},
+		{"invalid utf8", "\xed\xa0\x80"},
+		{"nul bytes", "a\x00b"},
+		{"crlf", "one\r\ntwo\r\n"},
+	}
+
+	for _, p := range payloads {
+		t.Run(p.name, func(t *testing.T) {
+			_, stdout, _, err := execWith(t, &fakes.ExecResponse{
+				CommandID: "cmd-1", Stdout: p.data,
+			}, nil)
+			assert.NilError(t, err)
+			assert.Check(t, cmp.DeepEqual(stdout, []byte(p.data)))
+		})
+	}
+}
+
+func TestExecSeparatesStreams(t *testing.T) {
+	_, stdout, stderr, err := execWith(t, &fakes.ExecResponse{
+		CommandID: "cmd-1", Stdout: "out\n", Stderr: "err\n",
+	}, nil)
+	assert.NilError(t, err)
+	assert.Equal(t, string(stdout), "out\n")
+	assert.Equal(t, string(stderr), "err\n")
+	assert.Check(t, !bytes.Contains(stdout, []byte("err")), "stderr leaked into stdout")
+}
+
+// Output larger than bufio.Scanner's old 64KiB token limit must arrive whole.
+func TestExecLargeOutput(t *testing.T) {
+	big := strings.Repeat("x", 300<<10)
+	_, stdout, _, err := execWith(t, &fakes.ExecResponse{CommandID: "cmd-1", Stdout: big}, nil)
+	assert.NilError(t, err)
+	assert.Equal(t, len(stdout), len(big))
+}
+
+func TestExecExitCodeAndSignal(t *testing.T) {
+	resp, _, _, err := execWith(t, &fakes.ExecResponse{
+		CommandID: "cmd-1", Stdout: "bye\n", ExitCode: 137, Signal: "killed",
+	}, nil)
+	assert.NilError(t, err)
+	assert.Equal(t, resp.ExitCode, 137)
+	assert.Equal(t, resp.Signal, "killed")
+}
+
+// A connection that ends without a terminal event means "interrupted": the
+// client must reconnect from its cursor and reassemble the transcript rather
+// than reporting a truncated stream as a result.
+func TestExecResumesAfterDroppedConnection(t *testing.T) {
+	resp, stdout, _, attempts, err := execCounting(t, &fakes.ExecResponse{
+		CommandID: "cmd-1", Stdout: "abcdefghij", ExitCode: 0,
+	}, func(f *fakes.FakeCircleCI) {
+		f.DropStreamsBeforeExit = 1
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, string(stdout), "abcdefghij",
+		"resume must not duplicate or drop bytes")
+	assert.Equal(t, resp.ExitCode, 0)
+	assert.Equal(t, attempts, 2, "the dropped stream must have been reconnected exactly once")
+}
+
+// Repeated drops must still converge, exercising the backoff loop rather than
+// giving up on the first retry.
+func TestExecResumesAcrossSeveralDrops(t *testing.T) {
+	resp, stdout, _, attempts, err := execCounting(t, &fakes.ExecResponse{
+		CommandID: "cmd-1", Stdout: "hello world", ExitCode: 3,
+	}, func(f *fakes.FakeCircleCI) {
+		f.DropStreamsBeforeExit = 2
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, string(stdout), "hello world")
+	assert.Equal(t, resp.ExitCode, 3)
+	assert.Equal(t, attempts, 3)
+}
+
+// The server caps every connection on a timer, so a long command is served as a
+// series of short streams. Reconnecting many times without new output must
+// therefore be normal, not a reason to give up — a command can be silent for
+// minutes while it compiles, and abandoning it then would be the whole bug back
+// again in a new form.
+func TestExecKeepsResumingWhileServerStaysAlive(t *testing.T) {
+	drops := maxStreamStalls * 4
+
+	resp, stdout, _, attempts, err := execCounting(t, &fakes.ExecResponse{
+		CommandID: "cmd-1", Stdout: "done\n", ExitCode: 0,
+	}, func(f *fakes.FakeCircleCI) {
+		f.DropStreamsBeforeExit = drops
+	})
+	assert.NilError(t, err, "a stream that keeps reconnecting must not be abandoned")
+	assert.Equal(t, string(stdout), "done\n", "output must not be duplicated across reconnects")
+	assert.Equal(t, resp.ExitCode, 0)
+	assert.Equal(t, attempts, drops+1)
+}
+
+// A server that keeps talking but never terminates the stream is still bounded,
+// so a bug there cannot spin forever.
+func TestExecGivesUpWhenStreamNeverTerminates(t *testing.T) {
+	previous := maxStreamAttempts
+	maxStreamAttempts = 5
+	t.Cleanup(func() { maxStreamAttempts = previous })
+
+	_, _, _, attempts, err := execCounting(t, &fakes.ExecResponse{
+		CommandID: "cmd-1", Stdout: "x", ExitCode: 0,
+	}, func(f *fakes.FakeCircleCI) {
+		f.DropStreamsBeforeExit = 10_000
+	})
+	assert.Check(t, err != nil, "an endlessly interrupted stream must eventually fail")
+	assert.Check(t, strings.Contains(err.Error(), "without the command finishing"), "got %v", err)
+	assert.Equal(t, attempts, 5)
+}
+
+// Attempts that deliver nothing at all are the ones worth counting: a far end
+// that cannot be reached will never be reached by trying harder.
+func TestExecGivesUpWhenAttemptsReturnNothing(t *testing.T) {
+	_, _, _, attempts, err := execCounting(t, &fakes.ExecResponse{
+		CommandID: "cmd-1", ExitCode: 0,
+	}, func(f *fakes.FakeCircleCI) {
+		f.CommandOutputStatusCode = 503
+		f.CommandOutputMessage = "upstream unavailable"
+	})
+	assert.Check(t, err != nil)
+	assert.Check(t, strings.Contains(err.Error(), "returned nothing"), "got %v", err)
+	// The request count exceeds the loop's attempt count because the HTTP client
+	// retries a 5xx itself; what matters is that the whole thing is bounded
+	// rather than spinning.
+	assert.Check(t, attempts > 0 && attempts < 50, "stalls must be bounded, got %d requests", attempts)
+}
+
+// An API speaking a format this build does not know must say so, rather than
+// looking like a stalled stream and sending someone hunting a network fault.
+func TestExecReportsUnrecognisedFormat(t *testing.T) {
+	// A server emitting only event types this client does not handle — which is
+	// exactly what an older API looks like.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/exec") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"id":"cmd-1","attributes":{"phase":"received"}}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: output\ndata: {\"stream\":\"stdout\",\"line\":\"hi\"}\n\n" +
+			"event: result\ndata: {\"command_id\":\"cmd-1\",\"exit_code\":0}\n\n"))
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).Exec(context.Background(), "sb-1", "sh", nil, nil, nil)
+	assert.Check(t, errors.Is(err, ErrOutputFormatUnsupported), "got %v", err)
+}
+
+// With no onOutput the client accumulates, which is what callers needing the
+// whole transcript rely on.
+func TestExecAccumulatesWhenNoCallback(t *testing.T) {
+	fake := fakes.NewFakeCircleCI()
+	fake.ExecResponse = &fakes.ExecResponse{
+		CommandID: "cmd-1", Stdout: "a\rb", Stderr: "oops\n", ExitCode: 0,
+	}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	resp, err := newTestClient(t, srv.URL).Exec(context.Background(), "sb-1", "sh", nil, nil, nil)
+	assert.NilError(t, err)
+	assert.Equal(t, resp.Stdout, "a\rb")
+	assert.Equal(t, resp.Stderr, "oops\n")
+}
+
+// A definitive rejection must fail immediately rather than being retried, since
+// reconnecting would only repeat it.
+func TestExecDoesNotRetryClientErrors(t *testing.T) {
+	fake := fakes.NewFakeCircleCI()
+	fake.ExecResponse = &fakes.ExecResponse{CommandID: "cmd-1"}
+	fake.CommandOutputStatusCode = 410
+	fake.CommandOutputMessage = "sidecar is out of date"
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).Exec(context.Background(), "sb-1", "sh", nil, nil, nil)
+	assert.Check(t, err != nil)
+
+	// One submit plus exactly one output attempt — no retry storm.
+	outputAttempts := 0
+	for _, req := range fake.Recorder.AllRequests() {
+		if strings.HasSuffix(req.URL.Path, "/output") {
+			outputAttempts++
+		}
+	}
+	assert.Equal(t, outputAttempts, 1, "a 410 must not be retried")
+}
+
+// The V3 error envelope nests the human-readable text as an object. Decoding
+// "error" as a string fails on it outright, which is why V3 errors used to reach
+// users as a raw JSON envelope complete with trace id.
+func TestExtractServerMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "v3 nested envelope",
+			body: `{"error":{"id":"ff5c93354749c51f","title":"sidecar is out of date; delete and recreate with: chunk sidecar create"}}`,
+			want: "sidecar is out of date; delete and recreate with: chunk sidecar create",
+		},
+		{name: "bare error string", body: `{"error":"gone away"}`, want: "gone away"},
+		{name: "message field", body: `{"message":"nope"}`, want: "nope"},
+		{name: "empty body", body: ``, want: ""},
+		{name: "unparseable falls back to raw", body: `not json`, want: "not json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, extractServerMessage([]byte(tt.body)), tt.want)
+		})
+	}
+}

--- a/internal/circleci/types.go
+++ b/internal/circleci/types.go
@@ -19,6 +19,9 @@ type ExecResponse struct {
 	Stdout    string `json:"stdout"`
 	Stderr    string `json:"stderr"`
 	ExitCode  int    `json:"exit_code"`
+	// Signal is the symbolic name of the signal that killed the command, empty
+	// if it exited normally. When set, ExitCode is 128+signum.
+	Signal string `json:"signal,omitempty"`
 }
 
 type AddSSHKeyRequest struct {

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -321,18 +321,34 @@ func newSidecarExecCmd() *cobra.Command {
 			allArgs := make([]string, 0, len(execArgs)+len(args))
 			allArgs = append(allArgs, execArgs...)
 			allArgs = append(allArgs, args...)
-			resp, err := sidecar.Exec(cmd.Context(), client, sidecarID, command, allArgs)
+			// Raw bytes, not lines: writing the command's own bytes through
+			// unchanged is what lets carriage-return redraws and ANSI colour
+			// render as the remote terminal intended.
+			onOutput := func(stream string, data []byte) {
+				w := io.Out
+				if stream == circleci.StreamStderr {
+					w = io.Err
+				}
+				_, _ = w.Write(data)
+			}
+			resp, err := sidecar.Exec(cmd.Context(), client, sidecarID, command, allArgs, onOutput)
 			if err != nil {
 				if err := notAuthorized("execute commands", err); err != nil {
 					return err
 				}
+				if err := outdatedSidecarAPI(err); err != nil {
+					return err
+				}
 				return err
 			}
-			if resp.Stdout != "" {
-				_, _ = fmt.Fprint(io.Out, resp.Stdout)
-			}
-			if resp.Stderr != "" {
-				_, _ = fmt.Fprint(io.Err, resp.Stderr)
+			// A remote command that failed must fail locally too, otherwise
+			// scripts and CI cannot tell success from failure. The command's own
+			// output has already been written, so exit silently with its code.
+			if resp.ExitCode != 0 {
+				if resp.Signal != "" {
+					io.ErrPrintf("Command killed by signal: %s\n", resp.Signal)
+				}
+				return &silentExitError{code: resp.ExitCode}
 			}
 			return nil
 		},

--- a/internal/cmd/usererr.go
+++ b/internal/cmd/usererr.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -44,6 +45,22 @@ func notAuthorized(action string, err error) error {
 		withCode("auth.not_authorized").
 		withSuggestion(suggestionReauth).
 		withExitCode(ExitAuthError).
+		wrap(err)
+}
+
+// outdatedSidecarAPI maps an unsupported output format to guidance that points
+// the right way. The API is behind this binary, not ahead of it, so telling
+// someone to upgrade chunk would send them in exactly the wrong direction —
+// there is nothing newer to install, and installing it again would not help.
+func outdatedSidecarAPI(err error) error {
+	if !errors.Is(err, circleci.ErrOutputFormatUnsupported) {
+		return nil
+	}
+	return newUserError("This build of chunk needs a newer CircleCI sidecar API.").
+		withCode("sidecar.output_format_unsupported").
+		withDetail("The API streamed command output in a format this build no longer reads.").
+		withSuggestion("The API has not been updated yet. Install the latest release with 'chunk upgrade', " +
+			"or if you built this from source, switch back to a released build until the API catches up.").
 		wrap(err)
 }
 
@@ -91,6 +108,7 @@ type userError struct {
 	exitCode   int    // 0 means ExitGeneral
 	errMsg     string // used only when err == nil
 	err        error  // when set, Error() delegates to err.Error()
+	hideDetail bool   // suppress the detail line entirely, see withoutDetail
 }
 
 // newUserError creates a userError with the given user-facing message.
@@ -106,6 +124,12 @@ func (e *userError) withExitCode(code int) *userError    { e.exitCode = code; re
 func (e *userError) wrap(err error) *userError           { e.err = err; return e }
 func (e *userError) wrapMsg(msg string) *userError       { e.errMsg = msg; return e }
 
+// withoutDetail states that the message and suggestion say everything, so no
+// detail line should be shown. Without it an empty detail falls back to the
+// wrapped error, which leaks Go-level wrapping like "exec: 410 Gone — ..." and,
+// when the message was translated from that same error, repeats itself.
+func (e *userError) withoutDetail() *userError { e.hideDetail = true; return e }
+
 func (e *userError) Error() string {
 	if e.err != nil {
 		return e.err.Error()
@@ -120,6 +144,10 @@ func (e *userError) UserMessage() string { return e.msg }
 func (e *userError) Detail() string      { return e.detail }
 func (e *userError) Suggestion() string  { return e.suggestion }
 func (e *userError) Unwrap() error       { return e.err }
+
+// HideDetail reports that this error is fully described by its message and
+// suggestion, so the display must not fall back to the wrapped error.
+func (e *userError) HideDetail() bool { return e.hideDetail }
 
 // ErrorCode returns the namespaced error code, e.g. "auth.token_missing".
 // Empty string means no code was set.
@@ -158,15 +186,37 @@ func errNoForce(action string) error {
 		withExitCode(ExitBadArgs)
 }
 
-// GoneError returns a formatted error when err contains a 410 Gone status,
-// which means the server no longer supports this version of the CLI. Returns
-// nil for any other error. Use at the top of main's error path to intercept
-// 410s before generic handling.
+// GoneError returns a formatted error when err contains a 410 Gone status, which
+// the API uses for two distinct conditions: this CLI being too old for the API,
+// and a sidecar being too old for the API. Returns nil for any other error. Use
+// at the top of main's error path to intercept 410s before generic handling.
 func GoneError(err error) error {
 	var se *circleci.StatusError
 	if !errors.As(err, &se) || se.StatusCode != http.StatusGone {
 		return nil
 	}
+
+	// A 410 covers two unrelated conditions with opposite remedies: the CLI
+	// being too old for the API, and a sidecar being too old for the API. Telling
+	// someone to upgrade the CLI when their sidecar is the stale one sends them
+	// to a version that will fail identically, so the two must be told apart.
+	//
+	// Matching on the server's own wording is a compromise: the V3 error envelope
+	// carries no machine-readable code, so there is nothing better to key off
+	// until the API supplies one. The server's message already names the remedy,
+	// so it is shown rather than replaced with a guess.
+	if strings.Contains(strings.ToLower(se.ServerMessage), "sidecar is out of date") {
+		// Deliberately no detail. The server's message states the condition and
+		// the remedy, both of which are already the message and the suggestion
+		// here, so including it says the same thing three times over.
+		return newUserError("This sidecar is out of date.").
+			withCode("sidecar.out_of_date").
+			withSuggestion("Recreate it with: chunk sidecar create").
+			withExitCode(ExitAPIError).
+			withoutDetail().
+			wrap(err)
+	}
+
 	detail := se.ServerMessage
 	if detail == "" {
 		detail = "This server no longer supports this version of chunk CLI."

--- a/internal/cmd/usererr_test.go
+++ b/internal/cmd/usererr_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+)
+
+// The API being behind this binary must not be reported as "upgrade chunk":
+// there is nothing newer to install, and that advice sends someone in exactly
+// the wrong direction.
+func TestOutdatedSidecarAPIPointsTheRightWay(t *testing.T) {
+	err := outdatedSidecarAPI(fmt.Errorf("remote test: %w", circleci.ErrOutputFormatUnsupported))
+	assert.Assert(t, err != nil, "the sentinel must be recognised through a wrapper")
+
+	um, ok := err.(interface{ UserMessage() string })
+	assert.Assert(t, ok)
+	assert.Check(t, strings.Contains(um.UserMessage(), "needs a newer"), "got %q", um.UserMessage())
+	assert.Check(t, !strings.Contains(strings.ToLower(um.UserMessage()), "upgrade chunk"),
+		"the message must not tell someone to upgrade a binary that is already ahead: %q", um.UserMessage())
+
+	s, ok := err.(interface{ Suggestion() string })
+	assert.Assert(t, ok)
+	assert.Check(t, strings.Contains(s.Suggestion(), "has not been updated yet"), "got %q", s.Suggestion())
+
+	assert.Check(t, outdatedSidecarAPI(errors.New("something else")) == nil,
+		"unrelated errors must pass through unmapped")
+	assert.Check(t, outdatedSidecarAPI(nil) == nil)
+}
+
+// A 410 is used for two conditions with opposite remedies. Telling someone to
+// upgrade the CLI when their *sidecar* is the stale one sends them to a version
+// that fails identically.
+func TestGoneErrorDistinguishesStaleSidecarFromStaleCLI(t *testing.T) {
+	t.Run("stale sidecar", func(t *testing.T) {
+		err := GoneError(&circleci.StatusError{
+			Op:            "stream command output",
+			StatusCode:    http.StatusGone,
+			ServerMessage: "sidecar is out of date; delete and recreate with: chunk sidecar create",
+		})
+		assert.Assert(t, err != nil)
+
+		um := err.(interface{ UserMessage() string }).UserMessage()
+		s := err.(interface{ Suggestion() string }).Suggestion()
+		assert.Check(t, strings.Contains(um, "sidecar is out of date"), "got %q", um)
+		assert.Check(t, strings.Contains(s, "chunk sidecar create"), "got %q", s)
+		assert.Check(t, !strings.Contains(s, "chunk upgrade"),
+			"upgrading the CLI does not fix a stale sidecar: %q", s)
+
+		// The server's message states both the condition and the remedy, so
+		// echoing it as detail would print the same thing three times. The
+		// suppression must be explicit, or the display falls back to the wrapped
+		// error and leaks "410 Gone" wrapping instead.
+		assert.Equal(t, err.(interface{ Detail() string }).Detail(), "",
+			"a translated message must not also repeat the server's")
+		assert.Check(t, err.(interface{ HideDetail() bool }).HideDetail(),
+			"an empty detail must be declared, not merely unset")
+	})
+
+	t.Run("stale CLI", func(t *testing.T) {
+		err := GoneError(&circleci.StatusError{
+			StatusCode:    http.StatusGone,
+			ServerMessage: "this endpoint has been removed",
+		})
+		assert.Assert(t, err != nil)
+		um := err.(interface{ UserMessage() string }).UserMessage()
+		s := err.(interface{ Suggestion() string }).Suggestion()
+		assert.Check(t, strings.Contains(um, "chunk CLI is out of date"), "got %q", um)
+		assert.Check(t, strings.Contains(s, "chunk upgrade"), "got %q", s)
+	})
+
+	t.Run("non-410 passes through", func(t *testing.T) {
+		assert.Check(t, GoneError(&circleci.StatusError{StatusCode: http.StatusNotFound}) == nil)
+		assert.Check(t, GoneError(errors.New("nope")) == nil)
+	})
+}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -105,7 +105,15 @@ func newValidateCmd() *cobra.Command {
 		SilenceUsage: true,
 		Args:         cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runValidateCmdE(cmd, args, &opts)
+			// Mapped here rather than at the exec call: the remote runners wrap
+			// errors with %w, and the top-level error reporter type-asserts on the
+			// error itself rather than unwrapping, so a userError buried under a
+			// wrapper would lose its message and suggestion.
+			err := runValidateCmdE(cmd, args, &opts)
+			if mapped := outdatedSidecarAPI(err); mapped != nil {
+				return mapped
+			}
+			return err
 		},
 	}
 
@@ -330,7 +338,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 			streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", cmdName)))
 		}
 		if sidecarID != "" && allRemote {
-			execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc)
+			execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, streams)
 			if err != nil {
 				return err
 			}
@@ -341,7 +349,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 
 	// All-remote execution (--remote flag): send everything to the sidecar.
 	if sidecarID != "" && allRemote {
-		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc)
+		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, streams)
 		if err != nil {
 			return err
 		}
@@ -354,7 +362,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 		if name != "" {
 			if cmd := cfg.FindCommand(name); cmd != nil && cmd.Remote {
 				statusFn(iostream.LevelInfo, fmt.Sprintf("running %s on sidecar %s", name, sidecarID))
-				execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc)
+				execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, streams)
 				if err != nil {
 					return err
 				}
@@ -442,7 +450,15 @@ func syncToSidecar(ctx context.Context, client *circleci.Client, sidecarID, iden
 
 // newExecFn builds a function that runs shell scripts on a remote sidecar via
 // the async HTTP exec API, along with the resolved remote working directory.
-func newExecFn(ctx context.Context, client *circleci.Client, sidecarID, workdir string, envVars map[string]string, rc config.ResolvedConfig) (func(context.Context, string) (string, string, int, error), string, error) {
+//
+// Output is written to streams as it arrives rather than buffered, so a long
+// command shows progress instead of going silent for minutes. The returned
+// stdout and stderr are therefore always empty — callers print output only when
+// it was not already streamed, so there is nothing left for them to do.
+func newExecFn(
+	ctx context.Context, client *circleci.Client, sidecarID, workdir string,
+	envVars map[string]string, rc config.ResolvedConfig, streams iostream.Streams,
+) (func(context.Context, string) (string, string, int, error), string, error) {
 	cwd, _ := os.Getwd()
 	_, repo, _ := gitremote.DetectOrgAndRepo(cwd)
 	dest, err := sidecar.ResolveWorkspace(ctx, workdir, repo)
@@ -456,12 +472,21 @@ func newExecFn(ctx context.Context, client *circleci.Client, sidecarID, workdir 
 	for k, v := range envVars {
 		merged[k] = v
 	}
+	// Raw bytes straight through, so carriage-return redraws and ANSI colour
+	// render as the remote command intended.
+	onOutput := func(stream string, data []byte) {
+		w := streams.Out
+		if stream == circleci.StreamStderr {
+			w = streams.Err
+		}
+		_, _ = w.Write(data)
+	}
 	execFn := func(ctx context.Context, script string) (string, string, int, error) {
-		result, err := client.Exec(ctx, sidecarID, "sh", []string{"-c", script}, merged)
+		result, err := client.Exec(ctx, sidecarID, "sh", []string{"-c", script}, merged, onOutput)
 		if err != nil {
 			return "", "", 0, err
 		}
-		return result.Stdout, result.Stderr, result.ExitCode, nil
+		return "", "", result.ExitCode, nil
 	}
 	return execFn, dest, nil
 }
@@ -494,7 +519,7 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 	}
 	var runErr error
 	if len(remoteCfg.Commands) > 0 {
-		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc)
+		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, streams)
 		if err != nil {
 			if freshlyCreated {
 				return newUserError(fmt.Sprintf("Could not reach newly created sidecar %s.", sidecarID)).

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http/httptest"
 	"os"
 	"os/exec"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 )
@@ -144,7 +146,8 @@ func TestOpenAPIExecPassesEnvVars(t *testing.T) {
 	assert.NilError(t, err)
 
 	envVars := map[string]string{"FOO": "bar", "BAZ": "qux"}
-	execFn, _, err := newExecFn(context.Background(), client, "sidecar-123", "", envVars, config.ResolvedConfig{})
+	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
+	execFn, _, err := newExecFn(context.Background(), client, "sidecar-123", "", envVars, config.ResolvedConfig{}, streams)
 	assert.NilError(t, err)
 
 	_, _, _, err = execFn(context.Background(), "echo hello")

--- a/internal/httpcl/client.go
+++ b/internal/httpcl/client.go
@@ -237,7 +237,10 @@ func (c *Client) Call(ctx context.Context, r Request) (int, error) {
 		req.Header.Set("User-Agent", c.userAgent)
 	}
 
+	// Per-request headers override the defaults set above rather than appending
+	// to them, so a caller can replace Accept (e.g. to request a stream).
 	for k, vals := range r.headers {
+		req.Header.Del(k)
 		for _, v := range vals {
 			req.Header.Add(k, v)
 		}

--- a/internal/httpcl/client_test.go
+++ b/internal/httpcl/client_test.go
@@ -125,6 +125,30 @@ func TestCallCustomAuthHeader(t *testing.T) {
 	}
 }
 
+func TestHeaderOverridesDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Client defaults to "application/json"; a per-request Header must
+		// replace it, not append, or Header.Get on the server still sees JSON.
+		if got := r.Header.Values("Accept"); len(got) != 1 || got[0] != "text/event-stream" {
+			t.Errorf("expected exactly one Accept of text/event-stream, got %q", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := hc.New(hc.Config{BaseURL: srv.URL})
+
+	status, err := c.Call(context.Background(), hc.NewRequest("GET", "/",
+		hc.Header("Accept", "text/event-stream"),
+	))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("expected 200, got %d", status)
+	}
+}
+
 func TestRouteParams(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v2/sidecar/instances/sb-42/exec" {

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -15,8 +15,10 @@ func Create(ctx context.Context, client *circleci.Client, orgID, name, image str
 	return client.CreateSidecar(ctx, orgID, name, image)
 }
 
-func Exec(ctx context.Context, client *circleci.Client, sidecarID, command string, args []string) (*circleci.ExecResponse, error) {
-	return client.Exec(ctx, sidecarID, command, args, nil)
+func Exec(
+	ctx context.Context, client *circleci.Client, sidecarID, command string, args []string, onOutput circleci.OutputFn,
+) (*circleci.ExecResponse, error) {
+	return client.Exec(ctx, sidecarID, command, args, nil, onOutput)
 }
 
 func AddSSHKey(ctx context.Context, client *circleci.Client, sidecarID, publicKey, publicKeyFile string) (*circleci.AddSSHKeyResponse, error) {

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -73,7 +73,7 @@ func TestExec(t *testing.T) {
 	cl := newClient(t, srv.URL)
 	ctx := context.Background()
 
-	resp, err := sidecar.Exec(ctx, cl, "sb-1", "echo", []string{"hello"})
+	resp, err := sidecar.Exec(ctx, cl, "sb-1", "echo", []string{"hello"}, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, resp.Stdout, "output\n")
 	assert.Equal(t, resp.ExitCode, 0)

--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -1,0 +1,183 @@
+// Package sse reads Server-Sent Events streams.
+//
+// It is a reader only — chunk consumes SSE, it never serves it. The server side
+// of this contract lives in sandbox-provisioner; the two are separate modules,
+// so the framing is implemented on both sides rather than shared.
+package sse
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// ErrFrameTooLarge is returned when a single line exceeds the configured
+// maximum. It is an explicit error rather than a silent stop: truncating a
+// stream because a frame was unexpectedly large is a failure that otherwise
+// reads as success. This is why bufio.Scanner, whose 64KiB limit fails exactly
+// that way, is deliberately not used here.
+var ErrFrameTooLarge = errors.New("sse: frame too large")
+
+// Frame is one decoded SSE frame.
+type Frame struct {
+	// Event is the "event:" field. Empty for an unnamed frame or a comment.
+	Event string
+	// ID is the "id:" field — an opaque cursor. Never interpret it; store it and
+	// echo it back as Last-Event-ID to resume.
+	ID string
+	// Data is the payload with the single optional space after the colon
+	// stripped.
+	Data []byte
+	// Comment is true for a ":" comment frame, i.e. a heartbeat.
+	Comment bool
+}
+
+// Scan reads frames from r until EOF, calling fn for each. It returns the last
+// non-empty id seen, so an interrupted reader knows where to resume from.
+//
+// A partial trailing frame — one with no terminating blank line — is discarded
+// rather than delivered, so a truncated stream never surfaces as a short but
+// plausible-looking event. maxFrame caps a single line.
+//
+// Terminators may be "\n" or "\r\n". A lone "\r" is not treated as one: no
+// producer we read emits it, and payloads are base64 or JSON so they cannot
+// contain one. Were it ever to appear it stays inside the payload rather than
+// splitting a line, so framing is undisturbed and the payload fails to decode
+// loudly instead of corrupting silently.
+func Scan(r io.Reader, maxFrame int, fn func(Frame) error) (string, error) {
+	br := bufio.NewReaderSize(r, 32<<10)
+
+	var (
+		lastID  string
+		f       Frame
+		hasData bool
+		pending bool
+	)
+
+	for {
+		line, err := readLine(br, maxFrame)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				// Any accumulated partial frame is intentionally dropped.
+				return lastID, nil
+			}
+			return lastID, err
+		}
+
+		if len(line) == 0 {
+			if pending {
+				if err := fn(f); err != nil {
+					return lastID, err
+				}
+				if f.ID != "" {
+					lastID = f.ID
+				}
+			}
+			f, hasData, pending = Frame{}, false, false
+			continue
+		}
+
+		if line[0] == ':' {
+			// Between frames a comment is a heartbeat worth surfacing; inside
+			// one it is just an ignorable line.
+			if !pending {
+				if err := fn(Frame{Comment: true}); err != nil {
+					return lastID, err
+				}
+			}
+			continue
+		}
+
+		name, value := splitField(line)
+		pending = true
+
+		switch name {
+		case "event":
+			f.Event = string(value)
+		case "id":
+			// Per spec an id containing a NUL is ignored rather than applied.
+			if !bytes.ContainsRune(value, 0) {
+				f.ID = string(value)
+			}
+		case "data":
+			if hasData {
+				// Spec-mandated rejoining of multi-line payloads.
+				f.Data = append(f.Data, '\n')
+				f.Data = append(f.Data, value...)
+				continue
+			}
+			f.Data = value
+			hasData = true
+		default:
+			// Unknown fields are ignored, which keeps the format extensible.
+		}
+	}
+}
+
+// readLine reads one line without its terminator. The result is freshly
+// allocated so the caller may retain it across subsequent reads.
+func readLine(r *bufio.Reader, limit int) ([]byte, error) {
+	var raw []byte
+	for {
+		part, err := r.ReadSlice('\n')
+		if len(raw)+len(part) > limit {
+			return nil, ErrFrameTooLarge
+		}
+		raw = append(raw, part...)
+		if err == nil {
+			break
+		}
+		if errors.Is(err, bufio.ErrBufferFull) {
+			continue
+		}
+		return nil, err
+	}
+
+	line := raw[:len(raw)-1] // drop '\n'
+	if len(line) > 0 && line[len(line)-1] == '\r' {
+		line = line[:len(line)-1]
+	}
+	return line, nil
+}
+
+// splitField splits a line into field name and value, stripping the single
+// optional space after the colon. This is why "data:x" and "data: x" are
+// equivalent — reading only the spaced form silently drops every frame from a
+// conformant server that omits it.
+func splitField(line []byte) (string, []byte) {
+	i := bytes.IndexByte(line, ':')
+	if i < 0 {
+		return string(line), nil
+	}
+	value := line[i+1:]
+	if len(value) > 0 && value[0] == ' ' {
+		value = value[1:]
+	}
+	return string(line[:i]), value
+}
+
+// ParseCursor splits the opaque per-stream cursor carried in a frame's id.
+// An empty string means "from the beginning" and is not an error, so a first
+// connection and a resume share one code path.
+func ParseCursor(s string) (stdout, stderr int64, err error) {
+	if s == "" {
+		return 0, 0, nil
+	}
+	out, errStream, ok := strings.Cut(s, ",")
+	if !ok {
+		return 0, 0, fmt.Errorf("sse: malformed cursor %q", s)
+	}
+	stdout, err = strconv.ParseInt(out, 10, 64)
+	if err != nil || stdout < 0 {
+		return 0, 0, fmt.Errorf("sse: malformed cursor %q", s)
+	}
+	stderr, err = strconv.ParseInt(errStream, 10, 64)
+	if err != nil || stderr < 0 {
+		return 0, 0, fmt.Errorf("sse: malformed cursor %q", s)
+	}
+	return stdout, stderr, nil
+}

--- a/internal/sse/sse_test.go
+++ b/internal/sse/sse_test.go
@@ -1,0 +1,139 @@
+package sse_test
+
+import (
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/sse"
+)
+
+func collect(t *testing.T, in string, maxFrame int) ([]sse.Frame, string, error) {
+	t.Helper()
+	var got []sse.Frame
+	last, err := sse.Scan(strings.NewReader(in), maxFrame, func(f sse.Frame) error {
+		got = append(got, sse.Frame{
+			Event:   f.Event,
+			ID:      f.ID,
+			Data:    append([]byte(nil), f.Data...),
+			Comment: f.Comment,
+		})
+		return nil
+	})
+	return got, last, err
+}
+
+func TestScan(t *testing.T) {
+	in := "event: stdout\nid: 4,0\ndata: aGk=\n\n" +
+		": ping\n\n" +
+		"event: exit\nid: 4,0\ndata: {\"exit_code\":2}\n\n"
+
+	got, last, err := collect(t, in, 1<<20)
+	assert.NilError(t, err)
+	assert.Equal(t, last, "4,0")
+	assert.Equal(t, len(got), 3)
+	assert.Equal(t, got[0].Event, "stdout")
+	assert.Equal(t, string(got[0].Data), "aGk=")
+	assert.Check(t, got[1].Comment)
+	assert.Equal(t, got[2].Event, "exit")
+}
+
+// The space after the colon is optional. Requiring it silently drops every frame
+// from a conformant server that omits it — which reads as "the stream ended
+// without a result" rather than as a parse bug.
+func TestScanOptionalSpace(t *testing.T) {
+	got, _, err := collect(t, "data:x\n\ndata:  y\n\n", 1<<20)
+	assert.NilError(t, err)
+	assert.Equal(t, string(got[0].Data), "x")
+	assert.Equal(t, string(got[1].Data), " y", "only one leading space is stripped")
+}
+
+func TestScanCRLF(t *testing.T) {
+	got, _, err := collect(t, "event: stdout\r\ndata: aGk=\r\n\r\n", 1<<20)
+	assert.NilError(t, err)
+	assert.Equal(t, len(got), 1)
+	assert.Equal(t, got[0].Event, "stdout")
+}
+
+// A frame with no terminating blank line must be dropped. Delivering it would
+// turn a truncated stream into a short-but-plausible event.
+func TestScanDiscardsPartialFrame(t *testing.T) {
+	got, last, err := collect(t, "event: stdout\nid: 2,0\ndata: aGk=\n\nevent: stdout\ndata: dHJ1", 1<<20)
+	assert.NilError(t, err)
+	assert.Equal(t, len(got), 1)
+	assert.Equal(t, last, "2,0")
+}
+
+// Frames past bufio.Scanner's 64KiB token limit must work; exceeding the
+// explicit cap must be a loud error rather than a silent stop.
+func TestScanLargeFrames(t *testing.T) {
+	big := strings.Repeat("A", 300<<10)
+	got, _, err := collect(t, "event: stdout\ndata: "+big+"\n\n", 1<<20)
+	assert.NilError(t, err)
+	assert.Equal(t, len(got[0].Data), len(big))
+
+	_, _, err = collect(t, "data: "+strings.Repeat("x", 4096)+"\n\n", 512)
+	assert.Check(t, errors.Is(err, sse.ErrFrameTooLarge), "got %v", err)
+}
+
+func TestScanUnknownFieldsIgnored(t *testing.T) {
+	got, _, err := collect(t, "event: stdout\nfuture: x\ndata: aGk=\n\n", 1<<20)
+	assert.NilError(t, err)
+	assert.Equal(t, len(got), 1)
+	assert.Equal(t, got[0].Event, "stdout")
+}
+
+// Arbitrary bytes must survive as base64 payloads, including the ones that break
+// naive line-oriented framing.
+func TestScanBase64PayloadsRoundTrip(t *testing.T) {
+	payloads := [][]byte{
+		[]byte("spinner\rredraw\r"),
+		{0x1b, '[', '3', '2', 'm', 'o', 'k'},
+		{0x00, 0xff, 0xfe},
+		[]byte("\xed\xa0\x80"),
+	}
+
+	var b strings.Builder
+	for _, p := range payloads {
+		b.WriteString("event: stdout\ndata: " + base64.StdEncoding.EncodeToString(p) + "\n\n")
+	}
+
+	got, _, err := collect(t, b.String(), 1<<20)
+	assert.NilError(t, err)
+	assert.Equal(t, len(got), len(payloads))
+	for i, f := range got {
+		raw, decErr := base64.StdEncoding.DecodeString(string(f.Data))
+		assert.NilError(t, decErr)
+		assert.Equal(t, string(raw), string(payloads[i]))
+	}
+}
+
+func TestParseCursor(t *testing.T) {
+	tests := []struct {
+		in             string
+		stdout, stderr int64
+		wantErr        bool
+	}{
+		{in: ""},
+		{in: "0,0"},
+		{in: "4096,12", stdout: 4096, stderr: 12},
+		{in: "4096", wantErr: true},
+		{in: "a,b", wantErr: true},
+		{in: "-1,0", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			out, errOff, err := sse.ParseCursor(tt.in)
+			if tt.wantErr {
+				assert.Check(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, out, tt.stdout)
+			assert.Equal(t, errOff, tt.stderr)
+		})
+	}
+}

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -1,9 +1,11 @@
 package fakes
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -11,16 +13,6 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/recorder"
 )
-
-// commandOutputLine mirrors the JSONL event emitted by GET /commands/:id/output.
-type commandOutputLine struct {
-	CommandID string `json:"command_id,omitempty"`
-	ExitCode  int    `json:"exit_code,omitempty"`
-	PID       int    `json:"pid,omitempty"`
-	Index     int    `json:"index,omitempty"`
-	Stream    string `json:"stream,omitempty"`
-	Line      string `json:"line,omitempty"`
-}
 
 type Collaboration struct {
 	ID      string `json:"id"`
@@ -61,6 +53,7 @@ type ExecResponse struct {
 	Stdout    string `json:"stdout"`
 	Stderr    string `json:"stderr"`
 	ExitCode  int    `json:"exit_code"`
+	Signal    string `json:"signal,omitempty"`
 }
 
 type CommandResponse struct {
@@ -99,12 +92,15 @@ type FakeCircleCI struct {
 	ExecStatusCode           int    // override for POST /sidecar/instances/:id/exec
 	CommandOutputStatusCode  int    // override for GET /sidecar/commands/:id/output
 	CommandOutputMessage     string // error message body when CommandOutputStatusCode is set
-	AddKeyStatusCode         int    // override for POST /sidecar/instances/:id/ssh/add-key
-	CreateSnapshotStatusCode int    // override for POST /sidecar/snapshots
-	GetSnapshotStatusCode    int    // override for GET /sidecar/snapshots/:id
-	ListSnapshotsStatusCode  int    // override for GET /sidecar/snapshots
-	GetCommandStatusCode     int    // override for GET /sidecar/commands/:id
-	CreateOrgStatusCode      int    // override for POST /api/v2/organization
+	// DropStreamsBeforeExit ends this many output streams after delivering their
+	// output but before the terminal event, so client resume can be exercised.
+	DropStreamsBeforeExit    int
+	AddKeyStatusCode         int // override for POST /sidecar/instances/:id/ssh/add-key
+	CreateSnapshotStatusCode int // override for POST /sidecar/snapshots
+	GetSnapshotStatusCode    int // override for GET /sidecar/snapshots/:id
+	ListSnapshotsStatusCode  int // override for GET /sidecar/snapshots
+	GetCommandStatusCode     int // override for GET /sidecar/commands/:id
+	CreateOrgStatusCode      int // override for POST /api/v2/organization
 
 	// ExtraHeaders are added to every response. Use to inject Deprecation/Sunset
 	// headers without changing individual handler logic.
@@ -390,31 +386,97 @@ func (f *FakeCircleCI) handleCommandOutput(c *gin.Context) {
 		}
 	}
 
-	c.Header("Content-Type", "application/x-ndjson")
+	// Mirror the real API: SSE frames with base64 payloads and an opaque cursor.
+	stdout := []byte(resp.Stdout)
+	stderr := []byte(resp.Stderr)
+	outOff := clampOffset(cursorPart(c, 0), len(stdout))
+	errOff := clampOffset(cursorPart(c, 1), len(stderr))
+
+	c.Header("Content-Type", "text/event-stream; charset=utf-8")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("X-Accel-Buffering", "no")
 	c.Status(http.StatusOK)
 
-	idx := 0
-	writeLines := func(stream, output string) {
-		for _, line := range strings.Split(strings.TrimRight(output, "\n"), "\n") {
-			b, _ := json.Marshal(commandOutputLine{Index: idx, Stream: stream, Line: line})
-			_, _ = fmt.Fprintf(c.Writer, "%s\n", b)
-			idx++
+	// Flushing per frame is what makes this a stream rather than one lump at the
+	// end — without it nothing here proves incremental delivery.
+	writeFrame := func(event, id string, data []byte) {
+		_, _ = fmt.Fprintf(c.Writer, "event: %s\nid: %s\ndata: %s\n\n", event, id, data)
+		c.Writer.Flush()
+	}
+
+	cursor := func() string { return fmt.Sprintf("%d,%d", outOff, errOff) }
+
+	start, _ := json.Marshal(map[string]any{
+		"command_id": resp.CommandID,
+		"status":     "running",
+		"stdout":     outOff,
+		"stderr":     errOff,
+	})
+	writeFrame("start", cursor(), start)
+
+	if rest := stdout[outOff:]; len(rest) > 0 {
+		outOff = int64(len(stdout))
+		writeFrame("stdout", cursor(), []byte(base64.StdEncoding.EncodeToString(rest)))
+	}
+	if rest := stderr[errOff:]; len(rest) > 0 {
+		errOff = int64(len(stderr))
+		writeFrame("stderr", cursor(), []byte(base64.StdEncoding.EncodeToString(rest)))
+	}
+
+	if f.dropBeforeExit() {
+		// End the response with no terminal event, which is how the API signals
+		// "interrupted, resume from your cursor".
+		return
+	}
+
+	exit, _ := json.Marshal(map[string]any{
+		"exit_code": resp.ExitCode,
+		"pid":       resp.PID,
+		"signal":    resp.Signal,
+	})
+	writeFrame("exit", cursor(), exit)
+}
+
+// dropBeforeExit reports whether this stream should end without a terminal
+// event, consuming one from the configured budget.
+func (f *FakeCircleCI) dropBeforeExit() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.DropStreamsBeforeExit <= 0 {
+		return false
+	}
+	f.DropStreamsBeforeExit--
+	return true
+}
+
+// cursorPart resolves one stream's resume offset from Last-Event-ID, falling
+// back to the per-stream query parameters, mirroring the real API.
+func cursorPart(c *gin.Context, part int) int64 {
+	if raw := c.GetHeader("Last-Event-ID"); raw != "" {
+		out, errOff, found := strings.Cut(raw, ",")
+		if found {
+			if part == 0 {
+				return parseInt64(out)
+			}
+			return parseInt64(errOff)
 		}
 	}
-
-	if resp.Stdout != "" {
-		writeLines("stdout", resp.Stdout)
+	if part == 0 {
+		return parseInt64(c.Query("stdout_offset"))
 	}
-	if resp.Stderr != "" {
-		writeLines("stderr", resp.Stderr)
-	}
+	return parseInt64(c.Query("stderr_offset"))
+}
 
-	result, _ := json.Marshal(commandOutputLine{
-		CommandID: resp.CommandID,
-		ExitCode:  resp.ExitCode,
-		PID:       resp.PID,
-	})
-	_, _ = fmt.Fprintf(c.Writer, "%s\n", result)
+func parseInt64(s string) int64 {
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+func clampOffset(off int64, size int) int64 {
+	return min(max(off, 0), int64(size))
 }
 
 func (f *FakeCircleCI) handleGetCommand(c *gin.Context) {

--- a/main.go
+++ b/main.go
@@ -71,6 +71,12 @@ func errorDetails(err error) (msg, detail, suggestion string, exitCode int) {
 	if d, ok := err.(interface{ Detail() string }); ok && d.Detail() != "" {
 		detail = d.Detail()
 	}
+	// An error that says it needs no detail gets none: the fallback to
+	// err.Error() above would otherwise show raw Go wrapping, and repeat itself
+	// when the message was translated from that same error.
+	if h, ok := err.(interface{ HideDetail() bool }); ok && h.HideDetail() {
+		detail = ""
+	}
 	if s, ok := err.(interface{ Suggestion() string }); ok && s.Suggestion() != "" {
 		suggestion = s.Suggestion()
 	}


### PR DESCRIPTION
Depends on circleci/sandbox-provisioner#344 — merge and deploy that first.
This client speaks the new wire format and will refuse the old one with a
clear message saying so.

## What was wrong

The output stream was parsed by string-matching a `data: ` prefix and
unmarshalling whatever followed. That meant:

- **A conformant `data:x` was silently dropped.** The space after the colon is
  optional in SSE, so a server omitting it produced an empty stream that
  surfaced as "stream ended without result".
- **`bufio.Scanner` capped frames at 64KiB**, failing by silently stopping —
  the failure mode that reads as success.
- **A stream that ended without a result was fatal.** There was no way to tell
  a dropped connection from a finished command, and no way to recover from
  either.
- **`sidecar exec` discarded the exit code**, so a remote command that failed
  still exited 0 — scripts and CI could not tell success from failure.
- **`validate --remote` went silent for minutes.** Output was buffered until
  the command finished, and discarded on failure, so a failed run showed
  nothing at all.

## What this does

Decodes real SSE frames and dispatches on event type.

The server keeps its 15s write timeout, so a long command is served as a
**series of short connections**: each ends without a terminal event, and that
absence is the signal to resume from the last cursor via `Last-Event-ID`.

Reconnecting is therefore routine rather than exceptional, which drives the
retry policy. An attempt that received **any** frame resets the budget even when
the command produced no new output — a command can be legitimately silent for
minutes while it compiles, and counting that as failure would abandon it at
around 75 seconds, which is the original bug wearing a different hat. Only
attempts that return nothing at all are counted, and a separate generous ceiling
bounds a server that talks but never terminates the stream. Healthy reconnects
do not back off, since pausing half a second every fifteen would make output
stutter for no reason.

Output is delivered as raw bytes rather than lines, so carriage returns, ANSI
colour and invalid UTF-8 reach the terminal exactly as the remote command wrote
them. `chunk sidecar exec` writes those bytes straight through — spinners and
progress bars render properly for the first time — and propagates the remote
exit code, reporting a signal by name when one killed the command.
`validate --remote` streams output as it arrives.

## Three error-reporting fixes, all found by using it

**An API older than this build says so.** The frame vocabulary only ever gains
event types, so recognising none of them places the API behind the client.
Advising "upgrade chunk" would have sent someone hunting a release that does not
exist.

**A 410 is no longer reported unconditionally as "chunk CLI is out of date".**
The API also uses 410 to say the *sidecar* is out of date, and the remedies are
opposite — upgrading the CLI lands on a version that fails identically while the
sidecar is still stale. Distinguishing them matches on the server's wording,
which is a compromise noted in the code: the V3 error envelope carries no
machine-readable code, so there is nothing better to key off until the API
supplies one.

**The detail line no longer prints raw JSON.** `extractServerMessage` decoded
`error` as a string while the V3 envelope nests it as an object, so the decode
failed and the whole body was dumped, trace id included. Every V3 error was
affected, not just these.

## Verification

Byte fidelity through the client for every payload the previous format
corrupted: bare `\r`, ANSI escapes, NULs, a lone surrogate, no-trailing-newline,
and output past the old 64KiB frame limit. Resume is asserted on the reconnect
count as well as the bytes, so it cannot pass without actually reconnecting;
a stream that keeps reconnecting without new output is asserted **not** to be
abandoned; and an endlessly interrupted one is asserted to give up rather than
spin. Error mapping is tested against the exact envelope seen in the wild.

Confirmed against a real sidecar on the current production API that the
version-skew path reports the right guidance rather than hanging. The full
end-to-end run has to wait for sandbox-provisioner#344 to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)