### PR TITLE
Clarify sidecar exec argument syntax in help output

### DIFF
--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -303,9 +303,19 @@ func newSidecarExecCmd() *cobra.Command {
 	var execArgs []string
 
 	cmd := &cobra.Command{
-		Use:   "exec",
+		Use:   "exec [-- args...]",
 		Short: "Execute a command in a sidecar",
-		Args:  cobra.ArbitraryArgs,
+		Long: `Execute a command in a sidecar.
+
+Arguments to the remote command can be passed as positional arguments (after --)
+or via the repeatable --args flag. Positional arguments are appended after any
+--args values.`,
+		Example: `  # Pass arguments after --
+  chunk sidecar exec --command sh -- -c "echo hello"
+
+  # Pass arguments with the repeatable --args flag
+  chunk sidecar exec --command sh --args="-c" --args="echo hello"`,
+		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
 			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
@@ -356,7 +366,7 @@ func newSidecarExecCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&sidecarID, "sidecar-id", "", "Sidecar ID (defaults to active sidecar)")
 	cmd.Flags().StringVar(&command, "command", "", "Command to execute")
-	cmd.Flags().StringArrayVar(&execArgs, "args", nil, "Command arguments")
+	cmd.Flags().StringArrayVar(&execArgs, "args", nil, "Command argument (repeatable; comma-separated values are NOT split)")
 	_ = cmd.MarkFlagRequired("command")
 
 	return cmd


### PR DESCRIPTION
## Summary

- The `--args` flag requires repeating for multiple values (e.g. `--args="-c" --args="<cmd>"`), but the help text gave no indication of this
- Users trying `--args "-c,<cmd>"` got the literal string passed as one argument
- Added `Long` description, examples showing both the `--` positional form and the repeatable `--args` form, and updated the flag help text to explicitly note that comma-separated values are not split

## Test plan

- [ ] Run `chunk sidecar exec --help` and verify the examples and description render correctly
- [ ] Confirm `chunk sidecar exec --command sh -- -c "echo hello"` works on a live sidecar
- [ ] Confirm `chunk sidecar exec --command sh --args="-c" --args="echo hello"` works on a live sidecar

🤖 Generated with [Claude Code](https://claude.com/claude-code)