### PR TITLE
Stop persisting the test command to .chunk/config.json

### DIFF
--- a/envbuilder/envbuilder.go
+++ b/envbuilder/envbuilder.go
@@ -586,7 +586,7 @@ func dockerfileContent(dir string, env *Environment) string { //nolint:gocyclo
 		sdkRe := regexp.MustCompile(`^(\d+)\.`)
 		tfmRe := regexp.MustCompile(`--framework net(\d+)\.0`)
 		if sdkM := sdkRe.FindStringSubmatch(env.ImageVersion); len(sdkM) == 2 {
-			if tfmM := tfmRe.FindStringSubmatch(env.SetupStep("test")); len(tfmM) == 2 {
+			if tfmM := tfmRe.FindStringSubmatch(env.SetupStep(envspec.StepTest)); len(tfmM) == 2 {
 				sdkMajor, sdkErr := strconv.Atoi(sdkM[1])
 				tfmMajor, tfmErr := strconv.Atoi(tfmM[1])
 				if sdkErr == nil && tfmErr == nil && sdkMajor > tfmMajor && tfmMajor >= 6 {
@@ -704,7 +704,7 @@ func dockerfileContent(dir string, env *Environment) string { //nolint:gocyclo
 		// test them one at a time.  $$ is the shell PID, used to give the
 		// temp file a unique name so concurrent runs don't collide.
 		sb.WriteString("\nCMD go list ./... > /tmp/mod-pkgs-$$ && go list -deps ./... | grep -Fxf /tmp/mod-pkgs-$$ | while IFS= read -r pkg; do go test \"$pkg\" || exit 1; done\n")
-	} else if testCmd := env.SetupStep("test"); testCmd != "" {
+	} else if testCmd := env.SetupStep(envspec.StepTest); testCmd != "" {
 		sb.WriteString("\nCMD " + testCmd + "\n")
 	}
 
@@ -2039,7 +2039,7 @@ func DetectEnvironment(ctx context.Context, dir string) (*Environment, error) {
 		setup = append(setup, Step{Name: "playwright-install", Command: pwCmd})
 	}
 	if test != "" && test != stackUnknown {
-		setup = append(setup, Step{Name: "test", Command: test})
+		setup = append(setup, Step{Name: envspec.StepTest, Command: test})
 	}
 
 	return &Environment{

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -16,6 +16,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/envbuilder"
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/envspec"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
@@ -625,7 +626,11 @@ generate a Dockerfile and build a test image.
 
 By default the detected environment is saved to .chunk/config.json so that
 'chunk sidecar setup' can reuse it without re-detecting. Pass --no-save to
-print only without writing.`,
+print only without writing.
+
+The saved copy omits the detected test command: it is an input to the test
+image's CMD, not a step that runs during setup. Pipe stdout into
+'chunk sidecar build' rather than reusing the saved spec.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 			if _, err := os.Stat(dir); err != nil {
@@ -651,7 +656,10 @@ print only without writing.`,
 				if loadErr != nil {
 					cfg = &config.ProjectConfig{}
 				}
-				cfg.Environment = env
+				// Save without the test step: it is only an input to the
+				// Dockerfile CMD, which is generated from the spec printed to
+				// stdout below, not from the saved copy.
+				cfg.Environment = env.ForConfig()
 				if saveErr := config.SaveProjectConfig(dir, cfg); saveErr != nil {
 					io.ErrPrintf("Warning: could not save environment to config: %v\n", saveErr)
 				}
@@ -963,7 +971,7 @@ Example:
 				status(iostream.LevelStep, fmt.Sprintf("Detecting environment in %s...", dir))
 				env, detectionErr = envbuilder.DetectEnvironment(cmd.Context(), dir)
 				if detectionErr == nil {
-					cfg.Environment = env
+					cfg.Environment = env.ForConfig()
 					if saveErr := config.SaveProjectConfig(dir, cfg); saveErr != nil {
 						streams.ErrPrintf("Warning: could not save config: %v\n", saveErr)
 					}
@@ -1045,12 +1053,9 @@ Example:
 			var stack string
 			if env != nil {
 				stack = env.Stack
-				for _, s := range env.Setup {
-					// test step runs in CI, not on the sidecar
-					if s.Name != "test" {
-						setupStepTotal++
-					}
-				}
+				// Count only the steps that actually ran on the sidecar; the test
+				// step is skipped (see sidecarSetupRunSetup).
+				setupStepTotal = len(env.ForConfig().Setup)
 			}
 			_ = telemetry.FromContext(cmd.Context()).Track("chunk_sidecar_setup", map[string]any{
 				"stack":            stack,
@@ -1205,8 +1210,11 @@ func sidecarSetupRunSetup(ctx context.Context, opts sidecarRunSetupOpts) error {
 	}
 
 	for _, step := range opts.env.Setup {
-		if step.Name == "test" {
-			continue // test step is for Dockerfile CMD only, not for SSH execution
+		// A freshly detected env still carries the test step (it feeds the
+		// Dockerfile CMD); only the saved copy has it stripped. Skip it here so
+		// setup never runs the project's test suite as a provisioning step.
+		if step.Name == envspec.StepTest {
+			continue
 		}
 		opts.status(iostream.LevelStep, fmt.Sprintf("Running setup step %q: %s", step.Name, step.Command))
 		session, err := sidecar.OpenSession(ctx, opts.client, opts.sidecarID, opts.identityFile, opts.authSock)

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -1055,7 +1055,7 @@ Example:
 				stack = env.Stack
 				// Count only the steps that actually ran on the sidecar; the test
 				// step is skipped (see sidecarSetupRunSetup).
-				setupStepTotal = len(env.ForConfig().Setup)
+				setupStepTotal = env.ProvisioningSteps()
 			}
 			_ = telemetry.FromContext(cmd.Context()).Track("chunk_sidecar_setup", map[string]any{
 				"stack":            stack,

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -73,6 +73,10 @@ func LoadProjectConfig(workDir string) (*ProjectConfig, error) {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse config.json: %w", err)
 	}
+	// Configs written by earlier versions may carry a "test" step in the saved
+	// environment. Drop it on load so it is neither run as a setup step nor
+	// written back out on the next save.
+	cfg.Environment = cfg.Environment.ForConfig()
 	return &cfg, nil
 }
 

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -1,10 +1,61 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/envspec"
 )
+
+func writeProjectConfig(t *testing.T, workDir, data string) {
+	t.Helper()
+	chunkDir := filepath.Join(workDir, ".chunk")
+	assert.NilError(t, os.MkdirAll(chunkDir, 0o700))
+	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), []byte(data), 0o600))
+}
+
+// Configs written before the test command stopped being persisted still carry a
+// "test" step; loading must drop it so it is never run as a setup step.
+func TestLoadProjectConfigDropsTestStep(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectConfig(t, dir, `{
+	  "environment": {
+	    "stack": "go",
+	    "setup": [
+	      {"name": "install", "command": "go mod download"},
+	      {"name": "test", "command": "go test -p 1 ./..."}
+	    ],
+	    "image": "cimg/go",
+	    "image_version": "1.26.2"
+	  }
+	}`)
+
+	cfg, err := LoadProjectConfig(dir)
+	assert.NilError(t, err)
+	assert.Equal(t, len(cfg.Environment.Setup), 1)
+	assert.Equal(t, cfg.Environment.Setup[0].Command, "go mod download")
+	assert.Equal(t, cfg.Environment.SetupStep(envspec.StepTest), "")
+
+	// And it is not written back out on the next save.
+	assert.NilError(t, SaveProjectConfig(dir, cfg))
+	reloaded, err := LoadProjectConfig(dir)
+	assert.NilError(t, err)
+	assert.Equal(t, len(reloaded.Environment.Setup), 1)
+	assert.Equal(t, reloaded.Environment.ImageVersion, "1.26.2")
+}
+
+func TestLoadProjectConfigWithoutEnvironment(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectConfig(t, dir, `{"commands":[{"name":"test","run":"task test"}]}`)
+
+	cfg, err := LoadProjectConfig(dir)
+	assert.NilError(t, err)
+	assert.Assert(t, cfg.Environment == nil)
+	assert.Equal(t, len(cfg.Commands), 1)
+}
 
 func TestHasSidecarImage(t *testing.T) {
 	assert.Assert(t, !(*ProjectConfig)(nil).HasSidecarImage())

--- a/internal/envspec/envspec.go
+++ b/internal/envspec/envspec.go
@@ -42,6 +42,21 @@ func (e *Environment) ForConfig() *Environment {
 	return &out
 }
 
+// ProvisioningSteps returns the number of steps that really run during setup,
+// i.e. Setup without StepTest. Zero for a nil receiver.
+func (e *Environment) ProvisioningSteps() int {
+	if e == nil {
+		return 0
+	}
+	n := 0
+	for _, s := range e.Setup {
+		if s.Name != StepTest {
+			n++
+		}
+	}
+	return n
+}
+
 // SetupStep returns the command for the named setup step, or "" if absent.
 func (e *Environment) SetupStep(name string) string {
 	for _, s := range e.Setup {

--- a/internal/envspec/envspec.go
+++ b/internal/envspec/envspec.go
@@ -14,6 +14,34 @@ type Environment struct {
 	ImageVersion string `json:"image_version"`
 }
 
+// StepTest is the detected test command. It is not a provisioning step: it
+// exists only as the input to the Dockerfile CMD that `chunk sidecar build`
+// generates from a piped env spec, and is never run as part of the sidecar
+// setup sequence. How a project's tests are actually invoked is user-owned
+// config — see config.ProjectConfig.Commands.
+const StepTest = "test"
+
+// ForConfig returns a copy of e suitable for persisting to .chunk/config.json,
+// with the StepTest step removed so that Setup contains only steps that are
+// really run during setup.
+//
+// Callers that generate a Dockerfile must use the full env spec, not this
+// copy: dropping StepTest drops the image's CMD.
+func (e *Environment) ForConfig() *Environment {
+	if e == nil {
+		return nil
+	}
+	out := *e
+	out.Setup = make([]Step, 0, len(e.Setup))
+	for _, s := range e.Setup {
+		if s.Name == StepTest {
+			continue
+		}
+		out.Setup = append(out.Setup, s)
+	}
+	return &out
+}
+
 // SetupStep returns the command for the named setup step, or "" if absent.
 func (e *Environment) SetupStep(name string) string {
 	for _, s := range e.Setup {

--- a/internal/envspec/envspec_test.go
+++ b/internal/envspec/envspec_test.go
@@ -52,3 +52,41 @@ func TestForConfig(t *testing.T) {
 		assert.Equal(t, len((&Environment{}).ForConfig().Setup), 0)
 	})
 }
+
+func TestProvisioningSteps(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		env  *Environment
+		want int
+	}{
+		{name: "nil receiver", env: nil, want: 0},
+		{name: "empty setup", env: &Environment{}, want: 0},
+		{
+			name: "test step is not counted",
+			env: &Environment{Setup: []Step{
+				{Name: "system", Command: "apt-get install git"},
+				{Name: "install", Command: "go mod download"},
+				{Name: StepTest, Command: "go test ./..."},
+			}},
+			want: 2,
+		},
+		{
+			name: "only a test step",
+			env:  &Environment{Setup: []Step{{Name: StepTest, Command: "go test ./..."}}},
+			want: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.env.ProvisioningSteps(), tc.want)
+			if tc.env != nil {
+				// Always agrees with the filtered copy written to config.
+				assert.Equal(t, tc.env.ProvisioningSteps(), len(tc.env.ForConfig().Setup))
+			}
+		})
+	}
+}

--- a/internal/envspec/envspec_test.go
+++ b/internal/envspec/envspec_test.go
@@ -1,0 +1,54 @@
+package envspec
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestForConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil receiver", func(t *testing.T) {
+		t.Parallel()
+		assert.Assert(t, (*Environment)(nil).ForConfig() == nil)
+	})
+
+	t.Run("drops the test step and keeps the rest in order", func(t *testing.T) {
+		t.Parallel()
+		env := &Environment{
+			Stack: "go",
+			Setup: []Step{
+				{Name: "system", Command: "apt-get install git"},
+				{Name: "install", Command: "go mod download"},
+				{Name: StepTest, Command: "go test -p 1 ./..."},
+			},
+			Image:        "cimg/go",
+			ImageVersion: "1.26.2",
+		}
+
+		got := env.ForConfig()
+		assert.DeepEqual(t, got.Setup, []Step{
+			{Name: "system", Command: "apt-get install git"},
+			{Name: "install", Command: "go mod download"},
+		})
+		assert.Equal(t, got.Stack, "go")
+		assert.Equal(t, got.Image, "cimg/go")
+		assert.Equal(t, got.ImageVersion, "1.26.2")
+
+		// The receiver keeps its test step so the Dockerfile CMD still has it.
+		assert.Equal(t, len(env.Setup), 3)
+		assert.Equal(t, env.SetupStep(StepTest), "go test -p 1 ./...")
+	})
+
+	t.Run("no test step is a no-op", func(t *testing.T) {
+		t.Parallel()
+		env := &Environment{Setup: []Step{{Name: "install", Command: "npm ci"}}}
+		assert.DeepEqual(t, env.ForConfig().Setup, env.Setup)
+	})
+
+	t.Run("empty setup", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, len((&Environment{}).ForConfig().Setup), 0)
+	})
+}


### PR DESCRIPTION
## What

`chunk sidecar env` and `chunk sidecar setup` were writing a `test` step into `.chunk/config.json`'s environment, alongside the real provisioning steps:

```json
"environment": {"setup": [{"name": "install", ...}, {"name": "test", "command": "go test -p 1 ./..."}]}
```

That step isn't part of setup — it's the input to the test image's `CMD`, and `sidecarSetupRunSetup` had to explicitly skip it when running steps over SSH. The project's real test invocation already lives in `commands[]` in the same file, with role, timeout, fileExt and remote flags.

So the fix is at the persistence boundary, not in detection:

- `envspec.Environment.ForConfig()` returns a copy without the test step; used at both save sites.
- `LoadProjectConfig` strips it too, so existing configs are cleaned on their next save instead of being carried forward — or run over SSH.
- The in-memory spec keeps the step, so `chunk sidecar env | chunk sidecar build` still populates `CMD`. `Dockerfile.test` output is unchanged, as is environment detection.

## Notes for review

- The `step.Name == StepTest` skip in `sidecarSetupRunSetup` stays. It's now a correct statement about a freshly detected spec rather than a workaround: only the saved copy is stripped.
- `chunk sidecar env` deliberately prints more than it saves. That's what keeps `CMD` working; noted in the command's help text and `ForConfig`'s doc comment.
- The two `ForConfig()` call sites in `sidecar.go` aren't directly tested — that needs Docker Hub stubbed through `DetectEnvironment`, and `dockerHubClient` has no injection point reachable from `internal/cmd`. `ForConfig` is unit-tested, and the load-path strip is tested through a real file including the save round-trip.

## Testing

`task test` — 1103 tests, 1 skipped (`TestSidecarsBuildEndToEnd`, needs `CHUNK_ENV_BUILDER_ACCEPTANCE=1`). `golangci-lint run ./...` clean. The `pylint` half of `task lint` couldn't run locally (not installed in the harness uv env); `harness/` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)