### PR TITLE
Pass --whitespace=nowarn to git apply during sidecar sync

### DIFF
--- a/internal/sidecar/sync.go
+++ b/internal/sidecar/sync.go
@@ -217,7 +217,7 @@ func BundleSync(ctx context.Context,
 	}
 	if patch != "" {
 		status(iostream.LevelInfo, fmt.Sprintf("Applying working-tree changes (%d bytes)...", len(patch)))
-		applyCmd := fmt.Sprintf("git -C %s apply", ShellEscape(repoPath))
+		applyCmd := fmt.Sprintf("git -C %s apply --whitespace=nowarn", ShellEscape(repoPath))
 		if result, err := ExecOverSSH(ctx, session, applyCmd, strings.NewReader(patch), nil); err != nil {
 			return fmt.Errorf("bundle sync: apply patch: %w", err)
 		} else if result.ExitCode != 0 {
@@ -359,7 +359,7 @@ func syncWorkspace(ctx context.Context, status iostream.StatusFunc, org, repo, r
 		return fmt.Errorf("git reset failed (exit code: %d): %s", resetResult.ExitCode, detail)
 	}
 
-	applyCmd := fmt.Sprintf("git -C %s apply", ShellEscape(repoPath))
+	applyCmd := fmt.Sprintf("git -C %s apply --whitespace=nowarn", ShellEscape(repoPath))
 	applyResult, err := ExecOverSSH(ctx, session, applyCmd, strings.NewReader(patch), nil)
 	if err != nil {
 		return err

--- a/internal/sidecar/sync_test.go
+++ b/internal/sidecar/sync_test.go
@@ -237,6 +237,85 @@ func TestBundleSync_NoOpSkipsBundle(t *testing.T) {
 		"expected reset --hard HEAD on no-op sync; got: %v", cmds)
 }
 
+// TestBundleSync_ApplyWhitespaceNowarn verifies that BundleSync passes
+// --whitespace=nowarn to git apply so that working-tree files with trailing
+// whitespace do not cause the sync to fail.
+func TestBundleSync_ApplyWhitespaceNowarn(t *testing.T) {
+	keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+
+	sshSrv := fakes.NewSSHServer(t, pubKey)
+	sshSrv.SetResult("", 0)
+
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = sshSrv.Addr()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	t.Setenv(config.EnvHome, t.TempDir())
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
+
+	repoDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	// Write an untracked file with trailing whitespace to force a non-empty patch.
+	assert.NilError(t, os.WriteFile(filepath.Join(repoDir, "trailing.txt"), []byte("hello   \n"), 0o644))
+	t.Chdir(repoDir)
+
+	cl := newClient(t, srv.URL)
+	noopStatus := iostream.StatusFunc(func(_ iostream.Level, _ string) {})
+
+	err := sidecar.BundleSync(context.Background(), cl, "sb-1", keyFile, "", "", repoDir, noopStatus)
+	assert.NilError(t, err)
+
+	var applyCmd string
+	for _, c := range sshSrv.Commands() {
+		if strings.Contains(c, "git") && strings.Contains(c, "apply") {
+			applyCmd = c
+			break
+		}
+	}
+	assert.Assert(t, applyCmd != "", "expected a git apply command; got: %v", sshSrv.Commands())
+	assert.Assert(t, strings.Contains(applyCmd, "--whitespace=nowarn"),
+		"git apply must use --whitespace=nowarn; got: %q", applyCmd)
+}
+
+// TestSync_ApplyWhitespaceNowarn verifies that the legacy Sync path also passes
+// --whitespace=nowarn to git apply.
+func TestSync_ApplyWhitespaceNowarn(t *testing.T) {
+	keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+
+	sshSrv := fakes.NewSSHServer(t, pubKey)
+	sshSrv.SetResult("", 0)
+
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = sshSrv.Addr()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	t.Setenv(config.EnvHome, t.TempDir())
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
+
+	repoDir := setupRepoWithOriginHEAD(t, "my-org", "my-repo")
+	// Write an untracked file with trailing whitespace to force a non-empty patch.
+	assert.NilError(t, os.WriteFile(filepath.Join(repoDir, "trailing.txt"), []byte("hello   \n"), 0o644))
+	t.Chdir(repoDir)
+
+	cl := newClient(t, srv.URL)
+	noopStatus := iostream.StatusFunc(func(_ iostream.Level, _ string) {})
+
+	err := sidecar.Sync(context.Background(), cl, "sb-1", keyFile, "", "", noopStatus)
+	assert.NilError(t, err)
+
+	var applyCmd string
+	for _, c := range sshSrv.Commands() {
+		if strings.Contains(c, "git") && strings.Contains(c, "apply") {
+			applyCmd = c
+			break
+		}
+	}
+	assert.Assert(t, applyCmd != "", "expected a git apply command; got: %v", sshSrv.Commands())
+	assert.Assert(t, strings.Contains(applyCmd, "--whitespace=nowarn"),
+		"git apply must use --whitespace=nowarn; got: %q", applyCmd)
+}
+
 func containsMatch(cmds []string, substr string) bool {
 	for _, c := range cmds {
 		if strings.Contains(c, substr) {


### PR DESCRIPTION
## Summary

`git apply` exits non-zero when a patch contains trailing whitespace, which was causing `BundleSync` (and the legacy `syncWorkspace` path) to surface a hard failure:

```
✗ Error: Could not sync to sidecar.
  bundle sync: apply patch: <stdin>:36: trailing whitespace.
```

Fix: add `--whitespace=nowarn` to both `git apply` invocations so the patch is applied as-is, faithfully mirroring the local working tree. We don't want `--whitespace=fix` here since that would silently rewrite the user's files on the sidecar.

## Test plan

- [ ] `go test ./internal/sidecar/ -race` passes
- [ ] Reproduce with a file that has trailing whitespace — sync no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)