### PR TITLE
Remove gitignore entries for sidecar state files

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -256,57 +256,6 @@ func writeSettingsExample(dir string, data []byte, streams iostream.Streams) err
 	return nil
 }
 
-var sidecarGitignoreEntries = []string{
-	".chunk/sidecar.json",
-	".chunk/sidecar.*.json",
-}
-
-// ensureGitignoreEntries appends sidecar tracking patterns to .gitignore if
-// they are not already present.
-func ensureGitignoreEntries(workDir string, streams iostream.Streams) error {
-	path := filepath.Join(workDir, ".gitignore")
-
-	existing, err := os.ReadFile(path)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("read .gitignore: %w", err)
-	}
-
-	content := string(existing)
-	var toAdd []string
-	for _, entry := range sidecarGitignoreEntries {
-		if !strings.Contains(content, entry) {
-			toAdd = append(toAdd, entry)
-		}
-	}
-	if len(toAdd) == 0 {
-		return nil
-	}
-
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return fmt.Errorf("open .gitignore: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	if len(existing) > 0 && existing[len(existing)-1] != '\n' {
-		if _, err := f.WriteString("\n"); err != nil {
-			return err
-		}
-	}
-
-	if _, err := f.WriteString("\n# chunk active sidecar tracking\n"); err != nil {
-		return err
-	}
-	for _, entry := range toAdd {
-		if _, err := f.WriteString(entry + "\n"); err != nil {
-			return err
-		}
-	}
-
-	streams.ErrPrintln(ui.Success("Updated .gitignore with sidecar tracking patterns"))
-	return nil
-}
-
 func installSkillsStep(workDir string, streams iostream.Streams) {
 	for _, r := range skills.InstallByName(skills.ScopeProject, workDir, "chunk-sidecar") {
 		if r.Skipped {
@@ -571,10 +520,6 @@ hook config files.`,
 				}
 			}
 			streams.ErrPrintln(ui.Success("Wrote .chunk/config.json"))
-
-			if err := ensureGitignoreEntries(workDir, streams); err != nil {
-				streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not update .gitignore: %v", err)))
-			}
 
 			// Step 3: Write hook config files for supported agents.
 			if !skipHooks {

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -413,53 +413,6 @@ func TestWriteGitHookAppendsToExisting(t *testing.T) {
 	assert.Assert(t, bytes.Contains(errOut.Bytes(), []byte("Updated .git/hooks/pre-commit")))
 }
 
-func TestEnsureGitignoreEntriesCreatesNew(t *testing.T) {
-	dir := t.TempDir()
-	streams, _, _ := testStreams()
-
-	err := ensureGitignoreEntries(dir, streams)
-	assert.NilError(t, err)
-
-	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
-	assert.NilError(t, err)
-	for _, entry := range sidecarGitignoreEntries {
-		assert.Assert(t, strings.Contains(string(data), entry), "missing %s", entry)
-	}
-}
-
-func TestEnsureGitignoreEntriesAppendsToExisting(t *testing.T) {
-	dir := t.TempDir()
-	existing := "node_modules/\n.env\n"
-	assert.NilError(t, os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(existing), 0o644))
-
-	streams, _, _ := testStreams()
-	err := ensureGitignoreEntries(dir, streams)
-	assert.NilError(t, err)
-
-	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
-	assert.NilError(t, err)
-	content := string(data)
-	assert.Assert(t, strings.HasPrefix(content, existing))
-	for _, entry := range sidecarGitignoreEntries {
-		assert.Assert(t, strings.Contains(content, entry), "missing %s", entry)
-	}
-}
-
-func TestEnsureGitignoreEntriesIdempotent(t *testing.T) {
-	dir := t.TempDir()
-	streams, _, _ := testStreams()
-
-	assert.NilError(t, ensureGitignoreEntries(dir, streams))
-	first, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
-	assert.NilError(t, err)
-
-	assert.NilError(t, ensureGitignoreEntries(dir, streams))
-	second, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
-	assert.NilError(t, err)
-
-	assert.Equal(t, string(first), string(second))
-}
-
 // TestInstallSkillsStepUsesProjectScope verifies that installSkillsStep writes
 // skills into the project's .claude/skills/ directory, not into the user's
 // home directory. Previously it called InstallByName(ScopeUser, homeDir, ...)

--- a/skills/chunk-sidecar/SKILL.md
+++ b/skills/chunk-sidecar/SKILL.md
@@ -9,7 +9,6 @@ allowed-tools:
   - Bash(chunk sidecar:*)
   - Bash(chunk validate:*)
   - Bash(cat .chunk/config.json)
-  - Bash(cat .chunk/sidecar.json)
   - Bash(test -n*)
   - Read
   - Write
@@ -96,7 +95,7 @@ For each round of edits:
 When validate returns non-zero:
 
 - Parse stderr — `chunk validate` prints per-command headers and propagates the first non-zero exit.
-- Map error paths back to local files: the sidecar mirrors your tree at `~/workspace/<repo>` (or the workspace configured in `.chunk/sidecar.json`). Run `chunk sidecar current --json` to see the resolved absolute path.
+- Map error paths back to local files: the sidecar mirrors your tree at `~/workspace/<repo>`. Run `chunk sidecar current --json` to see the resolved absolute workspace path.
 - Fix locally, then repeat Step 4. Do **not** edit files over SSH — changes will be overwritten on the next sync.
 - If the error looks environmental (missing binary, wrong language version, unreachable service), go to Troubleshooting.
 
@@ -175,7 +174,7 @@ This skill covers writing `test-suites.yml` and validating it with doctor on the
 
 ## Parallel sessions
 
-When `CLAUDE_SESSION_ID` is set, `chunk` auto-scopes the active-sidecar file to `.chunk/sidecar.<session-id>.json`. Two concurrent sessions in the same repo target different sidecars without conflict. Do not override this behavior or hand-edit those files.
+When `CLAUDE_SESSION_ID` is set, `chunk` auto-scopes the active-sidecar state to that session. Two concurrent sessions in the same repo target different sidecars without conflict.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Sidecar state files (`sidecar*.json`, `snapshot*.json`) are stored under XDG_DATA_HOME (`~/.local/share/chunk/<project-hash>/`), not in the working tree's `.chunk/` directory — confirmed by `active_test.go` which explicitly asserts they must not appear inside `.chunk/`.
- Writing `.gitignore` entries for `.chunk/sidecar*.json` was misleading and unnecessary.
- Removes `ensureGitignoreEntries`, `sidecarGitignoreEntries`, their three tests, the call site in `chunk init`, and stale references in the `chunk-sidecar` skill (`Bash(cat .chunk/sidecar.json)` allowed tool and two prose lines).

## Test plan

- [ ] `go test ./internal/cmd/ -race` passes
- [ ] `go tool golangci-lint run ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)