### PR TITLE
Watch TUI: show snapshot name, filter stale sidecars, add hook op type

### DIFF
--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -828,6 +828,9 @@ snapshot with 'chunk sidecar create --image <snapshot-id>'.`,
 				return err
 			}
 			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Created snapshot %s", snap.ID)))
+			if err := sidecar.SaveActiveSnapshot(cmd.Context(), sidecar.ActiveSnapshot{ID: snap.ID, Name: name}); err != nil {
+				io.ErrPrintf("Warning: could not save active snapshot: %v\n", err)
+			}
 
 			if err := client.DeleteSidecar(cmd.Context(), sidecarID); err != nil {
 				io.ErrPrintf("Warning: could not delete sidecar %s: %v\n", sidecarID, err)

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -298,7 +298,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	// sync and env-resolve status events are captured. Skipping when there is no
 	// sidecar avoids writing events with an empty sidecar_id that the TUI would
 	// filter out and never display.
-	statusFn = wrapEventLogStatusFn(statusFn, opts.sidecarID, activeSidecar, workDir)
+	statusFn = wrapEventLogStatusFn(statusFn, opts.sidecarID, activeSidecar, workDir, hook)
 
 	// Only load env vars and resolve secrets when a sidecar is actually
 	// being used — avoids parsing .env.local or hitting secrets APIs on
@@ -315,7 +315,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 // wrapEventLogStatusFn wraps statusFn with event log recording when a sidecar
 // is active. Returns statusFn unchanged when no sidecar is involved, so callers
 // with empty sidecar IDs never write events with a blank sidecar_id.
-func wrapEventLogStatusFn(statusFn iostream.StatusFunc, sidecarID string, activeSidecar *sidecar.ActiveSidecar, workDir string) iostream.StatusFunc {
+func wrapEventLogStatusFn(statusFn iostream.StatusFunc, sidecarID string, activeSidecar *sidecar.ActiveSidecar, workDir string, hook *hookContext) iostream.StatusFunc {
 	if sidecarID == "" {
 		return statusFn
 	}
@@ -327,13 +327,28 @@ func wrapEventLogStatusFn(statusFn iostream.StatusFunc, sidecarID string, active
 	if activeSidecar != nil && activeSidecar.SidecarID == sidecarID {
 		scName = activeSidecar.Name
 	}
-	return eventlog.WrapFromDir(dataDir, statusFn, eventlog.OpValidate, sidecarID, scName, sidecar.CurrentBranch(workDir))
+	op := eventlog.OpValidate
+	if hook != nil && hook.stopHookActive {
+		op = eventlog.OpHook
+	}
+	return eventlog.WrapFromDir(dataDir, statusFn, op, sidecarID, scName, sidecar.CurrentBranch(workDir))
 }
 
 // finishValidate reports the validate outcome and handles hook exit codes.
 func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start time.Time, sidecarID string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+	maxAttempts := validate.DefaultMaxAttempts
+	if hook != nil {
+		if ma := cfg.StopHookMaxAttempts; ma > 0 {
+			maxAttempts = ma
+		}
+	}
 	if execErr != nil {
-		statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed)", ui.FormatDuration(time.Since(start))))
+		if hook != nil {
+			attempt := validate.ReadAttempts(hook.sessionID) + 1
+			statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed, attempt %d/%d)", ui.FormatDuration(time.Since(start)), attempt, maxAttempts))
+		} else {
+			statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed)", ui.FormatDuration(time.Since(start))))
+		}
 	} else if hook == nil {
 		statusFn(iostream.LevelStep, fmt.Sprintf("done in %s", ui.FormatDuration(time.Since(start))))
 	}
@@ -346,10 +361,6 @@ func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start 
 	}
 	if hook == nil {
 		return execErr
-	}
-	maxAttempts := cfg.StopHookMaxAttempts
-	if maxAttempts <= 0 {
-		maxAttempts = validate.DefaultMaxAttempts
 	}
 	hookErr := validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
 	if hookErr == nil && execErr == nil {

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -23,6 +23,7 @@ const (
 	OpValidate Op = "validate"
 	OpExec     Op = "exec"
 	OpSetup    Op = "setup"
+	OpHook     Op = "hook"
 )
 
 // Event is a single status event written to the log.

--- a/internal/tui/watch/model.go
+++ b/internal/tui/watch/model.go
@@ -59,6 +59,7 @@ var (
 	stylePurple = lipgloss.NewStyle().Foreground(lipgloss.Color("140"))
 	styleTeal   = lipgloss.NewStyle().Foreground(lipgloss.Color("80"))
 	styleOrange = lipgloss.NewStyle().Foreground(lipgloss.Color("173"))
+	styleAmber  = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 	styleRed    = lipgloss.NewStyle().Foreground(lipgloss.Color("167"))
 	styleMuted  = lipgloss.NewStyle().Foreground(lipgloss.Color("242"))
 	styleVdim   = lipgloss.NewStyle().Foreground(lipgloss.Color("238"))
@@ -72,6 +73,7 @@ func blue(s string) string   { return styleBlue.Render(s) }
 func purple(s string) string { return stylePurple.Render(s) }
 func teal(s string) string   { return styleTeal.Render(s) }
 func orange(s string) string { return styleOrange.Render(s) }
+func amber(s string) string  { return styleAmber.Render(s) }
 func red(s string) string    { return styleRed.Render(s) }
 func muted(s string) string  { return styleMuted.Render(s) }
 func vdim(s string) string   { return styleVdim.Render(s) }
@@ -85,15 +87,16 @@ type ProjectEntry struct {
 
 // sidecarInfo holds display state for one sidecar.
 type sidecarInfo struct {
-	id              string
-	name            string
-	projectName     string
-	projectSnapshot bool // any snapshot*.json present in the project's data dir
-	lastSyncedRef   string
-	inSync          bool
-	running         bool
-	lastActivity    time.Time
-	lastOp          eventlog.Op
+	id            string
+	name          string
+	projectName   string
+	snapshotName  string    // name of the active snapshot for this project, if any
+	fileMtime     time.Time // mtime of the sidecar state file (fallback when no events yet)
+	lastSyncedRef string
+	inSync        bool
+	running       bool
+	lastActivity  time.Time
+	lastOp        eventlog.Op
 }
 
 type tickMsg struct{}
@@ -289,11 +292,10 @@ func (m Model) renderSidecarPane(maxLines int) []string {
 				add("")
 			}
 			label := truncate(sc.projectName, leftPaneWidth-4)
-			snap := ""
-			if sc.projectSnapshot {
-				snap = " " + vdim("◈")
+			add(vdim("── " + label))
+			if sc.snapshotName != "" {
+				add("   " + vdim("◈ "+truncate(sc.snapshotName, leftPaneWidth-6)))
 			}
-			add(vdim("── " + label + snap))
 			lastProject = sc.projectName
 		}
 
@@ -441,6 +443,8 @@ func opTag(op eventlog.Op) string {
 		return teal("exec    ")
 	case eventlog.OpSetup:
 		return orange("setup   ")
+	case eventlog.OpHook:
+		return amber("hook    ")
 	default:
 		return muted(fmt.Sprintf("%-8s", string(op)))
 	}
@@ -484,8 +488,8 @@ func (m Model) loadData() tea.Msg {
 	for i, p := range m.projects {
 		newBranches[i] = sidecar.CurrentBranch(p.ProjectRoot)
 		newHeadRefs[i] = headRef(p.ProjectRoot)
-		snap := hasSnapshotFile(p.DataDir)
-		sidecars := loadSidecars(p.DataDir, p.ProjectRoot, snap, newHeadRefs[i])
+		snapName := loadSnapshotName(p.DataDir)
+		sidecars := loadSidecars(p.DataDir, p.ProjectRoot, snapName, newHeadRefs[i])
 		allSidecars = append(allSidecars, sidecars...)
 
 		if p.Log == nil {
@@ -528,11 +532,13 @@ func (m Model) loadData() tea.Msg {
 		}
 	}
 
+	allSidecars = filterSidecars(allSidecars)
+
 	return dataMsg{sidecars: allSidecars, events: allEvents, offsets: newOffsets, branches: newBranches, headRefs: newHeadRefs}
 }
 
 // loadSidecars reads all sidecar*.json files from dataDir, deduplicates by ID.
-func loadSidecars(dataDir, projectRoot string, snap bool, head string) []sidecarInfo {
+func loadSidecars(dataDir, projectRoot string, snapshotName string, head string) []sidecarInfo {
 	matches, _ := filepath.Glob(filepath.Join(dataDir, "sidecar*.json"))
 	projectName := filepath.Base(projectRoot)
 	seen := map[string]bool{}
@@ -551,22 +557,68 @@ func loadSidecars(dataDir, projectRoot string, snap bool, head string) []sidecar
 		}
 		seen[as.SidecarID] = true
 		inSync := head != "" && as.LastSyncedRef != "" && head == as.LastSyncedRef
+		var mtime time.Time
+		if fi, err := os.Stat(path); err == nil {
+			mtime = fi.ModTime()
+		}
 		result = append(result, sidecarInfo{
-			id:              as.SidecarID,
-			name:            as.Name,
-			projectName:     projectName,
-			projectSnapshot: snap,
-			lastSyncedRef:   as.LastSyncedRef,
-			inSync:          inSync,
+			id:            as.SidecarID,
+			name:          as.Name,
+			projectName:   projectName,
+			snapshotName:  snapshotName,
+			fileMtime:     mtime,
+			lastSyncedRef: as.LastSyncedRef,
+			inSync:        inSync,
 		})
 	}
 	return result
 }
 
-// hasSnapshotFile reports whether any snapshot*.json exists in dataDir.
-func hasSnapshotFile(dataDir string) bool {
+const (
+	staleAge              = 24 * time.Hour
+	maxSidecarsPerProject = 3
+)
+
+// loadSnapshotName returns the Name field from any snapshot*.json in dataDir,
+// or "" if none is found or the name is not set.
+func loadSnapshotName(dataDir string) string {
 	matches, _ := filepath.Glob(filepath.Join(dataDir, "snapshot*.json"))
-	return len(matches) > 0
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var snap struct {
+			Name string `json:"name"`
+		}
+		if json.Unmarshal(data, &snap) == nil && snap.Name != "" {
+			return snap.Name
+		}
+	}
+	return ""
+}
+
+// filterSidecars drops sidecars that haven't been active within staleAge and
+// caps the remaining sidecars to maxSidecarsPerProject per project.
+func filterSidecars(sidecars []sidecarInfo) []sidecarInfo {
+	now := time.Now()
+	counts := map[string]int{}
+	result := sidecars[:0]
+	for _, sc := range sidecars {
+		eff := sc.lastActivity
+		if eff.IsZero() {
+			eff = sc.fileMtime
+		}
+		if !eff.IsZero() && now.Sub(eff) > staleAge {
+			continue
+		}
+		if counts[sc.projectName] >= maxSidecarsPerProject {
+			continue
+		}
+		counts[sc.projectName]++
+		result = append(result, sc)
+	}
+	return result
 }
 
 func anyRunning(sidecars []sidecarInfo) bool {

--- a/internal/tui/watch/model_test.go
+++ b/internal/tui/watch/model_test.go
@@ -196,7 +196,7 @@ func TestLoadSidecars_deduplicatesIDs(t *testing.T) {
 	// Duplicate id1 — should be deduplicated.
 	writeSidecarJSON(t, dir, "sidecar.sess2.json", `{"sidecar_id":"id1","name":"sc1"}`)
 
-	result := loadSidecars(dir, root, false, "abc123")
+	result := loadSidecars(dir, root, "", "abc123")
 	if len(result) != 2 {
 		t.Fatalf("want 2 unique sidecars, got %d", len(result))
 	}
@@ -208,7 +208,7 @@ func TestLoadSidecars_inSyncWhenHeadMatches(t *testing.T) {
 
 	writeSidecarJSON(t, dir, "sidecar.json", `{"sidecar_id":"id1","name":"sc1","last_synced_ref":"abc123"}`)
 
-	result := loadSidecars(dir, root, false, "abc123")
+	result := loadSidecars(dir, root, "", "abc123")
 	if len(result) != 1 {
 		t.Fatalf("want 1, got %d", len(result))
 	}
@@ -223,7 +223,7 @@ func TestLoadSidecars_notInSyncWhenHeadDiffers(t *testing.T) {
 
 	writeSidecarJSON(t, dir, "sidecar.json", `{"sidecar_id":"id1","last_synced_ref":"oldref"}`)
 
-	result := loadSidecars(dir, root, false, "newref")
+	result := loadSidecars(dir, root, "", "newref")
 	if len(result) != 1 {
 		t.Fatalf("want 1, got %d", len(result))
 	}
@@ -235,7 +235,7 @@ func TestLoadSidecars_notInSyncWhenHeadDiffers(t *testing.T) {
 func TestLoadSidecars_emptyDir(t *testing.T) {
 	dir := t.TempDir()
 	root := t.TempDir()
-	if result := loadSidecars(dir, root, false, ""); len(result) != 0 {
+	if result := loadSidecars(dir, root, "", ""); len(result) != 0 {
 		t.Errorf("want 0, got %d", len(result))
 	}
 }
@@ -246,22 +246,22 @@ func TestLoadSidecars_skipsEmptySidecarID(t *testing.T) {
 
 	writeSidecarJSON(t, dir, "sidecar.json", `{"sidecar_id":"","name":"empty"}`)
 
-	if result := loadSidecars(dir, root, false, ""); len(result) != 0 {
+	if result := loadSidecars(dir, root, "", ""); len(result) != 0 {
 		t.Errorf("want 0 (skipped empty ID), got %d", len(result))
 	}
 }
 
-func TestLoadSidecars_snapshotFlag(t *testing.T) {
+func TestLoadSidecars_snapshotName(t *testing.T) {
 	dir := t.TempDir()
 	root := t.TempDir()
 
 	writeSidecarJSON(t, dir, "sidecar.json", `{"sidecar_id":"id1","name":"sc1"}`)
 
-	result := loadSidecars(dir, root, true, "")
+	result := loadSidecars(dir, root, "my-snap", "")
 	if len(result) != 1 {
 		t.Fatalf("want 1, got %d", len(result))
 	}
-	if !result[0].projectSnapshot {
-		t.Error("projectSnapshot should be true when snap=true")
+	if result[0].snapshotName != "my-snap" {
+		t.Errorf("snapshotName should be 'my-snap', got %q", result[0].snapshotName)
 	}
 }

--- a/internal/validate/attempts.go
+++ b/internal/validate/attempts.go
@@ -35,6 +35,16 @@ func TrackFailedAttempt(sessionID string, warn io.Writer) int {
 	return state.Count
 }
 
+// ReadAttempts returns the current failure count for the given session without
+// modifying it. Returns 0 when no state file exists.
+func ReadAttempts(sessionID string) int {
+	var state attemptsState
+	if data, err := os.ReadFile(sessionPath(sessionID)); err == nil {
+		_ = json.Unmarshal(data, &state)
+	}
+	return state.Count
+}
+
 // ResetAttempts clears the failure counter for the given session.
 func ResetAttempts(sessionID string) {
 	_ = os.Remove(sessionPath(sessionID))


### PR DESCRIPTION
## Summary

- **Snapshot name in TUI**: replaces the bare `◈` icon with the actual snapshot name so it's clear which snapshot a project is pinned to
- **Stale sidecar filtering**: sidecars inactive for >24h are dropped from the watch pane; at most 3 sidecars are shown per project to avoid clutter
- **Hook op type**: adds `OpHook` to the event log and renders it in amber in the TUI, so stop-hook runs are visually distinct from plain `validate` runs
- **Attempt count in error messages**: validate failure messages now include `(attempt N/M)` when running inside a stop-hook, giving immediate retry feedback
- **Snapshot persistence**: after `chunk sidecar snapshot`, the new snapshot ID/name is saved to disk so subsequent TUI loads reflect it
- **`ReadAttempts` helper**: non-mutating read of the current hook failure count, used by `finishValidate`

## Test plan

- [ ] `task test` passes (unit + race detector)
- [ ] `task lint` clean
- [ ] Manual: run `chunk watch`, create a sidecar with a named snapshot, confirm the name appears in the left pane under the project
- [ ] Manual: trigger a stop-hook failure and confirm the `hook` amber tag appears and attempt count increments in the TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)