### PR TITLE
Split chunk-sidecar skill into onboarding and usage

### DIFF
--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -75,36 +75,59 @@ If no issues survive filtering, the skill reports "No significant issues identif
 
 **Trigger phrases**: "validate on the sidecar", "run tests on the sidecar", "sync to sidecar", "sidecar dev loop", "validate remotely", "run smarter testing doctor", "diagnose smarter testing"
 
-Runs the sync → validate loop on a remote CircleCI sidecar. Also handles one-time sidecar creation, environment setup, and snapshotting.
-
-**Prerequisites**:
-- CircleCI token configured (`chunk auth set circleci`)
-- An active sidecar (`chunk sidecar use <id>`)
+Smart entry point for all sidecar workflows. Probes your current state (CLI installed, auth configured, active sidecar, snapshot configured) and uses interactive questions to route you to the right flow: first-time setup, dev loop, debugging, test-suite scaffolding, or snapshot management.
 
 **What it does**:
 
-1. Checks auth status (`chunk auth status`)
-2. Finds the active sidecar (`chunk sidecar current`)
-3. Syncs local changes to the sidecar (`chunk sidecar sync`)
-4. Runs validation commands remotely (`chunk validate --remote`)
-5. Reports results; maps error paths back to local files
-
-If there is no active sidecar, the skill prompts you to select or create one before proceeding.
+1. Runs read-only state probes (`chunk --version`, `chunk auth status`, config, `chunk sidecar current`)
+2. Asks what you want to do, with options tailored to your current state
+3. Routes to the matching flow:
+   - No sidecar, no snapshot → delegates to `chunk-sidecar-setup` for first-time onboarding
+   - Snapshot configured, no active sidecar → launches from snapshot, then starts the dev loop
+   - Active sidecar → sync → validate loop, with options for debug, scaffolding, or snapshot management
 
 **The dev loop in practice**:
 
 ```
 You: validate on the sidecar
-Agent: syncing local changes...
-       running chunk validate --remote...
+Agent: [probes state — active sidecar found]
+       What would you like to do?
+       > Sync and validate (dev loop) ← chosen
+       syncing local changes...
+       running chunk validate...
        ✗ test failed: internal/store_test.go:88: assertion failed
        Fixing the issue...
        syncing again...
-       running chunk validate --remote...
+       running chunk validate...
        ✓ all validations passed
 ```
 
 **Parallel sessions**: When multiple Claude sessions are open in the same repo, each session automatically targets its own sidecar. State is keyed by `CLAUDE_SESSION_ID` and stored in `XDG_DATA_HOME` (see Architecture docs). No manual configuration is needed.
+
+---
+
+### chunk-sidecar-setup
+
+**Trigger phrases**: "set up chunk sidecar", "onboard to chunk", "first time sidecar", "configure sidecar from scratch", "walk me through sidecar setup", "I've never used a chunk sidecar before"
+
+Interactive onboarding wizard for setting up a sidecar from scratch. Also invoked automatically by `chunk-sidecar` when no sidecar or snapshot is configured.
+
+**Prerequisites**:
+- `chunk` CLI installed
+- CircleCI token available to configure (`chunk auth set circleci`)
+
+**What it does** (8 guided stages):
+
+1. **Prerequisites** — checks `chunk --version` and `chunk auth status`; explains each credential and what it's needed for
+2. **OrgID** — confirms your CircleCI org ID is set; explains how to find it in the dashboard if needed
+3. **Sidecar name** — asks whether to auto-generate a name or choose one
+4. **Create + sync** — runs `chunk sidecar create` and `chunk sidecar sync`; explains what sync does
+5. **Install dependencies** — auto-detect with `chunk sidecar setup`, custom commands, or skip
+6. **Smarter Testing** — asks whether to install `circleci-testsuite` on the sidecar
+7. **Validate** — runs `chunk validate` and loops on failures until it passes
+8. **Snapshot** — creates a reusable snapshot, persists the image ID in config, launches a clean sidecar from it, and re-verifies
+
+Ends with a summary of what was configured and instructions for using `/chunk-sidecar` for the dev loop going forward.
 
 ---
 

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -54,6 +54,10 @@ var All = []Skill{
 		Name:        "chunk-sidecar",
 		Description: `Run build/test/validate on a remote chunk sidecar instead of locally. Use when asked to "validate on the sidecar", "run tests on the sidecar", "sync to sidecar", "check this on the sidecar", "run smarter testing doctor", "diagnose smarter testing", or when edits need remote verification. Also covers creating sidecars, snapshots, and env customization.`,
 	},
+	{
+		Name:        "chunk-sidecar-setup",
+		Description: `Interactive onboarding wizard for setting up a chunk sidecar from scratch. Use when asked to "set up chunk sidecar", "onboard to chunk", "first time sidecar", "configure sidecar from scratch", "walk me through sidecar setup", or "I've never used a chunk sidecar before". Covers auth, orgID, sidecar creation, dependency install, snapshot creation, and handoff to the dev loop.`,
+	},
 }
 
 // Agent represents a target agent with its config directories.

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -11,7 +11,7 @@ import (
 	embeddedSkills "github.com/CircleCI-Public/chunk-cli/skills"
 )
 
-var skillNames = []string{"chunk-testing-gaps", "chunk-review", "debug-ci-failures", "chunk-sidecar"}
+var skillNames = []string{"chunk-testing-gaps", "chunk-review", "debug-ci-failures", "chunk-sidecar", "chunk-sidecar-setup"}
 
 func TestInstallBothAgents(t *testing.T) {
 	home := t.TempDir()

--- a/skills/chunk-sidecar-setup/SKILL.md
+++ b/skills/chunk-sidecar-setup/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: chunk-sidecar-setup
+description: Use when the user says "set up chunk sidecar", "onboard to chunk", "first time sidecar", "configure sidecar from scratch", "walk me through sidecar setup", "set up smarter testing from scratch", "sidecar onboarding", "new sidecar environment", or "I've never used a chunk sidecar before". Also invoked by the chunk-sidecar skill when first-time setup is selected. This is the interactive onboarding wizard — it covers auth, orgID, sidecar creation, dependency installation, snapshot creation, and handoff to the dev loop.
+version: 1.0.0
+allowed-tools:
+  - Bash(chunk --version)
+  - Bash(chunk auth status)
+  - Bash(chunk config set:*)
+  - Bash(chunk sidecar:*)
+  - Bash(chunk validate:*)
+  - Bash(cat .chunk/config.json)
+  - Bash(cat .chunk/sidecar.json)
+  - Bash(ls .circleci/test-suites.yml)
+  - Bash(test -n*)
+  - Bash(git remote get-url origin)
+  - Bash(basename*)
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+---
+
+# Chunk Sidecar Setup (Onboarding Wizard)
+
+This skill walks you through setting up a `chunk` sidecar from scratch. A sidecar is a remote Linux container provisioned on CircleCI. It mirrors your local working tree and runs your build, test, and validate commands in a clean, isolated environment — no local port conflicts, no dependency drift, no "works on my machine."
+
+**What you'll have by the end:**
+- Auth and credentials verified
+- A running sidecar with your project's dependencies installed
+- A reusable snapshot so future sessions start in seconds
+- `chunk validate` confirmed passing on the sidecar
+
+Work through the stages in order. At each decision point, call `AskUserQuestion` as specified. Do not skip ahead.
+
+---
+
+## Stage 1 — Check Prerequisites
+
+Run these three probes and evaluate the results:
+
+```bash
+chunk --version 2>&1 || echo "CHUNK_NOT_INSTALLED"
+chunk auth status 2>&1
+cat .chunk/config.json 2>&1 || echo "{}"
+```
+
+### `chunk --version`
+If the command is not found, stop and explain: "`chunk` is not installed or not on your PATH. Install it first (e.g. `brew install circleci/tools/chunk` on macOS), then re-run this skill."
+
+### `chunk auth status`
+Read the output carefully — it prints the status of each credential:
+
+| Credential  | Required for                              |
+|-------------|-------------------------------------------|
+| CircleCI    | All sidecar commands (required)           |
+| GitHub      | Validate commands that fetch PRs/issues   |
+| Anthropic   | Validate commands that invoke Claude      |
+
+If CircleCI shows "Not set", tell the user to run `chunk auth set circleci` and confirm it passes before continuing. For GitHub and Anthropic, surface that they're missing but do not block if the user's validate commands don't need them.
+
+**Never run `echo $CIRCLE_TOKEN`, `env`, `printenv`, or any command that exposes credential env vars.** The `chunk auth status` output masks tokens — that is the only safe way to check credentials.
+
+### Auth check-in
+
+After evaluating auth, ask:
+
+```
+AskUserQuestion:
+  header: "Auth check"
+  question: "Auth looks good — ready to continue, or do you want to re-check something?"
+  options:
+    - "Continue to sidecar setup"  ← Recommended
+    - "Re-run chunk auth status"
+      → run chunk auth status again and show output
+    - "I need to set a credential"
+      → ask which one, then tell user to run chunk auth set <service>
+```
+
+---
+
+## Stage 2 — Confirm OrgID
+
+A CircleCI org ID (UUID) is required before creating a sidecar. Interactive org selection does not work in agent sessions, so it must be pre-configured.
+
+1. Check `cat .chunk/config.json` for `orgID`.
+2. If absent, run `test -n "${CIRCLECI_ORG_ID:-}"` (do **not** print the value).
+3. If **both** are unset:
+
+```
+AskUserQuestion:
+  header: "OrgID required"
+  question: "Your CircleCI org ID isn't configured. What would you like to do?"
+  options:
+    - "I have my org ID — enter it now"
+      → ask user to paste the UUID
+        run: chunk config set orgID <id>
+    - "How do I find my org ID?"
+      → explain: "In the CircleCI web app, open Organization Settings (the gear icon
+         in the left nav). Your org ID is the UUID shown at the top of the page."
+        then ask for it and run: chunk config set orgID <id>
+```
+
+4. If `orgID` is already in config or env, tell the user: "OrgID is configured — good to go."
+
+---
+
+## Stage 3 — Name Your Sidecar (Optional)
+
+```
+AskUserQuestion:
+  header: "Sidecar name"
+  question: "Do you want to name your sidecar, or use an auto-generated name?"
+  options:
+    - "Auto-generate a name"  ← Recommended
+      description: "chunk picks a fun name like 'happy-quickly-tesla'. Easy to
+                    identify, no typing required."
+      → proceed without --name
+    - "I'll choose a name"
+      description: "Good if you want something memorable like 'dev' or your username."
+      → ask user for the name, then use --name <name> in Stage 4
+```
+
+---
+
+## Stage 4 — Create the Sidecar
+
+Create the sidecar:
+
+```bash
+chunk sidecar create [--name <name>]
+```
+
+This provisions a fresh Linux container on CircleCI. It takes 30–90 seconds. While it starts, explain: "The sidecar is starting up. Once it's ready, we'll sync your local code to it."
+
+Then sync your local working tree:
+
+```bash
+chunk sidecar sync
+```
+
+Sync mirrors your entire local tree (including staged and unstaged changes) to `~/workspace/<repo>` on the sidecar. You never need to commit or push first — the sidecar always sees exactly what's on your disk right now.
+
+After sync, run `chunk sidecar current --json` and show the user the resolved `workspace` path so they know where their code lives on the sidecar.
+
+---
+
+## Stage 5 — Install Dependencies
+
+```
+AskUserQuestion:
+  header: "Dependencies"
+  question: "How should we install your project's dependencies on the sidecar?"
+  options:
+    - "Auto-detect with chunk sidecar setup"  ← Recommended
+      description: "chunk detects your stack (Go, Node, Python, etc.) and runs
+                    the right install commands automatically."
+      → run: chunk sidecar setup --dir .
+    - "I'll specify the install commands"
+      description: "Run custom commands on the sidecar (e.g. 'go mod download')."
+      → ask user for commands
+        run each via: chunk validate --remote --cmd "<cmd>"
+    - "Skip — deps are already in the base image"
+      description: "Your sidecar image already has everything installed."
+      → skip to Stage 6
+```
+
+### Install circleci-testsuite (Smarter Testing)
+
+After dependency install, check locally:
+
+```bash
+ls .circleci/test-suites.yml 2>/dev/null && echo "FOUND" || echo "NOT_FOUND"
+```
+
+```
+AskUserQuestion:
+  header: "Smarter Testing"
+  question: "Does this project use CircleCI Smarter Testing (test-suites.yml)?"
+  options:
+    - "Yes — install circleci-testsuite on the sidecar"
+      description: "Installs the circleci CLI and circleci-testsuite plugin so
+                    you can run 'doctor' validation on the sidecar."
+      → install circleci CLI and circleci-testsuite:
+           chunk validate --remote --cmd "curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/main/install.sh | sudo bash"
+           chunk validate --remote --cmd "circleci update install"
+           (follow any additional circleci-testsuite install steps for the org)
+    - "No — skip"
+      → continue
+```
+
+If `test-suites.yml` was found locally, recommend "Yes" in the question text.
+
+---
+
+## Stage 6 — Run Validate
+
+Confirm the sidecar environment is working:
+
+```bash
+chunk validate
+```
+
+`chunk validate` runs all configured commands in `.chunk/config.json`. Commands marked `remote: true` run on the sidecar; others run locally. Zero exit = everything passed.
+
+**If it fails:**
+- Read the stderr output — `chunk validate` prints per-command headers and propagates the first non-zero exit.
+- Fix missing binaries: `chunk validate --remote --cmd "<install-command>"`.
+- Fix local file issues: edit locally, `chunk sidecar sync`, re-run `chunk validate`.
+- Repeat until it exits zero.
+
+When it passes, tell the user: "Validate passed. Your sidecar environment is healthy."
+
+---
+
+## Stage 7 — Create a Snapshot
+
+A snapshot saves the current sidecar state as a reusable image. Future sessions create a new sidecar from this snapshot and skip the whole install process — typically 30 seconds to a working environment instead of several minutes.
+
+**Always snapshot once validate passes — do not skip this step.**
+
+Ask the user for a name:
+
+```
+AskUserQuestion:
+  header: "Snapshot name"
+  question: "What should we call this snapshot?"
+  options:
+    - "Use repo name + today's date"
+      description: "e.g. 'chunk-cli-2026-08-12' — easy to identify later."
+      → construct name as <repo-basename>-<YYYY-MM-DD>
+        (read repo name from: basename $(git remote get-url origin) .git)
+    - "I'll choose a name"
+      description: "Type a descriptive name like 'go-dev-env' or 'main-snapshot'."
+      → ask user for the name
+```
+
+Create the snapshot:
+
+```bash
+chunk sidecar snapshot create --name <snapshot-name>
+```
+
+Note the snapshot ID from the output. The source sidecar is automatically deleted after a successful snapshot — that is expected behavior. Local active-sidecar state is also cleared; `chunk sidecar current` will return empty until you launch from the snapshot in Stage 8.
+
+Persist the snapshot ID:
+
+```bash
+chunk config set validation.sidecarImage <snapshot-id>
+```
+
+---
+
+## Stage 8 — Launch From Snapshot
+
+Create a fresh sidecar from the snapshot — this is the clean environment you'll use going forward:
+
+```bash
+chunk sidecar create --image <snapshot-id>
+chunk sidecar sync
+```
+
+Then re-verify:
+
+```bash
+chunk validate
+```
+
+This second validate confirms the snapshot boots correctly and your code is in sync.
+
+---
+
+## Done — You're Ready
+
+When Stage 8 validate passes, tell the user:
+
+> Setup complete. Here's what was configured:
+>
+> - OrgID: saved to `.chunk/config.json`
+> - Snapshot ID: `<snapshot-id>` saved as `validation.sidecarImage` in `.chunk/config.json`
+> - Active sidecar: running and passing validate
+>
+> **Going forward:** run `/chunk-sidecar` to start the dev loop. It will detect your snapshot and offer to launch a new sidecar automatically when needed. For the tight loop: sync → validate, repeat with each set of local edits.
+
+---
+
+## Troubleshooting
+
+- **`Could not select an organization` / `no interactive terminal`** — OrgID is missing. Return to Stage 2.
+- **Auth errors (401/403, "token invalid")** — run `chunk auth status` and follow its printed remediation. Never dump env vars.
+- **`permission denied (publickey)` on sync or exec** — run `chunk sidecar add-ssh-key --public-key-file ~/.ssh/chunk_ai.pub`. If it persists, tell the user to remove `~/.ssh/chunk_ai*` to regenerate the keypair on next use.
+- **`context deadline exceeded`** — sidecar is unhealthy. Run `chunk sidecar forget` and restart from Stage 4 with a new sidecar.
+- **Missing binary after `chunk sidecar setup`** — install with `chunk validate --remote --cmd "<install>"`, verify with `chunk validate`, then re-snapshot (Stage 7 onward).
+- **Snapshot `--image` won't boot a new sidecar** — snapshot IDs are org-scoped. Confirm the new sidecar is being created in the same org as the snapshot. Run `chunk sidecar snapshot list` to verify available IDs.

--- a/skills/chunk-sidecar/SKILL.md
+++ b/skills/chunk-sidecar/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: chunk-sidecar
 description: Use when the user says "validate on the sidecar", "run tests on the sidecar", "sync to sidecar", "sidecar dev loop", "check this on the sidecar", "validate remotely", "scaffold test-suites.yml", "set up smarter testing", "write .circleci/test-suites.yml", "run smarter testing doctor", or "diagnose smarter testing", or when you have made edits and want to verify them on a remote `chunk` sidecar instead of running locally. Also covers creating sidecars, snapshotting a configured environment, customizing the sidecar image via `chunk sidecar`, and scaffolding `.circleci/test-suites.yml` for CircleCI Smarter Testing.
-version: 1.6.0
+version: 2.0.0
 allowed-tools:
   - Bash(chunk --version)
   - Bash(chunk auth status)
@@ -9,6 +9,7 @@ allowed-tools:
   - Bash(chunk sidecar:*)
   - Bash(chunk validate:*)
   - Bash(cat .chunk/config.json)
+  - Bash(cat .chunk/sidecar.json)
   - Bash(test -n*)
   - Read
   - Write
@@ -17,182 +18,196 @@ allowed-tools:
   - Glob
 ---
 
-# Chunk Sidecar Skill
+# Chunk Sidecar
 
-Run the user's build, test, and validate commands on a remote `chunk` sidecar instead of locally. The 90% job is the **sync → validate** loop. This skill also covers one-time setup (create, snapshot, environment customization).
+Run your build, test, and validate commands on a remote CircleCI-provisioned Linux environment instead of locally. The 90% job is the **sync → validate** dev loop. This skill also handles first-time setup, debugging, test-suite scaffolding, and snapshot management.
 
-Sidecars are ephemeral Linux environments provisioned via CircleCI. They isolate work, avoid local port conflicts, and can be reset to known-good snapshots. Your local tree is mirrored to `~/workspace/<repo>` on the sidecar each time you sync — the absolute path depends on the SSH user's home (e.g. `/home/circleci/workspace/<repo>` on `cimg/*` images, `/home/user/workspace/<repo>` on the default Ubuntu template). To see the resolved workspace, run `chunk sidecar current --json` and read the `workspace` field.
+---
 
-`CIRCLE_TOKEN` is forwarded over SSH automatically, so authenticated CircleCI API calls work out of the box once a token is configured locally.
+## Step 0 — Probe State, Then Ask
 
-The bare default sidecar image does **not** include the `circleci` CLI or the `circleci-testsuite` Smarter Testing plugin. If your validate commands need either, install them during one-time setup (Step 3) and snapshot the result so future sidecars boot with them ready. A snapshot built from a `cimg/*` base does not include `circleci-testsuite` either.
+Run these probes **before anything else**. They are read-only and always safe:
 
-## Step 1: Prerequisites
+```bash
+chunk --version 2>&1 || echo "CHUNK_NOT_INSTALLED"
+chunk auth status 2>&1
+cat .chunk/config.json 2>&1 || echo "{}"
+chunk sidecar current 2>&1
+```
 
-Run these checks in order. Stop and report to the user if anything fails.
+**If `chunk` is not installed:** Stop. Tell the user to install `chunk` before using this skill.
 
-1. `chunk --version` — confirms the CLI is installed and on PATH.
-2. `chunk auth status` — validates the configured credentials. Rely on the **exit code**: non-zero means a *configured* credential failed validation. Zero does **not** mean every credential is set — a missing CircleCI or GitHub token prints "Not set" and still exits zero. Read the output: if CircleCI shows "Not set", stop and ask the user to run `chunk auth set circleci` before proceeding (the sidecar commands in Step 2 will otherwise fail with an auth error). The command's output masks tokens; do not dig into env vars yourself.
+**If auth shows CircleCI "Not set":** Stop. Tell the user to run `chunk auth set circleci` first.
 
-Do **not** run `echo $CIRCLE_TOKEN`, `env`, `printenv`, or any other command that reads credential environment variables. That leaks secrets into conversation context. If `chunk auth status` reports a failure or shows a required credential as "Not set", surface its printed remediation (e.g. "Run `chunk auth set circleci`") and stop.
+**Otherwise, call AskUserQuestion** based on detected state (choose the block that matches):
 
-3. **CircleCI orgID preflight** — run **before any** `chunk sidecar` subcommand. Interactive org selection does not work in agent sessions.
+---
 
-   1. `cat .chunk/config.json` and confirm `orgID` is set to a non-empty value.
-   2. If `orgID` is absent from the config, check whether `CIRCLECI_ORG_ID` is set **without printing its value** (e.g. `test -n "${CIRCLECI_ORG_ID:-}"`). Do not run `printenv`, `env`, or `echo` on credential variables.
-   3. If **both** are unset, **stop** — do not call `chunk sidecar create`, `chunk sidecar list`, or any other `chunk sidecar` command. Ask the user for their org ID **exactly once** using this message:
+### No active sidecar + no `validation.sidecarImage` in config (first time)
 
-      > No CircleCI orgID found in `.chunk/config.json`. Sidecar cannot select an org in a non-interactive session. Please provide your CircleCI org ID. To persist it for future sessions, I will run: `chunk config set orgID <id>`
+```
+AskUserQuestion:
+  header: "Sidecar intent"
+  question: "No sidecar is configured yet. What would you like to do?"
+  options:
+    - "Walk me through first-time setup"
+      → invoke the chunk-sidecar-setup skill via the Skill tool
+    - "I have a snapshot ID — create from it"
+      → ask user for the snapshot ID, then:
+         chunk sidecar create --image <id>
+         chunk sidecar sync
+         → continue to Dev Loop section
+    - "Diagnose what's missing"
+      → go to Prerequisites section, report findings
+    - "Scaffold test-suites.yml for Smarter Testing"
+      → go to Scaffolding section
+```
 
-      After the user provides the ID, run `chunk config set orgID <id>`, then continue to Step 2.
-   4. If only `CIRCLECI_ORG_ID` is set (config still lacks `orgID`), `chunk sidecar create` will detect it automatically. Persisting with `chunk config set orgID <id>` is recommended but not required before Step 2.
+---
 
-## Step 2: Find or create the active sidecar
+### No active sidecar + `validation.sidecarImage` IS set
 
-Run `chunk sidecar current`. Three cases:
+```
+AskUserQuestion:
+  header: "Sidecar action"
+  question: "You have a configured snapshot but no running sidecar. What would you like to do?"
+  options:
+    - "Launch from snapshot and start dev loop"  ← Recommended
+      → chunk sidecar create --image <sidecarImage>
+        chunk sidecar sync
+        → continue to Dev Loop section
+    - "Debug or fix something"
+      → go to Troubleshooting section
+    - "Scaffold test-suites.yml"
+      → go to Scaffolding section
+    - "Manage snapshots"
+      → go to Snapshot Management section
+```
 
-- **It prints a sidecar** — use it; go to Step 4.
-- **No active sidecar, and `validation.sidecarImage` is set in `.chunk/config.json`** — create a new sidecar from the snapshot, sync, and go straight to Step 4:
-  ```
-  chunk sidecar create --image <sidecarImage>
-  chunk sidecar sync
-  ```
-  Read `validation.sidecarImage` from `.chunk/config.json`; orgID is resolved automatically from config or `CIRCLECI_ORG_ID`.
-- **No active sidecar, no `sidecarImage` configured** — full environment setup is needed. Inform the user, then go to Step 3:
-  ```
-  chunk sidecar create
-  ```
+---
 
-`chunk sidecar create` resolves orgID automatically: first from `.chunk/config.json`, then from `CIRCLECI_ORG_ID`. The Step 1 preflight guarantees one of those is set before this point. `--name` is optional; a random adjective-adverb-noun name (e.g. `happy-quickly-tesla`) is generated automatically if omitted.
+### Active sidecar exists
 
-## Step 3: One-time setup
+```
+AskUserQuestion:
+  header: "Sidecar action"
+  question: "Your sidecar is active. What would you like to do?"
+  options:
+    - "Sync and validate (dev loop)"  ← Recommended
+      → go to Dev Loop section
+    - "Debug or fix something"
+      → go to Troubleshooting section
+    - "Scaffold test-suites.yml"
+      → go to Scaffolding section
+    - "Manage snapshots"
+      → go to Snapshot Management section
+```
 
-This step produces a reusable snapshot so future sessions boot fast. Follow it whenever a fresh sidecar has no snapshot to boot from (Step 2 case 3).
+---
 
-1. `chunk sidecar setup --dir .` — detects the stack, syncs files, and runs install steps on the sidecar. Pass `--name <name>` if you want a specific name; otherwise one is generated automatically.
-2. Verify the sidecar is working correctly: `chunk validate`. This uses per-command routing — commands marked `remote: true` run on the sidecar, the rest run locally. If any command fails with a missing binary or dependency, see Troubleshooting below, then re-run `chunk validate` until it passes.
-3. Snapshot the working sidecar: `chunk sidecar snapshot create --name <snapshot-name>`. This captures the configured state and returns a snapshot ID. **Always snapshot after confirming the sidecar is working — do not skip this step.** Snapshot names are limited to 255 characters; the CLI will reject longer names before making the API call. **The source sidecar is deleted after a successful snapshot** to avoid leaking the build instance, and local active-sidecar state is cleared — expect `chunk sidecar current` to return empty until you launch a new one in step 5. To look up snapshot IDs later, run `chunk sidecar snapshot list`.
-4. Record the snapshot ID in `.chunk/config.json`: `chunk config set validation.sidecarImage <snapshot-id>`.
-5. Create a **new** sidecar from the snapshot and set it as active — this is the clean environment you will use going forward:
-   ```
-   chunk sidecar create --image <snapshot-id>
-   chunk sidecar sync
-   ```
-6. Re-verify with `chunk validate` to confirm the snapshot-booted sidecar is healthy before entering the loop.
+## Prerequisites
 
-## Step 4: The tight loop
+Before any `chunk sidecar` command, confirm:
+
+1. `chunk --version` — CLI is installed and on PATH.
+2. `chunk auth status` — exit code 0, CircleCI shows "Configured". If not, run `chunk auth set circleci`.
+3. **OrgID** — read `cat .chunk/config.json` and check `orgID`. If missing, run `test -n "${CIRCLECI_ORG_ID:-}"`. If **both** are unset, ask the user for their org ID **exactly once** and persist with `chunk config set orgID <id>`.
+
+Never run `echo $CIRCLE_TOKEN`, `env`, `printenv`, or any command that exposes credential env vars.
+
+---
+
+## Dev Loop
 
 For each round of edits:
 
-1. `chunk sidecar sync` — pushes the local working tree (including staged and unstaged changes) to the active sidecar. You do **not** need to commit or push first. Skip this call if nothing has changed locally since the last sync.
-2. `chunk validate` — runs the project's configured validate commands using per-command routing: commands marked `remote: true` in `.chunk/config.json` run on the sidecar, the rest run locally.
-   - One command by name: `chunk validate <name>`.
-   - Ad-hoc command on the sidecar: `chunk validate --remote --cmd "<cmd>"`.
-3. Read the exit code. Zero = pass. Non-zero = go to Step 5.
+1. `chunk sidecar sync` — pushes the local working tree (staged + unstaged) to the active sidecar. Skip if nothing changed.
+2. `chunk validate` — runs configured commands. Commands marked `remote: true` in `.chunk/config.json` run on the sidecar; others run locally.
+   - One command by name: `chunk validate <name>`
+   - Ad-hoc remote command: `chunk validate --remote --cmd "<cmd>"`
+3. Zero exit = pass. Non-zero = go to Troubleshooting.
 
-## Step 5: Interpreting failures
+---
 
-When validate returns non-zero:
+## Snapshot Management
 
-- Parse stderr — `chunk validate` prints per-command headers and propagates the first non-zero exit.
-- Map error paths back to local files: the sidecar mirrors your tree at `~/workspace/<repo>`. Run `chunk sidecar current --json` to see the resolved absolute workspace path.
-- Fix locally, then repeat Step 4. Do **not** edit files over SSH — changes will be overwritten on the next sync.
-- If the error looks environmental (missing binary, wrong language version, unreachable service), go to Troubleshooting.
+Snapshots save a configured sidecar state so future sessions boot fast.
+
+- **Create:** `chunk sidecar snapshot create --name <name>` — captures current sidecar. The source sidecar is deleted after a successful snapshot.
+- **List:** `chunk sidecar snapshot list`
+- **Record in config:** `chunk config set validation.sidecarImage <snapshot-id>`
+- **Launch from:** `chunk sidecar create --image <snapshot-id>` then `chunk sidecar sync`
+
+Always snapshot after `chunk validate` passes.
+
+---
 
 ## Scaffolding `.circleci/test-suites.yml`
 
-CircleCI Smarter Testing splits a project's test suite into **atoms** (independent units) and runs only the subset the platform picks for a given shard. The split is driven by `.circleci/test-suites.yml`. `chunk init` skips generating this file by default because the built-in templates only cover Go and pytest — for other stacks, write it directly.
-
-### When to scaffold
-
-- The user asks to "scaffold test-suites.yml", "set up smarter testing", or "write `.circleci/test-suites.yml`".
-- During the validate loop, you notice `.circleci/test-suites.yml` is missing and the project has a recognizable test runner.
+CircleCI Smarter Testing splits your test suite into atoms and runs only the affected subset. Driven by `.circleci/test-suites.yml`.
 
 ### File shape
 
 ```yaml
 ---
 name: <suite-name>
-discover: <shell command that prints one test atom per line>
-run: <shell command that runs the atoms in `<< test.atoms >>`, writing junit XML to `<< outputs.junit >>`>
+discover: <command that prints one test atom per line>
+run: <command that runs `<< test.atoms >>` and writes junit XML to `<< outputs.junit >>`>
 outputs:
   junit: <path/to/junit.xml>
 ```
 
-CircleCI substitutes at run time:
-- `<< test.atoms >>` — space-separated subset of atoms picked for this shard.
-- `<< outputs.junit >>` — the path declared under `outputs.junit`; the platform ingests this file to report results.
+### Stack templates
 
-### Choosing `discover` and `run`
+**Go:**
+```yaml
+discover: go list -f '{{ if or (len .TestGoFiles) (len .XTestGoFiles) }} {{ .ImportPath }} {{end}}' ./...
+run: go tool gotestsum --junitfile="<< outputs.junit >>" -- -race << test.atoms >>
+```
 
-An atom is the smallest independent unit the runner accepts. Match the runner's natural sharding granularity:
+**Python (pytest):**
+```yaml
+discover: python -m pytest --collect-only -q
+run: python -m pytest --junit-xml=<< outputs.junit >> << test.atoms >>
+```
 
-- **Go** — atoms are import paths.
-  ```yaml
-  discover: go list -f '{{ if or (len .TestGoFiles) (len .XTestGoFiles) }} {{ .ImportPath }} {{end}}' ./...
-  run: go tool gotestsum --junitfile="<< outputs.junit >>" -- -race << test.atoms >>
-  ```
-- **Python (pytest)** — atoms are node ids.
-  ```yaml
-  discover: python -m pytest --collect-only -q
-  run: python -m pytest --junit-xml=<< outputs.junit >> << test.atoms >>
-  ```
-- **Node (Jest)** — atoms are test file paths.
-  ```yaml
-  discover: npx jest --listTests
-  run: JEST_JUNIT_OUTPUT_FILE=<< outputs.junit >> npx jest --reporters=default --reporters=jest-junit << test.atoms >>
-  ```
-- **Other stacks** — keep the same pattern: `discover` prints one atom per line; `run` accepts whatever subset `discover` could output. Install a junit reporter if the runner does not emit junit natively.
+**Node (Jest):**
+```yaml
+discover: npx jest --listTests
+run: JEST_JUNIT_OUTPUT_FILE=<< outputs.junit >> npx jest --reporters=default --reporters=jest-junit << test.atoms >>
+```
 
-### Constraints
+### Validate after writing
 
-- `discover` must be deterministic and exit non-zero on error — the platform calls it once per pipeline.
-- `run` must accept any subset of `discover`'s output, including a single atom and the full set. Verify locally with a hand-picked subset before committing.
-- `outputs.junit` must be a junit XML file the runner actually writes. The platform reads it to report pass/fail and timing.
-- `.circleci/test-suites.yml` is referenced from `.circleci/config.yml` via the `circleci-testsuite` plugin invoked directly in a test job (not via the Smarter Testing orb). After writing the suite, confirm the `circleci-testsuite exec --suite <name>` call uses the suite `name` you chose.
-
-### After writing
-
-Validate on the sidecar — the `circleci-testsuite` plugin and `circleci` CLI are pre-installed there, matching the CI environment.
-
-1. `chunk sidecar sync` — push the new file to the active sidecar.
-2. Run the doctor diagnostic on the sidecar:
+1. `chunk sidecar sync`
+2. Run doctor on the sidecar:
    ```
    chunk validate --remote --cmd 'script -q /dev/null circleci run testsuite "<suite-name>" --doctor'
    ```
-   Doctor validates YAML structure, the discover command, the run command with sample atoms, JUnit output, and config wiring in a single pass. Read its output and fix any reported issues locally, then sync and re-run doctor. Repeat until all checks pass.
+3. Fix reported issues locally, sync, re-run doctor. Repeat until all checks pass.
 
-If `circleci-testsuite` is not installed on the sidecar (see Step 3 for installing it), fall back to manual validation:
+If `circleci-testsuite` is not installed, fall back to manual validation (see v1 skill for manual steps).
 
-1. `chunk validate --remote --cmd "<discover-command>"` — confirm it prints one atom per line and exits zero.
-2. `chunk validate --remote --cmd "<run-command with one or two atoms>"` — confirm a junit XML file appears at the `outputs.junit` path.
-3. `chunk validate --remote --cmd "circleci config validate"` — confirm `.circleci/config.yml` parses and the `circleci-testsuite exec --suite <name>` call uses the suite `name` you chose.
-
-### Beyond scaffolding
-
-This skill covers writing `test-suites.yml` and validating it with doctor on the sidecar. For deeper Smarter Testing configuration — test impact analysis, dynamic test splitting, auto-rerun, CI job wiring, or troubleshooting doctor failures beyond YAML/command issues — see the **`circleci-smarter-testing`** skill (available as a CircleCI plugin skill via `CircleCI-Public/skills`). It provides runner-specific templates, reference docs, and a full onboarding workflow.
-
-## Parallel sessions
-
-When `CLAUDE_SESSION_ID` is set, `chunk` auto-scopes the active-sidecar state to that session. Two concurrent sessions in the same repo target different sidecars without conflict.
+---
 
 ## Troubleshooting
 
-- **`Could not select an organization`**, **`no interactive terminal available`**, or **`Pass --org-id instead`** — orgID was missing when a sidecar command ran. Return to Step 1 orgID preflight: ask the user exactly once, then `chunk config set orgID <id>`. Do not explore peripheral commands (`chunk config show`, `chunk --help | grep -i org`, etc.).
-- **Anti-pattern: orgID absent** — if `orgID` is not in `.chunk/config.json` and `CIRCLECI_ORG_ID` is unset, do not call `chunk sidecar create` or probe the CLI for org discovery. Ask the user once and persist with `chunk config set orgID <id>`.
-- **Auth errors (401/403, "token invalid", "unauthorized")** — run `chunk auth status` and follow its printed remediation (`chunk auth set circleci` / `github` / `anthropic`). Never dump env vars.
-- **Sidecar 404 on `current`, `sync`, or `validate`** — the sidecar was deleted externally. Run `chunk sidecar forget`, then return to Step 2.
-- **`permission denied (publickey)` on sync, ssh, or exec** — the sidecar does not have your SSH key registered. Run `chunk sidecar add-ssh-key --public-key-file ~/.ssh/chunk_ai.pub` (or pass `--public-key "<ssh-ed25519 ...>"` directly). The command requires one of those flags; invoking it bare returns "A public key is required." If the issue persists, tell the user they can remove `~/.ssh/chunk_ai*` to regenerate the keypair on next use.
-- **SSH key registration or API calls time out (`context deadline exceeded`)** — the sidecar is unhealthy. If `validation.sidecarImage` is set in `.chunk/config.json`, create a fresh sidecar from the snapshot (Step 2 case 2). If not, run `chunk sidecar forget` and repeat Step 3 with a new sidecar.
-- **Missing dependency or binary not on `$PATH` on the sidecar** — the environment setup steps may not have installed everything needed, or a runtime was installed to a non-standard path. Use `chunk validate --remote --cmd "<install-or-symlink-command>"` to install the missing tool or make it accessible. Once `chunk validate` passes, re-snapshot so future sidecars include it — note this deletes the current sidecar, so launch a new one from the snapshot to keep working.
-- **`sync` errors about merge base or upstream** — the local branch has no remote upstream. Ask the user to push the branch (`git push -u origin <branch>`) or rebase onto a tracked ref.
-- **Snapshot `--image` will not boot a new sidecar** — snapshot IDs are org-scoped. Confirm the new sidecar is being created in the same org as the snapshot. Run `chunk sidecar snapshot list` to verify available snapshot IDs.
+- **`Could not select an organization` / `no interactive terminal`** — orgID missing. Ask user once, then `chunk config set orgID <id>`.
+- **Auth errors (401/403, "token invalid")** — run `chunk auth status`, follow its printed remediation.
+- **Sidecar 404 on `current` / `sync` / `validate`** — sidecar was deleted externally. Run `chunk sidecar forget`, return to Step 0.
+- **`permission denied (publickey)`** — run `chunk sidecar add-ssh-key --public-key-file ~/.ssh/chunk_ai.pub`. If it persists, tell user to remove `~/.ssh/chunk_ai*` to regenerate the keypair.
+- **`context deadline exceeded` on SSH or API calls** — sidecar is unhealthy. If `sidecarImage` is set, create a fresh one from snapshot. Otherwise `chunk sidecar forget` and redo setup via `chunk-sidecar-setup`.
+- **Missing binary on sidecar** — `chunk validate --remote --cmd "<install-command>"`. Re-snapshot after `chunk validate` passes.
+- **`sync` errors about merge base** — ask user to push the branch (`git push -u origin <branch>`).
+- **Snapshot `--image` won't boot** — snapshot IDs are org-scoped. Confirm both the snapshot and new sidecar are in the same org.
 
-## Out of scope
+---
 
-This skill does **not**:
+## Parallel Sessions
 
-- Hand-edit `.chunk/config.json` or run `chunk init` for bulk project setup (user-owned). The skill **may** run `chunk config set` for `orgID` (Step 1 bootstrap) and `validation.sidecarImage` (Step 3 snapshot).
-- Install or change pre-commit hooks (that is `chunk init`).
-- Run `chunk init`.
-- Edit files on the sidecar over SSH — they will be wiped by the next `sync`.
+When `CLAUDE_SESSION_ID` is set, `chunk` auto-scopes the active-sidecar file to `.chunk/sidecar.<session-id>.json`. Two sessions in the same repo target different sidecars without conflict. Do not hand-edit those files.
+
+## Out of Scope
+
+- Running `chunk init` or bulk-editing `.chunk/config.json`. The skill may run `chunk config set` for `orgID` and `validation.sidecarImage` only.
+- Editing files on the sidecar over SSH — they will be overwritten on the next `sync`.

--- a/skills/embed.go
+++ b/skills/embed.go
@@ -2,7 +2,7 @@ package skills
 
 import "embed"
 
-//go:embed chunk-review/SKILL.md chunk-testing-gaps/SKILL.md chunk-sidecar/SKILL.md debug-ci-failures/SKILL.md
+//go:embed chunk-review/SKILL.md chunk-testing-gaps/SKILL.md chunk-sidecar/SKILL.md chunk-sidecar-setup/SKILL.md debug-ci-failures/SKILL.md
 
 // Content holds the embedded skill definition files.
 var Content embed.FS


### PR DESCRIPTION
[FACT380](https://linear.app/circleci/issue/FACT-380/split-the-chunk-sidecar-skill-into-onboarding-and-usage)
**Summary**
- Splits the chunk-sidecar skill into `/chunk-sidecar-setup` and `/chunk-sidecar`
- chunk-sidecar now probes state (CLI installed, auth, config, active sidecar) and calls AskUserQuestion to present context-aware options before taking any action
- chunk-sidecar-setup is an 8-stage interactive wizard covering auth, orgID, sidecar creation, dependency install, snapshot creation, and dev loop handoff
- Both skills ship via chunk skill install like the existing skills

**Implementation**

- skills/chunk-sidecar/SKILL.md — rewritten as a router: 4 read-only probes → AskUserQuestion with state-dependent menus → dispatches to named sections or invokes chunk-sidecar-setup via the Skill tool for first-time users
- skills/chunk-sidecar-setup/SKILL.md — new skill; 8 guided stages with AskUserQuestion at every decision point (auth check-in, orgID entry, sidecar naming, dep install strategy, Smarter Testing plugin, snapshot naming)
- skills/embed.go — added chunk-sidecar-setup/SKILL.md to //go:embed
- internal/skills/install.go — registered chunk-sidecar-setup in the All slice
- internal/skills/skills_test.go — updated skillNames to include the new skill (tests were asserting count = 4)
- docs/SKILLS.md — updated chunk-sidecar description, added chunk-sidecar-setup entry

**Test plan**

- [ ] task build compiles cleanly with the new embedded file
- [ ] go test -race ./internal/skills/... passes (was failing with count mismatch before fix)
- [ ] dist/chunk skill list shows 5 bundled skills including chunk-sidecar-setup
- [ ] dist/chunk skill install installs chunk-sidecar-setup to ~/.claude/skills/