### PR TITLE
Resume empty output streams instead of failing on them

### DIFF
--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -309,13 +309,13 @@ func (c *Client) streamCommandOutput(ctx context.Context, commandID string, onOu
 		}
 
 		// A connection that delivered any frame proves the far end is alive and
-		// talking, so it resets the stall count even when the command produced no
-		// new output — a command can legitimately be silent for minutes while it
-		// compiles, and the server closes each connection on a timer regardless.
-		// Counting those as failures would abandon a healthy but quiet command.
+		// talking, so it resets the stall count. An empty stream (no frames,
+		// no error) means the connection was interrupted before any data
+		// arrived — that is a resume trigger, not a failure. Only a genuine
+		// connectivity error (5xx, transport failure) counts as a stall.
 		if outcome.frames > 0 {
 			stalls = 0
-		} else {
+		} else if err != nil {
 			stalls++
 			if stalls > maxStreamStalls {
 				return nil, fmt.Errorf(
@@ -328,10 +328,9 @@ func (c *Client) streamCommandOutput(ctx context.Context, commandID string, onOu
 				"stream command output: gave up after %d reconnects without the command finishing", attempts)
 		}
 
-		// A stream cut short by the server's timeout is routine, so resume at
-		// once — inserting a delay every few seconds would make output stutter
-		// for no reason. Only back off when an attempt yielded nothing.
-		if stalls == 0 {
+		// Resume immediately after a normal drop or an interrupted empty
+		// connection. Only back off after a real connectivity error.
+		if err == nil || stalls == 0 {
 			continue
 		}
 		delay := min(time.Duration(stalls)*streamRetryBase, 10*streamRetryBase)

--- a/internal/circleci/exec_stream_test.go
+++ b/internal/circleci/exec_stream_test.go
@@ -171,6 +171,23 @@ func TestExecKeepsResumingWhileServerStaysAlive(t *testing.T) {
 	assert.Equal(t, attempts, drops+1)
 }
 
+// A command that produces no output while it runs forces every reconnect to
+// return an empty stream (no SSE frames at all). That is the normal "connection
+// interrupted" signal from the API and must not be counted as a failure.
+func TestExecKeepsResumingOnEmptyStreams(t *testing.T) {
+	empties := maxStreamStalls * 4
+
+	resp, stdout, _, attempts, err := execCounting(t, &fakes.ExecResponse{
+		CommandID: "cmd-1", Stdout: "done\n", ExitCode: 0,
+	}, func(f *fakes.FakeCircleCI) {
+		f.EmptyStreamsBeforeExit = empties
+	})
+	assert.NilError(t, err, "empty streams must not be treated as failures")
+	assert.Equal(t, string(stdout), "done\n")
+	assert.Equal(t, resp.ExitCode, 0)
+	assert.Equal(t, attempts, empties+1)
+}
+
 // A server that keeps talking but never terminates the stream is still bounded,
 // so a bug there cannot spin forever.
 func TestExecGivesUpWhenStreamNeverTerminates(t *testing.T) {

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -94,7 +94,12 @@ type FakeCircleCI struct {
 	CommandOutputMessage     string // error message body when CommandOutputStatusCode is set
 	// DropStreamsBeforeExit ends this many output streams after delivering their
 	// output but before the terminal event, so client resume can be exercised.
-	DropStreamsBeforeExit    int
+	DropStreamsBeforeExit int
+	// EmptyStreamsBeforeExit returns this many completely empty output responses
+	// (status 200, no body) before serving the real stream. This simulates an
+	// interrupted connection where no SSE frames arrive at all, which the client
+	// must treat as a resume trigger rather than a failure.
+	EmptyStreamsBeforeExit   int
 	AddKeyStatusCode         int // override for POST /sidecar/instances/:id/ssh/add-key
 	CreateSnapshotStatusCode int // override for POST /sidecar/snapshots
 	GetSnapshotStatusCode    int // override for GET /sidecar/snapshots/:id
@@ -376,6 +381,13 @@ func (f *FakeCircleCI) handleCommandOutput(c *gin.Context) {
 		return
 	}
 
+	if f.emptyStreamBeforeExit() {
+		// Return 200 with no body to simulate a connection interrupted before
+		// any SSE frames were written. The client must treat this as a resume.
+		c.Status(http.StatusOK)
+		return
+	}
+
 	if resp == nil {
 		resp = &ExecResponse{
 			CommandID: "cmd-123",
@@ -446,6 +458,18 @@ func (f *FakeCircleCI) dropBeforeExit() bool {
 		return false
 	}
 	f.DropStreamsBeforeExit--
+	return true
+}
+
+// emptyStreamBeforeExit reports whether this request should return an empty
+// body (no SSE frames), consuming one from the configured budget.
+func (f *FakeCircleCI) emptyStreamBeforeExit() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.EmptyStreamsBeforeExit <= 0 {
+		return false
+	}
+	f.EmptyStreamsBeforeExit--
 	return true
 }
 


### PR DESCRIPTION
## Summary

- Fix `streamCommandOutput` to treat an empty SSE stream (200 OK, no frames, no error) as a resume trigger rather than a stall, so commands that produce no output while running don't get abandoned prematurely
- Update the stall counter to increment only on genuine connectivity errors (`err != nil`), and skip the backoff delay when `err == nil || stalls == 0`
- Add `EmptyStreamsBeforeExit` to the fake CircleCI server and a corresponding test (`TestExecKeepsResumingOnEmptyStreams`) to cover this case

## Test plan

- [ ] `task test` passes with `-race`
- [ ] `TestExecKeepsResumingOnEmptyStreams` exercises the empty-stream path against the fake, confirming many consecutive empty responses don't exhaust the stall budget
- [ ] Existing resume tests (`TestExecKeepsResumingWhileServerStaysAlive`, `TestExecGivesUpAfterTooManyStalls`) still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)