### PR TITLE
Support pinned pnpm versions and auto-installing Playwright browsers in sidecar setup

### DIFF
--- a/envbuilder/envbuilder.go
+++ b/envbuilder/envbuilder.go
@@ -748,6 +748,13 @@ func detectStack(dir string) (string, error) {
 		}
 	}
 
+	// tsconfig.json is a definitive TypeScript indicator: any project that has
+	// one is TypeScript, even if .js config files outnumber .ts source files.
+	// Add a bonus so it outweighs package.json alone in the indicator phase.
+	if fileExists(dir, "tsconfig.json") {
+		scores[stackTypeScript] += 10
+	}
+
 	// .NET solution and project files have project-specific names so they cannot
 	// appear in the fixed indicatorFiles map.  Use glob matching in the root
 	// directory and give them the same weight as other indicator files.

--- a/envbuilder/envbuilder.go
+++ b/envbuilder/envbuilder.go
@@ -1696,6 +1696,70 @@ func findWorkspaceWithTest(dir, rootName string, patterns []string) string {
 	return ""
 }
 
+// detectPlaywrightInstallCmd returns the command to download Playwright browsers
+// and their OS-level dependencies if the project uses Playwright. Returns ""
+// when Playwright is not detected.
+func detectPlaywrightInstallCmd(dir string) string {
+	pkgPath := filepath.Join(dir, "package.json")
+	data, err := os.ReadFile(pkgPath)
+	if err != nil {
+		return ""
+	}
+	var pkg struct {
+		DevDeps      map[string]string `json:"devDependencies"`
+		Dependencies map[string]string `json:"dependencies"`
+	}
+	if json.Unmarshal(data, &pkg) != nil {
+		return ""
+	}
+	hasPlaywright := false
+	for _, p := range []string{"@playwright/test", "playwright"} {
+		if _, ok := pkg.DevDeps[p]; ok {
+			hasPlaywright = true
+			break
+		}
+		if _, ok := pkg.Dependencies[p]; ok {
+			hasPlaywright = true
+			break
+		}
+	}
+	if !hasPlaywright {
+		if !fileExists(dir, "playwright.config.ts") && !fileExists(dir, "playwright.config.js") {
+			return ""
+		}
+	}
+	switch {
+	case fileExists(dir, "pnpm-lock.yaml"):
+		return "pnpm exec playwright install --with-deps"
+	case fileExists(dir, "yarn.lock"):
+		return "yarn exec playwright install --with-deps"
+	default:
+		return "npx playwright install --with-deps"
+	}
+}
+
+// pnpmInstallCmd returns the shell command to install pnpm, pinning to the
+// version declared in package.json's "packageManager" field when present.
+func pnpmInstallCmd(dir string) string {
+	pkgPath := filepath.Join(dir, "package.json")
+	data, err := os.ReadFile(pkgPath)
+	if err == nil {
+		var pkg struct {
+			PackageManager string `json:"packageManager"`
+		}
+		if jsonErr := json.Unmarshal(data, &pkg); jsonErr == nil {
+			// "packageManager" is e.g. "pnpm@9.15.0" or "pnpm@9.15.0+sha512.abc"
+			if after, ok := strings.CutPrefix(pkg.PackageManager, "pnpm@"); ok {
+				version, _, _ := strings.Cut(after, "+")
+				if v := strings.TrimSpace(version); v != "" {
+					return "sudo npm install -g pnpm@" + v
+				}
+			}
+		}
+	}
+	return "sudo npm install -g pnpm"
+}
+
 // detectNodeMaxVersion reads package.json and returns the maximum Node.js major
 // version allowed by the "engines.node" field. Returns -1 if absent or unparseable.
 func detectNodeMaxVersion(dir string) int {
@@ -1943,6 +2007,8 @@ func DetectEnvironment(ctx context.Context, dir string) (*Environment, error) {
 		if dep == "node" {
 			major := strings.SplitN(imageVersion, ".", 2)[0]
 			cmd = nodeInstallCmd(major)
+		} else if dep == "pnpm" {
+			cmd = pnpmInstallCmd(dir)
 		} else if c, ok := extraDepInstalls[dep]; ok {
 			cmd = c
 			if strings.HasPrefix(image, cimgPrefix) {
@@ -1961,6 +2027,9 @@ func DetectEnvironment(ctx context.Context, dir string) (*Environment, error) {
 	}
 	if install != "" && install != stackUnknown {
 		setup = append(setup, Step{Name: "install", Command: install})
+	}
+	if pwCmd := detectPlaywrightInstallCmd(dir); pwCmd != "" {
+		setup = append(setup, Step{Name: "playwright-install", Command: pwCmd})
 	}
 	if test != "" && test != stackUnknown {
 		setup = append(setup, Step{Name: "test", Command: test})

--- a/envbuilder/envbuilder_test.go
+++ b/envbuilder/envbuilder_test.go
@@ -139,11 +139,25 @@ func TestDetectStack(t *testing.T) {
 			want:  stackPython,
 		},
 		{
-			// tsconfig.json scores 10 for typescript; .ts source files add 1 each
-			// package.json scores 10 for javascript — adding a .ts file breaks the tie
-			name:  "typescript beats javascript with source file tiebreak",
-			files: map[string]string{"tsconfig.json": "{}", "package.json": "{}", "index.ts": ""},
+			// tsconfig.json scores 20 (10 indicator + 10 bonus), package.json scores 10
+			name:  "typescript beats javascript when tsconfig.json present",
+			files: map[string]string{"tsconfig.json": "{}", "package.json": "{}"},
 			want:  stackTypeScript,
+		},
+		{
+			// Simulates a pnpm workspace (e.g. compass) with more .js config files
+			// than .ts source files — tsconfig.json bonus ensures TypeScript wins.
+			name: "typescript wins even when js config files outnumber ts source files",
+			files: map[string]string{
+				"tsconfig.json":         "{}",
+				"package.json":          "{}",
+				"scripts/build.js":      "",
+				"scripts/deploy.js":     "",
+				".storybook/main.js":    "",
+				".storybook/preview.js": "",
+				"src/index.ts":          "",
+			},
+			want: stackTypeScript,
 		},
 		{
 			name: "source extensions tiebreak",

--- a/envbuilder/envbuilder_test.go
+++ b/envbuilder/envbuilder_test.go
@@ -502,6 +502,47 @@ func TestDetectNodeTestCommand(t *testing.T) {
 	})
 }
 
+func TestDetectPlaywrightInstallCmd(t *testing.T) {
+	t.Parallel()
+
+	t.Run("@playwright/test in devDependencies uses pnpm", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "package.json", `{"devDependencies":{"@playwright/test":"1.56.0"}}`)
+		writeFile(t, dir, "pnpm-lock.yaml", "")
+		assert.Equal(t, "pnpm exec playwright install --with-deps", detectPlaywrightInstallCmd(dir))
+	})
+
+	t.Run("playwright in devDependencies uses yarn", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "package.json", `{"devDependencies":{"playwright":"1.56.0"}}`)
+		writeFile(t, dir, "yarn.lock", "")
+		assert.Equal(t, "yarn exec playwright install --with-deps", detectPlaywrightInstallCmd(dir))
+	})
+
+	t.Run("playwright.config.ts without package.json dep uses npx", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "package.json", `{"devDependencies":{}}`)
+		writeFile(t, dir, "playwright.config.ts", "")
+		assert.Equal(t, "npx playwright install --with-deps", detectPlaywrightInstallCmd(dir))
+	})
+
+	t.Run("no playwright returns empty string", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "package.json", `{"devDependencies":{"vitest":"2.0.0"}}`)
+		assert.Equal(t, "", detectPlaywrightInstallCmd(dir))
+	})
+
+	t.Run("no package.json returns empty string", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		assert.Equal(t, "", detectPlaywrightInstallCmd(dir))
+	})
+}
+
 func TestDetectNodeMaxVersion(t *testing.T) {
 	t.Parallel()
 	cases := []struct {


### PR DESCRIPTION
## Summary

- **pnpm version pinning**: `pnpmInstallCmd` now reads the `packageManager` field from `package.json` (e.g. `"pnpm@9.15.0"`) and installs that exact version on the sidecar instead of always pulling latest. This prevents version mismatches where a project uses pnpm v9 locally but the sidecar installs pnpm v10+, which introduced `ERR_PNPM_IGNORED_BUILDS` as a hard exit-1 error.
- **Playwright browser detection**: `detectPlaywrightInstallCmd` detects `@playwright/test` or `playwright` in `package.json` deps (or the presence of a `playwright.config.ts/js`) and adds a `playwright-install` step that runs `pnpm exec playwright install --with-deps` (or yarn/npx equivalent) after the install step.
- **TypeScript stack detection fix**: `tsconfig.json` now scores 20 points (10 indicator + 10 bonus) vs `package.json`'s 10, so TypeScript is correctly detected in pnpm workspaces where `scripts/` and `.storybook/` directories have more `.js` config files than `.ts` source files.

## Test plan

- [ ] TypeScript project with `"packageManager": "pnpm@9.x.y"` in `package.json` — sidecar setup installs that version
- [ ] TypeScript project with `playwright` or `@playwright/test` in devDependencies — sidecar setup runs `playwright install --with-deps` after `pnpm install`
- [ ] Project without Playwright — no `playwright-install` step added
- [ ] pnpm workspace with more `.js` config files than `.ts` source files — detected as TypeScript when `tsconfig.json` is present
- [ ] Unit tests pass: `task test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)