### PR TITLE
Adjust chunk init copy

### DIFF
--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -780,8 +780,8 @@ func TestInitSkipsTestSuitesByDefault(t *testing.T) {
 
 	assert.Assert(t, strings.Contains(result.Stderr, "chunk-sidecar"),
 		"expected sidecar hint in stderr, got: %s", result.Stderr)
-	assert.Assert(t, strings.Contains(result.Stderr, "sidecar dev loop"),
-		"expected hint to mention sidecar dev loop, got: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "set up a sidecar"),
+		"expected hint to mention setting up a sidecar, got: %s", result.Stderr)
 }
 
 func TestInitProjectDirNotGitRepo(t *testing.T) {

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -360,9 +360,9 @@ func printTestSuitesHint(workDir string, streams iostream.Streams) {
 		return
 	}
 	streams.ErrPrintln("")
-	streams.ErrPrintln(ui.Bold("Next step: set up the sidecar dev loop"))
-	streams.ErrPrintln(ui.Dim("  Ask your AI coding agent to run the chunk-sidecar skill to create"))
-	streams.ErrPrintln(ui.Dim("  a remote sidecar, sync your workspace, and run tests remotely."))
+	streams.ErrPrintln(ui.Bold("Next step: set up a sidecar"))
+	streams.ErrPrintln(ui.Dim("  Ask your AI coding agent to run the chunk-sidecar skill to spin up"))
+	streams.ErrPrintln(ui.Dim("  a microVM, sync your repo, and run tests remotely."))
 }
 
 // writeAllHookFiles writes hook config files for all supported agents.


### PR DESCRIPTION
## Summary

- Updates the post-init hint text to be more concise and accurate
- Changes heading from "set up the sidecar dev loop" to "set up a sidecar"
- Replaces "create a remote sidecar, sync your workspace, and run tests remotely" with "spin up a microVM, sync your repo, and run tests remotely"

## Test plan

- [ ] Run `chunk init` in a project without `.circleci/test-suites.yml` and verify the updated hint text appears as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)