### PR TITLE
update mutation testing skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ PLANS.md
 # unikraft
 .unikraft/
 test-fetch-on-stale-sidecar.log
+
+# toolchain installers downloaded into the repo root
+*.pkg
+*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ PLANS.md
 .chunk/sidecar.json
 .chunk/sidecar.*.json
 
+# mutation variants scratch file
+.chunk/variants.json
+
 # hook disable sentinel
 .chunk/hooks-disabled
 

--- a/acceptance/validate_variants_test.go
+++ b/acceptance/validate_variants_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/binary"
 	testenv "github.com/CircleCI-Public/chunk-cli/internal/testing/env"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/gitrepo"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/recorder"
 	"github.com/CircleCI-Public/chunk-cli/internal/variants"
 )
@@ -158,7 +159,9 @@ func TestValidateVariantsNamedCommand(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.CircleCIURL = srv.URL
 
-	workDir := env.HomeDir
+	// A git repo with an origin remote, so the remote workspace resolves to the
+	// same <sidecarHome>/<repo> the rest of the CLI syncs into.
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
 	writeChunkConfig(t, workDir, nil)
 	path := writeVariantsFile(t, workDir, []variants.Variant{
 		{ID: "MUT-001"},
@@ -207,7 +210,7 @@ func TestValidateVariantsCreatesAndDeletesSidecars(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.CircleCIURL = srv.URL
 
-	workDir := env.HomeDir
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
 	writeChunkConfig(t, workDir, nil)
 	path := writeVariantsFile(t, workDir, []variants.Variant{
 		{ID: "MUT-001"},
@@ -244,7 +247,7 @@ func TestValidateVariantsImageFromConfig(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.CircleCIURL = srv.URL
 
-	workDir := env.HomeDir
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
 	writeChunkConfig(t, workDir, map[string]interface{}{
 		"validation": map[string]interface{}{
 			"sidecarImage": "snap-from-config",
@@ -264,8 +267,79 @@ func TestValidateVariantsImageFromConfig(t *testing.T) {
 	creates := filterVariantRequests(reqs, "POST", "/api/v3/sidecar/instances")
 	assert.Assert(t, len(creates) >= 1, "expected at least 1 create request")
 
-	var body map[string]interface{}
+	// CreateSidecar sends the V3 envelope, so the image lives under
+	// data.attributes rather than at the top level. Asserting on the request body
+	// rather than cci.Sidecars because the run deletes its sidecar on the way out,
+	// leaving nothing in the fake's list to inspect.
+	var body struct {
+		Data struct {
+			Attributes struct {
+				Name  string `json:"name"`
+				Image string `json:"image"`
+			} `json:"attributes"`
+		} `json:"data"`
+	}
 	assert.NilError(t, json.Unmarshal(creates[0].Body, &body))
-	assert.Equal(t, body["image"], "snap-from-config",
-		"expected image from config, got: %v", body["image"])
+	assert.Equal(t, body.Data.Attributes.Image, "snap-from-config")
+	assert.Assert(t, strings.HasPrefix(body.Data.Attributes.Name, "variant-"),
+		"expected a variant-prefixed sidecar name, got %q", body.Data.Attributes.Name)
+}
+
+// TestValidateVariantsUnresolvableWorkspace pins the pre-flight failure. With no
+// origin remote and no active sidecar there is no way to know where the snapshot
+// prepared its dependencies, and guessing a path means every command fails for
+// environmental reasons and every mutant reads as caught. Failing before any
+// sidecar is booted is the only safe answer.
+func TestValidateVariantsUnresolvableWorkspace(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	// Not a git repo, so no org/repo can be detected.
+	workDir := t.TempDir()
+	writeChunkConfig(t, workDir, nil)
+	path := writeVariantsFile(t, workDir, []variants.Variant{
+		{ID: "MUT-001"},
+	})
+
+	result := binary.RunCLI(t, []string{
+		"validate", "variants", path,
+		"--org-id", "org-aaa",
+		"--image", "snap-abc",
+	}, env, workDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit code")
+	creates := filterVariantRequests(cci.Recorder.AllRequests(), "POST", "/api/v3/sidecar/instances")
+	assert.Equal(t, len(creates), 0, "no sidecar may be booted when the workspace is unknown")
+}
+
+// TestValidateVariantsWorkdirFlagOverridesDetection confirms --workdir still
+// works without a git remote, which is the escape hatch the error above suggests.
+func TestValidateVariantsWorkdirFlagOverridesDetection(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	workDir := t.TempDir()
+	writeChunkConfig(t, workDir, nil)
+	path := writeVariantsFile(t, workDir, []variants.Variant{
+		{ID: "MUT-001"},
+	})
+
+	result := binary.RunCLI(t, []string{
+		"validate", "variants", path,
+		"--org-id", "org-aaa",
+		"--image", "snap-abc",
+		"--workdir", "/home/user/my-repo",
+	}, env, workDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s\nstdout: %s", result.Stderr, result.Stdout)
+	creates := filterVariantRequests(cci.Recorder.AllRequests(), "POST", "/api/v3/sidecar/instances")
+	assert.Assert(t, len(creates) >= 1, "expected a sidecar to be created")
 }

--- a/acceptance/validate_variants_test.go
+++ b/acceptance/validate_variants_test.go
@@ -1,0 +1,271 @@
+package acceptance
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/chunk-cli/internal/testing/env"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/recorder"
+	"github.com/CircleCI-Public/chunk-cli/internal/variants"
+)
+
+// writeVariantsFile writes a variants JSON file to dir and returns its path.
+func writeVariantsFile(t *testing.T, dir string, vs []variants.Variant) string {
+	t.Helper()
+	data, err := json.Marshal(vs)
+	assert.NilError(t, err)
+	path := filepath.Join(dir, "variants.json")
+	assert.NilError(t, os.WriteFile(path, data, 0o644))
+	return path
+}
+
+// writeChunkConfig writes a minimal .chunk/config.json with one remote command.
+func writeChunkConfig(t *testing.T, dir string, extra map[string]interface{}) {
+	t.Helper()
+	chunkDir := filepath.Join(dir, ".chunk")
+	assert.NilError(t, os.MkdirAll(chunkDir, 0o755))
+	cfg := map[string]interface{}{
+		"commands": []map[string]interface{}{
+			{"name": "test", "run": "go test ./...", "remote": true},
+		},
+	}
+	for k, v := range extra {
+		cfg[k] = v
+	}
+	data, err := json.Marshal(cfg)
+	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), data, 0o644))
+}
+
+func filterVariantRequests(reqs []recorder.RecordedRequest, method, pathPrefix string) []recorder.RecordedRequest {
+	var out []recorder.RecordedRequest
+	for _, r := range reqs {
+		if r.Method == method && strings.HasPrefix(r.URL.Path, pathPrefix) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func TestValidateVariantsMissingFile(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+
+	result := binary.RunCLI(t, []string{
+		"validate", "variants", "/nonexistent/variants.json",
+		"--org-id", "org-aaa",
+	}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit code")
+}
+
+func TestValidateVariantsMissingArg(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+
+	result := binary.RunCLI(t, []string{"validate", "variants"}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit code")
+}
+
+func TestValidateVariantsMalformedJSON(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	path := filepath.Join(env.HomeDir, "bad.json")
+	assert.NilError(t, os.WriteFile(path, []byte("not json"), 0o644))
+
+	result := binary.RunCLI(t, []string{
+		"validate", "variants", path,
+		"--org-id", "org-aaa",
+	}, env, env.HomeDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit code")
+}
+
+func TestValidateVariantsEmptyArray(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	path := filepath.Join(env.HomeDir, "empty.json")
+	assert.NilError(t, os.WriteFile(path, []byte("[]"), 0o644))
+
+	result := binary.RunCLI(t, []string{
+		"validate", "variants", path,
+		"--org-id", "org-aaa",
+	}, env, env.HomeDir)
+
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(result.Stderr, "No variants"),
+		"expected 'No variants' in stderr, got: %s", result.Stderr)
+}
+
+func TestValidateVariantsMissingToken(t *testing.T) {
+	env := testenv.NewTestEnv(t)
+	env.CircleToken = ""
+
+	workDir := env.HomeDir
+	writeChunkConfig(t, workDir, nil)
+	path := writeVariantsFile(t, workDir, []variants.Variant{
+		{ID: "MUT-001", Description: "test"},
+	})
+
+	result := binary.RunCLI(t, []string{
+		"validate", "variants", path,
+		"--org-id", "org-aaa",
+	}, env, workDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit code")
+}
+
+func TestValidateVariantsNoRemoteCommands(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	workDir := env.HomeDir
+	// Write config with only local (non-remote) commands.
+	chunkDir := filepath.Join(workDir, ".chunk")
+	assert.NilError(t, os.MkdirAll(chunkDir, 0o755))
+	cfg := `{"commands":[{"name":"test","run":"go test ./...","remote":false}]}`
+	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), []byte(cfg), 0o644))
+
+	path := writeVariantsFile(t, workDir, []variants.Variant{
+		{ID: "MUT-001"},
+	})
+
+	result := binary.RunCLI(t, []string{
+		"validate", "variants", path,
+		"--org-id", "org-aaa",
+	}, env, workDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit code")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "remote"),
+		"expected 'remote' in error output, got: %s", combined)
+}
+
+func TestValidateVariantsNamedCommand(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	workDir := env.HomeDir
+	writeChunkConfig(t, workDir, nil)
+	path := writeVariantsFile(t, workDir, []variants.Variant{
+		{ID: "MUT-001"},
+	})
+
+	// --name references a command that is not marked remote; still accepted since
+	// --name bypasses the remote filter.
+	result := binary.RunCLI(t, []string{
+		"validate", "variants", path,
+		"--org-id", "org-aaa",
+		"--name", "test",
+	}, env, workDir)
+
+	// Command exits 0; individual errors are in JSON results (Sync fails — no SSH).
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s\nstdout: %s", result.Stderr, result.Stdout)
+}
+
+func TestValidateVariantsUnknownNamedCommand(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	workDir := env.HomeDir
+	writeChunkConfig(t, workDir, nil)
+	path := writeVariantsFile(t, workDir, []variants.Variant{
+		{ID: "MUT-001"},
+	})
+
+	result := binary.RunCLI(t, []string{
+		"validate", "variants", path,
+		"--org-id", "org-aaa",
+		"--name", "nonexistent",
+	}, env, workDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit code")
+}
+
+func TestValidateVariantsCreatesAndDeletesSidecars(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	workDir := env.HomeDir
+	writeChunkConfig(t, workDir, nil)
+	path := writeVariantsFile(t, workDir, []variants.Variant{
+		{ID: "MUT-001"},
+		{ID: "MUT-002"},
+	})
+
+	result := binary.RunCLI(t, []string{
+		"validate", "variants", path,
+		"--org-id", "org-aaa",
+		"--image", "snap-abc",
+	}, env, workDir)
+
+	// Command exits 0; Sync fails (no git repo / no SSH) but that's captured in Result.Error.
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s\nstdout: %s", result.Stderr, result.Stdout)
+
+	reqs := cci.Recorder.AllRequests()
+	creates := filterVariantRequests(reqs, "POST", "/api/v3/sidecar/instances")
+	deletes := filterVariantRequests(reqs, "DELETE", "/api/v3/sidecar/instances/")
+	assert.Check(t, len(creates) >= 2, "expected 2 create requests, got %d", len(creates))
+	assert.Check(t, len(deletes) >= 2, "expected 2 delete requests, got %d", len(deletes))
+
+	// Output should be valid JSON array.
+	var results []map[string]interface{}
+	assert.NilError(t, json.Unmarshal([]byte(result.Stdout), &results),
+		"expected valid JSON array in stdout, got: %s", result.Stdout)
+	assert.Equal(t, len(results), 2)
+}
+
+func TestValidateVariantsImageFromConfig(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+
+	workDir := env.HomeDir
+	writeChunkConfig(t, workDir, map[string]interface{}{
+		"validation": map[string]interface{}{
+			"sidecarImage": "snap-from-config",
+		},
+	})
+	path := writeVariantsFile(t, workDir, []variants.Variant{
+		{ID: "MUT-001"},
+	})
+
+	binary.RunCLI(t, []string{
+		"validate", "variants", path,
+		"--org-id", "org-aaa",
+		// No --image flag; should use config value.
+	}, env, workDir)
+
+	reqs := cci.Recorder.AllRequests()
+	creates := filterVariantRequests(reqs, "POST", "/api/v3/sidecar/instances")
+	assert.Assert(t, len(creates) >= 1, "expected at least 1 create request")
+
+	var body map[string]interface{}
+	assert.NilError(t, json.Unmarshal(creates[0].Body, &body))
+	assert.Equal(t, body["image"], "snap-from-config",
+		"expected image from config, got: %v", body["image"])
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -74,6 +74,14 @@ chunk
 │   --project <path>                # Override project directory
 │   -e / --env KEY=VALUE            # Set env var in remote sidecar session (repeatable)
 │   --env-file <path>               # Env file to load (default: .env.local; pass a path to override)
+│   │
+│   └── variants <variants-file>    # Run code variants on parallel throwaway sidecars
+│       --name <command>            # Validate command to run (default: all remote commands)
+│       --parallel <n>              # Max concurrent sidecars (default 5)
+│       --org-id <id>               # Organization ID
+│       --image <id>                # Snapshot image ID (default: validation.sidecarImage)
+│       --identity-file <path>      # SSH identity file
+│       --workdir <path>            # Remote working directory
 │
 ├── sidecar
 │   ├── list                        # List sidecars
@@ -191,6 +199,16 @@ chunk
   without one, and deletes nothing if the listing fails, since an empty listing is
   not proof of absence. A sidecar the API rejects as out of date (410) is deleted
   when a sync hits it, because no listing reveals that state.
+- **`validate variants` sidecars are outside that scheme.** Each variant gets its
+  own sidecar, and none of them are written to the active-sidecar file — parallel
+  workers would race on it and leave the user's own session pointing at a sidecar
+  about to be deleted. That also makes them invisible to the reaper above, so the
+  command cleans up after itself instead: it deletes each sidecar as its variant
+  finishes, catches SIGINT/SIGTERM so an interrupt still unwinds through those
+  deletes, and sweeps any sidecar named `variant-*` left over by an earlier
+  crashed run before starting a new one. For the same reason `validate variants`
+  syncs without persisting a workspace and therefore requires a resolvable
+  workdir.
 - Commands that require a CircleCI token (`task run`, `task config`, `sidecar *`,
   `validate --sidecar-id`) prompt for it inline at the point of need rather than
   failing with an error.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -78,6 +78,7 @@ chunk
 │   └── variants <variants-file>    # Run code variants on parallel throwaway sidecars
 │       --name <command>            # Validate command to run (default: all remote commands)
 │       --parallel <n>              # Max concurrent sidecars (default 5)
+│       --timeout <seconds>         # Per-command timeout when the command sets none (0 for no limit)
 │       --org-id <id>               # Organization ID
 │       --image <id>                # Snapshot image ID (default: validation.sidecarImage)
 │       --identity-file <path>      # SSH identity file
@@ -205,10 +206,26 @@ chunk
   about to be deleted. That also makes them invisible to the reaper above, so the
   command cleans up after itself instead: it deletes each sidecar as its variant
   finishes, catches SIGINT/SIGTERM so an interrupt still unwinds through those
-  deletes, and sweeps any sidecar named `variant-*` left over by an earlier
-  crashed run before starting a new one. For the same reason `validate variants`
-  syncs without persisting a workspace and therefore requires a resolvable
-  workdir.
+  deletes, and sweeps stranded `variant-*` sidecars from an earlier crashed run
+  before starting a new one. Variant sidecar names carry the run's start time
+  (`variant-<base36 seconds>-<id>`), which is what lets the sweep spare a
+  concurrent run's in-flight sidecars — two runs at once, in two worktrees or two
+  repos, is a normal shape for the mutation-testing skill — and only collect ones
+  too old for any live run to own. For the same reason `validate variants` syncs
+  without persisting a workspace and therefore requires a resolvable workdir; it
+  resolves one through `sidecar.ResolveWorkspace`, the same
+  `--workdir` → active sidecar → `<sidecarHome>/<repo>` order as every other
+  sidecar command, and fails before booting anything when none of the three
+  applies.
+- **`validate variants` never reports an environmental failure as a caught
+  mutant.** A killed variant means the validate command ran and exited non-zero
+  on its own terms. Exit codes 126 and 127 are the shell failing to run the
+  command at all, and a command that outruns its timeout never returned a verdict;
+  both are recorded as errors instead, and errors are neither kills nor survivors.
+  Commands are template-expanded locally before being shipped, since a literal
+  `{{CHANGED_PACKAGES}}` reaching the remote shell would otherwise fail every
+  variant the same way. The command warns when every variant was killed, because
+  that pattern is more often one broken command than a fully covered codebase.
 - Commands that require a CircleCI token (`task run`, `task config`, `sidecar *`,
   `validate --sidecar-id`) prompt for it inline at the point of need rather than
   failing with an error.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -207,11 +207,16 @@ chunk
   command cleans up after itself instead: it deletes each sidecar as its variant
   finishes, catches SIGINT/SIGTERM so an interrupt still unwinds through those
   deletes, and sweeps stranded `variant-*` sidecars from an earlier crashed run
-  before starting a new one. Variant sidecar names carry the run's start time
-  (`variant-<base36 seconds>-<id>`), which is what lets the sweep spare a
+  before starting a new one. Each name carries that sidecar's own creation time
+  (`variant-<base36 seconds>--<id>`), which is what lets the sweep spare a
   concurrent run's in-flight sidecars — two runs at once, in two worktrees or two
   repos, is a normal shape for the mutation-testing skill — and only collect ones
-  too old for any live run to own. For the same reason `validate variants` syncs
+  too old for any live run to own. Per-sidecar rather than per-run, because a run
+  of a hundred variants takes hours and its newest sidecar must not inherit the
+  age of the run that booted it. The delimiter is two dashes and variant IDs are
+  sanitised to collapse dash runs, so the timestamp is recoverable by a plain
+  split rather than by guessing which segment is a date. A name without one is
+  reported and left alone. For the same reason `validate variants` syncs
   without persisting a workspace and therefore requires a resolvable workdir; it
   resolves one through `sidecar.ResolveWorkspace`, the same
   `--workdir` → active sidecar → `<sidecarHome>/<repo>` order as every other

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -153,7 +153,7 @@ After installing, your agent gains these skills:
 |---|---|---|
 | `chunk-review` | "review my changes" / "chunk review" | Applies your team's review standards to the current diff |
 | `chunk-sidecar` | "validate on the sidecar" / "sidecar dev loop" | Syncs and validates changes on a remote CircleCI environment |
-| `chunk-testing-gaps` | "find testing gaps" / "mutation test" | Runs mutation testing to find undertested code |
+| `chunk-testing-gaps` | "find testing gaps" / "mutation test" | Runs mutation testing on parallel sidecars to find undertested code |
 | `debug-ci-failures` | "debug CI" / "why is CI failing" | Analyzes CircleCI build failures and flaky tests |
 
 See [docs/SKILLS.md](SKILLS.md) for full details on each skill.

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -117,9 +117,11 @@ Runs a four-stage mutation testing process to find undertested code paths.
 **What it does**:
 
 1. **Discovery** — identifies mutation candidates in changed code
-2. **Validation** — verifies surviving mutants using git worktrees and CI
+2. **Validation** — triages candidates locally, then runs the survivors on parallel throwaway sidecars via `chunk validate variants`
 3. **Production cross-reference** — checks whether survivors touch production code paths
 4. **Risk assessment** — reports high-risk survivors with recommended tests
+
+Mutants never leave your machine as VCS artifacts: each one is carried as a patch and applied on a sidecar that is deleted afterwards. No branches are pushed and no pull requests are opened.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.54.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/term v0.45.0
 	gotest.tools/v3 v3.5.2
 )
@@ -260,7 +261,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect

--- a/internal/cmd/errmsg.go
+++ b/internal/cmd/errmsg.go
@@ -8,6 +8,7 @@ const (
 	msgCouldNotLoadSidecar      = "Could not load the active sidecar."
 	msgHomeNotSet               = "HOME environment variable is not set."
 	errMsgHomeNotSet            = "HOME not set"
+	msgValidateNotConfigured    = "No validate commands configured."
 
 	suggestionCheckPerms   = "Check file permissions."
 	suggestionNetworkRetry = "Check your network connection and try again."

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -266,7 +266,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			return nil // no config in hook context: skip silently
 		}
 		return &userError{
-			msg:        "No validate commands configured.",
+			msg:        msgValidateNotConfigured,
 			suggestion: suggestionValidateNotConfigured,
 			errMsg:     "no validate commands configured",
 			hideDetail: true,
@@ -997,7 +997,7 @@ func execTarget(opts *validateOpts, cfg *config.ProjectConfig, active *sidecar.A
 func mapValidateError(err error) error {
 	if errors.Is(err, validate.ErrNotConfigured) {
 		return &userError{
-			msg:        "No validate commands configured.",
+			msg:        msgValidateNotConfigured,
 			suggestion: suggestionValidateNotConfigured,
 			hideDetail: true,
 			err:        err,

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -137,6 +137,8 @@ func newValidateCmd() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&opts.envVarsFlag, "env", "e", nil, "KEY=VALUE pairs to set in remote sidecar session (repeatable)")
 	cmd.Flags().StringVar(&opts.envFile, "env-file", defaultEnvFile, "Env file to load (default: .env.local; pass a path to override)")
 
+	cmd.AddCommand(newValidateVariantsCmd())
+
 	return cmd
 }
 

--- a/internal/cmd/validate_variants.go
+++ b/internal/cmd/validate_variants.go
@@ -1,0 +1,182 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
+	"github.com/CircleCI-Public/chunk-cli/internal/tui"
+	"github.com/CircleCI-Public/chunk-cli/internal/variants"
+)
+
+func newValidateVariantsCmd() *cobra.Command {
+	var name, orgID, image, identityFile, workdir string
+	var parallel int
+
+	cmd := &cobra.Command{
+		Use:          "variants <variants-file>",
+		Short:        "Run validation commands against code variants on parallel sidecars",
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			streams := iostream.FromCmd(cmd)
+			ctx := cmd.Context()
+
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return &userError{
+					msg: fmt.Sprintf("Could not read variants file %q.", args[0]),
+					err: err,
+				}
+			}
+			var vs []variants.Variant
+			if err := json.Unmarshal(data, &vs); err != nil {
+				return &userError{
+					msg:        "Invalid variants file.",
+					suggestion: "Expected a JSON array of {id, description, patch} objects.",
+					err:        err,
+				}
+			}
+			if len(vs) == 0 {
+				streams.ErrPrintln("No variants to run.")
+				return nil
+			}
+
+			workDir, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			cfg, err := config.LoadProjectConfig(workDir)
+			if err != nil {
+				return &userError{
+					msg:        "No validate commands configured.",
+					suggestion: "Run 'chunk init' first.",
+					err:        err,
+				}
+			}
+
+			var cmds []config.Command
+			if name != "" {
+				c := cfg.FindCommand(name)
+				if c == nil {
+					return &userError{
+						msg:    fmt.Sprintf("Command %q is not configured.", name),
+						errMsg: fmt.Sprintf("command %q not found", name),
+					}
+				}
+				cmds = []config.Command{*c}
+			} else {
+				for _, c := range cfg.Commands {
+					if c.Remote {
+						cmds = append(cmds, c)
+					}
+				}
+			}
+			if len(cmds) == 0 {
+				return &userError{
+					msg:        "No remote commands configured.",
+					suggestion: "Mark at least one command as remote in .chunk/config.json, or use --name to specify a command.",
+					errMsg:     "no remote commands configured",
+				}
+			}
+
+			rc, _ := config.Resolve("", "", insecureStorageFlag(cmd))
+			client, err := ensureCircleCIClient(ctx, cmd, rc, streams, tui.PromptHidden)
+			if err != nil {
+				return err
+			}
+
+			if orgID == "" && cfg.OrgID != "" {
+				orgID = cfg.OrgID
+			}
+			resolvedOrgID, err := resolveOrgID(orgID, workDir, orgPicker(ctx, client))
+			if err != nil {
+				return err
+			}
+
+			if image == "" && cfg.Validation != nil {
+				image = cfg.Validation.SidecarImage
+			}
+
+			workspace := resolveVariantsWorkspace(ctx, workdir, workDir)
+
+			// Sweep before booting anything: a crashed earlier run can leave
+			// sidecars the reaper will never collect, because variant sidecars
+			// are deliberately absent from the active-sidecar file.
+			statusFn := newStatusFunc(streams)
+			if swept := variants.SweepOrphans(ctx, client, resolvedOrgID, statusFn); swept > 0 {
+				statusFn(iostream.LevelInfo, fmt.Sprintf("swept %d orphaned variant sidecar(s) from a previous run", swept))
+			}
+
+			cmdStrings := make([]string, len(cmds))
+			for i, c := range cmds {
+				cmdStrings[i] = c.Run
+			}
+
+			authSock := os.Getenv(config.EnvSSHAuthSock)
+			results, err := variants.Run(ctx, client, vs, variants.Options{
+				OrgID:        resolvedOrgID,
+				Image:        image,
+				IdentityFile: identityFile,
+				AuthSock:     authSock,
+				Workspace:    workspace,
+				Parallel:     parallel,
+				Commands:     cmdStrings,
+				StatusFn:     statusFn,
+			})
+			if err != nil {
+				return &userError{msg: "Variants run failed.", err: err}
+			}
+
+			killed := 0
+			for _, r := range results {
+				if r.Killed {
+					killed++
+				}
+			}
+			statusFn(iostream.LevelDone, fmt.Sprintf("%d/%d variants killed", killed, len(results)))
+
+			out, err := json.MarshalIndent(results, "", "  ")
+			if err != nil {
+				return fmt.Errorf("encode results: %w", err)
+			}
+			streams.Printf("%s\n", out)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Validate command name to run (default: all remote commands)")
+	cmd.Flags().IntVar(&parallel, "parallel", 5, "Max concurrent sidecars")
+	cmd.Flags().StringVar(&orgID, "org-id", "", "Organization ID")
+	cmd.Flags().StringVar(&image, "image", "", "Snapshot image ID (default: validation.sidecarImage from config)")
+	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file")
+	cmd.Flags().StringVar(&workdir, "workdir", "", "Remote working directory")
+
+	return cmd
+}
+
+// resolveVariantsWorkspace derives the remote workspace path for variant workers.
+// Every worker gets the same path, which is safe because each one drives its own
+// sidecar: the path collides only within a machine, and no two variants share a
+// machine. Priority: --workdir flag, active sidecar, git remote default. The
+// result is always non-empty, which SyncEphemeral requires.
+func resolveVariantsWorkspace(ctx context.Context, workdirFlag, projectDir string) string {
+	if workdirFlag != "" {
+		return workdirFlag
+	}
+	if active, err := sidecar.LoadActive(ctx); err == nil && active != nil && active.Workspace != "" {
+		return active.Workspace
+	}
+	_, repo, err := gitremote.DetectOrgAndRepo(projectDir)
+	if err == nil && repo != "" {
+		return "./workspace/" + repo
+	}
+	return "./workspace"
+}

--- a/internal/cmd/validate_variants.go
+++ b/internal/cmd/validate_variants.go
@@ -57,7 +57,7 @@ func newValidateVariantsCmd() *cobra.Command {
 			cfg, err := config.LoadProjectConfig(workDir)
 			if err != nil {
 				return &userError{
-					msg:        "No validate commands configured.",
+					msg:        msgValidateNotConfigured,
 					suggestion: "Run 'chunk init' first.",
 					err:        err,
 				}

--- a/internal/cmd/validate_variants.go
+++ b/internal/cmd/validate_variants.go
@@ -13,12 +13,13 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
 	"github.com/CircleCI-Public/chunk-cli/internal/tui"
+	"github.com/CircleCI-Public/chunk-cli/internal/validate"
 	"github.com/CircleCI-Public/chunk-cli/internal/variants"
 )
 
 func newValidateVariantsCmd() *cobra.Command {
 	var name, orgID, image, identityFile, workdir string
-	var parallel int
+	var parallel, timeout int
 
 	cmd := &cobra.Command{
 		Use:          "variants <variants-file>",
@@ -105,7 +106,14 @@ func newValidateVariantsCmd() *cobra.Command {
 				image = cfg.Validation.SidecarImage
 			}
 
-			workspace := resolveVariantsWorkspace(ctx, workdir, workDir)
+			workspace, err := resolveVariantsWorkspace(ctx, workdir, workDir)
+			if err != nil {
+				return &userError{
+					msg:        "Could not determine the remote workspace to sync into.",
+					suggestion: "Run from a clone with an 'origin' remote, or pass --workdir.",
+					err:        err,
+				}
+			}
 
 			// Sweep before booting anything: a crashed earlier run can leave
 			// sidecars the reaper will never collect, because variant sidecars
@@ -113,11 +121,6 @@ func newValidateVariantsCmd() *cobra.Command {
 			statusFn := newStatusFunc(streams)
 			if swept := variants.SweepOrphans(ctx, client, resolvedOrgID, statusFn); swept > 0 {
 				statusFn(iostream.LevelInfo, fmt.Sprintf("swept %d orphaned variant sidecar(s) from a previous run", swept))
-			}
-
-			cmdStrings := make([]string, len(cmds))
-			for i, c := range cmds {
-				cmdStrings[i] = c.Run
 			}
 
 			authSock := os.Getenv(config.EnvSSHAuthSock)
@@ -128,20 +131,13 @@ func newValidateVariantsCmd() *cobra.Command {
 				AuthSock:     authSock,
 				Workspace:    workspace,
 				Parallel:     parallel,
-				Commands:     cmdStrings,
+				Commands:     variantCommands(cmds, workDir, timeout),
 				StatusFn:     statusFn,
 			})
 			if err != nil {
 				return &userError{msg: "Variants run failed.", err: err}
 			}
-
-			killed := 0
-			for _, r := range results {
-				if r.Killed {
-					killed++
-				}
-			}
-			statusFn(iostream.LevelDone, fmt.Sprintf("%d/%d variants killed", killed, len(results)))
+			reportVariantSummary(results, statusFn)
 
 			out, err := json.MarshalIndent(results, "", "  ")
 			if err != nil {
@@ -154,6 +150,8 @@ func newValidateVariantsCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&name, "name", "", "Validate command name to run (default: all remote commands)")
 	cmd.Flags().IntVar(&parallel, "parallel", 5, "Max concurrent sidecars")
+	cmd.Flags().IntVar(&timeout, "timeout", validate.DefaultTimeout,
+		"Per-command timeout in seconds, used when the command sets none (0 for no limit)")
 	cmd.Flags().StringVar(&orgID, "org-id", "", "Organization ID")
 	cmd.Flags().StringVar(&image, "image", "", "Snapshot image ID (default: validation.sidecarImage from config)")
 	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file")
@@ -162,21 +160,89 @@ func newValidateVariantsCmd() *cobra.Command {
 	return cmd
 }
 
+// variantCommands prepares the configured commands for remote execution.
+//
+// Templates are expanded here, exactly as the ordinary remote path does in
+// validate.RunRemote. Shipping a command unexpanded does not fail loudly: the
+// literal {{CHANGED_PACKAGES}} reaches the sidecar's shell, which exits non-zero
+// for a reason that has nothing to do with the code under test, and every variant
+// in the run would be recorded as a caught mutant.
+func variantCommands(cmds []config.Command, workDir string, defaultTimeout int) []variants.Command {
+	out := make([]variants.Command, len(cmds))
+	for i, c := range cmds {
+		out[i] = variants.Command{
+			Name:    c.Name,
+			Run:     validate.ExpandCommand(workDir, c.Run),
+			Timeout: commandTimeout(c.Timeout, defaultTimeout),
+		}
+	}
+	return out
+}
+
+// commandTimeout picks the timeout for one command in seconds: the command's own
+// setting when it has one, otherwise the run-wide default. A run-wide default of
+// 0 means no limit, which is why this cannot simply take the larger of the two.
+func commandTimeout(configured, fallback int) int {
+	if configured > 0 {
+		return configured
+	}
+	return fallback
+}
+
+// reportVariantSummary prints the run tally to stderr, alongside the JSON results
+// on stdout.
+//
+// It calls out anything that makes a clean-looking result untrustworthy.
+// Unassessed variants are gaps in the report rather than passes, and a run where
+// nothing survived at all is more often one validate command failing the same way
+// on every sidecar than a perfectly covered codebase — the two are
+// indistinguishable in the per-variant JSON, so the difference has to be said out
+// loud.
+func reportVariantSummary(results []variants.Result, statusFn iostream.StatusFunc) {
+	killed, unassessed := 0, 0
+	for _, r := range results {
+		switch {
+		case r.Killed:
+			killed++
+		case r.Error != "":
+			unassessed++
+		}
+	}
+
+	statusFn(iostream.LevelDone, fmt.Sprintf("%d/%d variants killed", killed, len(results)))
+	if unassessed > 0 {
+		statusFn(iostream.LevelWarn, fmt.Sprintf(
+			"%d variant(s) were not assessed and are neither killed nor survivors — see the 'error' field", unassessed))
+	}
+	if len(results) > 1 && killed == len(results) {
+		statusFn(iostream.LevelWarn,
+			"every variant was killed — check the failures look like test failures rather than a command that could not run on the snapshot")
+	}
+}
+
 // resolveVariantsWorkspace derives the remote workspace path for variant workers.
 // Every worker gets the same path, which is safe because each one drives its own
 // sidecar: the path collides only within a machine, and no two variants share a
-// machine. Priority: --workdir flag, active sidecar, git remote default. The
-// result is always non-empty, which SyncEphemeral requires.
-func resolveVariantsWorkspace(ctx context.Context, workdirFlag, projectDir string) string {
+// machine.
+//
+// It defers to sidecar.ResolveWorkspace rather than reimplementing the priority
+// order, so variants land where the rest of the CLI puts a workspace:
+// <sidecarHome>/<repo>. That is not a cosmetic detail. `chunk sidecar env build`
+// provisions dependencies in that directory before the snapshot is taken, so a
+// sync into any other path gets a tree the snapshot never prepared, every
+// command fails for environmental reasons, and every mutant reads as caught.
+//
+// The error is deliberate: SyncEphemeral has no shared state to fall back on, so
+// an unresolvable workspace has to stop the run rather than pick a guess.
+func resolveVariantsWorkspace(ctx context.Context, workdirFlag, projectDir string) (string, error) {
 	if workdirFlag != "" {
-		return workdirFlag
+		return workdirFlag, nil
 	}
-	if active, err := sidecar.LoadActive(ctx); err == nil && active != nil && active.Workspace != "" {
-		return active.Workspace
-	}
+	// A missing origin remote is not fatal on its own — an active sidecar may
+	// still name a workspace — so let ResolveWorkspace decide.
 	_, repo, err := gitremote.DetectOrgAndRepo(projectDir)
-	if err == nil && repo != "" {
-		return "./workspace/" + repo
+	if err != nil {
+		repo = ""
 	}
-	return "./workspace"
+	return sidecar.ResolveWorkspace(ctx, "", repo)
 }

--- a/internal/cmd/validate_variants_test.go
+++ b/internal/cmd/validate_variants_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/gitrepo"
+	"github.com/CircleCI-Public/chunk-cli/internal/variants"
+)
+
+// isolateSidecarState points the sidecar state directory at a temp dir so
+// resolveVariantsWorkspace sees no active sidecar and has to fall back to the
+// repo-derived default.
+func isolateSidecarState(t *testing.T) {
+	t.Helper()
+	isolateConfig(t)
+	t.Setenv(config.EnvXDGDataHome, filepath.Join(t.TempDir(), "data"))
+}
+
+// TestResolveVariantsWorkspaceDefaultsToSidecarHome is the regression guard for a
+// default that used to be ./workspace/<repo>. `chunk sidecar env build` provisions
+// dependencies in <sidecarHome>/<repo> before the snapshot is taken, so syncing
+// anywhere else hands every variant a tree the snapshot never prepared: the
+// commands fail environmentally and every mutant reads as caught.
+func TestResolveVariantsWorkspaceDefaultsToSidecarHome(t *testing.T) {
+	isolateSidecarState(t)
+	t.Setenv("CHUNK_SIDECAR_HOME", "/home/runner")
+
+	repoDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+
+	ws, err := resolveVariantsWorkspace(context.Background(), "", repoDir)
+	assert.NilError(t, err)
+	assert.Equal(t, ws, "/home/runner/my-repo")
+}
+
+func TestResolveVariantsWorkspacePrefersWorkdirFlag(t *testing.T) {
+	isolateSidecarState(t)
+
+	// No git repo and no active sidecar: the flag is the only source, and it wins
+	// before either is consulted.
+	ws, err := resolveVariantsWorkspace(context.Background(), "/somewhere/else", t.TempDir())
+	assert.NilError(t, err)
+	assert.Equal(t, ws, "/somewhere/else")
+}
+
+// TestResolveVariantsWorkspaceErrorsWithoutRepo covers the fresh clone, agent
+// worktree and CI cases: nothing names a workspace, so the run must stop rather
+// than guess a path the snapshot never prepared.
+func TestResolveVariantsWorkspaceErrorsWithoutRepo(t *testing.T) {
+	isolateSidecarState(t)
+
+	_, err := resolveVariantsWorkspace(context.Background(), "", t.TempDir())
+	assert.Assert(t, err != nil, "expected an error when no workspace can be resolved")
+}
+
+func TestCommandTimeout(t *testing.T) {
+	// A command's own timeout wins.
+	assert.Equal(t, commandTimeout(90, 300), 90)
+	// Otherwise the run-wide default applies.
+	assert.Equal(t, commandTimeout(0, 300), 300)
+	// A run-wide default of 0 means no limit, and must not be raised to one.
+	assert.Equal(t, commandTimeout(0, 0), 0)
+}
+
+// TestVariantCommandsExpandsTemplates guards the gap that let a literal
+// {{CHANGED_PACKAGES}} reach the sidecar's shell, where it exits non-zero for a
+// shell reason and reads as a caught mutant for every variant in the run.
+func TestVariantCommandsExpandsTemplates(t *testing.T) {
+	repoDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+
+	got := variantCommands([]config.Command{
+		{Name: "test-changed", Run: "task test -- {{CHANGED_PACKAGES}}", Remote: true},
+	}, repoDir, 300)
+
+	assert.Equal(t, len(got), 1)
+	assert.Equal(t, got[0].Name, "test-changed")
+	assert.Equal(t, got[0].Timeout, 300)
+	assert.Assert(t, !strings.Contains(got[0].Run, "{{CHANGED_PACKAGES}}"),
+		"template must be expanded before it is shipped, got %q", got[0].Run)
+}
+
+func captureStatus() (iostream.StatusFunc, func() string) {
+	var msgs []string
+	return func(_ iostream.Level, msg string) { msgs = append(msgs, msg) },
+		func() string { return strings.Join(msgs, "\n") }
+}
+
+// TestReportVariantSummaryWarnsWhenNothingSurvived covers the last line of defence
+// against a broken run reading as a clean bill of health: a snapshot missing the
+// project's tooling fails identically for every variant, which looks exactly like
+// perfect coverage in the per-variant JSON.
+func TestReportVariantSummaryWarnsWhenNothingSurvived(t *testing.T) {
+	status, dump := captureStatus()
+
+	reportVariantSummary([]variants.Result{
+		{ID: "MUT-001", Killed: true, ExitCode: 1},
+		{ID: "MUT-002", Killed: true, ExitCode: 1},
+	}, status)
+
+	out := dump()
+	assert.Assert(t, strings.Contains(out, "2/2 variants killed"), "got %q", out)
+	assert.Assert(t, strings.Contains(out, "every variant was killed"), "got %q", out)
+}
+
+func TestReportVariantSummaryCountsUnassessedSeparately(t *testing.T) {
+	status, dump := captureStatus()
+
+	reportVariantSummary([]variants.Result{
+		{ID: "MUT-001", Killed: true, ExitCode: 1},
+		{ID: "MUT-002"}, // survivor
+		{ID: "MUT-003", Error: "sync: no route to host"},
+	}, status)
+
+	out := dump()
+	// The unassessed variant counts as neither a kill nor a survivor.
+	assert.Assert(t, strings.Contains(out, "1/3 variants killed"), "got %q", out)
+	assert.Assert(t, strings.Contains(out, "not assessed"), "got %q", out)
+	assert.Assert(t, !strings.Contains(out, "every variant was killed"), "got %q", out)
+}

--- a/internal/sidecar/sync.go
+++ b/internal/sidecar/sync.go
@@ -63,6 +63,33 @@ func persistWorkspace(ctx context.Context, workspace string) error {
 func Sync(ctx context.Context,
 	client *circleci.Client, sidecarID, identityFile, authSock, workdir string, status iostream.StatusFunc) error {
 
+	return syncTo(ctx, client, sidecarID, identityFile, authSock, workdir, true, status)
+}
+
+// SyncEphemeral synchronises like Sync but neither reads nor writes the active
+// sidecar file. Callers that drive several sidecars concurrently — mutation
+// variants, one sidecar per variant — would otherwise race on that shared file
+// and leave it naming whichever worker happened to finish last, silently
+// repointing the user's own session at a sidecar that is about to be deleted.
+// workdir is required for the same reason: there is no shared state to fall
+// back on, so each caller must name its own destination.
+func SyncEphemeral(ctx context.Context,
+	client *circleci.Client, sidecarID, identityFile, authSock, workdir string, status iostream.StatusFunc) error {
+
+	if workdir == "" {
+		return fmt.Errorf("sync: workdir is required for an ephemeral sync")
+	}
+	return syncTo(ctx, client, sidecarID, identityFile, authSock, workdir, false, status)
+}
+
+// syncTo backs Sync and SyncEphemeral. persist controls whether the resolved
+// workspace is read from and written back to the active-sidecar file; it must
+// be false for concurrent callers. Deliberately not named sync: an identifier
+// in the package block collides with a file-block import of the same name, so
+// that would break the first file in this package to import stdlib sync.
+func syncTo(ctx context.Context, client *circleci.Client,
+	sidecarID, identityFile, authSock, workdir string, persist bool, status iostream.StatusFunc) error {
+
 	session, err := OpenSession(ctx, client, sidecarID, identityFile, authSock)
 	if err != nil {
 		return err
@@ -78,13 +105,15 @@ func Sync(ctx context.Context,
 		return &NoOriginRemoteError{Err: err}
 	}
 
-	repoPath, err := ResolveWorkspace(ctx, workdir, repo)
-	if err != nil {
-		return err
-	}
-
-	if err := persistWorkspace(ctx, repoPath); err != nil {
-		status(iostream.LevelWarn, fmt.Sprintf("Could not save workspace: %v", err))
+	repoPath := workdir
+	if persist {
+		repoPath, err = ResolveWorkspace(ctx, workdir, repo)
+		if err != nil {
+			return err
+		}
+		if err := persistWorkspace(ctx, repoPath); err != nil {
+			status(iostream.LevelWarn, fmt.Sprintf("Could not save workspace: %v", err))
+		}
 	}
 
 	// Try once and exit here if it worked

--- a/internal/testing/fakes/ssh.go
+++ b/internal/testing/fakes/ssh.go
@@ -30,6 +30,7 @@ type SSHServer struct {
 	mu       sync.Mutex
 	stdout   string
 	exitCode int
+	resultFn func(command string) (string, int)
 	commands []string
 	envVars  map[string]string
 }
@@ -122,6 +123,17 @@ func (s *SSHServer) SetResult(stdout string, exitCode int) {
 	defer s.mu.Unlock()
 	s.stdout = stdout
 	s.exitCode = exitCode
+}
+
+// SetResultFn configures a per-command result and takes precedence over
+// SetResult. Use it when a test needs one command in a sequence to behave
+// differently from the rest — a validate command exiting 127 while the sync
+// commands before it succeed, say. The function is called outside the server's
+// lock, so it may block to simulate a command that never returns.
+func (s *SSHServer) SetResultFn(fn func(command string) (stdout string, exitCode int)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.resultFn = fn
 }
 
 // Commands returns a copy of all exec command strings received so far.
@@ -221,10 +233,16 @@ func (s *SSHServer) handleSession(ch ssh.Channel, requests <-chan *ssh.Request) 
 		s.commands = append(s.commands, cmd)
 		stdout := s.stdout
 		exitCode := s.exitCode
+		resultFn := s.resultFn
 		s.mu.Unlock()
 
 		if req.WantReply {
 			_ = req.Reply(true, nil)
+		}
+		// Called after the lock is released so a resultFn that blocks — standing in
+		// for a command that never returns — does not stall the whole server.
+		if resultFn != nil {
+			stdout, exitCode = resultFn(cmd)
 		}
 		if stdout != "" {
 			_, _ = ch.Write([]byte(stdout))

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -146,7 +146,7 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 
 	maxWidth := nameWidth(commands)
 	for i, c := range commands {
-		run := expandCommand(workDir, c.Run)
+		run := ExpandCommand(workDir, c.Run)
 		script := "cd " + shellEscape(dest) + " && " + run
 		start := time.Now()
 		stdout, stderr, exitCode, err := execFn(ctx, script)
@@ -201,11 +201,16 @@ func RunRemoteInline(ctx context.Context, execFn func(ctx context.Context, scrip
 	return nil
 }
 
-// expandCommand replaces template variables in command before execution.
+// ExpandCommand replaces template variables in command before execution.
 // {{CHANGED_PACKAGES}} expands to the space-separated list of Go package
 // paths whose source files appear in `git diff HEAD`.
 // Expands to "./..." when no .go files changed.
-func expandCommand(workDir, command string) string {
+//
+// Exported because every path that ships a configured command somewhere else to
+// run must expand it first. Skipping expansion does not fail loudly: the literal
+// {{CHANGED_PACKAGES}} reaches the shell, which exits non-zero for a reason that
+// has nothing to do with the code under test.
+func ExpandCommand(workDir, command string) string {
 	if !strings.Contains(command, "{{CHANGED_PACKAGES}}") {
 		return command
 	}
@@ -236,7 +241,7 @@ func expandCommand(workDir, command string) string {
 }
 
 func runCommand(ctx context.Context, workDir, name, command string, timeoutSec, nameWidth int, status iostream.StatusFunc, streams iostream.Streams) error {
-	command = expandCommand(workDir, command)
+	command = ExpandCommand(workDir, command)
 
 	if timeoutSec <= 0 {
 		timeoutSec = DefaultTimeout

--- a/internal/variants/exec_test.go
+++ b/internal/variants/exec_test.go
@@ -1,0 +1,183 @@
+package variants
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+)
+
+func discardStatus(_ iostream.Level, _ string) {}
+
+// newSession opens a real SSH session against a fake sidecar, so the verdict
+// tests below exercise the actual exec path rather than a stub of it. exitFor
+// decides the result of each command the sidecar receives.
+func newSession(t *testing.T, exitFor func(command string) (string, int)) (*sidecar.Session, *fakes.SSHServer) {
+	t.Helper()
+
+	keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+	sshSrv := fakes.NewSSHServer(t, pubKey)
+	sshSrv.SetResultFn(exitFor)
+
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = sshSrv.Addr()
+	api := httptest.NewServer(cci)
+	t.Cleanup(api.Close)
+
+	// OpenSession resolves known_hosts under HOME; keep it in a temp dir.
+	t.Setenv(config.EnvHome, t.TempDir())
+
+	client, err := circleci.NewClient(circleci.Config{Token: "fake-token", BaseURL: api.URL})
+	assert.NilError(t, err)
+
+	session, err := sidecar.OpenSession(context.Background(), client, "sc-1", keyFile, "")
+	assert.NilError(t, err)
+	return session, sshSrv
+}
+
+func testOpts(cmds ...Command) Options {
+	return Options{
+		Workspace: "/home/user/repo",
+		Commands:  cmds,
+		StatusFn:  discardStatus,
+	}
+}
+
+// runOne drives runCommands against a fake sidecar and returns the verdict along
+// with the SSH server, whose Commands() is the race-free record of what actually
+// reached the sidecar.
+func runOne(t *testing.T, exitFor func(string) (string, int), cmds ...Command) (Result, *fakes.SSHServer) {
+	t.Helper()
+	session, sshSrv := newSession(t, exitFor)
+	v := Variant{ID: "MUT-001", Description: "invert nil guard"}
+	res := runCommands(context.Background(), session, v, Result{ID: v.ID, Description: v.Description}, testOpts(cmds...))
+	return res, sshSrv
+}
+
+// TestRunCommandsFailingSuiteIsKilled is the one case that may set Killed: the
+// command ran and the tests failed.
+func TestRunCommandsFailingSuiteIsKilled(t *testing.T) {
+	res, _ := runOne(t, func(string) (string, int) { return "--- FAIL: TestThing\n", 1 },
+		Command{Name: "test", Run: "go test ./..."})
+
+	assert.Equal(t, res.Killed, true)
+	assert.Equal(t, res.Error, "")
+	assert.Equal(t, res.ExitCode, 1)
+	assert.Equal(t, res.Command, "test")
+	assert.Assert(t, strings.Contains(res.Stdout, "FAIL"))
+}
+
+// TestRunCommandsShellFailureIsNotAKill covers the failure mode this whole
+// package has to avoid. The shell could not run the command at all, which looks
+// the same for every variant in a run, so recording it as a caught mutant would
+// turn a snapshot missing the project's tooling into a clean bill of health.
+func TestRunCommandsShellFailureIsNotAKill(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		exit int
+		want string
+	}{
+		{name: "command not found", exit: 127, want: "not found"},
+		{name: "not executable", exit: 126, want: "not executable"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, _ := runOne(t, func(string) (string, int) { return "", tc.exit },
+				Command{Name: "test", Run: "task test"})
+
+			assert.Equal(t, res.Killed, false)
+			assert.Equal(t, res.ExitCode, tc.exit)
+			assert.Equal(t, res.Command, "test")
+			assert.Assert(t, strings.Contains(res.Error, tc.want),
+				"expected %q in error, got %q", tc.want, res.Error)
+		})
+	}
+}
+
+// TestRunCommandsTimeoutIsNotAKill covers a mutant that makes the suite hang.
+// Nothing was proven, so it must not read as caught — and returning is what frees
+// the parallel slot and lets the caller delete the billed sidecar.
+func TestRunCommandsTimeoutIsNotAKill(t *testing.T) {
+	release := make(chan struct{})
+	// A defer, not a t.Cleanup: this must release the blocked handler before the
+	// cleanups that shut the servers down, not after.
+	defer close(release)
+
+	start := time.Now()
+	res, _ := runOne(t, func(string) (string, int) {
+		<-release
+		return "", 0
+	}, Command{Name: "test", Run: "go test ./...", Timeout: 1})
+
+	assert.Equal(t, res.Killed, false)
+	assert.Equal(t, res.Command, "test")
+	assert.Assert(t, strings.Contains(res.Error, "timed out"), "got error %q", res.Error)
+	assert.Assert(t, time.Since(start) < 30*time.Second, "timeout was not enforced")
+}
+
+func TestRunCommandsAllPassingSurvives(t *testing.T) {
+	res, _ := runOne(t, func(string) (string, int) { return "ok\n", 0 },
+		Command{Name: "lint", Run: "task lint"},
+		Command{Name: "test", Run: "go test ./..."})
+
+	assert.Equal(t, res.Killed, false)
+	assert.Equal(t, res.Error, "")
+	assert.Equal(t, res.ExitCode, 0)
+	// No command is credited with a survivor: every one of them passed.
+	assert.Equal(t, res.Command, "")
+}
+
+// TestRunCommandsStopsAtFirstFailure confirms the remaining commands are skipped
+// once a mutant is caught; they would only run against known-broken code.
+func TestRunCommandsStopsAtFirstFailure(t *testing.T) {
+	res, sshSrv := runOne(t, func(string) (string, int) { return "", 1 },
+		Command{Name: "lint", Run: "task lint"},
+		Command{Name: "test", Run: "go test ./..."})
+
+	assert.Equal(t, res.Killed, true)
+	assert.Equal(t, res.Command, "lint")
+
+	seen := sshSrv.Commands()
+	assert.Equal(t, len(seen), 1, "expected only the first command to run, got %v", seen)
+	assert.Assert(t, strings.Contains(seen[0], "task lint"))
+}
+
+func TestStartedAtRejectsNamesItCannotDate(t *testing.T) {
+	now := time.Date(2026, time.August, 11, 12, 0, 0, 0, time.UTC)
+
+	for _, name := range []string{
+		"happy-quickly-tesla", // not ours
+		"variant-",            // no token
+		"variant-mut-001",     // pre-token name: decodes to 1970
+		"variant-timeout-fix", // decodes far into the future
+		"variant-!!!-mut-001", // not base 36
+	} {
+		_, ok := startedAt(name, now)
+		assert.Check(t, !ok, "expected %q to be undatable", name)
+	}
+}
+
+func TestStartedAtRoundTripsSidecarName(t *testing.T) {
+	now := time.Date(2026, time.August, 11, 12, 0, 0, 0, time.UTC)
+	start := now.Add(-3 * time.Hour)
+
+	name := sidecarName(runToken(start), "MUT-001")
+	got, ok := startedAt(name, now)
+	assert.Assert(t, ok, "expected %q to be datable", name)
+	assert.Equal(t, got.Unix(), start.Unix())
+}
+
+// TestSidecarNameSanitisesID keeps names inside the charset the API accepts while
+// staying unique per run.
+func TestSidecarNameSanitisesID(t *testing.T) {
+	name := sidecarName("abc123", "MUT_001/x")
+	assert.Equal(t, name, "variant-abc123-mut-001-x")
+}

--- a/internal/variants/exec_test.go
+++ b/internal/variants/exec_test.go
@@ -150,34 +150,43 @@ func TestRunCommandsStopsAtFirstFailure(t *testing.T) {
 	assert.Assert(t, strings.Contains(seen[0], "task lint"))
 }
 
-func TestStartedAtRejectsNamesItCannotDate(t *testing.T) {
-	now := time.Date(2026, time.August, 11, 12, 0, 0, 0, time.UTC)
-
+// TestCreatedAtRejectsNamesItCannotDate covers everything the sweep must refuse
+// to date, and therefore must leave alone.
+func TestCreatedAtRejectsNamesItCannotDate(t *testing.T) {
 	for _, name := range []string{
-		"happy-quickly-tesla", // not ours
-		"variant-",            // no token
-		"variant-mut-001",     // pre-token name: decodes to 1970
-		"variant-timeout-fix", // decodes far into the future
-		"variant-!!!-mut-001", // not base 36
+		"happy-quickly-tesla",  // not ours
+		"variant-",             // nothing after the prefix
+		"variant-mut-001",      // pre-timestamp name: single dashes, no nameSep
+		"variant-timeout-fix",  // ditto, and would have parsed as base 36
+		"variant---mut-001",    // empty timestamp
+		"variant-!!!--mut-001", // timestamp is not base 36
 	} {
-		_, ok := startedAt(name, now)
+		_, ok := createdAt(name)
 		assert.Check(t, !ok, "expected %q to be undatable", name)
 	}
 }
 
-func TestStartedAtRoundTripsSidecarName(t *testing.T) {
-	now := time.Date(2026, time.August, 11, 12, 0, 0, 0, time.UTC)
-	start := now.Add(-3 * time.Hour)
+func TestCreatedAtRoundTripsSidecarName(t *testing.T) {
+	born := time.Date(2026, time.August, 11, 9, 0, 0, 0, time.UTC)
 
-	name := sidecarName(runToken(start), "MUT-001")
-	got, ok := startedAt(name, now)
+	name := sidecarName(born, "MUT-001")
+	got, ok := createdAt(name)
 	assert.Assert(t, ok, "expected %q to be datable", name)
-	assert.Equal(t, got.Unix(), start.Unix())
+	assert.Equal(t, got.Unix(), born.Unix())
 }
 
-// TestSidecarNameSanitisesID keeps names inside the charset the API accepts while
-// staying unique per run.
-func TestSidecarNameSanitisesID(t *testing.T) {
-	name := sidecarName("abc123", "MUT_001/x")
-	assert.Equal(t, name, "variant-abc123-mut-001-x")
+// TestSidecarNameCollapsesDashesInID is what keeps nameSep unambiguous: if a
+// variant ID could produce two dashes in a row, the split that recovers the
+// timestamp would land in the middle of the ID instead.
+func TestSidecarNameCollapsesDashesInID(t *testing.T) {
+	born := time.Date(2026, time.August, 11, 9, 0, 0, 0, time.UTC)
+
+	name := sidecarName(born, "MUT_001//x--y")
+	assert.Assert(t, strings.HasSuffix(name, nameSep+"mut-001-x-y"), "got %q", name)
+
+	// Still datable, and the timestamp is recovered intact despite the ID's own
+	// separators.
+	got, ok := createdAt(name)
+	assert.Assert(t, ok, "got %q", name)
+	assert.Equal(t, got.Unix(), born.Unix())
 }

--- a/internal/variants/variants.go
+++ b/internal/variants/variants.go
@@ -1,0 +1,204 @@
+package variants
+
+import (
+	"context"
+	"fmt"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
+)
+
+// namePrefix marks every sidecar this package creates. Variant sidecars are
+// deliberately absent from the active-sidecar file, so the reaper in
+// internal/sidecar cannot see them; the prefix is what makes them findable by
+// SweepOrphans instead.
+const namePrefix = "variant-"
+
+// Variant is one entry from the input JSON file.
+type Variant struct {
+	ID          string `json:"id"`
+	Description string `json:"description"`
+	Patch       string `json:"patch"`
+}
+
+// Result is one entry in the output JSON array.
+type Result struct {
+	ID          string `json:"id"`
+	Description string `json:"description"`
+	Killed      bool   `json:"killed"`
+	Stdout      string `json:"stdout"`
+	Stderr      string `json:"stderr"`
+	ExitCode    int    `json:"exit_code"`
+	Error       string `json:"error,omitempty"`
+}
+
+// Options holds all configuration for running variants.
+type Options struct {
+	OrgID        string
+	Image        string
+	IdentityFile string
+	AuthSock     string
+	Workspace    string   // remote working directory, must be non-empty
+	Parallel     int      // max concurrent sidecars (default 5)
+	Commands     []string // shell commands to run on each sidecar in order
+	StatusFn     iostream.StatusFunc
+}
+
+// Run executes all variants in parallel and returns results in input order.
+// It only returns an error for fatal pre-flight failures; per-variant errors
+// are captured in Result.Error.
+//
+// Run installs its own SIGINT/SIGTERM handler for the duration of the call.
+// Without it an interrupt kills the process outright, every deferred
+// DeleteSidecar is skipped, and each in-flight sidecar is left running and
+// billing. Catching the signal turns it into a context cancellation that
+// unwinds through those defers instead.
+func Run(ctx context.Context, client *circleci.Client, variants []Variant, opts Options) ([]Result, error) {
+	if len(variants) == 0 {
+		return nil, nil
+	}
+	if opts.Parallel <= 0 {
+		opts.Parallel = 5
+	}
+
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	results := make([]Result, len(variants))
+	sem := make(chan struct{}, opts.Parallel)
+
+	g, gctx := errgroup.WithContext(ctx)
+	for i, v := range variants {
+		i, v := i, v
+		g.Go(func() error {
+			// Acquiring the slot must observe cancellation too: on interrupt the
+			// queued variants have not created anything yet, and booting a fresh
+			// sidecar on the way out is the exact leak the signal handler exists
+			// to prevent.
+			select {
+			case sem <- struct{}{}:
+			case <-gctx.Done():
+				results[i] = Result{ID: v.ID, Description: v.Description, Error: "cancelled before start"}
+				return nil
+			}
+			defer func() { <-sem }()
+			results[i] = runVariant(gctx, client, v, opts)
+			return nil
+		})
+	}
+	_ = g.Wait()
+	return results, nil
+}
+
+func runVariant(ctx context.Context, client *circleci.Client, v Variant, opts Options) Result {
+	base := Result{ID: v.ID, Description: v.Description}
+
+	opts.StatusFn(iostream.LevelInfo, fmt.Sprintf("[%s] creating sidecar", v.ID))
+	sc, err := sidecar.Create(ctx, client, opts.OrgID, variantSidecarName(v.ID), opts.Image)
+	if err != nil {
+		base.Error = fmt.Sprintf("create sidecar: %v", err)
+		return base
+	}
+	defer func() {
+		// Use a fresh context so cleanup runs even when the parent is cancelled.
+		if err := client.DeleteSidecar(context.Background(), sc.ID); err != nil {
+			opts.StatusFn(iostream.LevelWarn, fmt.Sprintf("[%s] could not delete sidecar %s: %v", v.ID, sc.ID, err))
+		}
+	}()
+
+	opts.StatusFn(iostream.LevelInfo, fmt.Sprintf("[%s] syncing", v.ID))
+	if err := sidecar.SyncEphemeral(ctx, client, sc.ID, opts.IdentityFile, opts.AuthSock, opts.Workspace, opts.StatusFn); err != nil {
+		base.Error = fmt.Sprintf("sync: %v", err)
+		return base
+	}
+
+	session, err := sidecar.OpenSession(ctx, client, sc.ID, opts.IdentityFile, opts.AuthSock)
+	if err != nil {
+		base.Error = fmt.Sprintf("open session: %v", err)
+		return base
+	}
+
+	if v.Patch != "" {
+		opts.StatusFn(iostream.LevelInfo, fmt.Sprintf("[%s] applying patch", v.ID))
+		applyCmd := "git -C " + sidecar.ShellEscape(opts.Workspace) + " apply"
+		applyResult, err := sidecar.ExecOverSSH(ctx, session, applyCmd, strings.NewReader(v.Patch), nil)
+		if err != nil {
+			base.Error = fmt.Sprintf("apply patch: %v", err)
+			return base
+		}
+		if applyResult.ExitCode != 0 {
+			base.Error = "patch did not apply"
+			return base
+		}
+	}
+
+	opts.StatusFn(iostream.LevelInfo, fmt.Sprintf("[%s] running commands", v.ID))
+	for _, cmd := range opts.Commands {
+		script := "cd " + sidecar.ShellEscape(opts.Workspace) + " && " + cmd
+		result, err := sidecar.ExecOverSSH(ctx, session, "sh -c "+sidecar.ShellEscape(script), nil, nil)
+		if err != nil {
+			base.Error = fmt.Sprintf("exec: %v", err)
+			return base
+		}
+		if result.ExitCode != 0 {
+			base.Stdout = result.Stdout
+			base.Stderr = result.Stderr
+			base.ExitCode = result.ExitCode
+			base.Killed = true
+			opts.StatusFn(iostream.LevelDone, fmt.Sprintf("[%s] killed (exit %d)", v.ID, result.ExitCode))
+			return base
+		}
+	}
+
+	opts.StatusFn(iostream.LevelWarn, fmt.Sprintf("[%s] survived", v.ID))
+	return base
+}
+
+// variantSidecarName produces a sidecar-safe name from a variant ID.
+func variantSidecarName(id string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(id) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('-')
+		}
+	}
+	return namePrefix + b.String()
+}
+
+// SweepOrphans deletes sidecars in the org left behind by an earlier variants
+// run. It is a backstop, not the primary cleanup: Run deletes its own sidecars
+// and the signal handler covers interrupts, but a crash or a lost network
+// connection can still strand one, and nothing else will ever collect it.
+//
+// Only names carrying namePrefix are touched. Deletion failures are reported
+// and skipped rather than aborting the sweep — a stale entry the API refuses to
+// delete must not block the run the caller actually asked for.
+func SweepOrphans(ctx context.Context, client *circleci.Client, orgID string, status iostream.StatusFunc) int {
+	existing, err := client.ListSidecars(ctx, orgID, false)
+	if err != nil {
+		status(iostream.LevelWarn, fmt.Sprintf("could not list sidecars to sweep orphans: %v", err))
+		return 0
+	}
+
+	swept := 0
+	for _, sc := range existing {
+		if !strings.HasPrefix(sc.Name, namePrefix) {
+			continue
+		}
+		if err := client.DeleteSidecar(ctx, sc.ID); err != nil {
+			status(iostream.LevelWarn, fmt.Sprintf("could not delete orphaned sidecar %s (%s): %v", sc.Name, sc.ID, err))
+			continue
+		}
+		status(iostream.LevelInfo, fmt.Sprintf("swept orphaned sidecar %s", sc.Name))
+		swept++
+	}
+	return swept
+}

--- a/internal/variants/variants.go
+++ b/internal/variants/variants.go
@@ -22,6 +22,14 @@ import (
 // SweepOrphans instead.
 const namePrefix = "variant-"
 
+// nameSep separates the timestamp in a sidecar name from the variant ID.
+//
+// It is two dashes because sanitizeID collapses runs of dashes to one, so a
+// sanitized ID can never contain nameSep. That makes the split unambiguous by
+// construction: no plausibility check on the decoded time is needed to tell a
+// timestamp from an ID that merely happens to parse as one.
+const nameSep = "--"
+
 // orphanAfter is how long a variant sidecar must have existed before a later
 // run's pre-flight sweep may delete it.
 //
@@ -32,6 +40,9 @@ const namePrefix = "variant-"
 // run could still be waiting on it is collected. The cost of waiting is some
 // billed time on a genuinely stranded sidecar; the cost of not waiting is
 // destroying someone else's in-flight run.
+//
+// Two hours is far above any single variant's lifetime, because each command is
+// bounded by its own timeout, so a sidecar this old is stranded rather than busy.
 const orphanAfter = 2 * time.Hour
 
 // Variant is one entry from the input JSON file.
@@ -107,10 +118,6 @@ func Run(ctx context.Context, client *circleci.Client, variants []Variant, opts 
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	// Stamped once for the whole run so every sidecar this run creates carries
-	// the same start time, and a later run's sweep can date it.
-	token := runToken(time.Now())
-
 	results := make([]Result, len(variants))
 	sem := make(chan struct{}, opts.Parallel)
 
@@ -129,7 +136,7 @@ func Run(ctx context.Context, client *circleci.Client, variants []Variant, opts 
 				return nil
 			}
 			defer func() { <-sem }()
-			results[i] = runVariant(gctx, client, v, sidecarName(token, v.ID), opts)
+			results[i] = runVariant(gctx, client, v, opts)
 			return nil
 		})
 	}
@@ -137,11 +144,15 @@ func Run(ctx context.Context, client *circleci.Client, variants []Variant, opts 
 	return results, nil
 }
 
-func runVariant(ctx context.Context, client *circleci.Client, v Variant, name string, opts Options) Result {
+func runVariant(ctx context.Context, client *circleci.Client, v Variant, opts Options) Result {
 	base := Result{ID: v.ID, Description: v.Description}
 
 	opts.StatusFn(iostream.LevelInfo, fmt.Sprintf("[%s] creating sidecar", v.ID))
-	sc, err := sidecar.Create(ctx, client, opts.OrgID, name, opts.Image)
+	// Stamped here rather than once per run: the name has to date this sidecar,
+	// not the run that owns it. A run of a hundred variants can take hours, and a
+	// name carrying the run's start time would make a sidecar booted seconds ago
+	// look old enough for another run's sweep to delete.
+	sc, err := sidecar.Create(ctx, client, opts.OrgID, sidecarName(time.Now(), v.ID), opts.Image)
 	if err != nil {
 		base.Error = fmt.Sprintf("create sidecar: %v", err)
 		return base
@@ -294,67 +305,54 @@ func shellFailure(code int) string {
 	return ""
 }
 
-// runToken encodes a run's start time as the per-run segment of its sidecar
-// names. Base 36 keeps it short and inside the [a-z0-9-] set names allow.
-func runToken(start time.Time) string {
-	return strconv.FormatInt(start.Unix(), 36)
+// sidecarName produces a sidecar-safe name carrying the moment the sidecar was
+// created, so SweepOrphans can tell one that has been stranded from one a live
+// run is still using. Base 36 keeps the timestamp short and inside the
+// [a-z0-9-] set names allow.
+func sidecarName(born time.Time, id string) string {
+	return namePrefix + strconv.FormatInt(born.Unix(), 36) + nameSep + sanitizeID(id)
 }
 
-// sidecarName produces a sidecar-safe name from a run token and a variant ID.
-// The token makes the name unique per run, so two concurrent runs over the same
-// variant IDs do not collide, and datable, so SweepOrphans can tell an
-// abandoned sidecar from one a live run still owns.
-func sidecarName(token, id string) string {
+// sanitizeID reduces a variant ID to the characters a sidecar name allows, and
+// collapses runs of dashes to one so the result can never contain nameSep. That
+// collapse is what lets createdAt be recovered by a plain split, with no need to
+// guess whether a segment is a timestamp or an ID that happens to look like one.
+func sanitizeID(id string) string {
 	var b strings.Builder
-	b.WriteString(namePrefix)
-	b.WriteString(token)
-	b.WriteByte('-')
+	lastDash := false
 	for _, r := range strings.ToLower(id) {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
 			b.WriteRune(r)
-		} else {
-			b.WriteRune('-')
+			lastDash = false
+		case !lastDash:
+			b.WriteByte('-')
+			lastDash = true
 		}
 	}
-	return b.String()
+	return strings.Trim(b.String(), "-")
 }
 
-// tokenEpoch is the earliest time a run token may decode to, and tokenSkew is
-// how far past now it may decode and still be believed.
+// createdAt recovers the creation time encoded in a variant sidecar name.
 //
-// The bounds are what make a token distinguishable from anything else in its
-// position. Base 36 accepts every lowercase letter as a digit, so the sanitized
-// variant ID in a name this package did not write parses to a number too:
-// "variant-mut-001" reads as 1970 and "variant-timeout-fix" as the year 3970.
-// Neither is a plausible run, and only a plausible one is datable. The skew
-// covers ordinary clock differences between the machine that named a sidecar and
-// the machine sweeping it.
-var tokenEpoch = time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
-
-const tokenSkew = 24 * time.Hour
-
-// startedAt recovers the run start time encoded in a variant sidecar name.
-// ok is false for any name this package did not write, or whose token does not
-// decode to a plausible time. Such a name is never swept: a sweep that cannot
-// prove a sidecar is abandoned must leave it alone.
-func startedAt(name string, now time.Time) (time.Time, bool) {
+// ok is false for any name this package did not write, or whose timestamp does
+// not parse. Such a name is never swept: a sweep that cannot prove a sidecar is
+// abandoned must leave it alone. A name from before this scheme existed has no
+// nameSep in it, so it fails here and is spared rather than guessed at.
+func createdAt(name string) (time.Time, bool) {
 	rest, ok := strings.CutPrefix(name, namePrefix)
 	if !ok {
 		return time.Time{}, false
 	}
-	token, _, ok := strings.Cut(rest, "-")
-	if !ok || token == "" {
+	stamp, _, ok := strings.Cut(rest, nameSep)
+	if !ok || stamp == "" {
 		return time.Time{}, false
 	}
-	secs, err := strconv.ParseInt(token, 36, 64)
-	if err != nil {
+	secs, err := strconv.ParseInt(stamp, 36, 64)
+	if err != nil || secs <= 0 {
 		return time.Time{}, false
 	}
-	started := time.Unix(secs, 0)
-	if started.Before(tokenEpoch) || started.After(now.Add(tokenSkew)) {
-		return time.Time{}, false
-	}
-	return started, true
+	return time.Unix(secs, 0), true
 }
 
 // SweepOrphans deletes sidecars in the org left behind by an earlier variants
@@ -373,20 +371,19 @@ func SweepOrphans(ctx context.Context, client *circleci.Client, orgID string, st
 		return 0
 	}
 
-	now := time.Now()
-	cutoff := now.Add(-orphanAfter)
+	cutoff := time.Now().Add(-orphanAfter)
 	swept := 0
 	for _, sc := range existing {
 		if !strings.HasPrefix(sc.Name, namePrefix) {
 			continue
 		}
-		started, ok := startedAt(sc.Name, now)
+		born, ok := createdAt(sc.Name)
 		if !ok {
 			status(iostream.LevelWarn, fmt.Sprintf(
-				"leaving variant sidecar %s in place: its name carries no run timestamp, so it cannot be shown to be abandoned", sc.Name))
+				"leaving variant sidecar %s in place: its name carries no timestamp, so it cannot be shown to be abandoned", sc.Name))
 			continue
 		}
-		if started.After(cutoff) {
+		if born.After(cutoff) {
 			// Young enough that a concurrent run may still be using it.
 			continue
 		}

--- a/internal/variants/variants.go
+++ b/internal/variants/variants.go
@@ -154,6 +154,11 @@ func runVariant(ctx context.Context, client *circleci.Client, v Variant, opts Op
 	// look old enough for another run's sweep to delete.
 	sc, err := sidecar.Create(ctx, client, opts.OrgID, sidecarName(time.Now(), v.ID), opts.Image)
 	if err != nil {
+		// A failure here can still have created a sidecar: the request may have
+		// landed and only the response been lost, to cancellation or a dropped
+		// connection. There is no ID to delete by in that case, so SweepOrphans is
+		// the only thing that can collect it, and the name's timestamp is what lets
+		// it. That is the case the sweep exists for.
 		base.Error = fmt.Sprintf("create sidecar: %v", err)
 		return base
 	}

--- a/internal/variants/variants.go
+++ b/internal/variants/variants.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -20,6 +22,18 @@ import (
 // SweepOrphans instead.
 const namePrefix = "variant-"
 
+// orphanAfter is how long a variant sidecar must have existed before a later
+// run's pre-flight sweep may delete it.
+//
+// Two runs at once — two worktrees, two repos, an agent driving one while a
+// human drives another — is a normal shape for this command, and the sweep
+// cannot ask the API who owns what. So it goes by age instead: a sidecar young
+// enough to belong to a live run is left alone, and only one old enough that no
+// run could still be waiting on it is collected. The cost of waiting is some
+// billed time on a genuinely stranded sidecar; the cost of not waiting is
+// destroying someone else's in-flight run.
+const orphanAfter = 2 * time.Hour
+
 // Variant is one entry from the input JSON file.
 type Variant struct {
 	ID          string `json:"id"`
@@ -27,15 +41,38 @@ type Variant struct {
 	Patch       string `json:"patch"`
 }
 
+// Command is one validation command to run on each variant's sidecar.
+//
+// Run must already be expanded by the caller: a command carrying an unexpanded
+// {{CHANGED_PACKAGES}} exits non-zero in the shell, which this package would
+// otherwise read as a killed mutant.
+type Command struct {
+	Name    string
+	Run     string
+	Timeout int // seconds; 0 means no limit
+}
+
 // Result is one entry in the output JSON array.
+//
+// Killed and Error are mutually exclusive. Killed means the test suite ran and
+// failed, which is a caught mutant. A non-empty Error means the mutant was never
+// assessed — the sidecar died, the patch would not apply, the command was not
+// on the image, the suite never finished. Those must not be reported as kills:
+// an environmental failure that reads as a caught mutant turns a broken run into
+// a clean bill of health, which is the one direction this tool must not fail in.
 type Result struct {
 	ID          string `json:"id"`
 	Description string `json:"description"`
 	Killed      bool   `json:"killed"`
-	Stdout      string `json:"stdout"`
-	Stderr      string `json:"stderr"`
-	ExitCode    int    `json:"exit_code"`
-	Error       string `json:"error,omitempty"`
+
+	// Command names the validation command that produced the verdict, so a kill
+	// can be traced to the command that caught it and a failure to the command
+	// that could not run.
+	Command  string `json:"command,omitempty"`
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+	ExitCode int    `json:"exit_code"`
+	Error    string `json:"error,omitempty"`
 }
 
 // Options holds all configuration for running variants.
@@ -44,9 +81,9 @@ type Options struct {
 	Image        string
 	IdentityFile string
 	AuthSock     string
-	Workspace    string   // remote working directory, must be non-empty
-	Parallel     int      // max concurrent sidecars (default 5)
-	Commands     []string // shell commands to run on each sidecar in order
+	Workspace    string    // remote working directory, must be non-empty
+	Parallel     int       // max concurrent sidecars (default 5)
+	Commands     []Command // commands to run on each sidecar in order
 	StatusFn     iostream.StatusFunc
 }
 
@@ -70,6 +107,10 @@ func Run(ctx context.Context, client *circleci.Client, variants []Variant, opts 
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	// Stamped once for the whole run so every sidecar this run creates carries
+	// the same start time, and a later run's sweep can date it.
+	token := runToken(time.Now())
+
 	results := make([]Result, len(variants))
 	sem := make(chan struct{}, opts.Parallel)
 
@@ -88,7 +129,7 @@ func Run(ctx context.Context, client *circleci.Client, variants []Variant, opts 
 				return nil
 			}
 			defer func() { <-sem }()
-			results[i] = runVariant(gctx, client, v, opts)
+			results[i] = runVariant(gctx, client, v, sidecarName(token, v.ID), opts)
 			return nil
 		})
 	}
@@ -96,11 +137,11 @@ func Run(ctx context.Context, client *circleci.Client, variants []Variant, opts 
 	return results, nil
 }
 
-func runVariant(ctx context.Context, client *circleci.Client, v Variant, opts Options) Result {
+func runVariant(ctx context.Context, client *circleci.Client, v Variant, name string, opts Options) Result {
 	base := Result{ID: v.ID, Description: v.Description}
 
 	opts.StatusFn(iostream.LevelInfo, fmt.Sprintf("[%s] creating sidecar", v.ID))
-	sc, err := sidecar.Create(ctx, client, opts.OrgID, variantSidecarName(v.ID), opts.Image)
+	sc, err := sidecar.Create(ctx, client, opts.OrgID, name, opts.Image)
 	if err != nil {
 		base.Error = fmt.Sprintf("create sidecar: %v", err)
 		return base
@@ -139,30 +180,135 @@ func runVariant(ctx context.Context, client *circleci.Client, v Variant, opts Op
 	}
 
 	opts.StatusFn(iostream.LevelInfo, fmt.Sprintf("[%s] running commands", v.ID))
-	for _, cmd := range opts.Commands {
-		script := "cd " + sidecar.ShellEscape(opts.Workspace) + " && " + cmd
-		result, err := sidecar.ExecOverSSH(ctx, session, "sh -c "+sidecar.ShellEscape(script), nil, nil)
-		if err != nil {
-			base.Error = fmt.Sprintf("exec: %v", err)
+	return runCommands(ctx, session, v, base, opts)
+}
+
+// runCommands runs each validation command on the variant's sidecar in order and
+// returns the verdict. The first command to exit non-zero decides it, and the
+// rest are skipped: the mutant is already caught, and the remaining commands
+// would only be running against known-broken code.
+func runCommands(ctx context.Context, session *sidecar.Session, v Variant, base Result, opts Options) Result {
+	for _, c := range opts.Commands {
+		script := "cd " + sidecar.ShellEscape(opts.Workspace) + " && " + c.Run
+		result, timedOut, err := execCommand(ctx, session, "sh -c "+sidecar.ShellEscape(script), c.Timeout)
+
+		base.Command = c.Name
+		switch {
+		case timedOut:
+			// The suite never returned, so nothing was proven either way. Returning
+			// here is also what stops a runaway mutant from holding a billed sidecar
+			// and a parallel slot for the rest of the run: the deferred delete in
+			// runVariant fires on the way out.
+			base.Error = fmt.Sprintf("%s: timed out after %ds", c.Name, c.Timeout)
+			opts.StatusFn(iostream.LevelWarn, fmt.Sprintf("[%s] %s", v.ID, base.Error))
+			return base
+		case err != nil:
+			base.Error = fmt.Sprintf("%s: exec: %v", c.Name, err)
+			return base
+		case result.ExitCode == 0:
+			continue
+		}
+
+		base.Stdout = result.Stdout
+		base.Stderr = result.Stderr
+		base.ExitCode = result.ExitCode
+
+		if reason := shellFailure(result.ExitCode); reason != "" {
+			base.Error = fmt.Sprintf("%s: %s (exit %d)", c.Name, reason, result.ExitCode)
+			opts.StatusFn(iostream.LevelWarn, fmt.Sprintf("[%s] not assessed: %s", v.ID, base.Error))
 			return base
 		}
-		if result.ExitCode != 0 {
-			base.Stdout = result.Stdout
-			base.Stderr = result.Stderr
-			base.ExitCode = result.ExitCode
-			base.Killed = true
-			opts.StatusFn(iostream.LevelDone, fmt.Sprintf("[%s] killed (exit %d)", v.ID, result.ExitCode))
-			return base
-		}
+
+		base.Killed = true
+		opts.StatusFn(iostream.LevelDone, fmt.Sprintf("[%s] killed by %s (exit %d)", v.ID, c.Name, result.ExitCode))
+		return base
 	}
 
+	// Every command passed, so there is no command to attribute the outcome to;
+	// the loop left the last one's name behind.
+	base.Command = ""
 	opts.StatusFn(iostream.LevelWarn, fmt.Sprintf("[%s] survived", v.ID))
 	return base
 }
 
-// variantSidecarName produces a sidecar-safe name from a variant ID.
-func variantSidecarName(id string) string {
+// execCommand runs script on the sidecar, giving up after timeoutSecs seconds
+// when that is set.
+//
+// The deadline is enforced here rather than through the context because
+// ExecOverSSH's underlying ssh session.Run does not observe cancellation once
+// the command is running — a context deadline would expire silently and the call
+// would keep waiting. Racing the call against a timer means abandoning the SSH
+// session, which is harmless: the caller deletes the sidecar immediately after,
+// and that is what actually stops the remote command and the billing.
+func execCommand(
+	ctx context.Context, session *sidecar.Session, script string, timeoutSecs int,
+) (res *sidecar.ExecResult, timedOut bool, err error) {
+	if timeoutSecs <= 0 {
+		res, err = sidecar.ExecOverSSH(ctx, session, script, nil, nil)
+		return res, false, err
+	}
+
+	type outcome struct {
+		res *sidecar.ExecResult
+		err error
+	}
+	// Buffered so the abandoned goroutine can finish and exit once the SSH
+	// connection drops with the sidecar, rather than blocking forever on send.
+	done := make(chan outcome, 1)
+	go func() {
+		r, e := sidecar.ExecOverSSH(ctx, session, script, nil, nil)
+		done <- outcome{r, e}
+	}()
+
+	timer := time.NewTimer(time.Duration(timeoutSecs) * time.Second)
+	defer timer.Stop()
+
+	select {
+	case o := <-done:
+		return o.res, false, o.err
+	case <-timer.C:
+		return nil, true, fmt.Errorf("timed out after %ds", timeoutSecs)
+	case <-ctx.Done():
+		// The caller interrupted the run. Not a timeout: there is no verdict to
+		// report either way, and the distinction matters because a timeout is a
+		// property of the mutant while cancellation is a property of the run.
+		return nil, false, ctx.Err()
+	}
+}
+
+// shellFailure reports why an exit code means the command never ran, or ""
+// when the code is a genuine failure of the command itself.
+//
+// 127 and 126 are the shell's own failures rather than the command's: not found,
+// and found but not executable. Both are what a snapshot missing the project's
+// tooling looks like, and it looks the same for every variant in the run — so
+// reading them as kills would report a whole broken run as a perfectly covered
+// codebase.
+func shellFailure(code int) string {
+	switch code {
+	case 126:
+		return "command found but not executable on the sidecar"
+	case 127:
+		return "command not found on the sidecar"
+	}
+	return ""
+}
+
+// runToken encodes a run's start time as the per-run segment of its sidecar
+// names. Base 36 keeps it short and inside the [a-z0-9-] set names allow.
+func runToken(start time.Time) string {
+	return strconv.FormatInt(start.Unix(), 36)
+}
+
+// sidecarName produces a sidecar-safe name from a run token and a variant ID.
+// The token makes the name unique per run, so two concurrent runs over the same
+// variant IDs do not collide, and datable, so SweepOrphans can tell an
+// abandoned sidecar from one a live run still owns.
+func sidecarName(token, id string) string {
 	var b strings.Builder
+	b.WriteString(namePrefix)
+	b.WriteString(token)
+	b.WriteByte('-')
 	for _, r := range strings.ToLower(id) {
 		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
 			b.WriteRune(r)
@@ -170,7 +316,45 @@ func variantSidecarName(id string) string {
 			b.WriteRune('-')
 		}
 	}
-	return namePrefix + b.String()
+	return b.String()
+}
+
+// tokenEpoch is the earliest time a run token may decode to, and tokenSkew is
+// how far past now it may decode and still be believed.
+//
+// The bounds are what make a token distinguishable from anything else in its
+// position. Base 36 accepts every lowercase letter as a digit, so the sanitized
+// variant ID in a name this package did not write parses to a number too:
+// "variant-mut-001" reads as 1970 and "variant-timeout-fix" as the year 3970.
+// Neither is a plausible run, and only a plausible one is datable. The skew
+// covers ordinary clock differences between the machine that named a sidecar and
+// the machine sweeping it.
+var tokenEpoch = time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+const tokenSkew = 24 * time.Hour
+
+// startedAt recovers the run start time encoded in a variant sidecar name.
+// ok is false for any name this package did not write, or whose token does not
+// decode to a plausible time. Such a name is never swept: a sweep that cannot
+// prove a sidecar is abandoned must leave it alone.
+func startedAt(name string, now time.Time) (time.Time, bool) {
+	rest, ok := strings.CutPrefix(name, namePrefix)
+	if !ok {
+		return time.Time{}, false
+	}
+	token, _, ok := strings.Cut(rest, "-")
+	if !ok || token == "" {
+		return time.Time{}, false
+	}
+	secs, err := strconv.ParseInt(token, 36, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	started := time.Unix(secs, 0)
+	if started.Before(tokenEpoch) || started.After(now.Add(tokenSkew)) {
+		return time.Time{}, false
+	}
+	return started, true
 }
 
 // SweepOrphans deletes sidecars in the org left behind by an earlier variants
@@ -178,7 +362,8 @@ func variantSidecarName(id string) string {
 // and the signal handler covers interrupts, but a crash or a lost network
 // connection can still strand one, and nothing else will ever collect it.
 //
-// Only names carrying namePrefix are touched. Deletion failures are reported
+// Only names carrying namePrefix and older than orphanAfter are touched, so a
+// concurrent run's in-flight sidecars survive. Deletion failures are reported
 // and skipped rather than aborting the sweep — a stale entry the API refuses to
 // delete must not block the run the caller actually asked for.
 func SweepOrphans(ctx context.Context, client *circleci.Client, orgID string, status iostream.StatusFunc) int {
@@ -188,9 +373,21 @@ func SweepOrphans(ctx context.Context, client *circleci.Client, orgID string, st
 		return 0
 	}
 
+	now := time.Now()
+	cutoff := now.Add(-orphanAfter)
 	swept := 0
 	for _, sc := range existing {
 		if !strings.HasPrefix(sc.Name, namePrefix) {
+			continue
+		}
+		started, ok := startedAt(sc.Name, now)
+		if !ok {
+			status(iostream.LevelWarn, fmt.Sprintf(
+				"leaving variant sidecar %s in place: its name carries no run timestamp, so it cannot be shown to be abandoned", sc.Name))
+			continue
+		}
+		if started.After(cutoff) {
+			// Young enough that a concurrent run may still be using it.
 			continue
 		}
 		if err := client.DeleteSidecar(ctx, sc.ID); err != nil {

--- a/internal/variants/variants_test.go
+++ b/internal/variants/variants_test.go
@@ -42,10 +42,11 @@ func defaultOpts() variants.Options {
 	}
 }
 
-// variantName builds the sidecar name a run started at ts would produce for a
-// variant ID, mirroring the run-token scheme SweepOrphans dates names by.
+// variantName builds the sidecar name a variant created at ts would get,
+// mirroring the timestamp scheme SweepOrphans dates names by. The double dash is
+// the delimiter, which is why a sanitized ID can never contain one.
 func variantName(ts time.Time, id string) string {
-	return "variant-" + strconv.FormatInt(ts.Unix(), 36) + "-" + id
+	return "variant-" + strconv.FormatInt(ts.Unix(), 36) + "--" + id
 }
 
 func TestRunEmpty(t *testing.T) {
@@ -213,11 +214,18 @@ func TestSweepOrphansDeletesOnlyStaleVariantSidecars(t *testing.T) {
 // command. A sweep that deleted every variant sidecar it could see would kill the
 // other run's in-flight work, and those variants would come back as errors: not a
 // false pass, but a run silently destroyed by an unrelated one.
+//
+// The two sidecars here are what a long concurrent run looks like: it started
+// hours ago and is still going, so one of its sidecars is long finished and
+// stranded while the one it is working on right now was booted seconds ago. Only
+// the stranded one may be taken. This is why the name carries each sidecar's own
+// creation time rather than the run's start time — under a per-run stamp, every
+// sidecar in a run this old would look collectable, including the live one.
 func TestSweepOrphansSparesConcurrentRun(t *testing.T) {
 	cci := fakes.NewFakeCircleCI()
 	cci.Sidecars = []fakes.Sidecar{
-		{ID: "sc-live", Name: variantName(time.Now().Add(-30*time.Second), "mut-001"), OrgID: "org-aaa"},
-		{ID: "sc-stale", Name: variantName(time.Now().Add(-48*time.Hour), "mut-002"), OrgID: "org-aaa"},
+		{ID: "sc-live", Name: variantName(time.Now().Add(-30*time.Second), "mut-099"), OrgID: "org-aaa"},
+		{ID: "sc-stale", Name: variantName(time.Now().Add(-48*time.Hour), "mut-001"), OrgID: "org-aaa"},
 	}
 	srv := httptest.NewServer(cci)
 	defer srv.Close()
@@ -234,8 +242,9 @@ func TestSweepOrphansSparesConcurrentRun(t *testing.T) {
 }
 
 // TestSweepOrphansSparesUndatableNames covers a variant sidecar whose name has no
-// parseable run token. The sweep cannot show it is abandoned, so it must leave it
-// alone rather than guess.
+// parseable timestamp — including one written before this naming scheme existed.
+// The sweep cannot show it is abandoned, so it must leave it alone rather than
+// guess.
 func TestSweepOrphansSparesUndatableNames(t *testing.T) {
 	cci := fakes.NewFakeCircleCI()
 	cci.Sidecars = []fakes.Sidecar{

--- a/internal/variants/variants_test.go
+++ b/internal/variants/variants_test.go
@@ -153,13 +153,18 @@ func TestRunDeletesEverySidecarOnCancel(t *testing.T) {
 
 	var once sync.Once
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		isCreate := r.Method == http.MethodPost && r.URL.Path == sidecarInstancesPath
-		cci.ServeHTTP(w, r)
-		if isCreate {
-			// Cancel only once the response is written, so the first variant owns a
-			// real sidecar that now has to be cleaned up on the way out.
+		// Cancel on the first request after the create, rather than on the create
+		// itself. Cancelling during the create races the client's read of its own
+		// response: the sidecar exists server-side, but CreateSidecar returns an
+		// error, so runVariant returns before the deferred delete is registered and
+		// there is no ID to delete by — only SweepOrphans can collect that one. The
+		// add-key request happens only once create has returned, so by then the
+		// sidecar is known and the defer is armed, which is the leak this test is
+		// about.
+		if strings.HasSuffix(r.URL.Path, "/ssh/add-key") {
 			once.Do(cancel)
 		}
+		cci.ServeHTTP(w, r)
 	}))
 	defer srv.Close()
 

--- a/internal/variants/variants_test.go
+++ b/internal/variants/variants_test.go
@@ -5,8 +5,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
@@ -32,11 +35,17 @@ func defaultOpts() variants.Options {
 	return variants.Options{
 		OrgID:     "org-aaa",
 		Image:     "snap-abc",
-		Workspace: "./workspace/repo",
-		Commands:  []string{"go test ./..."},
+		Workspace: "/home/user/repo",
+		Commands:  []variants.Command{{Name: "test", Run: "go test ./..."}},
 		Parallel:  5,
 		StatusFn:  nopStatus,
 	}
+}
+
+// variantName builds the sidecar name a run started at ts would produce for a
+// variant ID, mirroring the run-token scheme SweepOrphans dates names by.
+func variantName(ts time.Time, id string) string {
+	return "variant-" + strconv.FormatInt(ts.Unix(), 36) + "-" + id
 }
 
 func TestRunEmpty(t *testing.T) {
@@ -128,14 +137,30 @@ func TestRunDeleteCalledOnCreateSuccess(t *testing.T) {
 // every in-flight sidecar kept billing. Cancellation is what the SIGINT handler
 // installed by Run reduces to, so asserting on a cancelled context covers it
 // without having to signal the test binary itself.
+//
+// The cancel has to land after a sidecar exists, which is why it fires from
+// inside the create handler rather than before Run. Cancelling up front makes
+// sidecar.Create fail on the dead context before any request is sent, leaving
+// creates and deletes both at zero — an assertion that passes with the deferred
+// delete removed entirely, and so guards nothing.
 func TestRunDeletesEverySidecarOnCancel(t *testing.T) {
 	cci := fakes.NewFakeCircleCI()
 	cci.AddKeyStatusCode = 500
-	srv := httptest.NewServer(cci)
-	defer srv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	defer cancel()
+
+	var once sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		isCreate := r.Method == http.MethodPost && r.URL.Path == sidecarInstancesPath
+		cci.ServeHTTP(w, r)
+		if isCreate {
+			// Cancel only once the response is written, so the first variant owns a
+			// real sidecar that now has to be cleaned up on the way out.
+			once.Do(cancel)
+		}
+	}))
+	defer srv.Close()
 
 	vs := []variants.Variant{{ID: "MUT-001"}, {ID: "MUT-002"}, {ID: "MUT-003"}}
 	opts := defaultOpts()
@@ -145,23 +170,25 @@ func TestRunDeletesEverySidecarOnCancel(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, cmp.Len(results, 3))
 
-	// Whichever variants won the race to start, none may outlive the run: a
-	// created sidecar without a matching delete is a leaked instance.
 	creates, deletes := countSidecarCalls(cci)
+	assert.Assert(t, creates >= 1, "expected the first variant to create a sidecar before the cancel landed")
 	assert.Equal(t, creates, deletes, "every created sidecar must be deleted")
 
 	for _, r := range results {
 		assert.Check(t, !r.Killed, "cancelled variant must not be reported as killed")
+		assert.Check(t, r.Error != "", "cancelled variant must carry an error, not a silent pass")
 	}
 }
 
-func TestSweepOrphansDeletesOnlyVariantSidecars(t *testing.T) {
+func TestSweepOrphansDeletesOnlyStaleVariantSidecars(t *testing.T) {
+	old := time.Now().Add(-24 * time.Hour)
+
 	cci := fakes.NewFakeCircleCI()
 	cci.Sidecars = []fakes.Sidecar{
-		{ID: "sc-1", Name: "variant-mut-001", OrgID: "org-aaa"},
+		{ID: "sc-1", Name: variantName(old, "mut-001"), OrgID: "org-aaa"},
 		{ID: "sc-2", Name: "happy-quickly-tesla", OrgID: "org-aaa"},
-		{ID: "sc-3", Name: "variant-mut-002", OrgID: "org-aaa"},
-		{ID: "sc-4", Name: "variant-mut-003", OrgID: "org-other"},
+		{ID: "sc-3", Name: variantName(old, "mut-002"), OrgID: "org-aaa"},
+		{ID: "sc-4", Name: variantName(old, "mut-003"), OrgID: "org-other"},
 	}
 	srv := httptest.NewServer(cci)
 	defer srv.Close()
@@ -179,6 +206,48 @@ func TestSweepOrphansDeletesOnlyVariantSidecars(t *testing.T) {
 	assert.Check(t, cmp.Contains(remaining, "sc-4"))
 	assert.Check(t, !slices.Contains(remaining, "sc-1"))
 	assert.Check(t, !slices.Contains(remaining, "sc-3"))
+}
+
+// TestSweepOrphansSparesConcurrentRun pins the hazard that two runs at once —
+// two worktrees, two repos, an agent and a human — are a normal shape for this
+// command. A sweep that deleted every variant sidecar it could see would kill the
+// other run's in-flight work, and those variants would come back as errors: not a
+// false pass, but a run silently destroyed by an unrelated one.
+func TestSweepOrphansSparesConcurrentRun(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.Sidecars = []fakes.Sidecar{
+		{ID: "sc-live", Name: variantName(time.Now().Add(-30*time.Second), "mut-001"), OrgID: "org-aaa"},
+		{ID: "sc-stale", Name: variantName(time.Now().Add(-48*time.Hour), "mut-002"), OrgID: "org-aaa"},
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	swept := variants.SweepOrphans(context.Background(), newTestClient(t, srv), "org-aaa", nopStatus)
+	assert.Equal(t, swept, 1)
+
+	var remaining []string
+	for _, s := range cci.Sidecars {
+		remaining = append(remaining, s.ID)
+	}
+	assert.Check(t, cmp.Contains(remaining, "sc-live"))
+	assert.Check(t, !slices.Contains(remaining, "sc-stale"))
+}
+
+// TestSweepOrphansSparesUndatableNames covers a variant sidecar whose name has no
+// parseable run token. The sweep cannot show it is abandoned, so it must leave it
+// alone rather than guess.
+func TestSweepOrphansSparesUndatableNames(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.Sidecars = []fakes.Sidecar{
+		{ID: "sc-1", Name: "variant-mut-001", OrgID: "org-aaa"},
+		{ID: "sc-2", Name: "variant-", OrgID: "org-aaa"},
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	swept := variants.SweepOrphans(context.Background(), newTestClient(t, srv), "org-aaa", nopStatus)
+	assert.Equal(t, swept, 0)
+	assert.Equal(t, len(cci.Sidecars), 2)
 }
 
 func TestSweepOrphansToleratesListFailure(t *testing.T) {

--- a/internal/variants/variants_test.go
+++ b/internal/variants/variants_test.go
@@ -1,0 +1,193 @@
+package variants_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+	"github.com/CircleCI-Public/chunk-cli/internal/variants"
+)
+
+const sidecarInstancesPath = "/api/v3/sidecar/instances"
+
+func nopStatus(_ iostream.Level, _ string) {}
+
+func newTestClient(t *testing.T, srv *httptest.Server) *circleci.Client {
+	t.Helper()
+	client, err := circleci.NewClient(circleci.Config{Token: "fake-token", BaseURL: srv.URL})
+	assert.NilError(t, err)
+	return client
+}
+
+func defaultOpts() variants.Options {
+	return variants.Options{
+		OrgID:     "org-aaa",
+		Image:     "snap-abc",
+		Workspace: "./workspace/repo",
+		Commands:  []string{"go test ./..."},
+		Parallel:  5,
+		StatusFn:  nopStatus,
+	}
+}
+
+func TestRunEmpty(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	results, err := variants.Run(context.Background(), newTestClient(t, srv), nil, defaultOpts())
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Len(results, 0))
+	assert.Check(t, cmp.Len(cci.Recorder.AllRequests(), 0))
+}
+
+func TestRunCreateError(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.CreateStatusCode = 500
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	vs := []variants.Variant{
+		{ID: "MUT-001", Description: "invert nil check", Patch: ""},
+	}
+	results, err := variants.Run(context.Background(), newTestClient(t, srv), vs, defaultOpts())
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Len(results, 1))
+	assert.Equal(t, results[0].ID, "MUT-001")
+	assert.Assert(t, results[0].Error != "", "expected error in result, got empty")
+	assert.Check(t, !results[0].Killed)
+}
+
+func TestRunResultsInOrder(t *testing.T) {
+	// All variants fail at create — fast path for ordering verification.
+	cci := fakes.NewFakeCircleCI()
+	cci.CreateStatusCode = 500
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	vs := []variants.Variant{
+		{ID: "MUT-001"},
+		{ID: "MUT-002"},
+		{ID: "MUT-003"},
+	}
+	results, err := variants.Run(context.Background(), newTestClient(t, srv), vs, defaultOpts())
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Len(results, 3))
+	assert.Equal(t, results[0].ID, "MUT-001")
+	assert.Equal(t, results[1].ID, "MUT-002")
+	assert.Equal(t, results[2].ID, "MUT-003")
+}
+
+// countSidecarCalls returns how many create and delete requests reached the API.
+func countSidecarCalls(cci *fakes.FakeCircleCI) (creates, deletes int) {
+	for _, r := range cci.Recorder.AllRequests() {
+		switch {
+		case r.URL.Path == sidecarInstancesPath && r.Method == http.MethodPost:
+			creates++
+		case strings.HasPrefix(r.URL.Path, sidecarInstancesPath+"/") && r.Method == http.MethodDelete:
+			deletes++
+		}
+	}
+	return creates, deletes
+}
+
+func TestRunDeleteCalledOnCreateSuccess(t *testing.T) {
+	// Create succeeds; Sync fails at SSH key registration so delete must still run.
+	// AddKeyStatusCode=500 prevents OpenSession from succeeding, so the variant
+	// dies after the sidecar exists — the case where a missing delete leaks a
+	// billed instance.
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyStatusCode = 500
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	vs := []variants.Variant{
+		{ID: "MUT-001", Patch: ""},
+	}
+	results, err := variants.Run(context.Background(), newTestClient(t, srv), vs, defaultOpts())
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Len(results, 1))
+	assert.Assert(t, results[0].Error != "", "expected error (no SSH server)")
+
+	creates, deletes := countSidecarCalls(cci)
+	assert.Check(t, creates >= 1, "expected at least 1 create request")
+	assert.Check(t, deletes >= 1, "expected at least 1 delete request")
+}
+
+// TestRunDeletesEverySidecarOnCancel is the regression guard for the leak an
+// interrupt used to cause: the process died before any deferred delete ran and
+// every in-flight sidecar kept billing. Cancellation is what the SIGINT handler
+// installed by Run reduces to, so asserting on a cancelled context covers it
+// without having to signal the test binary itself.
+func TestRunDeletesEverySidecarOnCancel(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyStatusCode = 500
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	vs := []variants.Variant{{ID: "MUT-001"}, {ID: "MUT-002"}, {ID: "MUT-003"}}
+	opts := defaultOpts()
+	opts.Parallel = 1
+
+	results, err := variants.Run(ctx, newTestClient(t, srv), vs, opts)
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Len(results, 3))
+
+	// Whichever variants won the race to start, none may outlive the run: a
+	// created sidecar without a matching delete is a leaked instance.
+	creates, deletes := countSidecarCalls(cci)
+	assert.Equal(t, creates, deletes, "every created sidecar must be deleted")
+
+	for _, r := range results {
+		assert.Check(t, !r.Killed, "cancelled variant must not be reported as killed")
+	}
+}
+
+func TestSweepOrphansDeletesOnlyVariantSidecars(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.Sidecars = []fakes.Sidecar{
+		{ID: "sc-1", Name: "variant-mut-001", OrgID: "org-aaa"},
+		{ID: "sc-2", Name: "happy-quickly-tesla", OrgID: "org-aaa"},
+		{ID: "sc-3", Name: "variant-mut-002", OrgID: "org-aaa"},
+		{ID: "sc-4", Name: "variant-mut-003", OrgID: "org-other"},
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	swept := variants.SweepOrphans(context.Background(), newTestClient(t, srv), "org-aaa", nopStatus)
+	assert.Equal(t, swept, 2)
+
+	// The user's own sidecar and another org's must survive: sweeping is a
+	// cleanup for this package's leftovers, not a general-purpose purge.
+	var remaining []string
+	for _, s := range cci.Sidecars {
+		remaining = append(remaining, s.ID)
+	}
+	assert.Check(t, cmp.Contains(remaining, "sc-2"))
+	assert.Check(t, cmp.Contains(remaining, "sc-4"))
+	assert.Check(t, !slices.Contains(remaining, "sc-1"))
+	assert.Check(t, !slices.Contains(remaining, "sc-3"))
+}
+
+func TestSweepOrphansToleratesListFailure(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.ListStatusCode = 500
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	// A sweep failure must not abort the run the caller actually asked for.
+	swept := variants.SweepOrphans(context.Background(), newTestClient(t, srv), "org-aaa", nopStatus)
+	assert.Equal(t, swept, 0)
+}

--- a/skills/chunk-testing-gaps/SKILL.md
+++ b/skills/chunk-testing-gaps/SKILL.md
@@ -122,13 +122,27 @@ This boots one throwaway sidecar per variant (5 at a time), applies that variant
 
 It prints a JSON array, one entry per variant:
 
-- `killed: true` → the test suite caught the bug. Mark as **killed**.
+- `killed: true` → the test suite ran and failed. Mark as **killed**. `command` names the validate command that caught it.
 - `killed: false` with no `error` → the tests passed on broken code. Mark as **survivor** — this is a real coverage gap.
-- `error` non-empty → the variant never ran (patch did not apply, sidecar failed to boot). Mark as **inconclusive** and either fix the patch and re-run just that variant, or report it as not assessed. Do not record an inconclusive variant as a survivor.
+- `error` non-empty → the mutant was never assessed. Mark as **inconclusive**. Causes include: the patch did not apply, the sidecar failed to boot, the sync failed, the validate command was not present on the snapshot, or the command timed out. Either fix the cause and re-run just that variant, or report it as not assessed.
 
-Raise `--parallel` for a faster run at higher concurrent cost; lower it if the org hits sidecar limits. Use `--name <command>` to run a single validate command instead of every remote one.
+`killed` and `error` are mutually exclusive, and an inconclusive variant is neither a kill nor a survivor. **Never record an inconclusive variant as either.** Counting one as killed is the worst outcome available here: it converts a broken run into a clean bill of health.
 
-**Cleanup**: the command deletes its own sidecars, including on Ctrl-C, and sweeps any orphans from a previous crashed run before it starts. You do not need to clean up sidecars by hand. Do delete `.chunk/variants.json` when the run is done.
+Raise `--parallel` for a faster run at higher concurrent cost; lower it if the org hits sidecar limits. Use `--name <command>` to run a single validate command instead of every remote one. `--timeout <seconds>` bounds each command for variants whose mutation makes the suite hang; a command's own `timeout` in `.chunk/config.json` takes precedence.
+
+Prefer a command that runs the whole suite. Template variables like `{{CHANGED_PACKAGES}}` expand against your *local* working tree before the command is sent, and the mutation exists only on the sidecar — so a changed-packages command can skip the very package it is meant to be testing and report a false survivor.
+
+#### Sanity-check the run before believing it
+
+A high kill rate is the result an environmental failure produces, because a snapshot missing the project's tooling fails the same way for every variant. Before reporting results:
+
+- **If every variant was killed, treat the run as suspect until proven otherwise.** The command warns when this happens. Open the `stdout`/`stderr` of two or three results and confirm the failures are test assertions failing, not a missing binary, a dependency that was never installed, or a shell error.
+- **If every variant was killed by the same command with the same exit code**, that is the signature of a broken environment rather than a well-tested codebase.
+- **Check the inconclusive count.** Variants that were not assessed are gaps in the report, not passes.
+
+If the environment is at fault, fix it — usually by rebuilding the snapshot via the `chunk-sidecar` skill — and re-run. Do not report a coverage verdict from a run you could not sanity-check.
+
+**Cleanup**: the command deletes its own sidecars, including on Ctrl-C, and sweeps orphans from a previous crashed run before it starts. The sweep only takes sidecars old enough that no live run could still own them, so a second `validate variants` in another worktree or repo is safe to run alongside the first. You do not need to clean up sidecars by hand. Do delete `.chunk/variants.json` when the run is done.
 
 #### Stage 2 Summary
 
@@ -139,6 +153,7 @@ Once the variants run has completed, produce a summary table:
 | MUT-001 | Inverted auth check | `pkg/auth/verify.go` | 42 | Survivor |
 | MUT-002 | Removed nil guard | `pkg/api/handler.go` | 118 | Killed (sidecar) |
 | MUT-003 | Weakened length check | `pkg/api/parse.go` | 55 | Killed (local) |
+| MUT-004 | Removed retry | `pkg/api/client.go` | 73 | Not assessed (timed out) |
 
 Report any inconclusive variants separately, with the reason they did not run, so the user can see what was left unassessed rather than reading their absence as a pass.
 

--- a/skills/chunk-testing-gaps/SKILL.md
+++ b/skills/chunk-testing-gaps/SKILL.md
@@ -3,9 +3,9 @@ name: chunk-testing-gaps
 description: >-
   Use when asked to "find testing gaps", "chunk testing-gaps", "mutation test",
   "mutate this code", "test mutation coverage", or "find surviving mutants".
-  Runs a 4-stage mutation testing process: discovery, validation via git
-  worktrees and CI, production cross-reference, and risk assessment.
-version: 1.0.0
+  Runs a 4-stage mutation testing process: discovery, validation on parallel
+  sidecars, production cross-reference, and risk assessment.
+version: 2.0.0
 ---
 
 # Chunk Mutate Skill
@@ -23,6 +23,18 @@ The objective is to find as many surviving mutants as possible, prioritised by r
 This prompt expects to be run in the context of a local clone of a VCS project. If that is not the case, stop and explain why you cannot proceed.
 
 Before any testing, ensure local dependencies are running (`docker compose up -d` or equivalent). On compose failure, check whether containers from another project are occupying ports and kill them.
+
+Stage 2 runs mutants on `chunk` sidecars, which needs `validation.sidecarImage` set in `.chunk/config.json`. Check it with `cat .chunk/config.json`. If it is missing, stop and tell the user to run the one-time setup in the `chunk-sidecar` skill (Step 3) first — booting a fresh unconfigured sidecar per mutant is slow enough to make the whole run impractical.
+
+## Never create VCS artifacts for a mutant
+
+A mutant is a deliberately broken copy of the code. It must never reach the remote.
+
+- **Do not** push branches, open pull requests (draft or otherwise), or create git worktrees for mutants.
+- **Do not** try to get CI to run a mutant. CI is not the execution environment for this skill; sidecars are.
+- Mutations are carried as patches in a variants file and applied on a throwaway sidecar. Nothing is committed and your working tree is left as you found it.
+
+Earlier versions of this skill pushed a branch per mutant and opened a draft PR to force a CI run. That flooded repositories with stale draft PRs. If you find yourself reaching for `git push` or `gh pr create` in Stage 2, you have taken a wrong turn — re-read Stage 2.
 
 ## What to Mutate
 
@@ -69,31 +81,66 @@ For each candidate, record:
 
 ### Stage 2 — Validation
 
-For each candidate mutation:
+Validation is two passes: a cheap local triage that discards the obvious kills, then a sidecar run for whatever is left. Triage first — it is what keeps the sidecar count, and therefore the cost, proportionate to the number of interesting mutants rather than to the number of candidates.
 
-1. Create a git worktree on a new branch named `chunk/mut-<NUMBER>-<short-kebab-description>` (e.g. `chunk/mut-042-remove-auth-check`).
-2. Apply the mutation.
-3. Run static analysis: linter, type checks, compilation — use the project's standard tooling (`./do`, `Taskfile`, or whatever is configured). If the project has no local tooling, check CI config for what tools are used and attempt to run them locally. **Do not install missing tools without prompting.**
-4. Run targeted local tests: tests in the mutated package/module that reference the mutated function or type. For Go, use the race detector and a 1-minute timeout (`-race -timeout 1m`). If tests take longer than 1 minute, consider the mutation viable and move on.
-5. **If static analysis or tests fail** → mark the mutant as **killed locally**, delete the worktree, and move to the next candidate.
-6. **If the mutant survives local validation** → push the branch to the remote and trigger or wait for the CI pipeline.
+#### 2a — Local triage
 
-**Batching**: push surviving branches in batches (e.g. 10–20 at a time) rather than sequentially. Poll for CI results across the batch before pushing the next.
+For each candidate mutation, working in your normal checkout one at a time:
 
-7. Monitor CI pipelines for each pushed branch. If CI fails → mark as **killed in CI**. If CI passes → mark as **survivor**.
+1. Apply the mutation with an in-place edit.
+2. Run static analysis: linter, type checks, compilation — use the project's standard tooling (`./do`, `Taskfile`, or whatever is configured). If the project has no local tooling, check CI config for what tools are used and attempt to run them locally. **Do not install missing tools without prompting.**
+3. Run targeted local tests: tests in the mutated package/module that reference the mutated function or type. For Go, use the race detector and a 1-minute timeout (`-race -timeout 1m`). If tests take longer than 1 minute, treat the mutation as viable and move on.
+4. **Revert the edit** before moving to the next candidate. Never leave a mutation in the working tree.
+5. **If static analysis or tests fail** → mark the mutant **killed locally** and drop it.
+6. **If the mutant survives** → capture the change as a patch for pass 2b, then revert.
 
-**Cleanup**: after a mutant is killed (locally or in CI), remove the worktree promptly to avoid disk/git overhead.
+A patch is the output of `git diff` for that single mutation, captured before the revert.
+
+#### 2b — Sidecar run
+
+Collect every local survivor into a single variants file at `.chunk/variants.json` (gitignored) — a JSON array of objects with `id`, `description`, and `patch`:
+
+```json
+[
+  {
+    "id": "MUT-001",
+    "description": "Inverted auth check in verifyToken",
+    "patch": "diff --git a/pkg/auth/verify.go b/pkg/auth/verify.go\n@@ ... @@\n-\tif !ok {\n+\tif ok {\n"
+  }
+]
+```
+
+The `patch` value must be the literal `git diff` text with newlines escaped, and must apply cleanly against the current `HEAD`.
+
+Then run the whole set in one command:
+
+```
+chunk validate variants .chunk/variants.json --parallel 5
+```
+
+This boots one throwaway sidecar per variant (5 at a time), applies that variant's patch there, runs the project's `remote: true` validate commands, and deletes the sidecar. Nothing is pushed and no PR is created.
+
+It prints a JSON array, one entry per variant:
+
+- `killed: true` → the test suite caught the bug. Mark as **killed**.
+- `killed: false` with no `error` → the tests passed on broken code. Mark as **survivor** — this is a real coverage gap.
+- `error` non-empty → the variant never ran (patch did not apply, sidecar failed to boot). Mark as **inconclusive** and either fix the patch and re-run just that variant, or report it as not assessed. Do not record an inconclusive variant as a survivor.
+
+Raise `--parallel` for a faster run at higher concurrent cost; lower it if the org hits sidecar limits. Use `--name <command>` to run a single validate command instead of every remote one.
+
+**Cleanup**: the command deletes its own sidecars, including on Ctrl-C, and sweeps any orphans from a previous crashed run before it starts. You do not need to clean up sidecars by hand. Do delete `.chunk/variants.json` when the run is done.
 
 #### Stage 2 Summary
 
-Once all CI pipelines have completed, produce a summary table:
+Once the variants run has completed, produce a summary table:
 
-| # | Mutation | File | Line | Branch Link | Status |
-|---|----------|------|------|-------------|--------|
-| MUT-001 | Inverted auth check | `pkg/auth/verify.go` | 42 | `chunk/mut-001-invert-auth` | Survivor |
-| MUT-002 | Removed nil guard | `pkg/api/handler.go` | 118 | `chunk/mut-002-rm-nil-guard` | Killed (CI) |
+| # | Mutation | File | Line | Status |
+|---|----------|------|------|--------|
+| MUT-001 | Inverted auth check | `pkg/auth/verify.go` | 42 | Survivor |
+| MUT-002 | Removed nil guard | `pkg/api/handler.go` | 118 | Killed (sidecar) |
+| MUT-003 | Weakened length check | `pkg/api/parse.go` | 55 | Killed (local) |
 
-Include links to the branch in the VCS for each mutation.
+Report any inconclusive variants separately, with the reason they did not run, so the user can see what was left unassessed rather than reading their absence as a pass.
 
 ### Stage 3 — Production Cross-Reference
 
@@ -121,7 +168,7 @@ Assign a risk level: **Critical**, **High**, **Medium**, or **Low**.
 
 Present the final summary table sorted by risk (highest first):
 
-| # | Mutation | File | Line | Branch | Production Traffic | Risk | Rationale |
-|---|----------|------|------|--------|--------------------|------|-----------|
-| MUT-001 | Inverted auth check | `pkg/auth/verify.go` | 42 | [link] | High | Critical | Auth bypass on a hot path, no test coverage |
-| MUT-017 | Hardcoded timeout to 0 | `pkg/worker/poll.go` | 89 | [link] | Low | Medium | Would cause tight loop but only in batch worker |
+| # | Mutation | File | Line | Production Traffic | Risk | Rationale |
+|---|----------|------|------|--------------------|------|-----------|
+| MUT-001 | Inverted auth check | `pkg/auth/verify.go` | 42 | High | Critical | Auth bypass on a hot path, no test coverage |
+| MUT-017 | Hardcoded timeout to 0 | `pkg/worker/poll.go` | 89 | Low | Medium | Would cause tight loop but only in batch worker |


### PR DESCRIPTION
Adds chunk validate variants for running mutation-testing variants across parallel ephemeral sidecars, with a non-racing SyncEphemeral path and an updated testing-gaps skill.