### PR TITLE
Add project-scope skill installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,9 +73,14 @@ jobs:
                 name: Verify skill content is embedded
                 command: |
                   mkdir -p ~/.claude
-                  ./dist/chunk skill install
-                  echo "OK: skill content embedded correctly"
+                  ./dist/chunk skill install --user
+                  echo "OK: user-scope skill content embedded correctly"
                   head -5 ~/.claude/skills/chunk-review/SKILL.md
+                  tmpdir=$(mktemp -d)
+                  cd "$tmpdir"
+                  ~/project/dist/chunk skill install
+                  echo "OK: project-scope skill content embedded correctly"
+                  head -5 .claude/skills/chunk-review/SKILL.md
 
 workflows:
   ci:

--- a/acceptance/skills_test.go
+++ b/acceptance/skills_test.go
@@ -19,7 +19,7 @@ func TestSkillsInstall(t *testing.T) {
 	err := os.MkdirAll(claudeDir, 0o755)
 	assert.NilError(t, err)
 
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "install", "--user"}, env, env.HomeDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 
@@ -43,7 +43,7 @@ func TestSkillsInstallSkipsUnavailableAgent(t *testing.T) {
 	claudeDir := filepath.Join(env.HomeDir, ".claude")
 	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
 
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "install", "--user"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0)
 
 	combined := result.Stdout + result.Stderr
@@ -61,10 +61,10 @@ func TestSkillsInstallUpToDate(t *testing.T) {
 	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
 
 	// First install.
-	binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	binary.RunCLI(t, []string{"skill", "install", "--user"}, env, env.HomeDir)
 
 	// Second install should show "up to date".
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "install", "--user"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0)
 
 	combined := result.Stdout + result.Stderr
@@ -75,7 +75,7 @@ func TestSkillsInstallUpToDate(t *testing.T) {
 func TestSkillsList(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 
-	result := binary.RunCLI(t, []string{"skill", "list"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "list", "--user"}, env, env.HomeDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 
@@ -96,7 +96,7 @@ func TestSkillsList(t *testing.T) {
 func TestSkillsListShowsDescriptions(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 
-	result := binary.RunCLI(t, []string{"skill", "list"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "list", "--user"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0)
 
 	combined := result.Stdout + result.Stderr
@@ -112,7 +112,7 @@ func TestSkillsInstallCodexPath(t *testing.T) {
 	codexDir := filepath.Join(env.HomeDir, ".agents")
 	assert.NilError(t, os.MkdirAll(codexDir, 0o755))
 
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "install", "--user"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 
 	combined := result.Stdout + result.Stderr
@@ -137,7 +137,7 @@ func TestSkillsInstallBothAgents(t *testing.T) {
 	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
 	assert.NilError(t, os.MkdirAll(codexDir, 0o755))
 
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "install", "--user"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 
 	combined := result.Stdout + result.Stderr
@@ -165,7 +165,7 @@ func TestSkillsInstallOutdatedUpdate(t *testing.T) {
 	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
 
 	// First install.
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "install", "--user"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0, "first install failed: %s", result.Stderr)
 
 	// Tamper with one skill file to make it outdated.
@@ -173,7 +173,7 @@ func TestSkillsInstallOutdatedUpdate(t *testing.T) {
 	assert.NilError(t, os.WriteFile(tampered, []byte("tampered content"), 0o644))
 
 	// Re-run install: should detect outdated and update.
-	result = binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result = binary.RunCLI(t, []string{"skill", "install", "--user"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0)
 
 	combined := result.Stdout + result.Stderr
@@ -195,7 +195,7 @@ func TestSkillsInstallNoAgentDirs(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 
 	// Don't create .claude or .agents.
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "install", "--user"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0)
 
 	combined := result.Stdout + result.Stderr
@@ -209,7 +209,7 @@ func TestSkillsInstallHomeNotSet(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.HomeDir = ""
 
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, os.TempDir())
+	result := binary.RunCLI(t, []string{"skill", "install", "--user"}, env, os.TempDir())
 	assert.Assert(t, result.ExitCode != 0,
 		"expected non-zero exit code when HOME is not set, got exit %d", result.ExitCode)
 
@@ -224,7 +224,7 @@ func TestSkillsListStateLabels(t *testing.T) {
 	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
 
 	// Before install: .claude exists so skills should show "missing".
-	result := binary.RunCLI(t, []string{"skill", "list"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "list", "--user"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0)
 	combined := result.Stdout + result.Stderr
 	assert.Assert(t, strings.Contains(combined, "missing"),
@@ -237,11 +237,11 @@ func TestSkillsListStateLabels(t *testing.T) {
 		"expected codex agent in list output, got: %s", combined)
 
 	// Install skills.
-	result = binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result = binary.RunCLI(t, []string{"skill", "install", "--user"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0, "install failed: %s", result.Stderr)
 
 	// After install: skills should show "current".
-	result = binary.RunCLI(t, []string{"skill", "list"}, env, env.HomeDir)
+	result = binary.RunCLI(t, []string{"skill", "list", "--user"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0)
 	combined = result.Stdout + result.Stderr
 	assert.Assert(t, strings.Contains(combined, "current"),
@@ -251,7 +251,7 @@ func TestSkillsListStateLabels(t *testing.T) {
 	tampered := filepath.Join(claudeDir, "skills", "chunk-review", "SKILL.md")
 	assert.NilError(t, os.WriteFile(tampered, []byte("tampered"), 0o644))
 
-	result = binary.RunCLI(t, []string{"skill", "list"}, env, env.HomeDir)
+	result = binary.RunCLI(t, []string{"skill", "list", "--user"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0)
 	combined = result.Stdout + result.Stderr
 	assert.Assert(t, strings.Contains(combined, "outdated"),
@@ -264,7 +264,7 @@ func TestSkillsListMixedStates(t *testing.T) {
 	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
 
 	// Install all skills first.
-	result := binary.RunCLI(t, []string{"skill", "install"}, env, env.HomeDir)
+	result := binary.RunCLI(t, []string{"skill", "install", "--user"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0, "install failed: %s", result.Stderr)
 
 	// Tamper one skill to make it outdated.
@@ -275,7 +275,7 @@ func TestSkillsListMixedStates(t *testing.T) {
 	assert.NilError(t, os.RemoveAll(filepath.Join(claudeDir, "skills", "debug-ci-failures")))
 
 	// List should show current, outdated, and missing.
-	result = binary.RunCLI(t, []string{"skill", "list"}, env, env.HomeDir)
+	result = binary.RunCLI(t, []string{"skill", "list", "--user"}, env, env.HomeDir)
 	assert.Equal(t, result.ExitCode, 0)
 	combined := result.Stdout + result.Stderr
 
@@ -285,4 +285,175 @@ func TestSkillsListMixedStates(t *testing.T) {
 		"expected 'outdated' for tampered skill, got: %s", combined)
 	assert.Assert(t, strings.Contains(combined, "missing"),
 		"expected 'missing' for deleted skill, got: %s", combined)
+}
+
+func TestSkillsInstallDefaultScopeIsProject(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	projectDir := t.TempDir()
+
+	// No --scope flag: should behave identically to --scope project.
+	result := binary.RunCLI(t, []string{"skill", "install"}, env, projectDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	for _, name := range []string{"chunk-review", "chunk-testing-gaps", "chunk-sidecar", "debug-ci-failures"} {
+		skillFile := filepath.Join(projectDir, ".claude", "skills", name, "SKILL.md")
+		info, err := os.Stat(skillFile)
+		assert.NilError(t, err, "expected default-scope skill %s to exist at %s", name, skillFile)
+		assert.Assert(t, info.Size() > 0, "expected default-scope skill %s to be non-empty", name)
+	}
+
+	// Nothing should land in the user's home dir.
+	_, err := os.Stat(filepath.Join(env.HomeDir, ".claude", "skills"))
+	assert.Assert(t, os.IsNotExist(err), "default install should not touch user home skills dir")
+}
+
+func TestSkillsInstallProjectScope(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	projectDir := t.TempDir()
+
+	// Project scope requires no pre-existing agent dirs.
+	result := binary.RunCLI(t, []string{"skill", "install", "--project"}, env, projectDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "claude:"),
+		"expected per-agent output for claude, got: %s", combined)
+
+	// Skills should be installed into the project dir, not the home dir.
+	for _, name := range []string{"chunk-review", "chunk-testing-gaps", "chunk-sidecar", "debug-ci-failures"} {
+		skillFile := filepath.Join(projectDir, ".claude", "skills", name, "SKILL.md")
+		info, err := os.Stat(skillFile)
+		assert.NilError(t, err, "expected project-scope skill %s to exist at %s", name, skillFile)
+		assert.Assert(t, info.Size() > 0, "expected project-scope skill %s to be non-empty", name)
+	}
+
+	// Nothing should be installed in the user's home dir.
+	_, err := os.Stat(filepath.Join(env.HomeDir, ".claude", "skills"))
+	assert.Assert(t, os.IsNotExist(err), "project-scope install should not touch user home skills dir")
+}
+
+func TestSkillsInstallProjectScopeUpToDate(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	projectDir := t.TempDir()
+
+	// First install.
+	binary.RunCLI(t, []string{"skill", "install", "--project"}, env, projectDir)
+
+	// Second install should show "up to date".
+	result := binary.RunCLI(t, []string{"skill", "install", "--project"}, env, projectDir)
+	assert.Equal(t, result.ExitCode, 0)
+
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "up to date"),
+		"expected up-to-date message on second project-scope install, got: %s", combined)
+}
+
+func TestSkillsInstallProjectScopeNotIsolatedFromUserScope(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	projectDir := t.TempDir()
+
+	// Install user-scope into home dir.
+	claudeDir := filepath.Join(env.HomeDir, ".claude")
+	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
+	binary.RunCLI(t, []string{"skill", "install", "--user"}, env, env.HomeDir)
+
+	// Install project-scope from a different dir.
+	result := binary.RunCLI(t, []string{"skill", "install", "--project"}, env, projectDir)
+	assert.Equal(t, result.ExitCode, 0, "project-scope install failed: %s", result.Stderr)
+
+	// Both locations should have skills.
+	for _, name := range []string{"chunk-review", "chunk-testing-gaps"} {
+		userFile := filepath.Join(claudeDir, "skills", name, "SKILL.md")
+		projectFile := filepath.Join(projectDir, ".claude", "skills", name, "SKILL.md")
+		_, err := os.Stat(userFile)
+		assert.NilError(t, err, "expected user-scope skill %s to still exist", name)
+		_, err = os.Stat(projectFile)
+		assert.NilError(t, err, "expected project-scope skill %s to exist", name)
+	}
+}
+
+func TestSkillsListProjectScope(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	projectDir := t.TempDir()
+
+	// Before install: project scope agents are always shown as available.
+	result := binary.RunCLI(t, []string{"skill", "list", "--project"}, env, projectDir)
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "claude:"),
+		"expected per-agent status for claude, got: %s", combined)
+	// Skills not yet installed should be missing.
+	assert.Assert(t, strings.Contains(combined, "missing"),
+		"expected 'missing' state before project-scope install, got: %s", combined)
+
+	// Install and re-list.
+	binary.RunCLI(t, []string{"skill", "install", "--project"}, env, projectDir)
+
+	result = binary.RunCLI(t, []string{"skill", "list", "--project"}, env, projectDir)
+	assert.Equal(t, result.ExitCode, 0)
+	combined = result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "current"),
+		"expected 'current' state after project-scope install, got: %s", combined)
+}
+
+func TestSkillsInstallMutuallyExclusiveFlags(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+
+	result := binary.RunCLI(t, []string{"skill", "install", "--user", "--project"}, env, env.HomeDir)
+	assert.Assert(t, result.ExitCode != 0,
+		"expected non-zero exit when --user and --project both set, got: %d", result.ExitCode)
+
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "mutually exclusive"),
+		"expected 'mutually exclusive' error, got: %s", combined)
+}
+
+// TestSkillsListNoFlagsDefaultsToProjectScope verifies that "chunk skill list" with no
+// flags resolves to project scope (i.e. uses the working directory, not the user home).
+// A regression in resolveScope for the list subcommand would cause it to use user scope,
+// which would show "n/a" for agents whose config dirs do not exist in the home dir,
+// rather than "missing" (agents are always available in project scope).
+func TestSkillsListNoFlagsDefaultsToProjectScope(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	projectDir := t.TempDir()
+
+	// No agent dirs exist in either the project dir or the user home dir.
+	// In project scope: agents are always available, so skills should show "missing".
+	// In user scope:    agents would show "n/a" because ~/.claude and ~/.agents do not exist.
+	result := binary.RunCLI(t, []string{"skill", "list"}, env, projectDir)
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+
+	combined := result.Stdout + result.Stderr
+
+	// Project scope always treats agents as available — "n/a" would indicate user scope.
+	assert.Assert(t, !strings.Contains(combined, "n/a"),
+		"expected no 'n/a' entries — project scope always shows agents as available, got: %s", combined)
+
+	// Skills not yet installed should appear as missing.
+	assert.Assert(t, strings.Contains(combined, "missing"),
+		"expected 'missing' state for uninstalled skills under project scope, got: %s", combined)
+
+	// The claude agent entry must be present.
+	assert.Assert(t, strings.Contains(combined, "claude:"),
+		"expected claude agent in list output, got: %s", combined)
+
+	// Install skills into the project dir using --project, then re-list with no flags.
+	result = binary.RunCLI(t, []string{"skill", "install", "--project"}, env, projectDir)
+	assert.Equal(t, result.ExitCode, 0, "project install failed: %s", result.Stderr)
+
+	result = binary.RunCLI(t, []string{"skill", "list"}, env, projectDir)
+	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+	combined = result.Stdout + result.Stderr
+
+	// After installing into the project dir, the no-flag list should see those skills as "current".
+	assert.Assert(t, strings.Contains(combined, "current"),
+		"expected 'current' state after project-scope install when listing with no flags, got: %s", combined)
+
+	// Nothing should have been installed in the user home dir.
+	_, err := os.Stat(filepath.Join(env.HomeDir, ".claude", "skills"))
+	assert.Assert(t, os.IsNotExist(err),
+		"default list should not have touched user home skills dir")
 }

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -307,12 +307,8 @@ func ensureGitignoreEntries(workDir string, streams iostream.Streams) error {
 	return nil
 }
 
-func installSkillsStep(streams iostream.Streams) {
-	homeDir := os.Getenv(config.EnvHome)
-	if homeDir == "" {
-		return
-	}
-	for _, r := range skills.InstallByName(homeDir, "chunk-sidecar") {
+func installSkillsStep(workDir string, streams iostream.Streams) {
+	for _, r := range skills.InstallByName(skills.ScopeProject, workDir, "chunk-sidecar") {
 		if r.Skipped {
 			continue
 		}
@@ -321,6 +317,9 @@ func installSkillsStep(streams iostream.Streams) {
 		}
 		for _, name := range r.Updated {
 			streams.ErrPrintln(ui.Success(fmt.Sprintf("Updated %s skill for %s", name, r.Agent)))
+		}
+		for _, msg := range r.Errors {
+			streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not install skill for %s: %s", r.Agent, msg)))
 		}
 	}
 }
@@ -605,7 +604,7 @@ hook config files.`,
 
 			// Step 6: Agent skills
 			if !skipSkills {
-				installSkillsStep(streams)
+				installSkillsStep(workDir, streams)
 			}
 
 			streams.ErrPrintln(ui.Success("Project initialized"))

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -460,6 +460,28 @@ func TestEnsureGitignoreEntriesIdempotent(t *testing.T) {
 	assert.Equal(t, string(first), string(second))
 }
 
+// TestInstallSkillsStepUsesProjectScope verifies that installSkillsStep writes
+// skills into the project's .claude/skills/ directory, not into the user's
+// home directory. Previously it called InstallByName(ScopeUser, homeDir, ...)
+// which diverged from the ScopeProject default used by the skills subcommand.
+func TestInstallSkillsStepUsesProjectScope(t *testing.T) {
+	workDir := t.TempDir()
+	home := t.TempDir()
+	t.Setenv(config.EnvHome, home)
+
+	streams, _, _ := testStreams()
+	installSkillsStep(workDir, streams)
+
+	// Skills must appear in the project dir, not in $HOME.
+	skillPath := filepath.Join(workDir, ".claude", "skills", "chunk-sidecar", "SKILL.md")
+	_, err := os.Stat(skillPath)
+	assert.NilError(t, err, "expected skill installed at %s", skillPath)
+
+	homePath := filepath.Join(home, ".claude", "skills", "chunk-sidecar", "SKILL.md")
+	_, err = os.Stat(homePath)
+	assert.Assert(t, os.IsNotExist(err), "skill must not be installed under $HOME")
+}
+
 func TestPrintInitSummaryWithCommands(t *testing.T) {
 	ui.SetColorEnabled(false)
 	defer ui.SetColorEnabled(true)

--- a/internal/cmd/skills.go
+++ b/internal/cmd/skills.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -26,26 +27,41 @@ func newSkillCmd() *cobra.Command {
 
 func newSkillInstallCmd() *cobra.Command {
 	var jsonOut bool
+	var userScope bool
+	var projectScope bool
 
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install or update all skills into agent config directories",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			home := os.Getenv(config.EnvHome)
-			if home == "" {
-				return &userError{msg: msgHomeNotSet, errMsg: errMsgHomeNotSet}
+			scope, baseDir, err := resolveScope(userScope, projectScope)
+			if err != nil {
+				return err
 			}
 			io := iostream.FromCmd(cmd)
-			results := skills.Install(home)
+			results := skills.Install(scope, baseDir)
 			if jsonOut {
-				return iostream.PrintJSON(io.Out, results)
+				if err := iostream.PrintJSON(io.Out, results); err != nil {
+					return err
+				}
+				for _, r := range results {
+					if len(r.Errors) > 0 {
+						return fmt.Errorf("one or more skills failed to install")
+					}
+				}
+				return nil
 			}
+			var installErr error
 			for _, r := range results {
 				if r.Skipped {
 					io.Println(ui.Dim(r.Agent + ": skipped (not installed)"))
 					continue
 				}
-				if len(r.Installed) == 0 && len(r.Updated) == 0 {
+				for _, msg := range r.Errors {
+					io.ErrPrintln(ui.Warning(r.Agent + ": error: " + msg))
+					installErr = fmt.Errorf("one or more skills failed to install")
+				}
+				if len(r.Installed) == 0 && len(r.Updated) == 0 && len(r.Errors) == 0 {
 					io.Println(r.Agent + ": " + ui.Green("all skills up to date"))
 					continue
 				}
@@ -56,25 +72,32 @@ func newSkillInstallCmd() *cobra.Command {
 					io.Println(r.Agent + ": " + ui.Yellow("updated "+name))
 				}
 			}
-			return nil
+			return installErr
 		},
 	}
 
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	cmd.Flags().BoolVar(&userScope, "user", false, "Install into user-level agent config directories (~/.claude/skills, ~/.agents/skills)")
+	cmd.Flags().BoolVar(&projectScope, "project", false, "Install into project-level agent config directories (.claude/skills, .agents/skills) [default]")
 
 	return cmd
 }
 
 func newSkillListCmd() *cobra.Command {
 	var jsonOut bool
+	var userScope bool
+	var projectScope bool
 
 	cmd := &cobra.Command{
 		Use:   cmdList,
 		Short: "List bundled skills and their per-agent installation status",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			home := os.Getenv(config.EnvHome)
+			scope, baseDir, err := resolveScope(userScope, projectScope)
+			if err != nil {
+				return err
+			}
 			io := iostream.FromCmd(cmd)
-			statuses := skills.Status(home)
+			statuses := skills.Status(scope, baseDir)
 
 			if jsonOut {
 				return iostream.PrintJSON(io.Out, statuses)
@@ -103,18 +126,40 @@ func newSkillListCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	cmd.Flags().BoolVar(&userScope, "user", false, "List user-level skill installation status (~/.claude/skills, ~/.agents/skills)")
+	cmd.Flags().BoolVar(&projectScope, "project", false, "List project-level skill installation status (.claude/skills, .agents/skills) [default]")
 
 	return cmd
+}
+
+// resolveScope picks a Scope and base directory from the --user / --project flags.
+// Project scope is the default when neither flag is set.
+func resolveScope(userFlag, projectFlag bool) (skills.Scope, string, error) {
+	if userFlag && projectFlag {
+		return "", "", &userError{msg: "--user and --project are mutually exclusive", errMsg: "mutually exclusive flags"}
+	}
+	if userFlag {
+		home := os.Getenv(config.EnvHome)
+		if home == "" {
+			return "", "", &userError{msg: msgHomeNotSet, errMsg: errMsgHomeNotSet}
+		}
+		return skills.ScopeUser, home, nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", "", fmt.Errorf("get working directory: %w", err)
+	}
+	return skills.ScopeProject, cwd, nil
 }
 
 func stateDisplay(state skills.State) (icon, label string) {
 	switch state {
 	case skills.StateCurrent:
-		return ui.Green("\u2713"), ui.Green("current")
+		return ui.Green("✓"), ui.Green("current")
 	case skills.StateOutdated:
-		return ui.Yellow("\u26a0"), ui.Yellow("outdated")
+		return ui.Yellow("⚠"), ui.Yellow("outdated")
 	case skills.StateMissing:
-		return ui.Dim("\u2717"), ui.Dim("missing")
+		return ui.Dim("✗"), ui.Dim("missing")
 	}
 	return ui.Dim("?"), ui.Dim("unknown")
 }

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -1,10 +1,23 @@
 package skills
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/CircleCI-Public/chunk-cli/skills"
+)
+
+// Scope determines where skills are installed.
+type Scope string
+
+const (
+	// ScopeUser installs into the user's agent config directories (~/.claude, ~/.agents).
+	// Agents whose config directories do not exist are skipped.
+	ScopeUser Scope = "user"
+	// ScopeProject installs into the project's agent config directories (.claude, .agents).
+	// Directories are created as needed; no pre-existing config dir is required.
+	ScopeProject Scope = "project"
 )
 
 // State describes the installation state of a skill for a specific agent.
@@ -45,23 +58,29 @@ var All = []Skill{
 
 // Agent represents a target agent with its config directories.
 type Agent struct {
-	Name      string
-	ConfigDir string // parent config dir (must exist for install)
-	SkillsDir string // where skill subdirectories live
+	Name         string
+	ConfigDir    string // parent config dir
+	SkillsDir    string // where skill subdirectories live
+	SkipIfAbsent bool   // when true, skip install if ConfigDir does not exist
 }
 
-// Agents returns the list of supported agents for the given home directory.
-func Agents(homeDir string) []Agent {
+// agents returns the list of supported agents for the given scope and base directory.
+// For ScopeUser, baseDir is the user's home directory.
+// For ScopeProject, baseDir is the project root directory.
+func agents(scope Scope, baseDir string) []Agent {
+	skipIfAbsent := scope == ScopeUser
 	return []Agent{
 		{
-			Name:      "claude",
-			ConfigDir: filepath.Join(homeDir, ".claude"),
-			SkillsDir: filepath.Join(homeDir, ".claude", "skills"),
+			Name:         "claude",
+			ConfigDir:    filepath.Join(baseDir, ".claude"),
+			SkillsDir:    filepath.Join(baseDir, ".claude", "skills"),
+			SkipIfAbsent: skipIfAbsent,
 		},
 		{
-			Name:      "codex",
-			ConfigDir: filepath.Join(homeDir, ".agents"),
-			SkillsDir: filepath.Join(homeDir, ".agents", "skills"),
+			Name:         "codex",
+			ConfigDir:    filepath.Join(baseDir, ".agents"),
+			SkillsDir:    filepath.Join(baseDir, ".agents", "skills"),
+			SkipIfAbsent: skipIfAbsent,
 		},
 	}
 }
@@ -89,22 +108,24 @@ type AgentInstallResult struct {
 	Skipped   bool     `json:"skipped"`
 	Installed []string `json:"installed"`
 	Updated   []string `json:"updated"`
+	Errors    []string `json:"errors,omitempty"`
 }
 
-// Install installs all embedded skills for agents whose config dirs exist.
-// Agents with missing config dirs are skipped.
-func Install(homeDir string) []AgentInstallResult {
-	agents := Agents(homeDir)
-	results := make([]AgentInstallResult, 0, len(agents))
-	for _, agent := range agents {
+// Install installs all embedded skills for the given scope and base directory.
+// For ScopeUser, agents whose config dirs do not exist are skipped.
+// For ScopeProject, dirs are created as needed.
+func Install(scope Scope, baseDir string) []AgentInstallResult {
+	all := agents(scope, baseDir)
+	results := make([]AgentInstallResult, 0, len(all))
+	for _, agent := range all {
 		results = append(results, installForAgent(agent, All))
 	}
 	return results
 }
 
-// InstallByName installs a single skill by name for agents whose config dirs exist.
+// InstallByName installs a single skill by name.
 // Returns nil if the skill name is not found.
-func InstallByName(homeDir, name string) []AgentInstallResult {
+func InstallByName(scope Scope, baseDir, name string) []AgentInstallResult {
 	var s *Skill
 	for i := range All {
 		if All[i].Name == name {
@@ -115,17 +136,19 @@ func InstallByName(homeDir, name string) []AgentInstallResult {
 	if s == nil {
 		return nil
 	}
-	agents := Agents(homeDir)
-	results := make([]AgentInstallResult, 0, len(agents))
-	for _, agent := range agents {
+	all := agents(scope, baseDir)
+	results := make([]AgentInstallResult, 0, len(all))
+	for _, agent := range all {
 		results = append(results, installForAgent(agent, []Skill{*s}))
 	}
 	return results
 }
 
 func installForAgent(agent Agent, subset []Skill) AgentInstallResult {
-	if _, err := os.Stat(agent.ConfigDir); os.IsNotExist(err) {
-		return AgentInstallResult{Agent: agent.Name, Skipped: true, Installed: make([]string, 0), Updated: make([]string, 0)}
+	if agent.SkipIfAbsent {
+		if _, err := os.Stat(agent.ConfigDir); err != nil {
+			return AgentInstallResult{Agent: agent.Name, Skipped: true, Installed: make([]string, 0), Updated: make([]string, 0)}
+		}
 	}
 
 	result := AgentInstallResult{Agent: agent.Name, Installed: make([]string, 0), Updated: make([]string, 0)}
@@ -143,10 +166,12 @@ func installForAgent(agent Agent, subset []Skill) AgentInstallResult {
 
 		dir := filepath.Join(agent.SkillsDir, s.Name)
 		if err := os.MkdirAll(dir, 0o755); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("create dir %s: %v", dir, err))
 			continue
 		}
 		dest := filepath.Join(dir, "SKILL.md")
 		if err := os.WriteFile(dest, data, 0o644); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("write %s: %v", dest, err))
 			continue
 		}
 
@@ -174,14 +199,18 @@ type AgentStatus struct {
 }
 
 // Status returns per-agent, per-skill installation state without modifying anything.
-func Status(homeDir string) []AgentStatus {
-	agents := Agents(homeDir)
-	results := make([]AgentStatus, 0, len(agents))
+// For ScopeUser, an agent is available only when its config dir exists.
+// For ScopeProject, agents are always considered available.
+func Status(scope Scope, baseDir string) []AgentStatus {
+	all := agents(scope, baseDir)
+	results := make([]AgentStatus, 0, len(all))
 
-	for _, agent := range agents {
+	for _, agent := range all {
 		available := true
-		if _, err := os.Stat(agent.ConfigDir); os.IsNotExist(err) {
-			available = false
+		if agent.SkipIfAbsent {
+			if _, err := os.Stat(agent.ConfigDir); err != nil {
+				available = false
+			}
 		}
 
 		ss := make([]AgentSkillStatus, 0, len(All))

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -21,7 +21,7 @@ func TestInstallBothAgents(t *testing.T) {
 		assert.NilError(t, os.MkdirAll(filepath.Join(home, dir), 0o755))
 	}
 
-	results := skills.Install(home)
+	results := skills.Install(skills.ScopeUser, home)
 	assert.Equal(t, len(results), 2)
 
 	for _, r := range results {
@@ -48,7 +48,7 @@ func TestInstallSkipsAgentWithoutConfigDir(t *testing.T) {
 	// Only create .claude, not .agents.
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	results := skills.Install(home)
+	results := skills.Install(skills.ScopeUser, home)
 	assert.Equal(t, len(results), 2)
 
 	var claude, codex skills.AgentInstallResult
@@ -75,11 +75,11 @@ func TestInstallIdempotent(t *testing.T) {
 	home := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	results1 := skills.Install(home)
+	results1 := skills.Install(skills.ScopeUser, home)
 	assert.Equal(t, len(results1[0].Installed), len(skillNames))
 
 	// Second install should report all up to date.
-	results2 := skills.Install(home)
+	results2 := skills.Install(skills.ScopeUser, home)
 	assert.Equal(t, len(results2[0].Installed), 0, "should have no new installs")
 	assert.Equal(t, len(results2[0].Updated), 0, "should have no updates")
 }
@@ -89,13 +89,13 @@ func TestInstallDetectsOutdated(t *testing.T) {
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
 	// First install.
-	skills.Install(home)
+	skills.Install(skills.ScopeUser, home)
 
 	// Tamper with one skill file to make it outdated.
 	path := filepath.Join(home, ".claude", "skills", "chunk-review", "SKILL.md")
 	assert.NilError(t, os.WriteFile(path, []byte("old content"), 0o644))
 
-	results := skills.Install(home)
+	results := skills.Install(skills.ScopeUser, home)
 	claude := results[0]
 	assert.Equal(t, len(claude.Installed), 0)
 	assert.Equal(t, len(claude.Updated), 1)
@@ -108,7 +108,7 @@ func TestInstallContentMatchesEmbedded(t *testing.T) {
 		assert.NilError(t, os.MkdirAll(filepath.Join(home, dir), 0o755))
 	}
 
-	skills.Install(home)
+	skills.Install(skills.ScopeUser, home)
 
 	for _, name := range skillNames {
 		claudePath := filepath.Join(home, ".claude", "skills", name, "SKILL.md")
@@ -124,10 +124,46 @@ func TestInstallContentMatchesEmbedded(t *testing.T) {
 	}
 }
 
+func TestInstallProjectScope(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Project scope does not require pre-existing agent dirs.
+	results := skills.Install(skills.ScopeProject, projectDir)
+	assert.Equal(t, len(results), 2)
+
+	for _, r := range results {
+		assert.Assert(t, !r.Skipped, "agent %s should not be skipped for project scope", r.Agent)
+		assert.Equal(t, len(r.Installed), len(skillNames),
+			"agent %s: expected %d installed, got %d", r.Agent, len(skillNames), len(r.Installed))
+	}
+
+	// Verify files exist under project-relative dirs.
+	for _, dir := range []string{".claude", ".agents"} {
+		for _, name := range skillNames {
+			path := filepath.Join(projectDir, dir, "skills", name, "SKILL.md")
+			info, err := os.Stat(path)
+			assert.NilError(t, err, "expected %s to exist for project scope", path)
+			assert.Assert(t, info.Size() > 0, "expected %s to be non-empty", path)
+		}
+	}
+}
+
+func TestInstallProjectScopeIdempotent(t *testing.T) {
+	projectDir := t.TempDir()
+
+	skills.Install(skills.ScopeProject, projectDir)
+
+	results := skills.Install(skills.ScopeProject, projectDir)
+	for _, r := range results {
+		assert.Equal(t, len(r.Installed), 0, "agent %s: should have no new installs on second run", r.Agent)
+		assert.Equal(t, len(r.Updated), 0, "agent %s: should have no updates on second run", r.Agent)
+	}
+}
+
 func TestStatusNotInstalled(t *testing.T) {
 	home := t.TempDir()
 
-	statuses := skills.Status(home)
+	statuses := skills.Status(skills.ScopeUser, home)
 	assert.Equal(t, len(statuses), 2)
 
 	for _, agent := range statuses {
@@ -143,9 +179,9 @@ func TestStatusCurrent(t *testing.T) {
 	home := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	skills.Install(home)
+	skills.Install(skills.ScopeUser, home)
 
-	statuses := skills.Status(home)
+	statuses := skills.Status(skills.ScopeUser, home)
 	var claude skills.AgentStatus
 	for _, s := range statuses {
 		if s.Agent == "claude" {
@@ -164,13 +200,13 @@ func TestStatusOutdated(t *testing.T) {
 	home := t.TempDir()
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	skills.Install(home)
+	skills.Install(skills.ScopeUser, home)
 
 	// Tamper with a skill.
 	path := filepath.Join(home, ".claude", "skills", "chunk-review", "SKILL.md")
 	assert.NilError(t, os.WriteFile(path, []byte("tampered"), 0o644))
 
-	statuses := skills.Status(home)
+	statuses := skills.Status(skills.ScopeUser, home)
 	var claude skills.AgentStatus
 	for _, s := range statuses {
 		if s.Agent == "claude" {
@@ -190,7 +226,7 @@ func TestStatusOutdated(t *testing.T) {
 func TestStatusIncludesDescriptions(t *testing.T) {
 	home := t.TempDir()
 
-	statuses := skills.Status(home)
+	statuses := skills.Status(skills.ScopeUser, home)
 	for _, agent := range statuses {
 		for _, s := range agent.Skills {
 			assert.Assert(t, s.Description != "",
@@ -204,7 +240,7 @@ func TestStatusAgentNotAvailable(t *testing.T) {
 	// Only create .claude.
 	assert.NilError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
 
-	statuses := skills.Status(home)
+	statuses := skills.Status(skills.ScopeUser, home)
 	for _, agent := range statuses {
 		if agent.Agent == "claude" {
 			assert.Assert(t, agent.Available)
@@ -213,6 +249,21 @@ func TestStatusAgentNotAvailable(t *testing.T) {
 			for _, s := range agent.Skills {
 				assert.Equal(t, s.State, skills.StateMissing)
 			}
+		}
+	}
+}
+
+func TestStatusProjectScopeAlwaysAvailable(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// No dirs created — project scope agents should still be "available".
+	statuses := skills.Status(skills.ScopeProject, projectDir)
+	assert.Equal(t, len(statuses), 2)
+	for _, agent := range statuses {
+		assert.Assert(t, agent.Available, "agent %s should be available for project scope", agent.Agent)
+		for _, s := range agent.Skills {
+			assert.Equal(t, s.State, skills.StateMissing,
+				"skill %s for %s should be missing before install", s.Name, agent.Agent)
 		}
 	}
 }
@@ -236,6 +287,57 @@ func TestSkillStateDetectsStates(t *testing.T) {
 	// Tamper to make outdated.
 	assert.NilError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("old"), 0o644))
 	assert.Equal(t, skills.SkillState(dir, s), skills.StateOutdated)
+}
+
+// TestInstallSurfacesWriteErrors verifies that write failures (e.g. permission
+// denied) are captured in AgentInstallResult.Errors rather than silently
+// swallowed as a continue, which previously caused the caller to print
+// "all skills up to date" with nothing actually written.
+func TestInstallSurfacesWriteErrors(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("cannot test permission errors as root")
+	}
+	home := t.TempDir()
+	claudeDir := filepath.Join(home, ".claude")
+	assert.NilError(t, os.MkdirAll(claudeDir, 0o755))
+
+	// Make the skills dir read-only so writes fail.
+	skillsDir := filepath.Join(claudeDir, "skills")
+	assert.NilError(t, os.MkdirAll(skillsDir, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(skillsDir, 0o755) })
+
+	results := skills.Install(skills.ScopeUser, home)
+	var claude skills.AgentInstallResult
+	for _, r := range results {
+		if r.Agent == "claude" {
+			claude = r
+		}
+	}
+
+	assert.Assert(t, len(claude.Errors) > 0, "expected write errors to be surfaced, got none")
+	assert.Equal(t, len(claude.Installed), 0, "no skills should be recorded as installed on write failure")
+}
+
+// TestInstallSkipIfAbsentOnPermissionError verifies that SkipIfAbsent skips an
+// agent whenever os.Stat returns any error — not only ENOENT. Previously
+// os.IsNotExist was used, which let EACCES pass through and the write loop
+// would run (also silently failing).
+func TestInstallSkipIfAbsentOnPermissionError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("cannot test permission errors as root")
+	}
+	home := t.TempDir()
+
+	// Remove execute permission on home so os.Stat on home/.claude returns EACCES.
+	assert.NilError(t, os.Chmod(home, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(home, 0o755) })
+
+	results := skills.Install(skills.ScopeUser, home)
+	for _, r := range results {
+		assert.Assert(t, r.Skipped,
+			"agent %s should be skipped when ConfigDir is inaccessible", r.Agent)
+		assert.Equal(t, len(r.Installed), 0)
+	}
 }
 
 func TestAllSkillsHaveEmbeddedContent(t *testing.T) {


### PR DESCRIPTION
## Summary

- Introduces a `Scope` enum (`ScopeUser`, `ScopeProject`) to the `internal/skills` package — all callers now pass a scope explicitly
- **Project scope** (default): installs into `.claude/skills` and `.agents/skills` relative to the current working directory, creating directories as needed
- **User scope**: existing behavior — installs into `~/.claude/skills` and `~/.agents/skills`, skipping agents whose config dirs don't exist
- Replaces `--scope user|project` with `--user` and `--project` boolean flags on both `skill install` and `skill list` (default: project)

## Steps to reproduce

```bash
# Build and symlink into PATH
task dev-install

# 1. Default (project scope) — installs into CWD/.claude/skills
cd /tmp && mkdir my-project && cd my-project
chunk skill install
ls .claude/skills/
# → chunk-review  chunk-sidecar  chunk-testing-gaps  debug-ci-failures

# 2. User scope — installs into ~/.claude/skills (existing behavior)
chunk skill install --user
ls ~/.claude/skills/
# → chunk-review  chunk-sidecar  chunk-testing-gaps  debug-ci-failures

# 3. Explicit project flag works too
chunk skill install --project

# 4. List shows per-scope state
chunk skill list           # project scope
chunk skill list --user    # user scope

# 5. Passing both flags exits non-zero with a clear error
chunk skill install --user --project
# → error: --user and --project are mutually exclusive
```

## Test plan

- [x] `TestSkillsInstallDefaultScopeIsProject` — bare `skill install` writes to CWD, not `$HOME`
- [x] All existing acceptance tests pass (now use `--user` flag)
- [x] `TestSkillsInstallProjectScope` — installs to project dir, leaves user home untouched
- [x] `TestSkillsInstallProjectScopeUpToDate` — idempotent on second run
- [x] `TestSkillsInstallProjectScopeNotIsolatedFromUserScope` — user and project installs coexist
- [x] `TestSkillsListProjectScope` — list shows missing before install, current after
- [x] `TestSkillsInstallMutuallyExclusiveFlags` — `--user --project` returns non-zero + clear error
- [x] Unit tests for `ScopeProject` in `internal/skills/skills_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
