### PR TITLE
Be helpful when chunk validate isn't configured

### DIFF
--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -233,7 +233,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		}
 		return &userError{
 			msg:        "No validate commands configured.",
-			suggestion: "Run 'chunk init' first.",
+			suggestion: suggestionValidateNotConfigured,
 			errMsg:     "no validate commands configured",
 		}
 	}
@@ -699,11 +699,14 @@ func sidecarAutoName(ctx context.Context, workDir string) string {
 	return base + "-validate"
 }
 
+const suggestionValidateNotConfigured = "Run 'chunk init' to detect and configure validation commands.\n" +
+	"This also installs the chunk-sidecar skill so your AI coding agent can help you set up remote validation on a sidecar'."
+
 func mapValidateError(err error) error {
 	if errors.Is(err, validate.ErrNotConfigured) {
 		return &userError{
 			msg:        "No validate commands configured.",
-			suggestion: "Run 'chunk init' first.",
+			suggestion: suggestionValidateNotConfigured,
 			err:        err,
 		}
 	}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -235,6 +235,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			msg:        "No validate commands configured.",
 			suggestion: suggestionValidateNotConfigured,
 			errMsg:     "no validate commands configured",
+			hideDetail: true,
 		}
 	}
 
@@ -700,13 +701,14 @@ func sidecarAutoName(ctx context.Context, workDir string) string {
 }
 
 const suggestionValidateNotConfigured = "Run 'chunk init' to detect and configure validation commands.\n" +
-	"This also installs the chunk-sidecar skill so your AI coding agent can help you set up remote validation on a sidecar'."
+	"This also installs the chunk-sidecar skill so your AI coding agent can help you set up remote validation on a sidecar."
 
 func mapValidateError(err error) error {
 	if errors.Is(err, validate.ErrNotConfigured) {
 		return &userError{
 			msg:        "No validate commands configured.",
 			suggestion: suggestionValidateNotConfigured,
+			hideDetail: true,
 			err:        err,
 		}
 	}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -701,7 +701,7 @@ func sidecarAutoName(ctx context.Context, workDir string) string {
 }
 
 const suggestionValidateNotConfigured = "Run 'chunk init' to detect and configure validation commands.\n" +
-	"This also installs the chunk-sidecar skill so your AI coding agent can help you set up remote validation on a sidecar."
+	"This also installs the /chunk-sidecar skill so your AI coding agent can help you set up remote validation on a sidecar."
 
 func mapValidateError(err error) error {
 	if errors.Is(err, validate.ErrNotConfigured) {

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -167,6 +167,26 @@ func TestOpenAPIExecPassesEnvVars(t *testing.T) {
 	assert.Equal(t, execReq.Env["BAZ"], "qux")
 }
 
+func TestValidateNoConfigShowsSkillHint(t *testing.T) {
+	isolateConfig(t)
+	dir := t.TempDir()
+
+	var outBuf, errBuf bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"validate", "--project", dir})
+	err := root.Execute()
+
+	assert.Assert(t, err != nil, "expected error when no validate commands configured")
+	var ue *userError
+	assert.Assert(t, errors.As(err, &ue), "expected userError, got %T: %v", err, err)
+	assert.Assert(t, strings.Contains(ue.Suggestion(), "chunk init"),
+		"expected suggestion to mention 'chunk init', got: %q", ue.Suggestion())
+	assert.Assert(t, strings.Contains(ue.Suggestion(), "chunk-sidecar"),
+		"expected suggestion to mention chunk-sidecar skill, got: %q", ue.Suggestion())
+}
+
 func TestValidateEnvFlagBadValue(t *testing.T) {
 	isolateConfig(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- When `chunk validate` is run with no commands configured, the error now points users toward `chunk init` and explains it installs the `chunk-sidecar` skill so their AI coding agent can pick up from there
- Suppressed the redundant detail line that was repeating the error message

## Test plan

- [ ] `TestValidateNoConfigShowsSkillHint` — asserts the suggestion mentions both `chunk init` and `chunk-sidecar`
- [ ] Run `chunk validate` in a project without `.chunk/config.json` and confirm the output reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)