### PR TITLE
Remove config fields nothing reads

### DIFF
--- a/.chunk/config.json
+++ b/.chunk/config.json
@@ -4,34 +4,25 @@
       "name": "test",
       "run": "task test",
       "role": "gate",
-      "fileExt": ".go",
       "timeout": 300,
-      "limit": 3,
       "remote": true
     },
     {
       "name": "test-changed",
       "run": "task test -- {{CHANGED_PACKAGES}}",
-      "role": "precheck",
-      "fileExt": ".go",
-      "timeout": 300,
-      "limit": 3
+      "timeout": 300
     },
     {
       "name": "lint",
       "run": "task lint",
       "role": "gate",
-      "fileExt": ".go",
-      "timeout": 60,
-      "limit": 3
+      "timeout": 60
     },
     {
       "name": "format",
       "run": "task fmt",
       "role": "autofix",
-      "timeout": 30,
-      "limit": 3,
-      "always": true
+      "timeout": 30
     }
   ],
   "vcs": {

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -26,15 +26,6 @@ type Command struct {
 	SidecarImage string `json:"sidecarImage,omitempty"`
 }
 
-// TaskConfig holds task delegation configuration.
-type TaskConfig struct {
-	Instructions string `json:"instructions,omitempty"`
-	Schema       string `json:"schema,omitempty"`
-	Limit        int    `json:"limit,omitempty"`
-	Always       bool   `json:"always,omitempty"`
-	Timeout      int    `json:"timeout,omitempty"`
-}
-
 // VCSConfig holds VCS configuration for the project.
 type VCSConfig struct {
 	Org  string `json:"org,omitempty"`
@@ -48,13 +39,12 @@ type ValidationConfig struct {
 
 // ProjectConfig is the per-repo configuration stored in .chunk/config.json.
 type ProjectConfig struct {
-	Commands            []Command             `json:"commands,omitempty"`
-	Tasks               map[string]TaskConfig `json:"tasks,omitempty"`
-	VCS                 *VCSConfig            `json:"vcs,omitempty"`
-	Validation          *ValidationConfig     `json:"validation,omitempty"`
-	OrgID               string                `json:"orgID,omitempty"`
-	StopHookMaxAttempts int                   `json:"stopHookMaxAttempts,omitempty"`
-	Environment         *envspec.Environment  `json:"environment,omitempty"`
+	Commands            []Command            `json:"commands,omitempty"`
+	VCS                 *VCSConfig           `json:"vcs,omitempty"`
+	Validation          *ValidationConfig    `json:"validation,omitempty"`
+	OrgID               string               `json:"orgID,omitempty"`
+	StopHookMaxAttempts int                  `json:"stopHookMaxAttempts,omitempty"`
+	Environment         *envspec.Environment `json:"environment,omitempty"`
 }
 
 // LoadProjectConfig reads .chunk/config.json from workDir.

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -9,11 +9,11 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/envspec"
 )
 
-// Command roles determine hook placement in settings.json.
+// Command roles describe what a command does. Only RoleGate is acted on:
+// sidecar setup marks gate commands for remote execution.
 const (
-	RoleGate     = "gate"     // enforce at Stop, run-and-record at PreToolUse
-	RolePrecheck = "precheck" // check at PreToolUse, enforce at Stop (changed-file variants)
-	RoleAutofix  = "autofix"  // run at PreToolUse, enforce at Stop (formatters)
+	RoleGate    = "gate"    // pass/fail check
+	RoleAutofix = "autofix" // rewrites files (formatters)
 )
 
 // Command is a single validation command.
@@ -21,11 +21,7 @@ type Command struct {
 	Name         string `json:"name"`
 	Run          string `json:"run"`
 	Role         string `json:"role,omitempty"`
-	FileExt      string `json:"fileExt,omitempty"`
 	Timeout      int    `json:"timeout,omitempty"`
-	Limit        int    `json:"limit,omitempty"`
-	Always       bool   `json:"always,omitempty"`
-	Staged       bool   `json:"staged,omitempty"`
 	Remote       bool   `json:"remote,omitempty"`
 	SidecarImage string `json:"sidecarImage,omitempty"`
 }
@@ -53,7 +49,6 @@ type ValidationConfig struct {
 // ProjectConfig is the per-repo configuration stored in .chunk/config.json.
 type ProjectConfig struct {
 	Commands            []Command             `json:"commands,omitempty"`
-	Triggers            map[string][]string   `json:"triggers,omitempty"`
 	Tasks               map[string]TaskConfig `json:"tasks,omitempty"`
 	VCS                 *VCSConfig            `json:"vcs,omitempty"`
 	Validation          *ValidationConfig     `json:"validation,omitempty"`

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -25,7 +25,7 @@ func TestMarkRemoteCommandsForSidecarSetup(t *testing.T) {
 			{Name: "install", Run: "npm ci"},
 			{Name: "test", Run: "npm test", Role: RoleGate},
 			{Name: "format", Run: "npm run format", Role: RoleAutofix},
-			{Name: "lint", Run: "npm run lint", Role: RolePrecheck},
+			{Name: "lint", Run: "npm run lint"},
 			{Name: "test-changed", Run: "npm test --changed", Role: RoleGate, Remote: true},
 		},
 	}

--- a/internal/validate/setup.go
+++ b/internal/validate/setup.go
@@ -41,52 +41,52 @@ func DetectCommands(ctx context.Context, claude *anthropic.Client, workDir strin
 	case has["Taskfile.yml"] || has["Taskfile.yaml"]:
 		if isGo {
 			return []config.Command{
-				{Name: "test", Run: "task test", Role: config.RoleGate, FileExt: ".go", Timeout: 300, Limit: 3},
-				{Name: "lint", Run: "task lint", Role: config.RoleGate, FileExt: ".go", Timeout: 60, Limit: 3},
-				{Name: "format", Run: "task fmt", Role: config.RoleAutofix, Always: true, Timeout: 30, Limit: 3},
+				{Name: "test", Run: "task test", Role: config.RoleGate, Timeout: 300},
+				{Name: "lint", Run: "task lint", Role: config.RoleGate, Timeout: 60},
+				{Name: "format", Run: "task fmt", Role: config.RoleAutofix, Timeout: 30},
 			}, nil
 		}
 		return []config.Command{
-			{Name: "test", Run: "task test", Role: config.RoleGate, Timeout: 300, Limit: 3},
+			{Name: "test", Run: "task test", Role: config.RoleGate, Timeout: 300},
 		}, nil
 
 	case has["Makefile"]:
 		if isGo {
 			return []config.Command{
-				{Name: "test", Run: "make test", Role: config.RoleGate, FileExt: ".go", Timeout: 300, Limit: 3},
-				{Name: "lint", Run: "make lint", Role: config.RoleGate, FileExt: ".go", Timeout: 60, Limit: 3},
+				{Name: "test", Run: "make test", Role: config.RoleGate, Timeout: 300},
+				{Name: "lint", Run: "make lint", Role: config.RoleGate, Timeout: 60},
 			}, nil
 		}
 		return []config.Command{
-			{Name: "test", Run: "make test", Role: config.RoleGate, Timeout: 300, Limit: 3},
+			{Name: "test", Run: "make test", Role: config.RoleGate, Timeout: 300},
 		}, nil
 
 	case isGo:
 		return []config.Command{
-			{Name: "test", Run: "go test ./...", Role: config.RoleGate, FileExt: ".go", Timeout: 300, Limit: 3},
-			{Name: "lint", Run: "golangci-lint run ./...", Role: config.RoleGate, FileExt: ".go", Timeout: 60, Limit: 3},
-			{Name: "format", Run: "gofmt -w .", Role: config.RoleAutofix, Always: true, Timeout: 30, Limit: 3},
+			{Name: "test", Run: "go test ./...", Role: config.RoleGate, Timeout: 300},
+			{Name: "lint", Run: "golangci-lint run ./...", Role: config.RoleGate, Timeout: 60},
+			{Name: "format", Run: "gofmt -w .", Role: config.RoleAutofix, Timeout: 30},
 		}, nil
 
 	case has["Cargo.toml"]:
 		return []config.Command{
-			{Name: "test", Run: "cargo test", Role: config.RoleGate, Timeout: 300, Limit: 3},
+			{Name: "test", Run: "cargo test", Role: config.RoleGate, Timeout: 300},
 		}, nil
 
 	case has["pyproject.toml"], has["requirements.txt"], has["setup.py"], has["Pipfile"]:
 		return []config.Command{
-			{Name: "test", Run: "pytest", Role: config.RoleGate, Timeout: 300, Limit: 3},
+			{Name: "test", Run: "pytest", Role: config.RoleGate, Timeout: 300},
 		}, nil
 
 	case has["Gemfile"]:
 		// Assumes Rake-based test task (Rails default). RSpec/Minitest-only stacks may need manual adjustment.
 		return []config.Command{
-			{Name: "test", Run: "bundle exec rake test", Role: config.RoleGate, Timeout: 300, Limit: 3},
+			{Name: "test", Run: "bundle exec rake test", Role: config.RoleGate, Timeout: 300},
 		}, nil
 
 	case has["pom.xml"]:
 		return []config.Command{
-			{Name: "test", Run: "mvn test", Role: config.RoleGate, Timeout: 300, Limit: 3},
+			{Name: "test", Run: "mvn test", Role: config.RoleGate, Timeout: 300},
 		}, nil
 
 	case has["build.gradle"], has["build.gradle.kts"]:
@@ -95,7 +95,7 @@ func DetectCommands(ctx context.Context, claude *anthropic.Client, workDir strin
 			gradleCmd = "./gradlew test"
 		}
 		return []config.Command{
-			{Name: "test", Run: gradleCmd, Role: config.RoleGate, Timeout: 300, Limit: 3},
+			{Name: "test", Run: gradleCmd, Role: config.RoleGate, Timeout: 300},
 		}, nil
 
 	case has["package.json"]:
@@ -105,14 +105,14 @@ func DetectCommands(ctx context.Context, claude *anthropic.Client, workDir strin
 			testCmd = pm.Name + " test"
 		}
 		return []config.Command{
-			{Name: "test", Run: testCmd, Role: config.RoleGate, Timeout: 300, Limit: 3},
+			{Name: "test", Run: testCmd, Role: config.RoleGate, Timeout: 300},
 		}, nil
 	}
 
 	// Monorepo with no root package.json but a detectable package manager in subdirs.
 	if pm := DetectPackageManager(workDir); pm != nil {
 		return []config.Command{
-			{Name: "test", Run: pm.Name + " test", Role: config.RoleGate, Timeout: 300, Limit: 3},
+			{Name: "test", Run: pm.Name + " test", Role: config.RoleGate, Timeout: 300},
 		}, nil
 	}
 

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -260,32 +260,29 @@ func TestRunAll(t *testing.T) {
 	})
 }
 
-// --- Config with FileExt / Timeout tests ---
+// --- Config timeout tests ---
 
-func TestCommandFileExtRoundTrip(t *testing.T) {
+func TestCommandTimeoutRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	chunkDir := filepath.Join(dir, ".chunk")
 	assert.NilError(t, os.MkdirAll(chunkDir, 0o755))
 
-	raw := `{"commands":[{"name":"lint","run":"eslint .","fileExt":".ts","timeout":60}]}`
+	raw := `{"commands":[{"name":"lint","run":"eslint .","timeout":60}]}`
 	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), []byte(raw), 0o644))
 
 	cfg, err := config.LoadProjectConfig(dir)
 	assert.NilError(t, err)
 	assert.Equal(t, len(cfg.Commands), 1)
-
-	c := cfg.Commands[0]
-	assert.Equal(t, c.FileExt, ".ts")
-	assert.Equal(t, c.Timeout, 60)
+	assert.Equal(t, cfg.Commands[0].Timeout, 60)
 
 	// Save and reload to verify round-trip
 	assert.NilError(t, config.SaveProjectConfig(dir, cfg))
 	cfg2, err := config.LoadProjectConfig(dir)
 	assert.NilError(t, err)
-	assert.Equal(t, cfg2.Commands[0].FileExt, ".ts")
+	assert.Equal(t, cfg2.Commands[0].Timeout, 60)
 }
 
-func TestCommandFileExtOmitted(t *testing.T) {
+func TestCommandTimeoutOmitted(t *testing.T) {
 	dir := t.TempDir()
 
 	cfg := &config.ProjectConfig{Commands: []config.Command{
@@ -295,8 +292,7 @@ func TestCommandFileExtOmitted(t *testing.T) {
 
 	data, err := os.ReadFile(filepath.Join(dir, ".chunk", "config.json"))
 	assert.NilError(t, err)
-	// fileExt and timeout should not appear when empty/zero
-	assert.Assert(t, !strings.Contains(string(data), "fileExt"), "expected fileExt to be omitted, got: %s", data)
+	// timeout should not appear when zero
 	assert.Assert(t, !strings.Contains(string(data), "timeout"), "expected timeout to be omitted, got: %s", data)
 }
 


### PR DESCRIPTION
`chunk init` wrote `fileExt`, `limit`, and `always` onto every detected command, and the `Command` struct also carried an unused `staged` flag. Nothing ever read any of them: command selection is by name, the only retry limit that applies is the project-level `stopHookMaxAttempts`, and no code path filters by file extension. `ProjectConfig.triggers` was never written or read.

`ProjectConfig.tasks` and its `TaskConfig` struct go too — same dead schema, one level up. They declared a `tasks` key for `.chunk/config.json` (carrying its own `instructions`, `schema`, `limit`, `always`, `timeout`) that no code wrote, no code read, and no config file or doc ever mentioned. This is unrelated to `chunk task config`, which writes `.chunk/run.json` through `internal/task` and has its own types — the name collision is the only connection.

Drops the `precheck` role along with them. No detection path assigned it, and because `MarkRemoteCommandsForSidecarSetup` only matches `install` and `gate`, a `precheck` command was silently excluded from remote execution.

Also corrects the role doc comment: it described PreToolUse/Stop hook placement that `settings.Build` does not implement — every command goes into one commit matcher plus a single Stop hook regardless of role.

`role` itself stays: it is still read to decide sidecar remote eligibility.

Existing configs carrying any of these keys still load unchanged — `LoadProjectConfig` uses plain `json.Unmarshal` with no `DisallowUnknownFields`, so dropped keys are ignored (and stripped on the next save).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
