### PR TITLE
Use OAuth login in sidecar skills, install setup skill on init

### DIFF
--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -114,7 +114,7 @@ Interactive onboarding wizard for setting up a sidecar from scratch. Also invoke
 
 **Prerequisites**:
 - `chunk` CLI installed
-- CircleCI token available to configure (`chunk auth set circleci`)
+- CircleCI auth (`chunk auth login`, or `chunk auth set circleci` for token auth)
 
 **What it does** (8 guided stages):
 

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -335,7 +335,7 @@ func newAuthStatusCmd() *cobra.Command {
 					io.ErrPrintln(ui.FormatError(
 						"CircleCI token validation failed.",
 						"",
-						"Run `chunk auth set circleci` to set a new token.",
+						"Run `chunk auth login` to log in again, or `chunk auth set circleci` to set a token manually.",
 					))
 					hasFailure = true
 				} else {

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -263,7 +263,7 @@ func writeSettingsExample(dir string, data []byte, streams iostream.Streams) err
 }
 
 func installSkillsStep(workDir string, streams iostream.Streams) {
-	for _, r := range skills.InstallByName(skills.ScopeProject, workDir, "chunk-sidecar") {
+	for _, r := range skills.InstallByName(skills.ScopeProject, workDir, "chunk-sidecar", "chunk-sidecar-setup") {
 		if r.Skipped {
 			continue
 		}

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -438,6 +438,23 @@ func TestInstallSkillsStepUsesProjectScope(t *testing.T) {
 	assert.Assert(t, os.IsNotExist(err), "skill must not be installed under $HOME")
 }
 
+// TestInstallSkillsStepInstallsSidecarSetup verifies the onboarding wizard ships
+// alongside chunk-sidecar. Without it, chunk-sidecar's first-time setup path
+// routes to a skill that is not installed.
+func TestInstallSkillsStepInstallsSidecarSetup(t *testing.T) {
+	workDir := t.TempDir()
+	t.Setenv(config.EnvHome, t.TempDir())
+
+	streams, _, _ := testStreams()
+	installSkillsStep(workDir, streams)
+
+	for _, name := range []string{"chunk-sidecar", "chunk-sidecar-setup"} {
+		skillPath := filepath.Join(workDir, ".claude", "skills", name, "SKILL.md")
+		_, err := os.Stat(skillPath)
+		assert.NilError(t, err, "expected skill installed at %s", skillPath)
+	}
+}
+
 func TestPrintInitSummaryWithCommands(t *testing.T) {
 	ui.SetColorEnabled(false)
 	defer ui.SetColorEnabled(true)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -43,7 +43,8 @@ func NewRootCmd(version string) *cobra.Command {
 	rootCmd.SetHelpTemplate(rootCmd.HelpTemplate() + `
 Getting started:
   chunk init                    Initialize project configuration
-  chunk auth set <provider>     Store credentials (CircleCI token, Anthropic API key)
+  chunk auth login              Log in to CircleCI via browser (recommended)
+  chunk auth set <provider>     Store a credential manually (circleci, anthropic, github)
   chunk build-prompt            Generate a review prompt from GitHub PR comments
   chunk task config             Set up CircleCI task configuration
   chunk task run --definition <name> --prompt "<task>"

--- a/internal/cmd/task.go
+++ b/internal/cmd/task.go
@@ -39,7 +39,7 @@ func newTaskRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Trigger a task run",
-		Long:  "Trigger a task run.\n\nRequires: CircleCI token (chunk auth set circleci)",
+		Long:  "Trigger a task run.\n\nRequires: CircleCI auth (chunk auth login)",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {
@@ -108,7 +108,7 @@ func newTaskConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Set up .chunk/run.json for this repository",
-		Long:  "Set up .chunk/run.json for this repository.\n\nRequires: CircleCI token (chunk auth set circleci)",
+		Long:  "Set up .chunk/run.json for this repository.\n\nRequires: CircleCI auth (chunk auth login)",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			io := iostream.FromCmd(cmd)
 			ctx := cmd.Context()

--- a/internal/oauth/login.go
+++ b/internal/oauth/login.go
@@ -57,20 +57,17 @@ func Login(ctx context.Context, cfg LoginConfig, status io.Writer) (string, erro
 
 	w := func(s string) { _, _ = fmt.Fprintln(status, s) }
 
-	if cfg.NoBrowser {
-		w("Open this URL in your browser to log in:")
-		w("")
-		w("  " + authorizeURL)
-		w("")
-	} else {
-		w(authorizeURL)
-		if waitForEnter(ctx, status) {
-			if err := OpenBrowser(authorizeURL); err != nil {
-				w("Could not open browser. Open this URL manually:")
-				w("")
-				w("  " + authorizeURL)
-				w("")
-			}
+	w("Open this URL in your browser to log in:")
+	w("")
+	w("  " + authorizeURL)
+	w("")
+
+	// Only offer to open a browser when there is a terminal to confirm on.
+	// Under an agent or a script stdin is not a terminal, and opening a window
+	// unprompted gives the user no say in where they are being sent.
+	if !cfg.NoBrowser && stdinIsTerminal() && waitForEnter(ctx, status) {
+		if err := OpenBrowser(authorizeURL); err != nil {
+			w("Could not open browser - use the URL above.")
 		}
 	}
 	w("Waiting for login (up to 5 minutes)...")
@@ -101,12 +98,13 @@ func Login(ctx context.Context, cfg LoginConfig, status io.Writer) (string, erro
 	return tok.AccessToken, nil
 }
 
+// stdinIsTerminal reports whether stdin is an interactive terminal.
+// Swapped out in tests.
+var stdinIsTerminal = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
+
 // waitForEnter prompts the user to press Enter before opening the browser.
-// Returns true if the browser should be opened, false if cancelled or non-interactive.
+// Returns true if the browser should be opened, false if cancelled.
 func waitForEnter(ctx context.Context, status io.Writer) bool {
-	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		return true
-	}
 	_, _ = fmt.Fprint(status, "Press Enter to open CircleCI in your browser...")
 	errCh := make(chan error, 1)
 	go func() {

--- a/internal/oauth/login_test.go
+++ b/internal/oauth/login_test.go
@@ -1,0 +1,36 @@
+package oauth
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+)
+
+// TestLoginPrintsURLWithoutBrowserPrompt covers the non-interactive path: with
+// no terminal on stdin there is nobody to confirm, so Login must print the
+// authorize URL and never reach the browser prompt.
+func TestLoginPrintsURLWithoutBrowserPrompt(t *testing.T) {
+	t.Setenv(config.EnvXDGStateHome, t.TempDir())
+	origIsTerminal := stdinIsTerminal
+	stdinIsTerminal = func() bool { return false }
+	t.Cleanup(func() { stdinIsTerminal = origIsTerminal })
+
+	// A cancelled context lets Login return as soon as it starts waiting for
+	// the callback, after the URL has been written.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var status bytes.Buffer
+	_, err := Login(ctx, LoginConfig{BaseURL: "https://circleci.example"}, &status)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	out := status.String()
+	assert.Assert(t, strings.Contains(out, "Open this URL in your browser"), "missing URL instruction:\n%s", out)
+	assert.Assert(t, strings.Contains(out, "https://circleci.example/oauth/authorize?"), "missing authorize URL:\n%s", out)
+	assert.Assert(t, !strings.Contains(out, "Press Enter"), "must not prompt to open a browser:\n%s", out)
+}

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -127,23 +127,25 @@ func Install(scope Scope, baseDir string) []AgentInstallResult {
 	return results
 }
 
-// InstallByName installs a single skill by name.
-// Returns nil if the skill name is not found.
-func InstallByName(scope Scope, baseDir, name string) []AgentInstallResult {
-	var s *Skill
-	for i := range All {
-		if All[i].Name == name {
-			s = &All[i]
-			break
+// InstallByName installs the named skills, in the order given.
+// Unknown names are ignored; returns nil if none of the names match.
+func InstallByName(scope Scope, baseDir string, names ...string) []AgentInstallResult {
+	subset := make([]Skill, 0, len(names))
+	for _, name := range names {
+		for i := range All {
+			if All[i].Name == name {
+				subset = append(subset, All[i])
+				break
+			}
 		}
 	}
-	if s == nil {
+	if len(subset) == 0 {
 		return nil
 	}
 	all := agents(scope, baseDir)
 	results := make([]AgentInstallResult, 0, len(all))
 	for _, agent := range all {
-		results = append(results, installForAgent(agent, []Skill{*s}))
+		results = append(results, installForAgent(agent, subset))
 	}
 	return results
 }

--- a/skills/chunk-sidecar-setup/SKILL.md
+++ b/skills/chunk-sidecar-setup/SKILL.md
@@ -63,15 +63,15 @@ If CircleCI shows "Not set", run the OAuth login yourself — see [Logging in](#
 
 #### Logging in
 
-OAuth is the default. It opens a browser, exchanges the code over PKCE, and stores the token in the system keychain — no token pasting.
+OAuth is the default. The user opens a URL, the code comes back over PKCE, and the token lands in the system keychain — no token pasting.
 
 ```bash
 chunk auth login
 ```
 
-- Run with a **Bash timeout of 300000ms**: it blocks until the browser callback lands (5 minute limit). Tell the user to finish the login in the browser window that opens.
-- Stdin is not a terminal under the agent, so it skips the "press Enter" prompt and opens the browser straight away.
-- No browser available (headless, SSH, remote sandbox)? Use `chunk auth login --no-browser` and relay the printed URL. The callback listens on `127.0.0.1` on **this** machine, so it only works from a browser on the same host.
+- Run with a **Bash timeout of 300000ms**: it blocks until the callback lands (5 minute limit).
+- No browser opens when the agent runs it. Stdin is not a terminal, so the command prints the authorize URL and waits. **Relay that URL and ask the user to open it** — never open a browser on their behalf.
+- The callback listens on `127.0.0.1` on **this** machine, so the URL only works from a browser on the same host.
 - If the source already reads `Environment`, `CIRCLE_TOKEN` is set and wins over the keychain. Do not log in — treat it as configured.
 - `chunk auth set circleci` (paste a personal API token) is the fallback for when OAuth fails or the user asks for token auth.
 

--- a/skills/chunk-sidecar-setup/SKILL.md
+++ b/skills/chunk-sidecar-setup/SKILL.md
@@ -5,6 +5,8 @@ version: 1.0.0
 allowed-tools:
   - Bash(chunk --version)
   - Bash(chunk auth status)
+  - Bash(chunk auth login)
+  - Bash(chunk auth login --no-browser)
   - Bash(chunk config set:*)
   - Bash(chunk sidecar:*)
   - Bash(chunk validate:*)
@@ -57,7 +59,21 @@ Read the output carefully — it prints the status of each credential:
 | GitHub      | Validate commands that fetch PRs/issues   |
 | Anthropic   | Validate commands that invoke Claude      |
 
-If CircleCI shows "Not set", tell the user to run `chunk auth set circleci` and confirm it passes before continuing. For GitHub and Anthropic, surface that they're missing but do not block if the user's validate commands don't need them.
+If CircleCI shows "Not set", run the OAuth login yourself — see [Logging in](#logging-in) below — then re-run `chunk auth status` and confirm it shows "Configured" before continuing. For GitHub and Anthropic, surface that they're missing but do not block if the user's validate commands don't need them.
+
+#### Logging in
+
+OAuth is the default. It opens a browser, exchanges the code over PKCE, and stores the token in the system keychain — no token pasting.
+
+```bash
+chunk auth login
+```
+
+- Run with a **Bash timeout of 300000ms**: it blocks until the browser callback lands (5 minute limit). Tell the user to finish the login in the browser window that opens.
+- Stdin is not a terminal under the agent, so it skips the "press Enter" prompt and opens the browser straight away.
+- No browser available (headless, SSH, remote sandbox)? Use `chunk auth login --no-browser` and relay the printed URL. The callback listens on `127.0.0.1` on **this** machine, so it only works from a browser on the same host.
+- If the source already reads `Environment`, `CIRCLE_TOKEN` is set and wins over the keychain. Do not log in — treat it as configured.
+- `chunk auth set circleci` (paste a personal API token) is the fallback for when OAuth fails or the user asks for token auth.
 
 **Never run `echo $CIRCLE_TOKEN`, `env`, `printenv`, or any command that exposes credential env vars.** The `chunk auth status` output masks tokens — that is the only safe way to check credentials.
 
@@ -74,7 +90,8 @@ AskUserQuestion:
     - "Re-run chunk auth status"
       → run chunk auth status again and show output
     - "I need to set a credential"
-      → ask which one, then tell user to run chunk auth set <service>
+      → for CircleCI, run chunk auth login (see Logging in);
+        for GitHub or Anthropic, tell user to run chunk auth set <service>
 ```
 
 ---
@@ -287,7 +304,7 @@ When Stage 8 validate passes, tell the user:
 ## Troubleshooting
 
 - **`Could not select an organization` / `no interactive terminal`** — OrgID is missing. Return to Stage 2.
-- **Auth errors (401/403, "token invalid")** — run `chunk auth status` and follow its printed remediation. Never dump env vars.
+- **Auth errors (401/403, "token invalid")** — run `chunk auth status`. If the CircleCI token is stale or missing, re-run `chunk auth login` ([Logging in](#logging-in)). Never dump env vars.
 - **`permission denied (publickey)` on sync or exec** — run `chunk sidecar add-ssh-key --public-key-file ~/.ssh/chunk_ai.pub`. If it persists, tell the user to remove `~/.ssh/chunk_ai*` to regenerate the keypair on next use.
 - **`context deadline exceeded`** — sidecar is unhealthy. Run `chunk sidecar forget` and restart from Stage 4 with a new sidecar.
 - **Missing binary after `chunk sidecar setup`** — install with `chunk validate --remote --cmd "<install>"`, verify with `chunk validate`, then re-snapshot (Stage 7 onward).

--- a/skills/chunk-sidecar/SKILL.md
+++ b/skills/chunk-sidecar/SKILL.md
@@ -128,9 +128,9 @@ OAuth is the default. It opens a browser, exchanges the code over PKCE, and stor
 chunk auth login
 ```
 
-Run it with a **Bash timeout of 300000ms** — the command blocks until the browser callback lands (5 minute server-side limit). It prints the authorize URL first, so tell the user to complete the login in the browser window that opens. Stdin is not a terminal under the agent, so it opens the browser immediately without waiting for Enter.
+Run it with a **Bash timeout of 300000ms** — the command blocks until the browser callback lands (5 minute limit). No browser opens when the agent runs it: stdin is not a terminal, so `chunk auth login` prints the authorize URL and waits. **Relay that URL to the user and ask them to open it.** Never open a browser on their behalf.
 
-If the browser cannot open (headless, SSH, remote sandbox), use `chunk auth login --no-browser` and relay the printed URL to the user. The callback still listens on `127.0.0.1` on **this** machine, so the URL only works from a browser on the same host.
+The callback listens on `127.0.0.1` on **this** machine, so the URL only works from a browser on the same host. `--no-browser` forces the same print-and-wait behaviour when a terminal is present.
 
 Fall back to `chunk auth set circleci` (paste a personal API token) only when OAuth is unavailable, or when the user explicitly asks for token auth. Both paths land in the keychain; `--insecure-storage` writes to `~/.config/chunk/config.json` instead.
 

--- a/skills/chunk-sidecar/SKILL.md
+++ b/skills/chunk-sidecar/SKILL.md
@@ -5,6 +5,8 @@ version: 2.1.0
 allowed-tools:
   - Bash(chunk --version)
   - Bash(chunk auth status)
+  - Bash(chunk auth login)
+  - Bash(chunk auth login --no-browser)
   - Bash(chunk config set:*)
   - Bash(chunk org list:*)
   - Bash(chunk sidecar:*)
@@ -38,7 +40,7 @@ chunk sidecar current 2>&1
 
 **If `chunk` is not installed:** Stop. Tell the user to install `chunk` before using this skill.
 
-**If auth shows CircleCI "Not set":** Stop. Tell the user to run `chunk auth set circleci` first.
+**If auth shows CircleCI "Not set":** Run the OAuth login for them — see [Logging in](#logging-in) — then re-run `chunk auth status`. Only continue once CircleCI shows "Configured".
 
 **Otherwise, call AskUserQuestion** based on detected state (choose the block that matches):
 
@@ -111,10 +113,28 @@ AskUserQuestion:
 Before any `chunk sidecar` command, confirm:
 
 1. `chunk --version` — CLI is installed and on PATH.
-2. `chunk auth status` — exit code 0, CircleCI shows "Configured". If not, run `chunk auth set circleci`.
-3. **OrgID** — read `cat .chunk/config.json` and check `orgID`. If missing, run `test -n "${CIRCLECI_ORG_ID:-}"`. If **both** are unset, run `chunk org list --json`: one org, use it automatically; several, show the list and ask **exactly once**; error or empty, stop and ask the user to run `chunk auth set circleci`. Persist with `chunk config set orgID <id>`.
+2. `chunk auth status` — exit code 0, CircleCI shows "Configured". If not, see [Logging in](#logging-in).
+3. **OrgID** — read `cat .chunk/config.json` and check `orgID`. If missing, run `test -n "${CIRCLECI_ORG_ID:-}"`. If **both** are unset, run `chunk org list --json`: one org, use it automatically; several, show the list and ask **exactly once**; error or empty, stop and see [Logging in](#logging-in). Persist with `chunk config set orgID <id>`.
 
 Never run `echo $CIRCLE_TOKEN`, `env`, `printenv`, or any command that exposes credential env vars.
+
+---
+
+## Logging in
+
+OAuth is the default. It opens a browser, exchanges the code over PKCE, and stores the token in the system keychain — no token pasting, nothing on disk in plaintext.
+
+```bash
+chunk auth login
+```
+
+Run it with a **Bash timeout of 300000ms** — the command blocks until the browser callback lands (5 minute server-side limit). It prints the authorize URL first, so tell the user to complete the login in the browser window that opens. Stdin is not a terminal under the agent, so it opens the browser immediately without waiting for Enter.
+
+If the browser cannot open (headless, SSH, remote sandbox), use `chunk auth login --no-browser` and relay the printed URL to the user. The callback still listens on `127.0.0.1` on **this** machine, so the URL only works from a browser on the same host.
+
+Fall back to `chunk auth set circleci` (paste a personal API token) only when OAuth is unavailable, or when the user explicitly asks for token auth. Both paths land in the keychain; `--insecure-storage` writes to `~/.config/chunk/config.json` instead.
+
+If `chunk auth status` reports the CircleCI source as `Environment`, do **not** log in — `CIRCLE_TOKEN` is already set and takes precedence over the keychain, so a login would store a token that never gets used. Treat it as configured and move on.
 
 ---
 
@@ -194,7 +214,7 @@ If `circleci-testsuite` is not installed, fall back to manual validation (see v1
 ## Troubleshooting
 
 - **`Could not select an organization` / `no interactive terminal`** — orgID missing. Run `chunk org list --json`, auto-select if there is one org, otherwise ask once, then `chunk config set orgID <id>`.
-- **Auth errors (401/403, "token invalid")** — run `chunk auth status`, follow its printed remediation.
+- **Auth errors (401/403, "token invalid")** — run `chunk auth status`. If the CircleCI token is stale or missing, re-run `chunk auth login` ([Logging in](#logging-in)); otherwise follow the printed remediation.
 - **Sidecar 404 on `current` / `sync` / `validate`** — sidecar was deleted externally. Run `chunk sidecar forget`, return to Step 0.
 - **`permission denied (publickey)`** — run `chunk sidecar add-ssh-key --public-key-file ~/.ssh/chunk_ai.pub`. If it persists, tell user to remove `~/.ssh/chunk_ai*` to regenerate the keypair.
 - **`context deadline exceeded` on SSH or API calls** — sidecar is unhealthy. If `sidecarImage` is set, create a fresh one from snapshot. Otherwise `chunk sidecar forget` and redo setup via `chunk-sidecar-setup`.


### PR DESCRIPTION
## Summary
- Both sidecar skills told the user to run `chunk auth set circleci` and paste a personal API token. They now point at `chunk auth login`, which does the PKCE browser flow and stores the token in the system keychain.
- Adds a **Logging in** section to each skill: the 300000ms Bash timeout needed for the 5 minute callback wait, the `--no-browser` fallback for headless hosts, and the note that the `127.0.0.1` callback only works from a browser on the same host.
- Guards against logging in when the CircleCI source reads `Environment`. `CIRCLE_TOKEN` takes precedence over the keychain and `authLogin` does not check for it, so a login there would store a token that never gets read.
- `Bash(chunk auth login)` and `Bash(chunk auth login --no-browser)` added to `allowed-tools` in both skills so the flow does not stall on a permission prompt.

## chunk init did not install the setup skill
`chunk init` installed only `chunk-sidecar`, so its first-time setup path routed to `chunk-sidecar-setup`, which was never present in the project. Agents fell back to whatever they already had, which for anyone with an older user-scope install was the pre-2.0.0 skill and its old token messaging. `InstallByName` now takes variadic names and `init` passes both sidecar skills.

## Remaining auth hints
Points root help, `task run` / `task config` long help, the `auth status` token-validation-failed remediation, and the sidecar docs at `chunk auth login`. `chunk auth set circleci` stays as the documented fallback for token auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)