### PR TITLE
Reap abandoned sidecars instead of resurrecting them

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -180,6 +180,17 @@ chunk
   (requires the branch to be pushed).
 - `sidecar ssh -- <cmd>` forwards stdin when the process stdin is a pipe, enabling
   patterns like `cat bundle | chunk sidecar ssh -- git fetch ...`.
+- **Abandoned sidecars are reaped automatically.** Local sidecar state is one file
+  per session and branch, and `validate` sweeps them before resolving a sidecar:
+  state naming a sidecar absent from the org listing is deleted, and a sidecar
+  still running whose state has not been touched for 5 days is deleted through the
+  API and its state dropped. The sidecar the current run is about to use is never
+  deleted by age, and one that is alive with recently touched state is left alone
+  so a concurrent session on another branch keeps its own. The sweep needs an org
+  ID that resolves without prompting (see **Org ID resolution**), skips silently
+  without one, and deletes nothing if the listing fails, since an empty listing is
+  not proof of absence. A sidecar the API rejects as out of date (410) is deleted
+  when a sync hits it, because no listing reveals that state.
 - Commands that require a CircleCI token (`task run`, `task config`, `sidecar *`,
   `validate --sidecar-id`) prompt for it inline at the point of need rather than
   failing with an error.

--- a/internal/circleci/staleness.go
+++ b/internal/circleci/staleness.go
@@ -1,0 +1,40 @@
+package circleci
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// SidecarOutOfDate reports whether err is the API refusing to talk to a sidecar
+// because the sidecar itself is too old.
+//
+// The API returns 410 Gone for two unrelated conditions with opposite remedies:
+// this CLI being too old for the API, and a sidecar being too old for the API.
+// Telling someone to upgrade the CLI when the sidecar is the stale one sends
+// them to a version that fails identically, so the two must be told apart.
+//
+// Matching on the server's own wording is a compromise: the V3 error envelope
+// carries no machine-readable code, so there is nothing better to key off until
+// the API supplies one.
+func SidecarOutOfDate(err error) bool {
+	var se *StatusError
+	if !errors.As(err, &se) || se.StatusCode != http.StatusGone {
+		return false
+	}
+	return strings.Contains(strings.ToLower(se.ServerMessage), "sidecar is out of date")
+}
+
+// SidecarGone reports whether err is a 404 from an operation addressed at a
+// specific sidecar, meaning that sidecar no longer exists: it was deleted, or
+// it expired server-side.
+//
+// Only call this on errors from sidecar-scoped requests. A 404 from anything
+// else means a missing route, not a missing sidecar.
+func SidecarGone(err error) bool {
+	var se *StatusError
+	if !errors.As(err, &se) {
+		return false
+	}
+	return se.StatusCode == http.StatusNotFound
+}

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -240,7 +240,7 @@ func newSidecarCreateCmd() *cobra.Command {
 				}
 			}
 			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Created sidecar %s (%s)", sb.Name, sb.ID)))
-			if err := sidecar.SaveActive(cmd.Context(), sidecar.ActiveSidecar{SidecarID: sb.ID, Name: sb.Name}); err != nil {
+			if err := sidecar.SaveActive(cmd.Context(), sidecar.ActiveSidecar{SidecarID: sb.ID, Name: sb.Name, OrgID: resolvedOrgID}); err != nil {
 				io.ErrPrintf("warning: could not save active sidecar: %v\n", err)
 			} else {
 				io.ErrPrintf("Set %s as active sidecar\n", sb.ID)
@@ -1137,7 +1137,7 @@ func sidecarSetupResolveSidecar(
 			err:        err,
 		}
 	}
-	if saveErr := sidecar.SaveActive(ctx, sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); saveErr != nil {
+	if saveErr := sidecar.SaveActive(ctx, sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name, OrgID: resolvedOrgID}); saveErr != nil {
 		streams.ErrPrintf("warning: could not save active sidecar: %v\n", saveErr)
 	}
 	status(iostream.LevelDone, fmt.Sprintf("Created sidecar %s (%s)", sc.Name, sc.ID))

--- a/internal/cmd/usererr.go
+++ b/internal/cmd/usererr.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -196,16 +195,10 @@ func GoneError(err error) error {
 		return nil
 	}
 
-	// A 410 covers two unrelated conditions with opposite remedies: the CLI
-	// being too old for the API, and a sidecar being too old for the API. Telling
-	// someone to upgrade the CLI when their sidecar is the stale one sends them
-	// to a version that will fail identically, so the two must be told apart.
-	//
-	// Matching on the server's own wording is a compromise: the V3 error envelope
-	// carries no machine-readable code, so there is nothing better to key off
-	// until the API supplies one. The server's message already names the remedy,
-	// so it is shown rather than replaced with a guess.
-	if strings.Contains(strings.ToLower(se.ServerMessage), "sidecar is out of date") {
+	// A 410 covers two unrelated conditions with opposite remedies, told apart by
+	// the server's wording; see circleci.SidecarOutOfDate. The server's message
+	// already names the remedy, so it is shown rather than replaced with a guess.
+	if circleci.SidecarOutOfDate(err) {
 		// Deliberately no detail. The server's message states the condition and
 		// the remedy, both of which are already the message and the suggestion
 		// here, so including it says the same thing three times over.

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -169,7 +169,7 @@ func validateNeedsSidecar(explicitRemote bool, cfg *config.ProjectConfig) bool {
 	return cfg.HasSidecarImage()
 }
 
-func loadSidecarEnvVars(ctx context.Context, client *circleci.Client, opts *validateOpts, workDir string, statusFn iostream.StatusFunc) (map[string]string, error) {
+func loadSidecarEnvVars(ctx context.Context, client *circleci.Client, opts *validateOpts, workDir string, statusFn iostream.StatusFunc, streams iostream.Streams) (map[string]string, error) {
 	if opts.sidecarID == "" {
 		return nil, nil
 	}
@@ -177,7 +177,7 @@ func loadSidecarEnvVars(ctx context.Context, client *circleci.Client, opts *vali
 	if err != nil {
 		return nil, err
 	}
-	if err := syncToSidecar(ctx, client, opts.sidecarID, opts.identityFile, opts.workdir, statusFn); err != nil {
+	if err := syncToSidecar(ctx, client, opts.sidecarID, opts.identityFile, opts.workdir, statusFn, streams); err != nil {
 		return nil, err
 	}
 	return envVars, nil
@@ -260,7 +260,6 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	rc, _ := config.ResolveCircleCI(insecureStorage)
 
 	explicitRemote := opts.remote || opts.sidecarID != ""
-	activeSidecar, _ := sidecar.LoadActive(ctx)
 	needsSidecar := validateNeedsSidecar(explicitRemote, cfg)
 	if hook != nil && needsSidecar && rc.CircleCIToken == "" {
 		streams.ErrPrintln("CircleCI auth is not configured.")
@@ -288,6 +287,14 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 
 	statusFn(iostream.LevelStep, "chunk validate")
 
+	// Reap before reading state, so a file naming a sidecar that no longer exists
+	// is gone before it can be promoted and reused. Loading first would hand
+	// setupRemote the very dead ID the reap just cleaned up.
+	if needsSidecar {
+		reapAbandonedSidecars(ctx, circleCIClient, workDir, statusFn, streams)
+	}
+	activeSidecar, _ := sidecar.LoadActive(ctx)
+
 	freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, activeSidecar, statusFn, workDir, streams)
 	if err != nil {
 		return err
@@ -298,13 +305,40 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	// sync and env-resolve status events are captured. Skipping when there is no
 	// sidecar avoids writing events with an empty sidecar_id that the TUI would
 	// filter out and never display.
+	// Kept unwrapped so a replacement sidecar can be rewrapped against its own ID
+	// rather than logging its events under the sidecar it replaced.
+	baseStatusFn := statusFn
 	statusFn = wrapEventLogStatusFn(statusFn, opts.sidecarID, activeSidecar, workDir, hook)
 
 	// Only load env vars and resolve secrets when a sidecar is actually
 	// being used — avoids parsing .env.local or hitting secrets APIs on
 	// purely local runs.
-	envVars, err := loadSidecarEnvVars(ctx, circleCIClient, opts, workDir, statusFn)
+	envVars, err := loadSidecarEnvVars(ctx, circleCIClient, opts, workDir, statusFn, streams)
+	if errors.Is(err, errSidecarUnusable) {
+		// The sidecar could not be used and its state has been dropped, so replace
+		// it here rather than failing and asking for the same command again. The
+		// reap cannot prevent this on its own: a sidecar can go away between the
+		// listing and the sync, and one the API rejects as out of date is listed
+		// like any other.
+		statusFn(iostream.LevelWarn, "sidecar was unusable, provisioning a replacement")
+		opts.sidecarID = ""
+		if _, createErr := resolveOrCreateSidecarID(ctx, circleCIClient, &opts.sidecarID, opts.orgID, image, workDir, streams); createErr != nil {
+			return createErr
+		}
+		// A replacement has none of the setup the old one had, so exec failures on
+		// it are real failures rather than grounds for falling back to local.
+		freshlyCreated = true
+		statusFn = wrapEventLogStatusFn(baseStatusFn, opts.sidecarID, nil, workDir, hook)
+		envVars, err = loadSidecarEnvVars(ctx, circleCIClient, opts, workDir, statusFn, streams)
+	}
 	if err != nil {
+		if errors.Is(err, errSidecarUnusable) {
+			// Twice in one run is not a stale sidecar, so stop rather than churn.
+			return newUserError("Could not get a usable sidecar.").
+				withCode("sidecar.unusable").
+				withSuggestion("Create one explicitly with: chunk sidecar create").
+				wrap(err)
+		}
 		return err
 	}
 
@@ -500,16 +534,72 @@ func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpt
 	return false, nil
 }
 
-func syncToSidecar(ctx context.Context, client *circleci.Client, sidecarID, identityFile, workdir string, statusFn iostream.StatusFunc) error {
+func syncToSidecar(ctx context.Context, client *circleci.Client, sidecarID, identityFile, workdir string, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	authSock := os.Getenv(config.EnvSSHAuthSock)
 	cwd, err := os.Getwd()
 	if err != nil {
 		return &userError{msg: "Could not sync to sidecar.", err: err}
 	}
 	if err := sidecar.BundleSync(ctx, client, sidecarID, identityFile, authSock, workdir, cwd, statusFn); err != nil {
-		return &userError{msg: "Could not sync to sidecar.", err: err}
+		return sidecarSyncError(ctx, client, sidecarID, err, streams)
 	}
 	return nil
+}
+
+// sidecarSyncError reports a failed sync, first dropping local state when the
+// failure means this sidecar can never be used again.
+//
+// Reap already removes deleted sidecars before anything syncs to them, so this
+// covers what a listing cannot show: a sidecar deleted since the list was
+// fetched, and one the API rejects as out of date. Without the prune an
+// out-of-date sidecar fails forever: it is still listed, and still recently
+// used, so the age sweep never touches it.
+func sidecarSyncError(ctx context.Context, client *circleci.Client, sidecarID string, err error, streams iostream.Streams) error {
+	switch {
+	case circleci.SidecarOutOfDate(err):
+		// Still running and still billable, so delete it rather than orphan it.
+		pruneSidecarState(ctx, client, sidecarID, true, streams)
+	case circleci.SidecarGone(err):
+		pruneSidecarState(ctx, client, sidecarID, false, streams)
+	default:
+		return &userError{msg: "Could not sync to sidecar.", err: err}
+	}
+	// Both wrapped, not replaced: the caller replaces the sidecar and retries, and
+	// only if that fails does the original surface. GoneError in main's error path
+	// still finds the 410 through the wrapping and phrases it.
+	return fmt.Errorf("%w: %w", errSidecarUnusable, err)
+}
+
+// errSidecarUnusable marks a sync failure that a fresh sidecar would fix: the
+// sidecar is gone, or permanently out of date, and its local state has already
+// been dropped, so provisioning a replacement is safe.
+var errSidecarUnusable = errors.New("sidecar unusable")
+
+// pruneSidecarState drops local state for an unusable sidecar, warning on
+// failure. A prune that fails must not mask the error that triggered it.
+func pruneSidecarState(ctx context.Context, client *circleci.Client, sidecarID string, deleteRemote bool, streams iostream.Streams) {
+	if err := sidecar.PruneID(ctx, client, sidecarID, deleteRemote); err != nil {
+		streams.ErrPrintf("warning: could not clear state for unusable sidecar %s: %v\n", sidecarID, err)
+	}
+}
+
+// reapAbandonedSidecars deletes sidecars this project has abandoned and drops
+// their local state. Errors are reported and then ignored: a cleanup sweep must
+// never fail a validate run.
+func reapAbandonedSidecars(ctx context.Context, client *circleci.Client, workDir string, statusFn iostream.StatusFunc, streams iostream.Streams) {
+	orgID, _ := config.ResolveOrgID(workDir)
+	if orgID == "" {
+		// The only remaining way to get an org is the interactive picker, and a
+		// background sweep must never prompt.
+		return
+	}
+	res, err := sidecar.Reap(ctx, client, orgID)
+	if err != nil {
+		streams.ErrPrintf("warning: could not reap abandoned sidecars: %v\n", err)
+	}
+	if summary := res.Summary(); summary != "" {
+		statusFn(iostream.LevelInfo, summary)
+	}
 }
 
 // newExecFn builds a function that runs shell scripts on a remote sidecar via
@@ -714,7 +804,7 @@ func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, side
 			err:        err,
 		}
 	}
-	if saveErr := sidecar.SaveActive(ctx, sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name}); saveErr != nil {
+	if saveErr := sidecar.SaveActive(ctx, sidecar.ActiveSidecar{SidecarID: sc.ID, Name: sc.Name, OrgID: resolvedOrgID}); saveErr != nil {
 		streams.ErrPrintf("warning: could not save active sidecar: %v\n", saveErr)
 	}
 	// Persist the org ID so future sidecar creation skips the picker.

--- a/internal/cmd/validate_sidecar_retry_test.go
+++ b/internal/cmd/validate_sidecar_retry_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
+)
+
+// syncErrEnv gives a project rooted in a temp dir with its own state directory,
+// so pruning is observable without touching the developer's real state.
+func syncErrEnv(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
+
+	stateDir, err := sidecar.StateDir()
+	assert.NilError(t, err)
+	assert.NilError(t, os.MkdirAll(stateDir, 0o755))
+	return stateDir
+}
+
+func seedState(t *testing.T, id string) string {
+	t.Helper()
+	ctx := context.Background()
+	assert.NilError(t, sidecar.SaveActive(ctx, sidecar.ActiveSidecar{SidecarID: id}))
+	stateDir, err := sidecar.StateDir()
+	assert.NilError(t, err)
+	return filepath.Join(stateDir, "sidecar.json")
+}
+
+func statePresent(t *testing.T, path string) bool {
+	t.Helper()
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// TestSidecarSyncErrorSignalsRetryWhenGone covers a sidecar deleted between the
+// reap's listing and the sync: state is dropped and the caller is told a fresh
+// sidecar will fix it, rather than being asked to run the command again.
+func TestSidecarSyncErrorSignalsRetryWhenGone(t *testing.T) {
+	syncErrEnv(t)
+	path := seedState(t, "sb-gone")
+
+	syncErr := &circleci.StatusError{Op: "add ssh key", StatusCode: http.StatusNotFound}
+	err := sidecarSyncError(context.Background(), nil, "sb-gone", syncErr, iostream.Streams{Err: os.Stderr})
+
+	assert.Assert(t, errors.Is(err, errSidecarUnusable), "a gone sidecar must be retryable, got: %v", err)
+	assert.Assert(t, !statePresent(t, path), "state for a gone sidecar must be dropped")
+}
+
+// TestSidecarSyncErrorSignalsRetryWhenOutOfDate covers the 410 no listing can
+// reveal. The error stays unwrappable to the StatusError so GoneError can still
+// phrase it if the retry also fails.
+func TestSidecarSyncErrorSignalsRetryWhenOutOfDate(t *testing.T) {
+	syncErrEnv(t)
+	path := seedState(t, "sb-old")
+
+	syncErr := &circleci.StatusError{
+		Op:            "exec",
+		StatusCode:    http.StatusGone,
+		ServerMessage: "This sidecar is out of date, recreate it",
+	}
+	err := sidecarSyncError(context.Background(), nil, "sb-old", syncErr, iostream.Streams{Err: os.Stderr})
+
+	assert.Assert(t, errors.Is(err, errSidecarUnusable), "an out-of-date sidecar must be retryable")
+	assert.Assert(t, !statePresent(t, path), "state for an out-of-date sidecar must be dropped")
+	assert.Assert(t, circleci.SidecarOutOfDate(err), "the 410 must stay reachable through the wrapping")
+	assert.Assert(t, GoneError(err) != nil, "GoneError must still phrase the wrapped 410")
+}
+
+// TestSidecarSyncErrorKeepsStateOnOrdinaryFailure covers a sync that failed for
+// reasons that say nothing about the sidecar, such as the network. Replacing it
+// would destroy a working sidecar over a transient fault.
+func TestSidecarSyncErrorKeepsStateOnOrdinaryFailure(t *testing.T) {
+	syncErrEnv(t)
+	path := seedState(t, "sb-fine")
+
+	err := sidecarSyncError(context.Background(), nil, "sb-fine",
+		errors.New("dial tcp: connection refused"), iostream.Streams{Err: os.Stderr})
+
+	assert.Assert(t, !errors.Is(err, errSidecarUnusable), "a transient fault must not replace the sidecar")
+	assert.Assert(t, statePresent(t, path), "state must survive a fault unrelated to the sidecar")
+}

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
@@ -19,8 +18,12 @@ import (
 
 // ActiveSidecar holds the currently active sidecar for a project.
 type ActiveSidecar struct {
-	SidecarID     string `json:"sidecar_id"`
-	Name          string `json:"name,omitempty"`
+	SidecarID string `json:"sidecar_id"`
+	Name      string `json:"name,omitempty"`
+	// OrgID records which org the sidecar belongs to, so Reap can tell a sidecar
+	// that has been deleted from one that simply lives in an org it is not
+	// listing. Empty on state written before this field existed.
+	OrgID         string `json:"org_id,omitempty"`
 	Workspace     string `json:"workspace,omitempty"`
 	LastSyncedRef string `json:"last_synced_ref,omitempty"`
 }
@@ -96,37 +99,24 @@ func LoadAnyActive(_ context.Context) (*ActiveSidecar, error) {
 	if err != nil {
 		return nil, err
 	}
-	matches, err := filepath.Glob(filepath.Join(dir, "sidecar*.json"))
-	if err != nil || len(matches) == 0 {
-		return nil, nil
+	entries, err := loadStateEntries(dir)
+	if err != nil || len(entries) == 0 {
+		return nil, err
 	}
-	var best string
-	var bestTime time.Time
-	for _, m := range matches {
-		info, statErr := os.Stat(m)
-		if statErr != nil {
+	var best *stateEntry
+	for i, e := range entries {
+		if e.active.SidecarID == "" {
 			continue
 		}
-		if info.ModTime().After(bestTime) {
-			bestTime = info.ModTime()
-			best = m
+		if best == nil || e.modTime.After(best.modTime) {
+			best = &entries[i]
 		}
 	}
-	if best == "" {
+	if best == nil {
 		return nil, nil
 	}
-	data, err := os.ReadFile(best)
-	if err != nil {
-		return nil, err
-	}
-	var a ActiveSidecar
-	if err := json.Unmarshal(data, &a); err != nil {
-		return nil, err
-	}
-	if a.SidecarID == "" {
-		return nil, nil
-	}
-	return &a, nil
+	active := best.active
+	return &active, nil
 }
 
 // LoadActiveFrom reads the active sidecar from dir.

--- a/internal/sidecar/reap.go
+++ b/internal/sidecar/reap.go
@@ -1,0 +1,271 @@
+package sidecar
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/session"
+)
+
+// StaleAfter is how long a sidecar's state file may go untouched before the
+// sidecar is treated as abandoned and deleted.
+//
+// Every save rewrites the state file, so its mtime is the only record of when
+// the sidecar was last used, and a cold file means nobody has used it since.
+// Five days keeps a sidecar alive across a long weekend while still reclaiming
+// spend on the ones whose session was closed and forgotten.
+const StaleAfter = 5 * 24 * time.Hour
+
+// ReapResult records what Reap did, so the caller can report it.
+type ReapResult struct {
+	// Deleted holds sidecars that were still running but abandoned, and so were
+	// deleted through the API.
+	Deleted []string
+	// Vanished holds sidecars already absent server-side. Only their local state
+	// files were removed; there was nothing left to delete.
+	Vanished []string
+	// Failed holds sidecars the API refused to delete. Their state is still
+	// dropped, so the leak is reported rather than silent.
+	Failed []string
+}
+
+// record files the outcome of deleting id.
+//
+// A 404 means the sidecar went away before the delete landed, which is the same
+// end state as never having been listed. Anything else is a sidecar that may
+// still be running, and is reported so it can be chased.
+//
+// Either way the state file goes, which is why this returns nothing to act on.
+// The sidecar has already been judged abandoned, and a file kept back becomes
+// the sidecar the next run picks up: a failed delete would hand every future run
+// a box the API will not let go of, which is the resurrection this is meant to
+// stop. Whatever survives server-side expires on its own.
+func (r *ReapResult) record(id string, err error) {
+	switch {
+	case err == nil:
+		r.Deleted = append(r.Deleted, id)
+	case circleci.SidecarGone(err):
+		r.Vanished = append(r.Vanished, id)
+	default:
+		r.Failed = append(r.Failed, id)
+	}
+}
+
+// Empty reports whether the reap changed nothing.
+func (r ReapResult) Empty() bool {
+	return len(r.Deleted) == 0 && len(r.Vanished) == 0 && len(r.Failed) == 0
+}
+
+// Summary describes the result in one line, or "" when nothing changed.
+func (r ReapResult) Summary() string {
+	var parts []string
+	if n := len(r.Deleted); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d deleted", n))
+	}
+	if n := len(r.Vanished); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d already gone", n))
+	}
+	if n := len(r.Failed); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d could not be deleted and may still be running", n))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	total := len(r.Deleted) + len(r.Vanished) + len(r.Failed)
+	return fmt.Sprintf("reaped %d abandoned %s (%s)", total, plural("sidecar", total), strings.Join(parts, ", "))
+}
+
+func plural(word string, n int) string {
+	if n == 1 {
+		return word
+	}
+	return word + "s"
+}
+
+// stateEntry is a parsed sidecar state file on disk.
+type stateEntry struct {
+	path    string
+	active  ActiveSidecar
+	modTime time.Time
+}
+
+// ids returns the sidecar IDs recorded in a state file. It is the only place
+// that knows the state holds a single ID, so widening the state to a group of
+// sidecars changes this function and nothing else in this file.
+func (e stateEntry) ids() []string {
+	if e.active.SidecarID == "" {
+		return nil
+	}
+	return []string{e.active.SidecarID}
+}
+
+// Reap deletes abandoned sidecars for the current project and removes their
+// local state files.
+//
+// State accumulates one file per session and branch, and nothing else removes
+// them, which causes two problems. Forgotten sidecars keep costing money. Worse,
+// LoadAnyActive promotes the most recently modified file it can find, so a file
+// naming a sidecar that no longer exists resurrects that dead ID run after run,
+// and every command against it fails with a bare 404.
+//
+// Three cases, deliberately treated differently:
+//
+//   - Absent from the org's sidecar list: the state is worthless, so the file
+//     goes. This includes the current session's own file, because there is no
+//     live sidecar left to protect and leaving it is exactly what causes the
+//     resurrection.
+//   - Present but untouched for longer than StaleAfter: deleted through the API,
+//     then the file goes. The current session's file is spared, since deleting
+//     the sidecar this run is about to use only forces an immediate recreate.
+//   - Present and recently used: left alone. A concurrent session on another
+//     branch legitimately owns its own sidecar, and its warm mtime says so.
+//
+// Reap fails open. If the sidecar list cannot be fetched, nothing is deleted and
+// nothing is pruned: an empty or partial list is not proof of absence, and
+// destroying a live sidecar is far worse than leaving a stale file behind.
+func Reap(ctx context.Context, client *circleci.Client, orgID string) (ReapResult, error) {
+	var res ReapResult
+	if client == nil || orgID == "" {
+		return res, nil
+	}
+	dir, err := saveDir()
+	if err != nil {
+		return res, err
+	}
+	entries, err := loadStateEntries(dir)
+	if err != nil || len(entries) == 0 {
+		return res, err
+	}
+
+	live, err := client.ListSidecars(ctx, orgID, false)
+	if err != nil {
+		return res, fmt.Errorf("list sidecars: %w", err)
+	}
+	liveIDs := make(map[string]bool, len(live))
+	for _, sc := range live {
+		liveIDs[sc.ID] = true
+	}
+
+	root, _ := projectRoot()
+	current := filepath.Join(dir, sidecarFileName(session.IDFromCtx(ctx), CurrentBranch(root)))
+	cutoff := time.Now().Add(-StaleAfter)
+
+	var errs []error
+	for _, e := range entries {
+		// A state file recording a different org cannot be judged against this
+		// org's list; its sidecar would look absent when it is merely elsewhere.
+		// Files written before the org was recorded are assumed to belong to this
+		// project's org, which is the only org they could have come from unless
+		// the project config changed underneath them.
+		if e.active.OrgID != "" && e.active.OrgID != orgID {
+			continue
+		}
+		keep := false
+		for _, id := range e.ids() {
+			switch {
+			case !liveIDs[id]:
+				res.Vanished = append(res.Vanished, id)
+			case e.modTime.After(cutoff) || e.path == current:
+				keep = true
+			default:
+				res.record(id, client.DeleteSidecar(ctx, id))
+			}
+		}
+		if keep {
+			continue
+		}
+		if err := removeState(e.path); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return res, errors.Join(errs...)
+}
+
+// PruneID removes every state file for the current project that names sidecarID,
+// deleting the sidecar through the API first when it still exists.
+//
+// Removing one file is not enough. LoadAnyActive copies an ID into a fresh
+// session-and-branch file every time it promotes one, so the same ID is often
+// recorded two or three times over; dropping a single file leaves a duplicate
+// behind that resurrects the dead ID on the next run.
+//
+// deleteRemote separates the two ways a sidecar stops being usable. Already
+// deleted (404) leaves nothing to delete. Out of date (410) means it is still
+// running, still costing money, and can never be used again, so it is deleted
+// before its state is dropped.
+func PruneID(ctx context.Context, client *circleci.Client, sidecarID string, deleteRemote bool) error {
+	if sidecarID == "" {
+		return nil
+	}
+	dir, err := saveDir()
+	if err != nil {
+		return err
+	}
+	entries, err := loadStateEntries(dir)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	if deleteRemote && client != nil {
+		if err := client.DeleteSidecar(ctx, sidecarID); err != nil {
+			// Keep going: the sidecar may already be gone, and either way the local
+			// state must be dropped or the next run reuses the same dead ID.
+			errs = append(errs, fmt.Errorf("delete sidecar %s: %w", sidecarID, err))
+		}
+	}
+	for _, e := range entries {
+		for _, id := range e.ids() {
+			if id != sidecarID {
+				continue
+			}
+			if err := removeState(e.path); err != nil {
+				errs = append(errs, err)
+			}
+			break
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// loadStateEntries reads every sidecar state file in dir. Files that cannot be
+// read or parsed are skipped rather than failing the sweep, so one corrupt file
+// does not block cleaning up the rest.
+func loadStateEntries(dir string) ([]stateEntry, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "sidecar*.json"))
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]stateEntry, 0, len(matches))
+	for _, path := range matches {
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			continue
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			continue
+		}
+		var a ActiveSidecar
+		if jsonErr := json.Unmarshal(data, &a); jsonErr != nil {
+			continue
+		}
+		entries = append(entries, stateEntry{path: path, active: a, modTime: info.ModTime()})
+	}
+	return entries, nil
+}
+
+// removeState deletes a state file, treating an already-absent file as success.
+func removeState(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove sidecar state %s: %w", filepath.Base(path), err)
+	}
+	return nil
+}

--- a/internal/sidecar/reap_test.go
+++ b/internal/sidecar/reap_test.go
@@ -1,0 +1,311 @@
+package sidecar
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/session"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+)
+
+const testOrg = "org-1"
+
+// reapEnv is a project rooted in a temp dir with its own state directory and a
+// client pointed at a fake API.
+type reapEnv struct {
+	t        *testing.T
+	fake     *fakes.FakeCircleCI
+	client   *circleci.Client
+	stateDir string
+}
+
+func newReapEnv(t *testing.T) *reapEnv {
+	t.Helper()
+	dir := t.TempDir()
+	t.Chdir(dir)
+	setupXDGData(t)
+
+	fake := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+
+	client, err := circleci.NewClient(circleci.Config{Token: "fake-token", BaseURL: srv.URL})
+	assert.NilError(t, err)
+
+	stateDir, err := config.ProjectDataDir(dir)
+	assert.NilError(t, err)
+	assert.NilError(t, os.MkdirAll(stateDir, 0o755))
+
+	return &reapEnv{t: t, fake: fake, client: client, stateDir: stateDir}
+}
+
+// writeState writes a state file under name, aged by age, and registers the
+// sidecar as live in the fake unless live is false.
+func (e *reapEnv) writeState(name string, active ActiveSidecar, age time.Duration, live bool) string {
+	e.t.Helper()
+	path := filepath.Join(e.stateDir, name)
+	data, err := json.Marshal(active)
+	assert.NilError(e.t, err)
+	assert.NilError(e.t, os.WriteFile(path, data, 0o644))
+
+	stamp := time.Now().Add(-age)
+	assert.NilError(e.t, os.Chtimes(path, stamp, stamp))
+
+	if live {
+		e.fake.Sidecars = append(e.fake.Sidecars, fakes.Sidecar{
+			ID: active.SidecarID, Name: active.Name, OrgID: testOrg,
+		})
+	}
+	return path
+}
+
+func (e *reapEnv) liveIDs() []string {
+	e.t.Helper()
+	ids := make([]string, 0, len(e.fake.Sidecars))
+	for _, s := range e.fake.Sidecars {
+		ids = append(ids, s.ID)
+	}
+	return ids
+}
+
+func exists(t *testing.T, path string) bool {
+	t.Helper()
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// TestReapDropsStateForVanishedSidecar covers the resurrection bug: a state file
+// naming a sidecar that no longer exists must go, even when it is the file for
+// the current session, since that is exactly the file LoadAnyActive promotes.
+func TestReapDropsStateForVanishedSidecar(t *testing.T) {
+	e := newReapEnv(t)
+	ctx := context.Background()
+	// Written under the no-session name, which is also the current session's name,
+	// and recent enough that the age sweep would never touch it.
+	path := e.writeState("sidecar.json", ActiveSidecar{SidecarID: "sb-dead"}, time.Minute, false)
+
+	res, err := Reap(ctx, e.client, testOrg)
+	assert.NilError(t, err)
+
+	assert.DeepEqual(t, res.Vanished, []string{"sb-dead"})
+	assert.Equal(t, len(res.Deleted), 0)
+	assert.Assert(t, !exists(t, path), "state for a vanished sidecar must be removed")
+}
+
+// TestReapDeletesAbandonedSidecar covers a sidecar that is still running but
+// whose state has not been touched for longer than StaleAfter.
+func TestReapDeletesAbandonedSidecar(t *testing.T) {
+	e := newReapEnv(t)
+	ctx := session.WithID(context.Background(), "sess-current")
+	path := e.writeState("sidecar.sess-old-deadbeef.json",
+		ActiveSidecar{SidecarID: "sb-old", OrgID: testOrg}, StaleAfter+time.Hour, true)
+
+	res, err := Reap(ctx, e.client, testOrg)
+	assert.NilError(t, err)
+
+	assert.DeepEqual(t, res.Deleted, []string{"sb-old"})
+	assert.Assert(t, !exists(t, path), "state for a deleted sidecar must be removed")
+	assert.Equal(t, len(e.liveIDs()), 0, "sidecar must be deleted through the API")
+}
+
+// TestReapKeepsRecentlyUsedSidecar covers a concurrent session on another
+// branch: its sidecar is alive and its state file is warm, so it is not ours to
+// delete.
+func TestReapKeepsRecentlyUsedSidecar(t *testing.T) {
+	e := newReapEnv(t)
+	ctx := session.WithID(context.Background(), "sess-current")
+	path := e.writeState("sidecar.sess-other-deadbeef.json",
+		ActiveSidecar{SidecarID: "sb-busy", OrgID: testOrg}, time.Hour, true)
+
+	res, err := Reap(ctx, e.client, testOrg)
+	assert.NilError(t, err)
+
+	assert.Assert(t, res.Empty(), "a recently used sidecar must be left alone")
+	assert.Assert(t, exists(t, path), "state for a live sidecar in use must be kept")
+	assert.DeepEqual(t, e.liveIDs(), []string{"sb-busy"})
+}
+
+// TestReapSparesCurrentSessionFromAgeSweep covers the sidecar this run is about
+// to use. Even when its state is old, deleting it would only force an immediate
+// recreate.
+func TestReapSparesCurrentSessionFromAgeSweep(t *testing.T) {
+	e := newReapEnv(t)
+	ctx := session.WithID(context.Background(), "sess-current")
+	// No git repo under the temp dir, so the current state file carries no branch.
+	path := e.writeState(StateFileName("sess-current", ""),
+		ActiveSidecar{SidecarID: "sb-mine", OrgID: testOrg}, StaleAfter+time.Hour, true)
+
+	res, err := Reap(ctx, e.client, testOrg)
+	assert.NilError(t, err)
+
+	assert.Assert(t, res.Empty(), "the current session's own sidecar must not be reaped by age")
+	assert.Assert(t, exists(t, path), "the current session's state must be kept")
+	assert.DeepEqual(t, e.liveIDs(), []string{"sb-mine"})
+}
+
+// TestReapFailsOpenWhenListFails covers the case that matters most: an empty or
+// failed listing is not proof of absence, so nothing may be destroyed.
+func TestReapFailsOpenWhenListFails(t *testing.T) {
+	e := newReapEnv(t)
+	ctx := context.Background()
+	path := e.writeState("sidecar.sess-a-deadbeef.json",
+		ActiveSidecar{SidecarID: "sb-1", OrgID: testOrg}, StaleAfter+time.Hour, true)
+	e.fake.ListStatusCode = 500
+
+	res, err := Reap(ctx, e.client, testOrg)
+	assert.Assert(t, err != nil, "a failed list must be reported")
+	assert.Assert(t, res.Empty(), "a failed list must delete nothing")
+	assert.Assert(t, exists(t, path), "a failed list must prune nothing")
+	assert.DeepEqual(t, e.liveIDs(), []string{"sb-1"})
+}
+
+// TestReapIgnoresOtherOrgs covers state recorded against a different org, which
+// this org's listing cannot judge.
+func TestReapIgnoresOtherOrgs(t *testing.T) {
+	e := newReapEnv(t)
+	ctx := context.Background()
+	// Absent from the listing, but only because it belongs to another org.
+	path := e.writeState("sidecar.sess-a-deadbeef.json",
+		ActiveSidecar{SidecarID: "sb-elsewhere", OrgID: "org-2"}, StaleAfter+time.Hour, false)
+
+	res, err := Reap(ctx, e.client, testOrg)
+	assert.NilError(t, err)
+
+	assert.Assert(t, res.Empty(), "another org's sidecar must not be reaped")
+	assert.Assert(t, exists(t, path), "another org's state must be kept")
+}
+
+func TestReapSkipsWithoutOrgOrClient(t *testing.T) {
+	e := newReapEnv(t)
+	ctx := context.Background()
+	path := e.writeState("sidecar.json", ActiveSidecar{SidecarID: "sb-dead"}, time.Minute, false)
+
+	res, err := Reap(ctx, e.client, "")
+	assert.NilError(t, err)
+	assert.Assert(t, res.Empty())
+
+	res, err = Reap(ctx, nil, testOrg)
+	assert.NilError(t, err)
+	assert.Assert(t, res.Empty())
+	assert.Assert(t, exists(t, path), "state must survive a skipped reap")
+}
+
+// TestPruneIDRemovesEveryDuplicate covers the duplication that made a single
+// ClearActive useless: promotion copies an ID into a new file, so the same dead
+// ID is recorded several times over.
+func TestPruneIDRemovesEveryDuplicate(t *testing.T) {
+	e := newReapEnv(t)
+	ctx := context.Background()
+	dup1 := e.writeState("sidecar.json", ActiveSidecar{SidecarID: "sb-dead"}, time.Minute, false)
+	dup2 := e.writeState("sidecar.sess-a-deadbeef.json", ActiveSidecar{SidecarID: "sb-dead"}, time.Hour, false)
+	other := e.writeState("sidecar.sess-b-cafebabe.json", ActiveSidecar{SidecarID: "sb-live"}, time.Hour, true)
+
+	assert.NilError(t, PruneID(ctx, e.client, "sb-dead", false))
+
+	assert.Assert(t, !exists(t, dup1), "every file naming the dead sidecar must go")
+	assert.Assert(t, !exists(t, dup2), "every file naming the dead sidecar must go")
+	assert.Assert(t, exists(t, other), "unrelated state must be untouched")
+	// No remote delete was asked for, so the live sidecar is still there.
+	assert.DeepEqual(t, e.liveIDs(), []string{"sb-live"})
+}
+
+// TestPruneIDDeletesRemoteWhenAsked covers a sidecar that still exists but can
+// never be used again, so it must be deleted rather than orphaned.
+func TestPruneIDDeletesRemoteWhenAsked(t *testing.T) {
+	e := newReapEnv(t)
+	ctx := context.Background()
+	path := e.writeState("sidecar.json", ActiveSidecar{SidecarID: "sb-stale"}, time.Minute, true)
+
+	assert.NilError(t, PruneID(ctx, e.client, "sb-stale", true))
+
+	assert.Assert(t, !exists(t, path))
+	assert.Equal(t, len(e.liveIDs()), 0, "an unusable sidecar must be deleted, not orphaned")
+}
+
+// TestPruneIDDropsStateWhenRemoteDeleteFails covers the ordering that keeps a
+// dead ID from coming back: the local state must go even when the API call for
+// it fails, or the next run reuses the same unusable sidecar.
+func TestPruneIDDropsStateWhenRemoteDeleteFails(t *testing.T) {
+	e := newReapEnv(t)
+	ctx := context.Background()
+	path := e.writeState("sidecar.json", ActiveSidecar{SidecarID: "sb-stale"}, time.Minute, true)
+	e.fake.DeleteStatusCode = 500
+
+	err := PruneID(ctx, e.client, "sb-stale", true)
+	assert.Assert(t, err != nil, "a failed delete must be reported")
+	assert.Assert(t, !exists(t, path), "state must be dropped even when the delete fails")
+}
+
+// TestReapStopsResurrection is the end-to-end shape of the original bug: a dead
+// ID duplicated across files came back through LoadAnyActive on every run.
+func TestReapStopsResurrection(t *testing.T) {
+	e := newReapEnv(t)
+	ctx := context.Background()
+	e.writeState("sidecar.json", ActiveSidecar{SidecarID: "sb-dead"}, time.Minute, false)
+	e.writeState("sidecar.sess-old-deadbeef.json", ActiveSidecar{SidecarID: "sb-dead"}, 20*24*time.Hour, false)
+
+	// Before the reap, the dead sidecar is still promotable.
+	before, err := LoadAnyActive(ctx)
+	assert.NilError(t, err)
+	assert.Assert(t, before != nil)
+	assert.Equal(t, before.SidecarID, "sb-dead")
+
+	_, err = Reap(ctx, e.client, testOrg)
+	assert.NilError(t, err)
+
+	after, err := LoadAnyActive(ctx)
+	assert.NilError(t, err)
+	assert.Assert(t, after == nil, "a reaped sidecar must not be promotable again")
+}
+
+// TestReapDropsStateWhenDeleteReturnsGone covers a sidecar the listing still
+// shows but the API has already let go of. The end state is the same as one that
+// was never listed.
+func TestReapDropsStateWhenDeleteReturnsGone(t *testing.T) {
+	e := newReapEnv(t)
+	ctx := context.Background()
+	path := e.writeState("sidecar.sess-a-deadbeef.json",
+		ActiveSidecar{SidecarID: "sb-ghost", OrgID: testOrg}, StaleAfter+time.Hour, true)
+	e.fake.DeleteStatusCode = 404
+
+	res, err := Reap(ctx, e.client, testOrg)
+	assert.NilError(t, err)
+
+	assert.DeepEqual(t, res.Vanished, []string{"sb-ghost"})
+	assert.Equal(t, len(res.Failed), 0, "a 404 is not a failure to report")
+	assert.Assert(t, !exists(t, path))
+}
+
+// TestReapDropsStateWhenDeleteFails is the regression for the state file that
+// survived a failed delete, became the active sidecar, and made every following
+// run fail against a box the API would not release.
+func TestReapDropsStateWhenDeleteFails(t *testing.T) {
+	e := newReapEnv(t)
+	ctx := context.Background()
+	path := e.writeState("sidecar.sess-a-deadbeef.json",
+		ActiveSidecar{SidecarID: "sb-stuck", OrgID: testOrg}, StaleAfter+time.Hour, true)
+	e.fake.DeleteStatusCode = 500
+
+	res, err := Reap(ctx, e.client, testOrg)
+	assert.NilError(t, err)
+
+	assert.DeepEqual(t, res.Failed, []string{"sb-stuck"})
+	assert.Assert(t, !exists(t, path), "a failed delete must not leave promotable state")
+
+	// The whole point: it cannot come back as the active sidecar.
+	after, err := LoadAnyActive(ctx)
+	assert.NilError(t, err)
+	assert.Assert(t, after == nil, "an undeletable sidecar must not be promotable")
+	assert.Assert(t, strings.Contains(res.Summary(), "may still be running"),
+		"the leak must be reported, got: %s", res.Summary())
+}


### PR DESCRIPTION
## Summary

- Sidecar state is one file per session and branch, and nothing pruned it. `sidecar delete` only cleared the current session's key, so the same ID left behind in another session's file was promoted straight back by `LoadAnyActive` on the next run, and every command against the dead sidecar failed with a bare `add ssh key: 404 Not Found`. One project had 13 files going back seven weeks, two of them naming the same deleted sidecar.
- `validate` now sweeps before it resolves state, so nothing is promoted before it has been checked. State naming a sidecar absent from the org listing is dropped, including the current session's own file, since that file is the one being resurrected and there is no live sidecar left to protect. A sidecar still running whose state has gone untouched for `StaleAfter` (5 days) is deleted through the API, which also reclaims the spend nothing was collecting.
- The sidecar this run is about to use is spared the age sweep, and one that is alive with warm state is left alone so a concurrent session on another branch keeps its own.
- State is dropped whichever way a delete goes. Keeping a file back on failure only makes an undeletable sidecar the one the next resolve picks up, which is the resurrection this exists to stop. A delete that 404s is recorded as already gone. Whatever survives expires on its own, and the summary says so.
- The sweep fails open: without an org that resolves without prompting it skips silently, and a failed listing deletes nothing, since an empty listing is not proof of absence.
- Being listed does not mean usable, so the sweep cannot close the gap on its own. A sidecar can go away between the listing and the sync, and one the API rejects as out of date is listed like any other. A sync that fails either way drops the state, provisions a replacement, and retries once in the same run rather than asking for the same command again. Twice in one run stops rather than churning, and a refused connection is left untouched.
- The 410 wording match this needs already existed in `GoneError`, so it moves to `circleci.SidecarOutOfDate` and both callers share it. `ActiveSidecar` records its org so a sidecar living in an org that is not being listed is not mistaken for a deleted one, and `LoadAnyActive` now shares the state reader with the sweep.]
- 
<img width="1144" height="495" alt="Screenshot 2026-08-07 at 17 55 44" src="https://github.com/user-attachments/assets/4ee4c0ed-4d8a-4f3a-a6dd-c07f072ce4be" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)