### PR TITLE
skill: install locally by default, add --user flag for user scope

### DIFF
--- a/acceptance/skills_test.go
+++ b/acceptance/skills_test.go
@@ -12,19 +12,20 @@ import (
 	testenv "github.com/CircleCI-Public/chunk-cli/internal/testing/env"
 )
 
+// --- Project-level install (default, uses CWD) ---
+
 func TestSkillsInstall(t *testing.T) {
 	env := testenv.NewTestEnv(t)
+	dir := t.TempDir()
 
-	claudeDir := filepath.Join(env.HomeDir, ".claude")
-	err := os.MkdirAll(claudeDir, 0o755)
-	assert.NilError(t, err)
+	claudeDir := filepath.Join(dir, ".claude")
+	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
 
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "install"}, env, dir)
 
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 
 	combined := result.Stdout + result.Stderr
-	// Claude skills should be installed.
 	assert.Assert(t, strings.Contains(combined, "claude:"),
 		"expected per-agent output for claude, got: %s", combined)
 
@@ -36,35 +37,80 @@ func TestSkillsInstall(t *testing.T) {
 	}
 }
 
-func TestSkillsInstallSkipsUnavailableAgent(t *testing.T) {
+func TestSkillsInstallCodexPath(t *testing.T) {
 	env := testenv.NewTestEnv(t)
+	dir := t.TempDir()
 
-	// Only create .claude, not .agents.
-	claudeDir := filepath.Join(env.HomeDir, ".claude")
+	// .codex is the project-level config dir for codex.
+	codexDir := filepath.Join(dir, ".codex")
+	assert.NilError(t, os.MkdirAll(codexDir, 0o755))
+
+	result := binary.RunCLI(t, []string{"skill", "install"}, env, dir)
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "codex:"),
+		"expected per-agent output for codex, got: %s", combined)
+	assert.Assert(t, !strings.Contains(combined, "claude:"),
+		"expected no claude output when .claude absent, got: %s", combined)
+
+	for _, name := range []string{"chunk-review", "chunk-testing-gaps", "chunk-sidecar", "debug-ci-failures"} {
+		skillFile := filepath.Join(codexDir, "skills", name, "SKILL.md")
+		info, err := os.Stat(skillFile)
+		assert.NilError(t, err, "expected skill %s to exist under .codex", name)
+		assert.Assert(t, info.Size() > 0, "expected skill %s to be non-empty", name)
+	}
+}
+
+func TestSkillsInstallBothAgents(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	dir := t.TempDir()
+
+	claudeDir := filepath.Join(dir, ".claude")
+	codexDir := filepath.Join(dir, ".codex")
 	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
+	assert.NilError(t, os.MkdirAll(codexDir, 0o755))
 
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "install"}, env, dir)
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "claude:"),
+		"expected per-agent output for claude, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "codex:"),
+		"expected per-agent output for codex, got: %s", combined)
+	assert.Assert(t, !strings.Contains(combined, "skipped"),
+		"expected no skipped agents, got: %s", combined)
+
+	for _, agentDir := range []string{claudeDir, codexDir} {
+		for _, name := range []string{"chunk-review", "chunk-testing-gaps", "chunk-sidecar", "debug-ci-failures"} {
+			skillFile := filepath.Join(agentDir, "skills", name, "SKILL.md")
+			_, err := os.Stat(skillFile)
+			assert.NilError(t, err, "expected skill %s under %s", name, agentDir)
+		}
+	}
+}
+
+func TestSkillsInstallNoAgentDirs(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	dir := t.TempDir()
+
+	result := binary.RunCLI(t, []string{"skill", "install"}, env, dir)
 	assert.Equal(t, result.ExitCode, 0)
 
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "codex: skipped"),
-		"expected codex skipped message, got: %s", combined)
-
-	// .agents dir should not have been created.
-	_, err := os.Stat(filepath.Join(env.HomeDir, ".agents", "skills"))
-	assert.Assert(t, os.IsNotExist(err), "should not create .agents/skills")
+	assert.Assert(t, strings.Contains(combined, "no supported agent config directories"),
+		"expected 'no supported agent config directories' message, got: %s", combined)
 }
 
 func TestSkillsInstallUpToDate(t *testing.T) {
 	env := testenv.NewTestEnv(t)
-	claudeDir := filepath.Join(env.HomeDir, ".claude")
-	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
+	dir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
 
-	// First install.
-	binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	binary.RunCLI(t, []string{"skill", "install"}, env, dir)
 
-	// Second install should show "up to date".
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "install"}, env, dir)
 	assert.Equal(t, result.ExitCode, 0)
 
 	combined := result.Stdout + result.Stderr
@@ -72,47 +118,87 @@ func TestSkillsInstallUpToDate(t *testing.T) {
 		"expected up-to-date message on second install, got: %s", combined)
 }
 
-func TestSkillsList(t *testing.T) {
+func TestSkillsInstallOutdatedUpdate(t *testing.T) {
 	env := testenv.NewTestEnv(t)
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
 
-	result := binary.RunCLI(t, []string{"skill", "list"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "install"}, env, dir)
+	assert.Equal(t, result.ExitCode, 0, "first install failed: %s", result.Stderr)
 
-	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	tampered := filepath.Join(claudeDir, "skills", "chunk-review", "SKILL.md")
+	assert.NilError(t, os.WriteFile(tampered, []byte("tampered content"), 0o644))
 
-	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "chunk-review"),
-		"expected 'chunk-review' in output, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "chunk-testing-gaps"),
-		"expected 'chunk-testing-gaps' in output, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "debug-ci-failures"),
-		"expected 'debug-ci-failures' in output, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "chunk-sidecar"),
-		"expected 'chunk-sidecar' in output, got: %s", combined)
-	// Should show per-agent status.
-	assert.Assert(t, strings.Contains(combined, "claude:"),
-		"expected per-agent status for claude, got: %s", combined)
-}
-
-func TestSkillsListShowsDescriptions(t *testing.T) {
-	env := testenv.NewTestEnv(t)
-
-	result := binary.RunCLI(t, []string{"skill", "list"}, env, env.HomeDir)
+	result = binary.RunCLI(t, []string{"skill", "install"}, env, dir)
 	assert.Equal(t, result.ExitCode, 0)
 
 	combined := result.Stdout + result.Stderr
-	// Check for a fragment from one of the descriptions.
-	assert.Assert(t, strings.Contains(combined, "mutation test"),
-		"expected skill description in output, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "updated"),
+		"expected 'updated' message for tampered skill, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "chunk-review"),
+		"expected chunk-review in update output, got: %s", combined)
+
+	restored, err := os.ReadFile(tampered)
+	assert.NilError(t, err)
+	assert.Assert(t, string(restored) != "tampered content",
+		"expected content to be restored after update")
+	assert.Assert(t, len(restored) > 100,
+		"expected restored skill file to have substantial content, got %d bytes", len(restored))
 }
 
-func TestSkillsInstallCodexPath(t *testing.T) {
-	env := testenv.NewTestEnv(t)
+// --- User-level install (--user flag) ---
 
-	// Only create .agents, not .claude.
+func TestSkillsInstallUserFlag(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	dir := t.TempDir() // workdir with no agent dirs
+
+	claudeDir := filepath.Join(env.HomeDir, ".claude")
+	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
+
+	result := binary.RunCLI(t, []string{"skill", "install", "--user"}, env, dir)
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "claude:"),
+		"expected per-agent output for claude, got: %s", combined)
+
+	// Skills should land in $HOME/.claude/skills/, not in dir.
+	for _, name := range []string{"chunk-review", "chunk-testing-gaps", "chunk-sidecar", "debug-ci-failures"} {
+		skillFile := filepath.Join(claudeDir, "skills", name, "SKILL.md")
+		info, err := os.Stat(skillFile)
+		assert.NilError(t, err, "expected skill %s to exist under $HOME/.claude", name)
+		assert.Assert(t, info.Size() > 0)
+	}
+}
+
+func TestSkillsInstallUserFlagSkipsUnavailableAgent(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	dir := t.TempDir()
+
+	// Only create $HOME/.claude, not $HOME/.agents.
+	assert.NilError(t, os.MkdirAll(filepath.Join(env.HomeDir, ".claude"), 0o755))
+
+	result := binary.RunCLI(t, []string{"skill", "install", "--user"}, env, dir)
+	assert.Equal(t, result.ExitCode, 0)
+
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "codex: skipped"),
+		"expected codex skipped message, got: %s", combined)
+
+	_, err := os.Stat(filepath.Join(env.HomeDir, ".agents", "skills"))
+	assert.Assert(t, os.IsNotExist(err), "should not create $HOME/.agents/skills")
+}
+
+func TestSkillsInstallUserFlagCodexPath(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	dir := t.TempDir()
+
+	// Only create $HOME/.agents, not $HOME/.claude.
 	codexDir := filepath.Join(env.HomeDir, ".agents")
 	assert.NilError(t, os.MkdirAll(codexDir, 0o755))
 
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "install", "--user"}, env, dir)
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 
 	combined := result.Stdout + result.Stderr
@@ -124,20 +210,19 @@ func TestSkillsInstallCodexPath(t *testing.T) {
 	for _, name := range []string{"chunk-review", "chunk-testing-gaps", "chunk-sidecar", "debug-ci-failures"} {
 		skillFile := filepath.Join(codexDir, "skills", name, "SKILL.md")
 		info, err := os.Stat(skillFile)
-		assert.NilError(t, err, "expected skill %s to exist under .agents", name)
-		assert.Assert(t, info.Size() > 0, "expected skill %s to be non-empty", name)
+		assert.NilError(t, err, "expected skill %s to exist under $HOME/.agents", name)
+		assert.Assert(t, info.Size() > 0)
 	}
 }
 
-func TestSkillsInstallBothAgents(t *testing.T) {
+func TestSkillsInstallUserFlagBothAgents(t *testing.T) {
 	env := testenv.NewTestEnv(t)
+	dir := t.TempDir()
 
-	claudeDir := filepath.Join(env.HomeDir, ".claude")
-	codexDir := filepath.Join(env.HomeDir, ".agents")
-	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
-	assert.NilError(t, os.MkdirAll(codexDir, 0o755))
+	assert.NilError(t, os.MkdirAll(filepath.Join(env.HomeDir, ".claude"), 0o755))
+	assert.NilError(t, os.MkdirAll(filepath.Join(env.HomeDir, ".agents"), 0o755))
 
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "install", "--user"}, env, dir)
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 
 	combined := result.Stdout + result.Stderr
@@ -145,57 +230,16 @@ func TestSkillsInstallBothAgents(t *testing.T) {
 		"expected per-agent output for claude, got: %s", combined)
 	assert.Assert(t, strings.Contains(combined, "codex:"),
 		"expected per-agent output for codex, got: %s", combined)
-	// Neither should be skipped.
 	assert.Assert(t, !strings.Contains(combined, "skipped"),
 		"expected no skipped agents, got: %s", combined)
-
-	// Verify files exist under both agent dirs.
-	for _, dir := range []string{claudeDir, codexDir} {
-		for _, name := range []string{"chunk-review", "chunk-testing-gaps", "chunk-sidecar", "debug-ci-failures"} {
-			skillFile := filepath.Join(dir, "skills", name, "SKILL.md")
-			_, err := os.Stat(skillFile)
-			assert.NilError(t, err, "expected skill %s under %s", name, dir)
-		}
-	}
 }
 
-func TestSkillsInstallOutdatedUpdate(t *testing.T) {
+func TestSkillsInstallUserFlagNoAgentDirs(t *testing.T) {
 	env := testenv.NewTestEnv(t)
-	claudeDir := filepath.Join(env.HomeDir, ".claude")
-	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
+	dir := t.TempDir()
 
-	// First install.
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
-	assert.Equal(t, result.ExitCode, 0, "first install failed: %s", result.Stderr)
-
-	// Tamper with one skill file to make it outdated.
-	tampered := filepath.Join(claudeDir, "skills", "chunk-review", "SKILL.md")
-	assert.NilError(t, os.WriteFile(tampered, []byte("tampered content"), 0o644))
-
-	// Re-run install: should detect outdated and update.
-	result = binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
-	assert.Equal(t, result.ExitCode, 0)
-
-	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "updated"),
-		"expected 'updated' message for tampered skill, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "chunk-review"),
-		"expected chunk-review in update output, got: %s", combined)
-
-	// Verify file content is restored (no longer tampered).
-	restored, err := os.ReadFile(tampered)
-	assert.NilError(t, err)
-	assert.Assert(t, string(restored) != "tampered content",
-		"expected content to be restored after update")
-	assert.Assert(t, len(restored) > 100,
-		"expected restored skill file to have substantial content, got %d bytes", len(restored))
-}
-
-func TestSkillsInstallNoAgentDirs(t *testing.T) {
-	env := testenv.NewTestEnv(t)
-
-	// Don't create .claude or .agents.
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	// No $HOME/.claude or $HOME/.agents.
+	result := binary.RunCLI(t, []string{"skill", "install", "--user"}, env, dir)
 	assert.Equal(t, result.ExitCode, 0)
 
 	combined := result.Stdout + result.Stderr
@@ -205,43 +249,69 @@ func TestSkillsInstallNoAgentDirs(t *testing.T) {
 		"expected codex skipped, got: %s", combined)
 }
 
-func TestSkillsInstallHomeNotSet(t *testing.T) {
+func TestSkillsInstallUserFlagHomeNotSet(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.HomeDir = ""
 
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, os.TempDir())
+	result := binary.RunCLI(t, []string{"skill", "install", "--user"}, env, os.TempDir())
 	assert.Assert(t, result.ExitCode != 0,
-		"expected non-zero exit code when HOME is not set, got exit %d", result.ExitCode)
+		"expected non-zero exit code when HOME is not set with --user, got exit %d", result.ExitCode)
 
 	combined := result.Stdout + result.Stderr
 	assert.Assert(t, strings.Contains(combined, "HOME environment variable is not set"),
-		"expected 'HOME environment variable is not set' error, got: %s", combined)
+		"expected HOME error, got: %s", combined)
+}
+
+// --- Skill list ---
+
+func TestSkillsList(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	dir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
+
+	result := binary.RunCLI(t, []string{"skill", "list"}, env, dir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "chunk-review"), "expected 'chunk-review' in output, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "chunk-testing-gaps"), "expected 'chunk-testing-gaps' in output, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "debug-ci-failures"), "expected 'debug-ci-failures' in output, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "chunk-sidecar"), "expected 'chunk-sidecar' in output, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "claude:"), "expected per-agent status for claude, got: %s", combined)
+}
+
+func TestSkillsListShowsDescriptions(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	dir := t.TempDir()
+
+	result := binary.RunCLI(t, []string{"skill", "list"}, env, dir)
+	assert.Equal(t, result.ExitCode, 0)
+
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "mutation test"),
+		"expected skill description in output, got: %s", combined)
 }
 
 func TestSkillsListStateLabels(t *testing.T) {
 	env := testenv.NewTestEnv(t)
-	claudeDir := filepath.Join(env.HomeDir, ".claude")
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
 	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
 
 	// Before install: .claude exists so skills should show "missing".
-	result := binary.RunCLI(t, []string{"skill", "list"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "list"}, env, dir)
 	assert.Equal(t, result.ExitCode, 0)
 	combined := result.Stdout + result.Stderr
 	assert.Assert(t, strings.Contains(combined, "missing"),
 		"expected 'missing' state before install, got: %s", combined)
 
-	// .agents does not exist, so codex should show "n/a".
-	assert.Assert(t, strings.Contains(combined, "n/a"),
-		"expected 'n/a' for codex (not installed), got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "codex:"),
-		"expected codex agent in list output, got: %s", combined)
-
 	// Install skills.
-	result = binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result = binary.RunCLI(t, []string{"skill", "install"}, env, dir)
 	assert.Equal(t, result.ExitCode, 0, "install failed: %s", result.Stderr)
 
 	// After install: skills should show "current".
-	result = binary.RunCLI(t, []string{"skill", "list"}, env, env.HomeDir)
+	result = binary.RunCLI(t, []string{"skill", "list"}, env, dir)
 	assert.Equal(t, result.ExitCode, 0)
 	combined = result.Stdout + result.Stderr
 	assert.Assert(t, strings.Contains(combined, "current"),
@@ -251,7 +321,7 @@ func TestSkillsListStateLabels(t *testing.T) {
 	tampered := filepath.Join(claudeDir, "skills", "chunk-review", "SKILL.md")
 	assert.NilError(t, os.WriteFile(tampered, []byte("tampered"), 0o644))
 
-	result = binary.RunCLI(t, []string{"skill", "list"}, env, env.HomeDir)
+	result = binary.RunCLI(t, []string{"skill", "list"}, env, dir)
 	assert.Equal(t, result.ExitCode, 0)
 	combined = result.Stdout + result.Stderr
 	assert.Assert(t, strings.Contains(combined, "outdated"),
@@ -260,29 +330,36 @@ func TestSkillsListStateLabels(t *testing.T) {
 
 func TestSkillsListMixedStates(t *testing.T) {
 	env := testenv.NewTestEnv(t)
-	claudeDir := filepath.Join(env.HomeDir, ".claude")
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
 	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
 
-	// Install all skills first.
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "install"}, env, dir)
 	assert.Equal(t, result.ExitCode, 0, "install failed: %s", result.Stderr)
 
-	// Tamper one skill to make it outdated.
 	tampered := filepath.Join(claudeDir, "skills", "chunk-review", "SKILL.md")
 	assert.NilError(t, os.WriteFile(tampered, []byte("tampered"), 0o644))
-
-	// Delete another skill entirely to make it missing.
 	assert.NilError(t, os.RemoveAll(filepath.Join(claudeDir, "skills", "debug-ci-failures")))
 
-	// List should show current, outdated, and missing.
-	result = binary.RunCLI(t, []string{"skill", "list"}, env, env.HomeDir)
+	result = binary.RunCLI(t, []string{"skill", "list"}, env, dir)
 	assert.Equal(t, result.ExitCode, 0)
 	combined := result.Stdout + result.Stderr
 
-	assert.Assert(t, strings.Contains(combined, "current"),
-		"expected 'current' for untouched skill, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "outdated"),
-		"expected 'outdated' for tampered skill, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "missing"),
-		"expected 'missing' for deleted skill, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "current"), "expected 'current' for untouched skill, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "outdated"), "expected 'outdated' for tampered skill, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "missing"), "expected 'missing' for deleted skill, got: %s", combined)
+}
+
+func TestSkillsListUserFlag(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	dir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(env.HomeDir, ".claude"), 0o755))
+
+	result := binary.RunCLI(t, []string{"skill", "list", "--user"}, env, dir)
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "claude:"), "expected per-agent status for claude, got: %s", combined)
+	// $HOME/.agents not present, so codex shows "n/a".
+	assert.Assert(t, strings.Contains(combined, "n/a"), "expected 'n/a' for codex (not installed), got: %s", combined)
 }

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -307,23 +307,8 @@ func ensureGitignoreEntries(workDir string, streams iostream.Streams) error {
 	return nil
 }
 
-func installSkillsStep(dir string, streams iostream.Streams) {
-	for _, r := range skills.InstallByNameInDir(dir, "chunk-sidecar") {
-		for _, name := range r.Installed {
-			streams.ErrPrintln(ui.Success(fmt.Sprintf("Installed %s skill for %s", name, r.Agent)))
-		}
-		for _, name := range r.Updated {
-			streams.ErrPrintln(ui.Success(fmt.Sprintf("Updated %s skill for %s", name, r.Agent)))
-		}
-	}
-}
-
-func installSkillsStepUser(streams iostream.Streams) {
-	homeDir := os.Getenv(config.EnvHome)
-	if homeDir == "" {
-		return
-	}
-	for _, r := range skills.InstallByName(homeDir, "chunk-sidecar") {
+func installSkillsStep(agents []skills.Agent, streams iostream.Streams) {
+	for _, r := range skills.InstallByNameAgents(agents, "chunk-sidecar") {
 		if r.Skipped {
 			continue
 		}
@@ -590,11 +575,15 @@ hook config files.`,
 
 			// Step 6: Agent skills
 			if !skipSkills {
+				var skillAgents []skills.Agent
 				if userSkills {
-					installSkillsStepUser(streams)
+					if homeDir := os.Getenv(config.EnvHome); homeDir != "" {
+						skillAgents = skills.Agents(homeDir)
+					}
 				} else {
-					installSkillsStep(workDir, streams)
+					skillAgents = skills.ProjectAgents(workDir)
 				}
+				installSkillsStep(skillAgents, streams)
 			}
 
 			streams.ErrPrintln(ui.Success("Project initialized"))

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -308,7 +308,12 @@ func ensureGitignoreEntries(workDir string, streams iostream.Streams) error {
 }
 
 func installSkillsStep(scope skills.Scope, streams iostream.Streams) {
-	for _, r := range skills.InstallByName(scope, "chunk-sidecar") {
+	results, err := skills.InstallByName(scope, "chunk-sidecar")
+	if err != nil {
+		streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not install skills: %v", err)))
+		return
+	}
+	for _, r := range results {
 		if r.Skipped {
 			continue
 		}
@@ -575,13 +580,9 @@ hook config files.`,
 
 			// Step 6: Agent skills
 			if !skipSkills {
-				var scope skills.Scope
+				scope := skills.ProjectScope
 				if userSkills {
-					if homeDir := os.Getenv(config.EnvHome); homeDir != "" {
-						scope = skills.UserScope(homeDir)
-					}
-				} else {
-					scope = skills.ProjectScope(workDir)
+					scope = skills.UserScope
 				}
 				installSkillsStep(scope, streams)
 			}

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -307,7 +307,18 @@ func ensureGitignoreEntries(workDir string, streams iostream.Streams) error {
 	return nil
 }
 
-func installSkillsStep(streams iostream.Streams) {
+func installSkillsStep(dir string, streams iostream.Streams) {
+	for _, r := range skills.InstallByNameInDir(dir, "chunk-sidecar") {
+		for _, name := range r.Installed {
+			streams.ErrPrintln(ui.Success(fmt.Sprintf("Installed %s skill for %s", name, r.Agent)))
+		}
+		for _, name := range r.Updated {
+			streams.ErrPrintln(ui.Success(fmt.Sprintf("Updated %s skill for %s", name, r.Agent)))
+		}
+	}
+}
+
+func installSkillsStepUser(streams iostream.Streams) {
 	homeDir := os.Getenv(config.EnvHome)
 	if homeDir == "" {
 		return
@@ -448,7 +459,7 @@ func writeGitHook(gitCommonDir string, streams iostream.Streams) error {
 }
 
 func newInitCmd() *cobra.Command {
-	var force, skipHooks, skipGitHook, skipValidate, skipCompletions, skipSkills, skipTestSuites bool
+	var force, skipHooks, skipGitHook, skipValidate, skipCompletions, skipSkills, skipTestSuites, userSkills bool
 	var projectDir string
 
 	cmd := &cobra.Command{
@@ -579,7 +590,11 @@ hook config files.`,
 
 			// Step 6: Agent skills
 			if !skipSkills {
-				installSkillsStep(streams)
+				if userSkills {
+					installSkillsStepUser(streams)
+				} else {
+					installSkillsStep(workDir, streams)
+				}
 			}
 
 			streams.ErrPrintln(ui.Success("Project initialized"))
@@ -593,6 +608,7 @@ hook config files.`,
 	cmd.Flags().BoolVar(&skipValidate, "skip-validate", false, "Skip validate command detection")
 	cmd.Flags().BoolVar(&skipCompletions, "skip-completions", false, "Skip shell completion installation")
 	cmd.Flags().BoolVar(&skipSkills, "skip-skills", false, "Skip agent skill installation")
+	cmd.Flags().BoolVar(&userSkills, "user", false, "Install skills into user-level agent directories (~/.claude, ~/.agents) instead of the project directory")
 	cmd.Flags().BoolVar(&skipTestSuites, "skip-test-suites", true, "Skip CircleCI test-suites.yml generation (default: skip; pass =false to use built-in Go/pytest templates)")
 	cmd.Flags().StringVar(&projectDir, "project-dir", "", "Project directory (defaults to current directory)")
 

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -307,8 +307,8 @@ func ensureGitignoreEntries(workDir string, streams iostream.Streams) error {
 	return nil
 }
 
-func installSkillsStep(agents []skills.Agent, streams iostream.Streams) {
-	for _, r := range skills.InstallByNameAgents(agents, "chunk-sidecar") {
+func installSkillsStep(scope skills.Scope, streams iostream.Streams) {
+	for _, r := range skills.InstallByName(scope, "chunk-sidecar") {
 		if r.Skipped {
 			continue
 		}
@@ -575,15 +575,15 @@ hook config files.`,
 
 			// Step 6: Agent skills
 			if !skipSkills {
-				var skillAgents []skills.Agent
+				var scope skills.Scope
 				if userSkills {
 					if homeDir := os.Getenv(config.EnvHome); homeDir != "" {
-						skillAgents = skills.Agents(homeDir)
+						scope = skills.UserScope(homeDir)
 					}
 				} else {
-					skillAgents = skills.ProjectAgents(workDir)
+					scope = skills.ProjectScope(workDir)
 				}
-				installSkillsStep(skillAgents, streams)
+				installSkillsStep(scope, streams)
 			}
 
 			streams.ErrPrintln(ui.Success("Project initialized"))

--- a/internal/cmd/skills.go
+++ b/internal/cmd/skills.go
@@ -25,22 +25,21 @@ func newSkillCmd() *cobra.Command {
 	return cmd
 }
 
-// resolveAgents returns agents to operate on based on the --user flag.
-// User-level returns all defined agents (absent ones are marked skipped on install).
-// Project-level returns only agents with existing dot directories in the cwd.
-func resolveAgents(userLevel bool) ([]skills.Agent, error) {
+// resolveScope returns the skill installation scope based on the --user flag.
+// User-level targets $HOME agent directories; project-level targets dot dirs in the cwd.
+func resolveScope(userLevel bool) (skills.Scope, error) {
 	if userLevel {
 		home := os.Getenv(config.EnvHome)
 		if home == "" {
-			return nil, &userError{msg: msgHomeNotSet, errMsg: errMsgHomeNotSet}
+			return skills.Scope{}, &userError{msg: msgHomeNotSet, errMsg: errMsgHomeNotSet}
 		}
-		return skills.Agents(home), nil
+		return skills.UserScope(home), nil
 	}
 	cwd, err := os.Getwd()
 	if err != nil {
-		return nil, &userError{msg: "Could not determine current directory.", err: err}
+		return skills.Scope{}, &userError{msg: "Could not determine current directory.", err: err}
 	}
-	return skills.ProjectAgents(cwd), nil
+	return skills.ProjectScope(cwd), nil
 }
 
 func newSkillInstallCmd() *cobra.Command {
@@ -52,12 +51,12 @@ func newSkillInstallCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 
-			agents, err := resolveAgents(userLevel)
+			scope, err := resolveScope(userLevel)
 			if err != nil {
 				return err
 			}
 
-			results := skills.InstallAgents(agents)
+			results := skills.Install(scope)
 			if len(results) == 0 {
 				io.Println(ui.Dim("no supported agent config directories found (" + strings.Join(skills.SupportedProjectDotDirs(), ", ") + ")"))
 				return nil
@@ -101,12 +100,12 @@ func newSkillListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 
-			agents, err := resolveAgents(userLevel)
+			scope, err := resolveScope(userLevel)
 			if err != nil {
 				return err
 			}
 
-			statuses := skills.StatusAgents(agents)
+			statuses := skills.Status(scope)
 
 			if jsonOut {
 				return iostream.PrintJSON(io.Out, statuses)

--- a/internal/cmd/skills.go
+++ b/internal/cmd/skills.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -25,18 +26,33 @@ func newSkillCmd() *cobra.Command {
 }
 
 func newSkillInstallCmd() *cobra.Command {
-	var jsonOut bool
+	var jsonOut, userLevel bool
 
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install or update all skills into agent config directories",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			home := os.Getenv(config.EnvHome)
-			if home == "" {
-				return &userError{msg: msgHomeNotSet, errMsg: errMsgHomeNotSet}
-			}
 			io := iostream.FromCmd(cmd)
-			results := skills.Install(home)
+
+			var results []skills.AgentInstallResult
+			if userLevel {
+				home := os.Getenv(config.EnvHome)
+				if home == "" {
+					return &userError{msg: msgHomeNotSet, errMsg: errMsgHomeNotSet}
+				}
+				results = skills.Install(home)
+			} else {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return &userError{msg: "Could not determine current directory.", err: err}
+				}
+				results = skills.InstallInDir(cwd)
+				if len(results) == 0 {
+					io.Println(ui.Dim("no supported agent config directories found (" + strings.Join(skills.SupportedProjectDotDirs(), ", ") + ")"))
+					return nil
+				}
+			}
+
 			if jsonOut {
 				return iostream.PrintJSON(io.Out, results)
 			}
@@ -61,20 +77,31 @@ func newSkillInstallCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	cmd.Flags().BoolVar(&userLevel, "user", false, "Install into user-level agent directories (~/.claude, ~/.agents) instead of the current directory")
 
 	return cmd
 }
 
 func newSkillListCmd() *cobra.Command {
-	var jsonOut bool
+	var jsonOut, userLevel bool
 
 	cmd := &cobra.Command{
 		Use:   cmdList,
 		Short: "List bundled skills and their per-agent installation status",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			home := os.Getenv(config.EnvHome)
 			io := iostream.FromCmd(cmd)
-			statuses := skills.Status(home)
+
+			var statuses []skills.AgentStatus
+			if userLevel {
+				home := os.Getenv(config.EnvHome)
+				statuses = skills.Status(home)
+			} else {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return &userError{msg: "Could not determine current directory.", err: err}
+				}
+				statuses = skills.StatusInDir(cwd)
+			}
 
 			if jsonOut {
 				return iostream.PrintJSON(io.Out, statuses)
@@ -87,14 +114,26 @@ func newSkillListCmd() *cobra.Command {
 				io.Printf("  %s\n", ui.Green(s.Name))
 				io.Printf("    %s\n", ui.Dim(s.Description))
 
-				for _, agent := range statuses {
-					skill := agent.Skills[i]
-					if !agent.Available {
-						io.Printf("      %s: %s\n", ui.Dim(agent.Agent), ui.Dim("n/a (agent not installed)"))
-						continue
+				if userLevel {
+					for _, agent := range statuses {
+						skill := agent.Skills[i]
+						if !agent.Available {
+							io.Printf("      %s: %s\n", ui.Dim(agent.Agent), ui.Dim("n/a (agent not installed)"))
+							continue
+						}
+						icon, label := stateDisplay(skill.State)
+						io.Printf("      %s: %s %s\n", agent.Agent, icon, label)
 					}
-					icon, label := stateDisplay(skill.State)
-					io.Printf("      %s: %s %s\n", agent.Agent, icon, label)
+				} else {
+					if len(statuses) == 0 {
+						io.Printf("      %s\n", ui.Dim("no supported agent config directories found ("+strings.Join(skills.SupportedProjectDotDirs(), ", ")+")"))
+					} else {
+						for _, agent := range statuses {
+							skill := agent.Skills[i]
+							icon, label := stateDisplay(skill.State)
+							io.Printf("      %s: %s %s\n", agent.Agent, icon, label)
+						}
+					}
 				}
 				io.Println()
 			}
@@ -103,6 +142,7 @@ func newSkillListCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	cmd.Flags().BoolVar(&userLevel, "user", false, "Show status for user-level agent directories instead of the current directory")
 
 	return cmd
 }
@@ -110,11 +150,11 @@ func newSkillListCmd() *cobra.Command {
 func stateDisplay(state skills.State) (icon, label string) {
 	switch state {
 	case skills.StateCurrent:
-		return ui.Green("\u2713"), ui.Green("current")
+		return ui.Green("✓"), ui.Green("current")
 	case skills.StateOutdated:
-		return ui.Yellow("\u26a0"), ui.Yellow("outdated")
+		return ui.Yellow("⚠"), ui.Yellow("outdated")
 	case skills.StateMissing:
-		return ui.Dim("\u2717"), ui.Dim("missing")
+		return ui.Dim("✗"), ui.Dim("missing")
 	}
 	return ui.Dim("?"), ui.Dim("unknown")
 }

--- a/internal/cmd/skills.go
+++ b/internal/cmd/skills.go
@@ -25,6 +25,24 @@ func newSkillCmd() *cobra.Command {
 	return cmd
 }
 
+// resolveAgents returns agents to operate on based on the --user flag.
+// User-level returns all defined agents (absent ones are marked skipped on install).
+// Project-level returns only agents with existing dot directories in the cwd.
+func resolveAgents(userLevel bool) ([]skills.Agent, error) {
+	if userLevel {
+		home := os.Getenv(config.EnvHome)
+		if home == "" {
+			return nil, &userError{msg: msgHomeNotSet, errMsg: errMsgHomeNotSet}
+		}
+		return skills.Agents(home), nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, &userError{msg: "Could not determine current directory.", err: err}
+	}
+	return skills.ProjectAgents(cwd), nil
+}
+
 func newSkillInstallCmd() *cobra.Command {
 	var jsonOut, userLevel bool
 
@@ -34,23 +52,15 @@ func newSkillInstallCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 
-			var results []skills.AgentInstallResult
-			if userLevel {
-				home := os.Getenv(config.EnvHome)
-				if home == "" {
-					return &userError{msg: msgHomeNotSet, errMsg: errMsgHomeNotSet}
-				}
-				results = skills.Install(home)
-			} else {
-				cwd, err := os.Getwd()
-				if err != nil {
-					return &userError{msg: "Could not determine current directory.", err: err}
-				}
-				results = skills.InstallInDir(cwd)
-				if len(results) == 0 {
-					io.Println(ui.Dim("no supported agent config directories found (" + strings.Join(skills.SupportedProjectDotDirs(), ", ") + ")"))
-					return nil
-				}
+			agents, err := resolveAgents(userLevel)
+			if err != nil {
+				return err
+			}
+
+			results := skills.InstallAgents(agents)
+			if len(results) == 0 {
+				io.Println(ui.Dim("no supported agent config directories found (" + strings.Join(skills.SupportedProjectDotDirs(), ", ") + ")"))
+				return nil
 			}
 
 			if jsonOut {
@@ -91,49 +101,34 @@ func newSkillListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 
-			var statuses []skills.AgentStatus
-			if userLevel {
-				home := os.Getenv(config.EnvHome)
-				statuses = skills.Status(home)
-			} else {
-				cwd, err := os.Getwd()
-				if err != nil {
-					return &userError{msg: "Could not determine current directory.", err: err}
-				}
-				statuses = skills.StatusInDir(cwd)
+			agents, err := resolveAgents(userLevel)
+			if err != nil {
+				return err
 			}
+
+			statuses := skills.StatusAgents(agents)
 
 			if jsonOut {
 				return iostream.PrintJSON(io.Out, statuses)
 			}
 
-			skillDefs := skills.All
-			io.Printf("\nBundled skills (%d):\n\n", len(skillDefs))
+			io.Printf("\nBundled skills (%d):\n\n", len(skills.All))
 
-			for i, s := range skillDefs {
+			for i, s := range skills.All {
 				io.Printf("  %s\n", ui.Green(s.Name))
 				io.Printf("    %s\n", ui.Dim(s.Description))
 
-				if userLevel {
-					for _, agent := range statuses {
-						skill := agent.Skills[i]
-						if !agent.Available {
-							io.Printf("      %s: %s\n", ui.Dim(agent.Agent), ui.Dim("n/a (agent not installed)"))
-							continue
-						}
-						icon, label := stateDisplay(skill.State)
-						io.Printf("      %s: %s %s\n", agent.Agent, icon, label)
+				if len(statuses) == 0 {
+					io.Printf("      %s\n", ui.Dim("no supported agent config directories found ("+strings.Join(skills.SupportedProjectDotDirs(), ", ")+")"))
+				}
+				for _, agent := range statuses {
+					skill := agent.Skills[i]
+					if !agent.Available {
+						io.Printf("      %s: %s\n", ui.Dim(agent.Agent), ui.Dim("n/a (agent not installed)"))
+						continue
 					}
-				} else {
-					if len(statuses) == 0 {
-						io.Printf("      %s\n", ui.Dim("no supported agent config directories found ("+strings.Join(skills.SupportedProjectDotDirs(), ", ")+")"))
-					} else {
-						for _, agent := range statuses {
-							skill := agent.Skills[i]
-							icon, label := stateDisplay(skill.State)
-							io.Printf("      %s: %s %s\n", agent.Agent, icon, label)
-						}
-					}
+					icon, label := stateDisplay(skill.State)
+					io.Printf("      %s: %s %s\n", agent.Agent, icon, label)
 				}
 				io.Println()
 			}

--- a/internal/cmd/skills.go
+++ b/internal/cmd/skills.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/skills"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
@@ -25,23 +23,6 @@ func newSkillCmd() *cobra.Command {
 	return cmd
 }
 
-// resolveScope returns the skill installation scope based on the --user flag.
-// User-level targets $HOME agent directories; project-level targets dot dirs in the cwd.
-func resolveScope(userLevel bool) (skills.Scope, error) {
-	if userLevel {
-		home := os.Getenv(config.EnvHome)
-		if home == "" {
-			return skills.Scope{}, &userError{msg: msgHomeNotSet, errMsg: errMsgHomeNotSet}
-		}
-		return skills.UserScope(home), nil
-	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return skills.Scope{}, &userError{msg: "Could not determine current directory.", err: err}
-	}
-	return skills.ProjectScope(cwd), nil
-}
-
 func newSkillInstallCmd() *cobra.Command {
 	var jsonOut, userLevel bool
 
@@ -51,12 +32,15 @@ func newSkillInstallCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 
-			scope, err := resolveScope(userLevel)
-			if err != nil {
-				return err
+			scope := skills.ProjectScope
+			if userLevel {
+				scope = skills.UserScope
 			}
 
-			results := skills.Install(scope)
+			results, err := skills.Install(scope)
+			if err != nil {
+				return &userError{msg: "Could not install skills.", err: err}
+			}
 			if len(results) == 0 {
 				io.Println(ui.Dim("no supported agent config directories found (" + strings.Join(skills.SupportedProjectDotDirs(), ", ") + ")"))
 				return nil
@@ -100,12 +84,15 @@ func newSkillListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 
-			scope, err := resolveScope(userLevel)
-			if err != nil {
-				return err
+			scope := skills.ProjectScope
+			if userLevel {
+				scope = skills.UserScope
 			}
 
-			statuses := skills.Status(scope)
+			statuses, err := skills.Status(scope)
+			if err != nil {
+				return &userError{msg: "Could not list skills.", err: err}
+			}
 
 			if jsonOut {
 				return iostream.PrintJSON(io.Out, statuses)

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -43,53 +43,58 @@ var All = []Skill{
 	},
 }
 
-// Agent represents a target agent with its config directories.
-type Agent struct {
-	Name      string
-	ConfigDir string // parent config dir (must exist for install)
-	SkillsDir string // where skill subdirectories live
+// agent represents a target agent with its config directories.
+type agent struct {
+	name      string
+	configDir string // parent config dir (must exist for install)
+	skillsDir string // where skill subdirectories live
 }
 
-// Agents returns the list of supported agents for the given home directory.
-func Agents(homeDir string) []Agent {
-	return []Agent{
+// Scope determines which agent directories to target for skill operations.
+type Scope struct {
+	agents []agent
+}
+
+// UserScope returns a Scope targeting user-level agent directories ($HOME/.claude, $HOME/.agents).
+func UserScope(homeDir string) Scope {
+	return Scope{agents: []agent{
 		{
-			Name:      "claude",
-			ConfigDir: filepath.Join(homeDir, ".claude"),
-			SkillsDir: filepath.Join(homeDir, ".claude", "skills"),
+			name:      "claude",
+			configDir: filepath.Join(homeDir, ".claude"),
+			skillsDir: filepath.Join(homeDir, ".claude", "skills"),
 		},
 		{
-			Name:      "codex",
-			ConfigDir: filepath.Join(homeDir, ".agents"),
-			SkillsDir: filepath.Join(homeDir, ".agents", "skills"),
+			name:      "codex",
+			configDir: filepath.Join(homeDir, ".agents"),
+			skillsDir: filepath.Join(homeDir, ".agents", "skills"),
 		},
-	}
+	}}
 }
 
 // supportedProjectDirs maps dot directory names to agent names for project-level detection.
 var supportedProjectDirs = []struct {
 	dotDir string
-	agent  string
+	name   string
 }{
 	{".claude", "claude"},
 	{".codex", "codex"},
 }
 
-// ProjectAgents returns agents found in dir by inspecting for supported dot directories.
-// Only agents with existing dot directories are returned.
-func ProjectAgents(dir string) []Agent {
-	var agents []Agent
+// ProjectScope returns a Scope targeting agent directories found in dir (.claude, .codex).
+// Only directories that already exist are included.
+func ProjectScope(dir string) Scope {
+	var agents []agent
 	for _, d := range supportedProjectDirs {
 		configDir := filepath.Join(dir, d.dotDir)
 		if _, err := os.Stat(configDir); err == nil {
-			agents = append(agents, Agent{
-				Name:      d.agent,
-				ConfigDir: configDir,
-				SkillsDir: filepath.Join(configDir, "skills"),
+			agents = append(agents, agent{
+				name:      d.name,
+				configDir: configDir,
+				skillsDir: filepath.Join(configDir, "skills"),
 			})
 		}
 	}
-	return agents
+	return Scope{agents: agents}
 }
 
 // SupportedProjectDotDirs returns the dot directory names checked for project-level installs.
@@ -126,18 +131,18 @@ type AgentInstallResult struct {
 	Updated   []string `json:"updated"`
 }
 
-// InstallAgents installs all embedded skills for the given agents.
-func InstallAgents(agents []Agent) []AgentInstallResult {
-	results := make([]AgentInstallResult, 0, len(agents))
-	for _, agent := range agents {
-		results = append(results, installForAgent(agent, All))
+// Install installs all embedded skills for the agents in scope.
+func Install(scope Scope) []AgentInstallResult {
+	results := make([]AgentInstallResult, 0, len(scope.agents))
+	for _, a := range scope.agents {
+		results = append(results, installForAgent(a, All))
 	}
 	return results
 }
 
-// InstallByNameAgents installs a single skill by name for the given agents.
+// InstallByName installs a single skill by name for the agents in scope.
 // Returns nil if the skill name is not found.
-func InstallByNameAgents(agents []Agent, name string) []AgentInstallResult {
+func InstallByName(scope Scope, name string) []AgentInstallResult {
 	var s *Skill
 	for i := range All {
 		if All[i].Name == name {
@@ -148,22 +153,22 @@ func InstallByNameAgents(agents []Agent, name string) []AgentInstallResult {
 	if s == nil {
 		return nil
 	}
-	results := make([]AgentInstallResult, 0, len(agents))
-	for _, agent := range agents {
-		results = append(results, installForAgent(agent, []Skill{*s}))
+	results := make([]AgentInstallResult, 0, len(scope.agents))
+	for _, a := range scope.agents {
+		results = append(results, installForAgent(a, []Skill{*s}))
 	}
 	return results
 }
 
-func installForAgent(agent Agent, subset []Skill) AgentInstallResult {
-	if _, err := os.Stat(agent.ConfigDir); os.IsNotExist(err) {
-		return AgentInstallResult{Agent: agent.Name, Skipped: true, Installed: make([]string, 0), Updated: make([]string, 0)}
+func installForAgent(a agent, subset []Skill) AgentInstallResult {
+	if _, err := os.Stat(a.configDir); os.IsNotExist(err) {
+		return AgentInstallResult{Agent: a.name, Skipped: true, Installed: make([]string, 0), Updated: make([]string, 0)}
 	}
 
-	result := AgentInstallResult{Agent: agent.Name, Installed: make([]string, 0), Updated: make([]string, 0)}
+	result := AgentInstallResult{Agent: a.name, Installed: make([]string, 0), Updated: make([]string, 0)}
 
 	for _, s := range subset {
-		state := SkillState(agent.SkillsDir, s)
+		state := SkillState(a.skillsDir, s)
 		if state == StateCurrent {
 			continue
 		}
@@ -173,7 +178,7 @@ func installForAgent(agent Agent, subset []Skill) AgentInstallResult {
 			continue
 		}
 
-		dir := filepath.Join(agent.SkillsDir, s.Name)
+		dir := filepath.Join(a.skillsDir, s.Name)
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			continue
 		}
@@ -205,19 +210,19 @@ type AgentStatus struct {
 	Skills    []AgentSkillStatus `json:"skills"`
 }
 
-// StatusAgents returns per-agent, per-skill installation state for the given agents.
-func StatusAgents(agents []Agent) []AgentStatus {
-	results := make([]AgentStatus, 0, len(agents))
-	for _, agent := range agents {
+// Status returns per-agent, per-skill installation state for the agents in scope.
+func Status(scope Scope) []AgentStatus {
+	results := make([]AgentStatus, 0, len(scope.agents))
+	for _, a := range scope.agents {
 		available := true
-		if _, err := os.Stat(agent.ConfigDir); os.IsNotExist(err) {
+		if _, err := os.Stat(a.configDir); os.IsNotExist(err) {
 			available = false
 		}
 		ss := make([]AgentSkillStatus, 0, len(All))
 		for _, s := range All {
 			state := StateMissing
 			if available {
-				state = SkillState(agent.SkillsDir, s)
+				state = SkillState(a.skillsDir, s)
 			}
 			ss = append(ss, AgentSkillStatus{
 				Name:        s.Name,
@@ -226,7 +231,7 @@ func StatusAgents(agents []Agent) []AgentStatus {
 			})
 		}
 		results = append(results, AgentStatus{
-			Agent:     agent.Name,
+			Agent:     a.name,
 			Available: available,
 			Skills:    ss,
 		})

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -66,6 +66,94 @@ func Agents(homeDir string) []Agent {
 	}
 }
 
+// supportedProjectDirs maps dot directory names to agent names for project-level detection.
+var supportedProjectDirs = []struct {
+	dotDir string
+	agent  string
+}{
+	{".claude", "claude"},
+	{".codex", "codex"},
+}
+
+// ProjectAgents returns agents found in dir by inspecting for supported dot directories.
+// Only agents with existing dot directories are returned.
+func ProjectAgents(dir string) []Agent {
+	var agents []Agent
+	for _, d := range supportedProjectDirs {
+		configDir := filepath.Join(dir, d.dotDir)
+		if _, err := os.Stat(configDir); err == nil {
+			agents = append(agents, Agent{
+				Name:      d.agent,
+				ConfigDir: configDir,
+				SkillsDir: filepath.Join(configDir, "skills"),
+			})
+		}
+	}
+	return agents
+}
+
+// SupportedProjectDotDirs returns the dot directory names checked for project-level installs.
+func SupportedProjectDotDirs() []string {
+	names := make([]string, len(supportedProjectDirs))
+	for i, d := range supportedProjectDirs {
+		names[i] = d.dotDir
+	}
+	return names
+}
+
+// InstallInDir installs all skills into supported dot directories found in dir.
+func InstallInDir(dir string) []AgentInstallResult {
+	agents := ProjectAgents(dir)
+	results := make([]AgentInstallResult, 0, len(agents))
+	for _, agent := range agents {
+		results = append(results, installForAgent(agent, All))
+	}
+	return results
+}
+
+// InstallByNameInDir installs a single skill by name into supported dot directories found in dir.
+// Returns nil if the skill name is not found.
+func InstallByNameInDir(dir, name string) []AgentInstallResult {
+	var s *Skill
+	for i := range All {
+		if All[i].Name == name {
+			s = &All[i]
+			break
+		}
+	}
+	if s == nil {
+		return nil
+	}
+	agents := ProjectAgents(dir)
+	results := make([]AgentInstallResult, 0, len(agents))
+	for _, agent := range agents {
+		results = append(results, installForAgent(agent, []Skill{*s}))
+	}
+	return results
+}
+
+// StatusInDir returns per-agent, per-skill state for supported dot directories found in dir.
+func StatusInDir(dir string) []AgentStatus {
+	agents := ProjectAgents(dir)
+	results := make([]AgentStatus, 0, len(agents))
+	for _, agent := range agents {
+		ss := make([]AgentSkillStatus, 0, len(All))
+		for _, s := range All {
+			ss = append(ss, AgentSkillStatus{
+				Name:        s.Name,
+				Description: s.Description,
+				State:       SkillState(agent.SkillsDir, s),
+			})
+		}
+		results = append(results, AgentStatus{
+			Agent:     agent.Name,
+			Available: true,
+			Skills:    ss,
+		})
+	}
+	return results
+}
+
 // SkillState checks the installation state of a skill for an agent.
 func SkillState(skillsDir string, s Skill) State {
 	path := filepath.Join(skillsDir, s.Name, "SKILL.md")

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -101,59 +101,6 @@ func SupportedProjectDotDirs() []string {
 	return names
 }
 
-// InstallInDir installs all skills into supported dot directories found in dir.
-func InstallInDir(dir string) []AgentInstallResult {
-	agents := ProjectAgents(dir)
-	results := make([]AgentInstallResult, 0, len(agents))
-	for _, agent := range agents {
-		results = append(results, installForAgent(agent, All))
-	}
-	return results
-}
-
-// InstallByNameInDir installs a single skill by name into supported dot directories found in dir.
-// Returns nil if the skill name is not found.
-func InstallByNameInDir(dir, name string) []AgentInstallResult {
-	var s *Skill
-	for i := range All {
-		if All[i].Name == name {
-			s = &All[i]
-			break
-		}
-	}
-	if s == nil {
-		return nil
-	}
-	agents := ProjectAgents(dir)
-	results := make([]AgentInstallResult, 0, len(agents))
-	for _, agent := range agents {
-		results = append(results, installForAgent(agent, []Skill{*s}))
-	}
-	return results
-}
-
-// StatusInDir returns per-agent, per-skill state for supported dot directories found in dir.
-func StatusInDir(dir string) []AgentStatus {
-	agents := ProjectAgents(dir)
-	results := make([]AgentStatus, 0, len(agents))
-	for _, agent := range agents {
-		ss := make([]AgentSkillStatus, 0, len(All))
-		for _, s := range All {
-			ss = append(ss, AgentSkillStatus{
-				Name:        s.Name,
-				Description: s.Description,
-				State:       SkillState(agent.SkillsDir, s),
-			})
-		}
-		results = append(results, AgentStatus{
-			Agent:     agent.Name,
-			Available: true,
-			Skills:    ss,
-		})
-	}
-	return results
-}
-
 // SkillState checks the installation state of a skill for an agent.
 func SkillState(skillsDir string, s Skill) State {
 	path := filepath.Join(skillsDir, s.Name, "SKILL.md")
@@ -179,10 +126,8 @@ type AgentInstallResult struct {
 	Updated   []string `json:"updated"`
 }
 
-// Install installs all embedded skills for agents whose config dirs exist.
-// Agents with missing config dirs are skipped.
-func Install(homeDir string) []AgentInstallResult {
-	agents := Agents(homeDir)
+// InstallAgents installs all embedded skills for the given agents.
+func InstallAgents(agents []Agent) []AgentInstallResult {
 	results := make([]AgentInstallResult, 0, len(agents))
 	for _, agent := range agents {
 		results = append(results, installForAgent(agent, All))
@@ -190,9 +135,9 @@ func Install(homeDir string) []AgentInstallResult {
 	return results
 }
 
-// InstallByName installs a single skill by name for agents whose config dirs exist.
+// InstallByNameAgents installs a single skill by name for the given agents.
 // Returns nil if the skill name is not found.
-func InstallByName(homeDir, name string) []AgentInstallResult {
+func InstallByNameAgents(agents []Agent, name string) []AgentInstallResult {
 	var s *Skill
 	for i := range All {
 		if All[i].Name == name {
@@ -203,7 +148,6 @@ func InstallByName(homeDir, name string) []AgentInstallResult {
 	if s == nil {
 		return nil
 	}
-	agents := Agents(homeDir)
 	results := make([]AgentInstallResult, 0, len(agents))
 	for _, agent := range agents {
 		results = append(results, installForAgent(agent, []Skill{*s}))
@@ -261,17 +205,14 @@ type AgentStatus struct {
 	Skills    []AgentSkillStatus `json:"skills"`
 }
 
-// Status returns per-agent, per-skill installation state without modifying anything.
-func Status(homeDir string) []AgentStatus {
-	agents := Agents(homeDir)
+// StatusAgents returns per-agent, per-skill installation state for the given agents.
+func StatusAgents(agents []Agent) []AgentStatus {
 	results := make([]AgentStatus, 0, len(agents))
-
 	for _, agent := range agents {
 		available := true
 		if _, err := os.Stat(agent.ConfigDir); os.IsNotExist(err) {
 			available = false
 		}
-
 		ss := make([]AgentSkillStatus, 0, len(All))
 		for _, s := range All {
 			state := StateMissing

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -1,6 +1,7 @@
 package skills
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -43,32 +44,21 @@ var All = []Skill{
 	},
 }
 
+// Scope determines where skills are installed.
+type Scope int
+
+const (
+	// ProjectScope targets agent config directories found in the current directory (.claude, .codex).
+	ProjectScope Scope = iota
+	// UserScope targets user-level agent directories ($HOME/.claude, $HOME/.agents).
+	UserScope
+)
+
 // agent represents a target agent with its config directories.
 type agent struct {
 	name      string
-	configDir string // parent config dir (must exist for install)
-	skillsDir string // where skill subdirectories live
-}
-
-// Scope determines which agent directories to target for skill operations.
-type Scope struct {
-	agents []agent
-}
-
-// UserScope returns a Scope targeting user-level agent directories ($HOME/.claude, $HOME/.agents).
-func UserScope(homeDir string) Scope {
-	return Scope{agents: []agent{
-		{
-			name:      "claude",
-			configDir: filepath.Join(homeDir, ".claude"),
-			skillsDir: filepath.Join(homeDir, ".claude", "skills"),
-		},
-		{
-			name:      "codex",
-			configDir: filepath.Join(homeDir, ".agents"),
-			skillsDir: filepath.Join(homeDir, ".agents", "skills"),
-		},
-	}}
+	configDir string
+	skillsDir string
 }
 
 // supportedProjectDirs maps dot directory names to agent names for project-level detection.
@@ -80,23 +70,6 @@ var supportedProjectDirs = []struct {
 	{".codex", "codex"},
 }
 
-// ProjectScope returns a Scope targeting agent directories found in dir (.claude, .codex).
-// Only directories that already exist are included.
-func ProjectScope(dir string) Scope {
-	var agents []agent
-	for _, d := range supportedProjectDirs {
-		configDir := filepath.Join(dir, d.dotDir)
-		if _, err := os.Stat(configDir); err == nil {
-			agents = append(agents, agent{
-				name:      d.name,
-				configDir: configDir,
-				skillsDir: filepath.Join(configDir, "skills"),
-			})
-		}
-	}
-	return Scope{agents: agents}
-}
-
 // SupportedProjectDotDirs returns the dot directory names checked for project-level installs.
 func SupportedProjectDotDirs() []string {
 	names := make([]string, len(supportedProjectDirs))
@@ -104,6 +77,39 @@ func SupportedProjectDotDirs() []string {
 		names[i] = d.dotDir
 	}
 	return names
+}
+
+func resolveAgents(scope Scope) ([]agent, error) {
+	switch scope {
+	case UserScope:
+		home := os.Getenv("HOME")
+		if home == "" {
+			return nil, fmt.Errorf("HOME environment variable is not set")
+		}
+		return []agent{
+			{name: "claude", configDir: filepath.Join(home, ".claude"), skillsDir: filepath.Join(home, ".claude", "skills")},
+			{name: "codex", configDir: filepath.Join(home, ".agents"), skillsDir: filepath.Join(home, ".agents", "skills")},
+		}, nil
+	case ProjectScope:
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("could not determine current directory: %w", err)
+		}
+		var agents []agent
+		for _, d := range supportedProjectDirs {
+			configDir := filepath.Join(cwd, d.dotDir)
+			if _, err := os.Stat(configDir); err == nil {
+				agents = append(agents, agent{
+					name:      d.name,
+					configDir: configDir,
+					skillsDir: filepath.Join(configDir, "skills"),
+				})
+			}
+		}
+		return agents, nil
+	default:
+		return nil, fmt.Errorf("unknown scope %d", scope)
+	}
 }
 
 // SkillState checks the installation state of a skill for an agent.
@@ -131,18 +137,22 @@ type AgentInstallResult struct {
 	Updated   []string `json:"updated"`
 }
 
-// Install installs all embedded skills for the agents in scope.
-func Install(scope Scope) []AgentInstallResult {
-	results := make([]AgentInstallResult, 0, len(scope.agents))
-	for _, a := range scope.agents {
+// Install installs all embedded skills for the given scope.
+func Install(scope Scope) ([]AgentInstallResult, error) {
+	agents, err := resolveAgents(scope)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]AgentInstallResult, 0, len(agents))
+	for _, a := range agents {
 		results = append(results, installForAgent(a, All))
 	}
-	return results
+	return results, nil
 }
 
-// InstallByName installs a single skill by name for the agents in scope.
+// InstallByName installs a single skill by name for the given scope.
 // Returns nil if the skill name is not found.
-func InstallByName(scope Scope, name string) []AgentInstallResult {
+func InstallByName(scope Scope, name string) ([]AgentInstallResult, error) {
 	var s *Skill
 	for i := range All {
 		if All[i].Name == name {
@@ -151,13 +161,17 @@ func InstallByName(scope Scope, name string) []AgentInstallResult {
 		}
 	}
 	if s == nil {
-		return nil
+		return nil, nil
 	}
-	results := make([]AgentInstallResult, 0, len(scope.agents))
-	for _, a := range scope.agents {
+	agents, err := resolveAgents(scope)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]AgentInstallResult, 0, len(agents))
+	for _, a := range agents {
 		results = append(results, installForAgent(a, []Skill{*s}))
 	}
-	return results
+	return results, nil
 }
 
 func installForAgent(a agent, subset []Skill) AgentInstallResult {
@@ -210,10 +224,14 @@ type AgentStatus struct {
 	Skills    []AgentSkillStatus `json:"skills"`
 }
 
-// Status returns per-agent, per-skill installation state for the agents in scope.
-func Status(scope Scope) []AgentStatus {
-	results := make([]AgentStatus, 0, len(scope.agents))
-	for _, a := range scope.agents {
+// Status returns per-agent, per-skill installation state for the given scope.
+func Status(scope Scope) ([]AgentStatus, error) {
+	agents, err := resolveAgents(scope)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]AgentStatus, 0, len(agents))
+	for _, a := range agents {
 		available := true
 		if _, err := os.Stat(a.configDir); os.IsNotExist(err) {
 			available = false
@@ -236,5 +254,5 @@ func Status(scope Scope) []AgentStatus {
 			Skills:    ss,
 		})
 	}
-	return results
+	return results, nil
 }

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -33,7 +33,7 @@ func TestInstallInDir(t *testing.T) {
 	dir := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
 
-	results := skills.InstallInDir(dir)
+	results := skills.InstallAgents(skills.ProjectAgents(dir))
 	assert.Equal(t, len(results), 1)
 	assert.Equal(t, results[0].Agent, "claude")
 	assert.Assert(t, !results[0].Skipped)
@@ -49,7 +49,7 @@ func TestInstallInDir(t *testing.T) {
 
 func TestInstallInDirNoDirs(t *testing.T) {
 	dir := t.TempDir()
-	assert.Equal(t, len(skills.InstallInDir(dir)), 0)
+	assert.Equal(t, len(skills.InstallAgents(skills.ProjectAgents(dir))), 0)
 }
 
 func TestInstallInDirBothAgents(t *testing.T) {
@@ -57,7 +57,7 @@ func TestInstallInDirBothAgents(t *testing.T) {
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".codex"), 0o755))
 
-	results := skills.InstallInDir(dir)
+	results := skills.InstallAgents(skills.ProjectAgents(dir))
 	assert.Equal(t, len(results), 2)
 	for _, r := range results {
 		assert.Equal(t, len(r.Installed), len(skillNames))
@@ -68,7 +68,7 @@ func TestInstallByNameInDir(t *testing.T) {
 	dir := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
 
-	results := skills.InstallByNameInDir(dir, "chunk-review")
+	results := skills.InstallByNameAgents(skills.ProjectAgents(dir), "chunk-review")
 	assert.Equal(t, len(results), 1)
 	assert.Equal(t, len(results[0].Installed), 1)
 	assert.Equal(t, results[0].Installed[0], "chunk-review")
@@ -80,18 +80,18 @@ func TestInstallByNameInDir(t *testing.T) {
 func TestInstallByNameInDirUnknownSkill(t *testing.T) {
 	dir := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
-	assert.Assert(t, skills.InstallByNameInDir(dir, "does-not-exist") == nil)
+	assert.Assert(t, skills.InstallByNameAgents(skills.ProjectAgents(dir), "does-not-exist") == nil)
 }
 
 func TestStatusInDir(t *testing.T) {
 	dir := t.TempDir()
 
-	assert.Equal(t, len(skills.StatusInDir(dir)), 0)
+	assert.Equal(t, len(skills.StatusAgents(skills.ProjectAgents(dir))), 0)
 
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
-	skills.InstallInDir(dir)
+	skills.InstallAgents(skills.ProjectAgents(dir))
 
-	statuses := skills.StatusInDir(dir)
+	statuses := skills.StatusAgents(skills.ProjectAgents(dir))
 	assert.Equal(t, len(statuses), 1)
 	assert.Equal(t, statuses[0].Agent, "claude")
 	assert.Assert(t, statuses[0].Available)
@@ -118,7 +118,7 @@ func TestInstallBothAgents(t *testing.T) {
 		assert.NilError(t, os.MkdirAll(filepath.Join(home, dir), 0o755))
 	}
 
-	results := skills.Install(home)
+	results := skills.InstallAgents(skills.Agents(home))
 	assert.Equal(t, len(results), 2)
 
 	for _, r := range results {
@@ -145,7 +145,7 @@ func TestInstallSkipsAgentWithoutConfigDir(t *testing.T) {
 	// Only create .claude, not .agents.
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	results := skills.Install(home)
+	results := skills.InstallAgents(skills.Agents(home))
 	assert.Equal(t, len(results), 2)
 
 	var claude, codex skills.AgentInstallResult
@@ -172,11 +172,11 @@ func TestInstallIdempotent(t *testing.T) {
 	home := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	results1 := skills.Install(home)
+	results1 := skills.InstallAgents(skills.Agents(home))
 	assert.Equal(t, len(results1[0].Installed), len(skillNames))
 
 	// Second install should report all up to date.
-	results2 := skills.Install(home)
+	results2 := skills.InstallAgents(skills.Agents(home))
 	assert.Equal(t, len(results2[0].Installed), 0, "should have no new installs")
 	assert.Equal(t, len(results2[0].Updated), 0, "should have no updates")
 }
@@ -186,13 +186,13 @@ func TestInstallDetectsOutdated(t *testing.T) {
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
 	// First install.
-	skills.Install(home)
+	skills.InstallAgents(skills.Agents(home))
 
 	// Tamper with one skill file to make it outdated.
 	path := filepath.Join(home, ".claude", "skills", "chunk-review", "SKILL.md")
 	assert.NilError(t, os.WriteFile(path, []byte("old content"), 0o644))
 
-	results := skills.Install(home)
+	results := skills.InstallAgents(skills.Agents(home))
 	claude := results[0]
 	assert.Equal(t, len(claude.Installed), 0)
 	assert.Equal(t, len(claude.Updated), 1)
@@ -205,7 +205,7 @@ func TestInstallContentMatchesEmbedded(t *testing.T) {
 		assert.NilError(t, os.MkdirAll(filepath.Join(home, dir), 0o755))
 	}
 
-	skills.Install(home)
+	skills.InstallAgents(skills.Agents(home))
 
 	for _, name := range skillNames {
 		claudePath := filepath.Join(home, ".claude", "skills", name, "SKILL.md")
@@ -224,7 +224,7 @@ func TestInstallContentMatchesEmbedded(t *testing.T) {
 func TestStatusNotInstalled(t *testing.T) {
 	home := t.TempDir()
 
-	statuses := skills.Status(home)
+	statuses := skills.StatusAgents(skills.Agents(home))
 	assert.Equal(t, len(statuses), 2)
 
 	for _, agent := range statuses {
@@ -240,9 +240,9 @@ func TestStatusCurrent(t *testing.T) {
 	home := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	skills.Install(home)
+	skills.InstallAgents(skills.Agents(home))
 
-	statuses := skills.Status(home)
+	statuses := skills.StatusAgents(skills.Agents(home))
 	var claude skills.AgentStatus
 	for _, s := range statuses {
 		if s.Agent == "claude" {
@@ -261,13 +261,13 @@ func TestStatusOutdated(t *testing.T) {
 	home := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	skills.Install(home)
+	skills.InstallAgents(skills.Agents(home))
 
 	// Tamper with a skill.
 	path := filepath.Join(home, ".claude", "skills", "chunk-review", "SKILL.md")
 	assert.NilError(t, os.WriteFile(path, []byte("tampered"), 0o644))
 
-	statuses := skills.Status(home)
+	statuses := skills.StatusAgents(skills.Agents(home))
 	var claude skills.AgentStatus
 	for _, s := range statuses {
 		if s.Agent == "claude" {
@@ -287,7 +287,7 @@ func TestStatusOutdated(t *testing.T) {
 func TestStatusIncludesDescriptions(t *testing.T) {
 	home := t.TempDir()
 
-	statuses := skills.Status(home)
+	statuses := skills.StatusAgents(skills.Agents(home))
 	for _, agent := range statuses {
 		for _, s := range agent.Skills {
 			assert.Assert(t, s.Description != "",
@@ -301,7 +301,7 @@ func TestStatusAgentNotAvailable(t *testing.T) {
 	// Only create .claude.
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	statuses := skills.Status(home)
+	statuses := skills.StatusAgents(skills.Agents(home))
 	for _, agent := range statuses {
 		if agent.Agent == "claude" {
 			assert.Assert(t, agent.Available)

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -13,6 +13,103 @@ import (
 
 var skillNames = []string{"chunk-testing-gaps", "chunk-review", "debug-ci-failures", "chunk-sidecar"}
 
+func TestProjectAgentsFindsExistingDotDirs(t *testing.T) {
+	dir := t.TempDir()
+
+	assert.Equal(t, len(skills.ProjectAgents(dir)), 0)
+
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
+	agents := skills.ProjectAgents(dir)
+	assert.Equal(t, len(agents), 1)
+	assert.Equal(t, agents[0].Name, "claude")
+	assert.Equal(t, agents[0].ConfigDir, filepath.Join(dir, ".claude"))
+	assert.Equal(t, agents[0].SkillsDir, filepath.Join(dir, ".claude", "skills"))
+
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".codex"), 0o755))
+	assert.Equal(t, len(skills.ProjectAgents(dir)), 2)
+}
+
+func TestInstallInDir(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
+
+	results := skills.InstallInDir(dir)
+	assert.Equal(t, len(results), 1)
+	assert.Equal(t, results[0].Agent, "claude")
+	assert.Assert(t, !results[0].Skipped)
+	assert.Equal(t, len(results[0].Installed), len(skillNames))
+
+	for _, name := range skillNames {
+		path := filepath.Join(dir, ".claude", "skills", name, "SKILL.md")
+		info, err := os.Stat(path)
+		assert.NilError(t, err, "expected %s to exist", path)
+		assert.Assert(t, info.Size() > 0)
+	}
+}
+
+func TestInstallInDirNoDirs(t *testing.T) {
+	dir := t.TempDir()
+	assert.Equal(t, len(skills.InstallInDir(dir)), 0)
+}
+
+func TestInstallInDirBothAgents(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".codex"), 0o755))
+
+	results := skills.InstallInDir(dir)
+	assert.Equal(t, len(results), 2)
+	for _, r := range results {
+		assert.Equal(t, len(r.Installed), len(skillNames))
+	}
+}
+
+func TestInstallByNameInDir(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
+
+	results := skills.InstallByNameInDir(dir, "chunk-review")
+	assert.Equal(t, len(results), 1)
+	assert.Equal(t, len(results[0].Installed), 1)
+	assert.Equal(t, results[0].Installed[0], "chunk-review")
+
+	_, err := os.Stat(filepath.Join(dir, ".claude", "skills", "chunk-sidecar", "SKILL.md"))
+	assert.Assert(t, os.IsNotExist(err), "only the named skill should be installed")
+}
+
+func TestInstallByNameInDirUnknownSkill(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
+	assert.Assert(t, skills.InstallByNameInDir(dir, "does-not-exist") == nil)
+}
+
+func TestStatusInDir(t *testing.T) {
+	dir := t.TempDir()
+
+	assert.Equal(t, len(skills.StatusInDir(dir)), 0)
+
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
+	skills.InstallInDir(dir)
+
+	statuses := skills.StatusInDir(dir)
+	assert.Equal(t, len(statuses), 1)
+	assert.Equal(t, statuses[0].Agent, "claude")
+	assert.Assert(t, statuses[0].Available)
+	for _, s := range statuses[0].Skills {
+		assert.Equal(t, s.State, skills.StateCurrent, "skill %s should be current", s.Name)
+	}
+}
+
+func TestSupportedProjectDotDirs(t *testing.T) {
+	dirs := skills.SupportedProjectDotDirs()
+	found := map[string]bool{}
+	for _, d := range dirs {
+		found[d] = true
+	}
+	assert.Assert(t, found[".claude"], "expected .claude in supported dirs")
+	assert.Assert(t, found[".codex"], "expected .codex in supported dirs")
+}
+
 func TestInstallBothAgents(t *testing.T) {
 	home := t.TempDir()
 

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -13,27 +13,31 @@ import (
 
 var skillNames = []string{"chunk-testing-gaps", "chunk-review", "debug-ci-failures", "chunk-sidecar"}
 
-func TestProjectAgentsFindsExistingDotDirs(t *testing.T) {
+func TestProjectScopeDetectsDotDirs(t *testing.T) {
 	dir := t.TempDir()
 
-	assert.Equal(t, len(skills.ProjectAgents(dir)), 0)
+	// No dirs: install produces no results.
+	assert.Equal(t, len(skills.Install(skills.ProjectScope(dir))), 0)
 
+	// .claude present: claude agent is included.
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
-	agents := skills.ProjectAgents(dir)
-	assert.Equal(t, len(agents), 1)
-	assert.Equal(t, agents[0].Name, "claude")
-	assert.Equal(t, agents[0].ConfigDir, filepath.Join(dir, ".claude"))
-	assert.Equal(t, agents[0].SkillsDir, filepath.Join(dir, ".claude", "skills"))
+	results := skills.Install(skills.ProjectScope(dir))
+	assert.Equal(t, len(results), 1)
+	assert.Equal(t, results[0].Agent, "claude")
+	// Skills land under .claude/skills/.
+	_, err := os.Stat(filepath.Join(dir, ".claude", "skills", "chunk-review", "SKILL.md"))
+	assert.NilError(t, err)
 
+	// .codex added: both agents included.
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".codex"), 0o755))
-	assert.Equal(t, len(skills.ProjectAgents(dir)), 2)
+	assert.Equal(t, len(skills.Status(skills.ProjectScope(dir))), 2)
 }
 
 func TestInstallInDir(t *testing.T) {
 	dir := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
 
-	results := skills.InstallAgents(skills.ProjectAgents(dir))
+	results := skills.Install(skills.ProjectScope(dir))
 	assert.Equal(t, len(results), 1)
 	assert.Equal(t, results[0].Agent, "claude")
 	assert.Assert(t, !results[0].Skipped)
@@ -49,7 +53,7 @@ func TestInstallInDir(t *testing.T) {
 
 func TestInstallInDirNoDirs(t *testing.T) {
 	dir := t.TempDir()
-	assert.Equal(t, len(skills.InstallAgents(skills.ProjectAgents(dir))), 0)
+	assert.Equal(t, len(skills.Install(skills.ProjectScope(dir))), 0)
 }
 
 func TestInstallInDirBothAgents(t *testing.T) {
@@ -57,7 +61,7 @@ func TestInstallInDirBothAgents(t *testing.T) {
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".codex"), 0o755))
 
-	results := skills.InstallAgents(skills.ProjectAgents(dir))
+	results := skills.Install(skills.ProjectScope(dir))
 	assert.Equal(t, len(results), 2)
 	for _, r := range results {
 		assert.Equal(t, len(r.Installed), len(skillNames))
@@ -68,7 +72,7 @@ func TestInstallByNameInDir(t *testing.T) {
 	dir := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
 
-	results := skills.InstallByNameAgents(skills.ProjectAgents(dir), "chunk-review")
+	results := skills.InstallByName(skills.ProjectScope(dir), "chunk-review")
 	assert.Equal(t, len(results), 1)
 	assert.Equal(t, len(results[0].Installed), 1)
 	assert.Equal(t, results[0].Installed[0], "chunk-review")
@@ -80,18 +84,18 @@ func TestInstallByNameInDir(t *testing.T) {
 func TestInstallByNameInDirUnknownSkill(t *testing.T) {
 	dir := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
-	assert.Assert(t, skills.InstallByNameAgents(skills.ProjectAgents(dir), "does-not-exist") == nil)
+	assert.Assert(t, skills.InstallByName(skills.ProjectScope(dir), "does-not-exist") == nil)
 }
 
 func TestStatusInDir(t *testing.T) {
 	dir := t.TempDir()
 
-	assert.Equal(t, len(skills.StatusAgents(skills.ProjectAgents(dir))), 0)
+	assert.Equal(t, len(skills.Status(skills.ProjectScope(dir))), 0)
 
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
-	skills.InstallAgents(skills.ProjectAgents(dir))
+	skills.Install(skills.ProjectScope(dir))
 
-	statuses := skills.StatusAgents(skills.ProjectAgents(dir))
+	statuses := skills.Status(skills.ProjectScope(dir))
 	assert.Equal(t, len(statuses), 1)
 	assert.Equal(t, statuses[0].Agent, "claude")
 	assert.Assert(t, statuses[0].Available)
@@ -118,7 +122,7 @@ func TestInstallBothAgents(t *testing.T) {
 		assert.NilError(t, os.MkdirAll(filepath.Join(home, dir), 0o755))
 	}
 
-	results := skills.InstallAgents(skills.Agents(home))
+	results := skills.Install(skills.UserScope(home))
 	assert.Equal(t, len(results), 2)
 
 	for _, r := range results {
@@ -145,7 +149,7 @@ func TestInstallSkipsAgentWithoutConfigDir(t *testing.T) {
 	// Only create .claude, not .agents.
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	results := skills.InstallAgents(skills.Agents(home))
+	results := skills.Install(skills.UserScope(home))
 	assert.Equal(t, len(results), 2)
 
 	var claude, codex skills.AgentInstallResult
@@ -172,11 +176,11 @@ func TestInstallIdempotent(t *testing.T) {
 	home := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	results1 := skills.InstallAgents(skills.Agents(home))
+	results1 := skills.Install(skills.UserScope(home))
 	assert.Equal(t, len(results1[0].Installed), len(skillNames))
 
 	// Second install should report all up to date.
-	results2 := skills.InstallAgents(skills.Agents(home))
+	results2 := skills.Install(skills.UserScope(home))
 	assert.Equal(t, len(results2[0].Installed), 0, "should have no new installs")
 	assert.Equal(t, len(results2[0].Updated), 0, "should have no updates")
 }
@@ -186,13 +190,13 @@ func TestInstallDetectsOutdated(t *testing.T) {
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
 	// First install.
-	skills.InstallAgents(skills.Agents(home))
+	skills.Install(skills.UserScope(home))
 
 	// Tamper with one skill file to make it outdated.
 	path := filepath.Join(home, ".claude", "skills", "chunk-review", "SKILL.md")
 	assert.NilError(t, os.WriteFile(path, []byte("old content"), 0o644))
 
-	results := skills.InstallAgents(skills.Agents(home))
+	results := skills.Install(skills.UserScope(home))
 	claude := results[0]
 	assert.Equal(t, len(claude.Installed), 0)
 	assert.Equal(t, len(claude.Updated), 1)
@@ -205,7 +209,7 @@ func TestInstallContentMatchesEmbedded(t *testing.T) {
 		assert.NilError(t, os.MkdirAll(filepath.Join(home, dir), 0o755))
 	}
 
-	skills.InstallAgents(skills.Agents(home))
+	skills.Install(skills.UserScope(home))
 
 	for _, name := range skillNames {
 		claudePath := filepath.Join(home, ".claude", "skills", name, "SKILL.md")
@@ -224,7 +228,7 @@ func TestInstallContentMatchesEmbedded(t *testing.T) {
 func TestStatusNotInstalled(t *testing.T) {
 	home := t.TempDir()
 
-	statuses := skills.StatusAgents(skills.Agents(home))
+	statuses := skills.Status(skills.UserScope(home))
 	assert.Equal(t, len(statuses), 2)
 
 	for _, agent := range statuses {
@@ -240,9 +244,9 @@ func TestStatusCurrent(t *testing.T) {
 	home := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	skills.InstallAgents(skills.Agents(home))
+	skills.Install(skills.UserScope(home))
 
-	statuses := skills.StatusAgents(skills.Agents(home))
+	statuses := skills.Status(skills.UserScope(home))
 	var claude skills.AgentStatus
 	for _, s := range statuses {
 		if s.Agent == "claude" {
@@ -261,13 +265,13 @@ func TestStatusOutdated(t *testing.T) {
 	home := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	skills.InstallAgents(skills.Agents(home))
+	skills.Install(skills.UserScope(home))
 
 	// Tamper with a skill.
 	path := filepath.Join(home, ".claude", "skills", "chunk-review", "SKILL.md")
 	assert.NilError(t, os.WriteFile(path, []byte("tampered"), 0o644))
 
-	statuses := skills.StatusAgents(skills.Agents(home))
+	statuses := skills.Status(skills.UserScope(home))
 	var claude skills.AgentStatus
 	for _, s := range statuses {
 		if s.Agent == "claude" {
@@ -287,7 +291,7 @@ func TestStatusOutdated(t *testing.T) {
 func TestStatusIncludesDescriptions(t *testing.T) {
 	home := t.TempDir()
 
-	statuses := skills.StatusAgents(skills.Agents(home))
+	statuses := skills.Status(skills.UserScope(home))
 	for _, agent := range statuses {
 		for _, s := range agent.Skills {
 			assert.Assert(t, s.Description != "",
@@ -301,7 +305,7 @@ func TestStatusAgentNotAvailable(t *testing.T) {
 	// Only create .claude.
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	statuses := skills.StatusAgents(skills.Agents(home))
+	statuses := skills.Status(skills.UserScope(home))
 	for _, agent := range statuses {
 		if agent.Agent == "claude" {
 			assert.Assert(t, agent.Available)

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -13,31 +13,50 @@ import (
 
 var skillNames = []string{"chunk-testing-gaps", "chunk-review", "debug-ci-failures", "chunk-sidecar"}
 
+// inDir changes the working directory to dir for the duration of the test.
+func inDir(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	assert.NilError(t, err)
+	assert.NilError(t, os.Chdir(dir))
+	t.Cleanup(func() { os.Chdir(orig) })
+}
+
+// withHome sets HOME to dir for the duration of the test.
+func withHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+}
+
+// --- ProjectScope tests ---
+
 func TestProjectScopeDetectsDotDirs(t *testing.T) {
 	dir := t.TempDir()
+	inDir(t, dir)
 
-	// No dirs: install produces no results.
-	assert.Equal(t, len(skills.Install(skills.ProjectScope(dir))), 0)
+	results, err := skills.Install(skills.ProjectScope)
+	assert.NilError(t, err)
+	assert.Equal(t, len(results), 0, "expected no results before any dot dirs exist")
 
-	// .claude present: claude agent is included.
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
-	results := skills.Install(skills.ProjectScope(dir))
+	results, err = skills.Install(skills.ProjectScope)
+	assert.NilError(t, err)
 	assert.Equal(t, len(results), 1)
 	assert.Equal(t, results[0].Agent, "claude")
-	// Skills land under .claude/skills/.
-	_, err := os.Stat(filepath.Join(dir, ".claude", "skills", "chunk-review", "SKILL.md"))
-	assert.NilError(t, err)
 
-	// .codex added: both agents included.
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".codex"), 0o755))
-	assert.Equal(t, len(skills.Status(skills.ProjectScope(dir))), 2)
+	statuses, err := skills.Status(skills.ProjectScope)
+	assert.NilError(t, err)
+	assert.Equal(t, len(statuses), 2)
 }
 
 func TestInstallInDir(t *testing.T) {
 	dir := t.TempDir()
+	inDir(t, dir)
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
 
-	results := skills.Install(skills.ProjectScope(dir))
+	results, err := skills.Install(skills.ProjectScope)
+	assert.NilError(t, err)
 	assert.Equal(t, len(results), 1)
 	assert.Equal(t, results[0].Agent, "claude")
 	assert.Assert(t, !results[0].Skipped)
@@ -52,16 +71,20 @@ func TestInstallInDir(t *testing.T) {
 }
 
 func TestInstallInDirNoDirs(t *testing.T) {
-	dir := t.TempDir()
-	assert.Equal(t, len(skills.Install(skills.ProjectScope(dir))), 0)
+	inDir(t, t.TempDir())
+	results, err := skills.Install(skills.ProjectScope)
+	assert.NilError(t, err)
+	assert.Equal(t, len(results), 0)
 }
 
 func TestInstallInDirBothAgents(t *testing.T) {
 	dir := t.TempDir()
+	inDir(t, dir)
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".codex"), 0o755))
 
-	results := skills.Install(skills.ProjectScope(dir))
+	results, err := skills.Install(skills.ProjectScope)
+	assert.NilError(t, err)
 	assert.Equal(t, len(results), 2)
 	for _, r := range results {
 		assert.Equal(t, len(r.Installed), len(skillNames))
@@ -70,32 +93,42 @@ func TestInstallInDirBothAgents(t *testing.T) {
 
 func TestInstallByNameInDir(t *testing.T) {
 	dir := t.TempDir()
+	inDir(t, dir)
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
 
-	results := skills.InstallByName(skills.ProjectScope(dir), "chunk-review")
+	results, err := skills.InstallByName(skills.ProjectScope, "chunk-review")
+	assert.NilError(t, err)
 	assert.Equal(t, len(results), 1)
 	assert.Equal(t, len(results[0].Installed), 1)
 	assert.Equal(t, results[0].Installed[0], "chunk-review")
 
-	_, err := os.Stat(filepath.Join(dir, ".claude", "skills", "chunk-sidecar", "SKILL.md"))
+	_, err = os.Stat(filepath.Join(dir, ".claude", "skills", "chunk-sidecar", "SKILL.md"))
 	assert.Assert(t, os.IsNotExist(err), "only the named skill should be installed")
 }
 
 func TestInstallByNameInDirUnknownSkill(t *testing.T) {
 	dir := t.TempDir()
+	inDir(t, dir)
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
-	assert.Assert(t, skills.InstallByName(skills.ProjectScope(dir), "does-not-exist") == nil)
+	results, err := skills.InstallByName(skills.ProjectScope, "does-not-exist")
+	assert.NilError(t, err)
+	assert.Assert(t, results == nil)
 }
 
 func TestStatusInDir(t *testing.T) {
 	dir := t.TempDir()
+	inDir(t, dir)
 
-	assert.Equal(t, len(skills.Status(skills.ProjectScope(dir))), 0)
+	statuses, err := skills.Status(skills.ProjectScope)
+	assert.NilError(t, err)
+	assert.Equal(t, len(statuses), 0)
 
 	assert.NilError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o755))
-	skills.Install(skills.ProjectScope(dir))
+	_, err = skills.Install(skills.ProjectScope)
+	assert.NilError(t, err)
 
-	statuses := skills.Status(skills.ProjectScope(dir))
+	statuses, err = skills.Status(skills.ProjectScope)
+	assert.NilError(t, err)
 	assert.Equal(t, len(statuses), 1)
 	assert.Equal(t, statuses[0].Agent, "claude")
 	assert.Assert(t, statuses[0].Available)
@@ -114,15 +147,17 @@ func TestSupportedProjectDotDirs(t *testing.T) {
 	assert.Assert(t, found[".codex"], "expected .codex in supported dirs")
 }
 
+// --- UserScope tests ---
+
 func TestInstallBothAgents(t *testing.T) {
 	home := t.TempDir()
-
-	// Create both agent config dirs.
+	withHome(t, home)
 	for _, dir := range []string{".claude", ".agents"} {
 		assert.NilError(t, os.MkdirAll(filepath.Join(home, dir), 0o755))
 	}
 
-	results := skills.Install(skills.UserScope(home))
+	results, err := skills.Install(skills.UserScope)
+	assert.NilError(t, err)
 	assert.Equal(t, len(results), 2)
 
 	for _, r := range results {
@@ -132,7 +167,6 @@ func TestInstallBothAgents(t *testing.T) {
 		assert.Equal(t, len(r.Updated), 0)
 	}
 
-	// Verify files exist.
 	for _, dir := range []string{".claude", ".agents"} {
 		for _, name := range skillNames {
 			path := filepath.Join(home, dir, "skills", name, "SKILL.md")
@@ -145,11 +179,11 @@ func TestInstallBothAgents(t *testing.T) {
 
 func TestInstallSkipsAgentWithoutConfigDir(t *testing.T) {
 	home := t.TempDir()
-
-	// Only create .claude, not .agents.
+	withHome(t, home)
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	results := skills.Install(skills.UserScope(home))
+	results, err := skills.Install(skills.UserScope)
+	assert.NilError(t, err)
 	assert.Equal(t, len(results), 2)
 
 	var claude, codex skills.AgentInstallResult
@@ -167,36 +201,38 @@ func TestInstallSkipsAgentWithoutConfigDir(t *testing.T) {
 	assert.Assert(t, codex.Skipped, "codex should be skipped when .agents dir missing")
 	assert.Equal(t, len(codex.Installed), 0)
 
-	// Verify .agents skills dir was not created.
-	_, err := os.Stat(filepath.Join(home, ".agents", "skills"))
+	_, err = os.Stat(filepath.Join(home, ".agents", "skills"))
 	assert.Assert(t, os.IsNotExist(err), "should not create .agents/skills when .agents missing")
 }
 
 func TestInstallIdempotent(t *testing.T) {
 	home := t.TempDir()
+	withHome(t, home)
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	results1 := skills.Install(skills.UserScope(home))
+	results1, err := skills.Install(skills.UserScope)
+	assert.NilError(t, err)
 	assert.Equal(t, len(results1[0].Installed), len(skillNames))
 
-	// Second install should report all up to date.
-	results2 := skills.Install(skills.UserScope(home))
+	results2, err := skills.Install(skills.UserScope)
+	assert.NilError(t, err)
 	assert.Equal(t, len(results2[0].Installed), 0, "should have no new installs")
 	assert.Equal(t, len(results2[0].Updated), 0, "should have no updates")
 }
 
 func TestInstallDetectsOutdated(t *testing.T) {
 	home := t.TempDir()
+	withHome(t, home)
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	// First install.
-	skills.Install(skills.UserScope(home))
+	_, err := skills.Install(skills.UserScope)
+	assert.NilError(t, err)
 
-	// Tamper with one skill file to make it outdated.
 	path := filepath.Join(home, ".claude", "skills", "chunk-review", "SKILL.md")
 	assert.NilError(t, os.WriteFile(path, []byte("old content"), 0o644))
 
-	results := skills.Install(skills.UserScope(home))
+	results, err := skills.Install(skills.UserScope)
+	assert.NilError(t, err)
 	claude := results[0]
 	assert.Equal(t, len(claude.Installed), 0)
 	assert.Equal(t, len(claude.Updated), 1)
@@ -205,80 +241,78 @@ func TestInstallDetectsOutdated(t *testing.T) {
 
 func TestInstallContentMatchesEmbedded(t *testing.T) {
 	home := t.TempDir()
+	withHome(t, home)
 	for _, dir := range []string{".claude", ".agents"} {
 		assert.NilError(t, os.MkdirAll(filepath.Join(home, dir), 0o755))
 	}
 
-	skills.Install(skills.UserScope(home))
+	_, err := skills.Install(skills.UserScope)
+	assert.NilError(t, err)
 
 	for _, name := range skillNames {
-		claudePath := filepath.Join(home, ".claude", "skills", name, "SKILL.md")
-		codexPath := filepath.Join(home, ".agents", "skills", name, "SKILL.md")
-
-		claudeData, err := os.ReadFile(claudePath)
+		claudeData, err := os.ReadFile(filepath.Join(home, ".claude", "skills", name, "SKILL.md"))
 		assert.NilError(t, err)
-		codexData, err := os.ReadFile(codexPath)
+		codexData, err := os.ReadFile(filepath.Join(home, ".agents", "skills", name, "SKILL.md"))
 		assert.NilError(t, err)
-
 		assert.Equal(t, string(claudeData), string(codexData),
 			"content mismatch for skill %s between .claude and .agents", name)
 	}
 }
 
 func TestStatusNotInstalled(t *testing.T) {
-	home := t.TempDir()
-
-	statuses := skills.Status(skills.UserScope(home))
+	withHome(t, t.TempDir())
+	statuses, err := skills.Status(skills.UserScope)
+	assert.NilError(t, err)
 	assert.Equal(t, len(statuses), 2)
-
 	for _, agent := range statuses {
 		assert.Assert(t, !agent.Available, "agent %s should not be available", agent.Agent)
 		for _, s := range agent.Skills {
-			assert.Equal(t, s.State, skills.StateMissing,
-				"skill %s for %s should be missing", s.Name, agent.Agent)
+			assert.Equal(t, s.State, skills.StateMissing, "skill %s for %s should be missing", s.Name, agent.Agent)
 		}
 	}
 }
 
 func TestStatusCurrent(t *testing.T) {
 	home := t.TempDir()
+	withHome(t, home)
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	skills.Install(skills.UserScope(home))
+	_, err := skills.Install(skills.UserScope)
+	assert.NilError(t, err)
 
-	statuses := skills.Status(skills.UserScope(home))
+	statuses, err := skills.Status(skills.UserScope)
+	assert.NilError(t, err)
 	var claude skills.AgentStatus
 	for _, s := range statuses {
 		if s.Agent == "claude" {
 			claude = s
 		}
 	}
-
 	assert.Assert(t, claude.Available)
 	for _, s := range claude.Skills {
-		assert.Equal(t, s.State, skills.StateCurrent,
-			"skill %s should be current after install", s.Name)
+		assert.Equal(t, s.State, skills.StateCurrent, "skill %s should be current after install", s.Name)
 	}
 }
 
 func TestStatusOutdated(t *testing.T) {
 	home := t.TempDir()
+	withHome(t, home)
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	skills.Install(skills.UserScope(home))
+	_, err := skills.Install(skills.UserScope)
+	assert.NilError(t, err)
 
-	// Tamper with a skill.
 	path := filepath.Join(home, ".claude", "skills", "chunk-review", "SKILL.md")
 	assert.NilError(t, os.WriteFile(path, []byte("tampered"), 0o644))
 
-	statuses := skills.Status(skills.UserScope(home))
+	statuses, err := skills.Status(skills.UserScope)
+	assert.NilError(t, err)
 	var claude skills.AgentStatus
 	for _, s := range statuses {
 		if s.Agent == "claude" {
 			claude = s
 		}
 	}
-
 	for _, s := range claude.Skills {
 		if s.Name == "chunk-review" {
 			assert.Equal(t, s.State, skills.StateOutdated)
@@ -289,23 +323,23 @@ func TestStatusOutdated(t *testing.T) {
 }
 
 func TestStatusIncludesDescriptions(t *testing.T) {
-	home := t.TempDir()
-
-	statuses := skills.Status(skills.UserScope(home))
+	withHome(t, t.TempDir())
+	statuses, err := skills.Status(skills.UserScope)
+	assert.NilError(t, err)
 	for _, agent := range statuses {
 		for _, s := range agent.Skills {
-			assert.Assert(t, s.Description != "",
-				"skill %s should have a description", s.Name)
+			assert.Assert(t, s.Description != "", "skill %s should have a description", s.Name)
 		}
 	}
 }
 
 func TestStatusAgentNotAvailable(t *testing.T) {
 	home := t.TempDir()
-	// Only create .claude.
+	withHome(t, home)
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	statuses := skills.Status(skills.UserScope(home))
+	statuses, err := skills.Status(skills.UserScope)
+	assert.NilError(t, err)
 	for _, agent := range statuses {
 		if agent.Agent == "claude" {
 			assert.Assert(t, agent.Available)
@@ -318,23 +352,21 @@ func TestStatusAgentNotAvailable(t *testing.T) {
 	}
 }
 
+// --- SkillState (independent of scope) ---
+
 func TestSkillStateDetectsStates(t *testing.T) {
 	dir := t.TempDir()
 	s := skills.All[0] // chunk-testing-gaps
 
-	// Missing: no file at all.
 	assert.Equal(t, skills.SkillState(dir, s), skills.StateMissing)
 
-	// Install the file with correct content.
 	skillDir := filepath.Join(dir, s.Name)
 	assert.NilError(t, os.MkdirAll(skillDir, 0o755))
 	content, err := embeddedSkills.Content.ReadFile(filepath.Join(s.Name, "SKILL.md"))
 	assert.NilError(t, err)
 	assert.NilError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), content, 0o644))
-
 	assert.Equal(t, skills.SkillState(dir, s), skills.StateCurrent)
 
-	// Tamper to make outdated.
 	assert.NilError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("old"), 0o644))
 	assert.Equal(t, skills.SkillState(dir, s), skills.StateOutdated)
 }


### PR DESCRIPTION
## Summary

- Skills now install into the **local project** (`.claude/skills/`, `.codex/skills/`) by default, keeping skill versions scoped to each repository
- New `--user` flag on `chunk skill install` and `chunk skill list` installs/shows status at user scope (`~/.claude`, `~/.codex`) instead
- Codex agent directory renamed from `.agents` to `.codex` to align with the tool's actual config directory
- `installSkillsStep` in `chunk init` now uses the project working directory instead of `$HOME`
- A directory is only written to if it already exists — `chunk skill install` never creates `.claude` or `.codex`

## Test plan

- [ ] `chunk skill install` installs into `.claude/skills/` when `.claude/` exists in cwd
- [ ] `chunk skill install` installs into `.codex/skills/` when `.codex/` exists in cwd
- [ ] `chunk skill install` skips agents whose directories don't exist
- [ ] `chunk skill install --user` installs into `~/.claude/skills/` and `~/.codex/skills/`
- [ ] `chunk skill install --user` errors when `$HOME` is not set
- [ ] `chunk skill install` (without `--user`) succeeds even when `$HOME` is not set
- [ ] Unit tests pass: `go test -race ./internal/skills/... ./internal/cmd/...`
- [ ] Acceptance tests pass: `task acceptance-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)