### PR TITLE
goreleaser: bundle shell completions in release archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Build output
 bin/
 dist/
+share/
 /chunk
 /chunk-*
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,6 +3,11 @@
 
 version: 2
 
+before:
+  hooks:
+    - go run . completion bash --output share/bash-completion/completions/chunk
+    - go run . completion zsh --output share/zsh/site-functions/_chunk
+
 builds:
   - id: chunk
     binary: chunk
@@ -40,6 +45,10 @@ archives:
     files:
       - LICENSE
       - README.md
+      - src: ./share/bash-completion/completions/chunk
+        dst: share/bash-completion/completions/chunk
+      - src: ./share/zsh/site-functions/_chunk
+        dst: share/zsh/site-functions/_chunk
 
 checksum:
   name_template: 'checksums.txt'
@@ -71,6 +80,8 @@ brews:
       system "#{bin}/chunk"
     install: |
       bin.install "chunk"
+      bash_completion.install "share/bash-completion/completions/chunk"
+      zsh_completion.install "share/zsh/site-functions/_chunk"
 
 # Nix package (for NUR - Nix User Repository)
 nix:

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -160,25 +161,59 @@ func newCompletionInstallCmd() *cobra.Command {
 }
 
 func newCompletionZshCmd() *cobra.Command {
-	return &cobra.Command{
+	var outputPath string
+	cmd := &cobra.Command{
 		Use:    "zsh",
 		Short:  "Generate zsh completion script",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Root().GenZshCompletion(iostream.FromCmd(cmd).Out)
+			w, closeOut, err := openCompletionOutput(outputPath, iostream.FromCmd(cmd).Out)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = closeOut() }()
+			return cmd.Root().GenZshCompletion(w)
 		},
 	}
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "Write completion script to this file instead of stdout")
+	return cmd
 }
 
 func newCompletionBashCmd() *cobra.Command {
-	return &cobra.Command{
+	var outputPath string
+	cmd := &cobra.Command{
 		Use:    "bash",
 		Short:  "Generate bash completion script",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Root().GenBashCompletion(iostream.FromCmd(cmd).Out)
+			w, closeOut, err := openCompletionOutput(outputPath, iostream.FromCmd(cmd).Out)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = closeOut() }()
+			return cmd.Root().GenBashCompletion(w)
 		},
 	}
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "Write completion script to this file instead of stdout")
+	return cmd
+}
+
+// openCompletionOutput resolves the output destination for a completion
+// command. When path is empty it returns w (the command's stdout) with a
+// no-op closer; otherwise it creates the file and any missing parent
+// directories and returns it with its Close method.
+func openCompletionOutput(path string, w io.Writer) (io.Writer, func() error, error) {
+	if path == "" {
+		return w, func() error { return nil }, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, nil, fmt.Errorf("create output directory: %w", err)
+	}
+	f, err := os.Create(path) //#nosec:G304 // path is user-supplied
+	if err != nil {
+		return nil, nil, fmt.Errorf("create output file: %w", err)
+	}
+	return f, f.Close, nil
 }
 
 func newCompletionUninstallCmd() *cobra.Command {


### PR DESCRIPTION
## Summary

- Adds goreleaser `before` hooks to generate bash and zsh completion scripts at release time
- Bundles them in release archives at the standard UNIX paths (`share/bash-completion/completions/chunk`, `share/zsh/site-functions/_chunk`)
- The Homebrew formula installs these to the standard completion directories automatically — no subprocess spawned on shell startup
- Adds `--output/-o` flag to `chunk completion bash` and `chunk completion zsh` so the hooks don't need shell redirection or `mkdir -p` wrappers (mirrors circleci-cli)
- Adds `share/` to `.gitignore` (generated artifact)
- `completion install` is unchanged and continues to work as a fallback for manual curl installs

## Motivation

`chunk completion install` was writing `source <(chunk completion zsh)` to `.zshrc`, which spawns a `chunk` subprocess on every new shell session. This was generating ~400 telemetry events per day from shell startups rather than intentional user invocations.

For Homebrew users (the majority), completions now land in the right system directories during installation with no runtime cost. The `completion install` fallback is preserved for users who install via curl.

## Reproduction steps

```bash
# 1. Build the binary and verify --output creates the file and any missing parent directories
task build
./dist/chunk completion bash --output /tmp/chunk-completion-test/chunk
./dist/chunk completion zsh --output /tmp/chunk-completion-test/_chunk
head -3 /tmp/chunk-completion-test/chunk   # → bash completion header
head -3 /tmp/chunk-completion-test/_chunk  # → #compdef chunk

# 2. Run goreleaser hooks and verify share/ is populated
goreleaser build --snapshot --clean
ls -la share/bash-completion/completions/chunk share/zsh/site-functions/_chunk

# 3. Verify the files land in the release archive
goreleaser release --snapshot --clean --skip=publish,announce,validate
tar tzf dist/chunk-cli_Darwin_arm64.tar.gz | grep share
# share/bash-completion/completions/chunk
# share/zsh/site-functions/_chunk
```

## Test plan

- [ ] Steps above pass locally
- [ ] CI passes
- [ ] After next Homebrew release: `brew install chunk-cli && chunk <TAB>` completes without spawning a subprocess

🤖 Generated with [Claude Code](https://claude.com/claude-code)