### PR TITLE
Add remote vs local label to validate output and watch TUI

### DIFF
--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -405,7 +405,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			// A hit is a success, so it finishes the same way a real successful run
 			// does rather than repeating that bookkeeping here: clearing the failure
 			// counter, and whatever else the success branch grows later.
-			return finishValidate(cmd, hook, nil, start, opts.sidecarID, cfg, wrapEventLogStatusFn(statusFn, "", nil, workDir, hook), streams)
+			return finishValidate(cmd, hook, nil, start, cfg, wrapEventLogStatusFn(statusFn, "", nil, workDir, hook), streams)
 		}
 	}
 
@@ -463,7 +463,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			streams.ErrPrintf("  %s\n", ui.ErrDim(fmt.Sprintf("chunk validate: cache write failed: %v", err)))
 		}
 	}
-	return finishValidate(cmd, hook, execErr, start, opts.sidecarID, cfg, statusFn, streams)
+	return finishValidate(cmd, hook, execErr, start, cfg, statusFn, streams)
 }
 
 // loadEnvVarsWithRetry loads sidecar env vars, and if the sidecar is unusable
@@ -529,7 +529,7 @@ func wrapEventLogStatusFn(statusFn iostream.StatusFunc, sidecarID string, active
 }
 
 // finishValidate reports the validate outcome and handles hook exit codes.
-func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start time.Time, sidecarID string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start time.Time, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	maxAttempts := validate.DefaultMaxAttempts
 	if hook != nil {
 		if ma := cfg.StopHookMaxAttempts; ma > 0 {
@@ -537,27 +537,22 @@ func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start 
 		}
 	}
 
-	location := "local"
-	if sidecarID != "" {
-		location = "remote"
-	}
-
 	if execErr != nil {
 		if hook != nil {
 			attempt := validate.ReadAttempts(hook.sessionID) + 1
-			statusFn(iostream.LevelError, fmt.Sprintf("done in %s (%s, failed, attempt %d/%d)", ui.FormatDuration(time.Since(start)), location, attempt, maxAttempts))
+			statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed, attempt %d/%d)", ui.FormatDuration(time.Since(start)), attempt, maxAttempts))
 		} else {
-			statusFn(iostream.LevelError, fmt.Sprintf("done in %s (%s, failed)", ui.FormatDuration(time.Since(start)), location))
+			statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed)", ui.FormatDuration(time.Since(start))))
 		}
 	} else {
-		statusFn(iostream.LevelDone, fmt.Sprintf("done in %s (%s)", ui.FormatDuration(time.Since(start)), location))
+		statusFn(iostream.LevelDone, fmt.Sprintf("done in %s", ui.FormatDuration(time.Since(start))))
 	}
 	if hook == nil {
 		return execErr
 	}
 	hookErr := validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
 	if hookErr == nil && execErr == nil {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.Success(fmt.Sprintf("chunk validate passed (%s · %s)", ui.FormatDuration(time.Since(start)), location)))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.Success(fmt.Sprintf("chunk validate passed (%s)", ui.FormatDuration(time.Since(start)))))
 		return nil
 	}
 	return hookErr
@@ -673,7 +668,6 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 	}
 
 	// Run all
-	statusFn(iostream.LevelInfo, "running locally")
 	return mapValidateError(validate.RunAll(ctx, workDir, cfg, statusFn, streams))
 }
 

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -48,6 +48,25 @@ func newStatusFunc(streams iostream.Streams) iostream.StatusFunc {
 	}
 }
 
+// commandCounter counts per-command pass/fail events emitted by the validate
+// runner. It detects command results by the "(local)" or "(remote)" suffix that
+// RunRemote and runCommand append to every per-command status line.
+type commandCounter struct {
+	passed int
+	total  int
+}
+
+func (c *commandCounter) wrap(fn iostream.StatusFunc) iostream.StatusFunc {
+	return func(level iostream.Level, msg string) {
+		if strings.HasSuffix(msg, "(local)") || strings.HasSuffix(msg, "(remote)") {
+			if level == iostream.LevelDone {
+				c.passed++
+			}
+		}
+		fn(level, msg)
+	}
+}
+
 // hookContext holds the Claude Code Stop hook payload fields.
 type hookContext struct {
 	sessionID      string
@@ -405,7 +424,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			// A hit is a success, so it finishes the same way a real successful run
 			// does rather than repeating that bookkeeping here: clearing the failure
 			// counter, and whatever else the success branch grows later.
-			return finishValidate(cmd, hook, nil, start, cfg, wrapEventLogStatusFn(statusFn, "", nil, workDir, hook), streams)
+			return finishValidate(cmd, hook, nil, start, cfg, &commandCounter{}, wrapEventLogStatusFn(statusFn, "", nil, workDir, hook), streams)
 		}
 	}
 
@@ -457,13 +476,22 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return err
 	}
 
+	counter := &commandCounter{}
+	switch {
+	case opts.inlineCmd != "", name != "":
+		counter.total = 1
+	default:
+		counter.total = len(cfg.Commands)
+	}
+	statusFn = counter.wrap(statusFn)
+
 	execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
 	if execErr == nil && resultCache != nil {
 		if err := resultCache.Put(cacheKey, validate.CachedResult{CachedAt: time.Now()}); err != nil {
 			streams.ErrPrintf("  %s\n", ui.ErrDim(fmt.Sprintf("chunk validate: cache write failed: %v", err)))
 		}
 	}
-	return finishValidate(cmd, hook, execErr, start, cfg, statusFn, streams)
+	return finishValidate(cmd, hook, execErr, start, cfg, counter, statusFn, streams)
 }
 
 // loadEnvVarsWithRetry loads sidecar env vars, and if the sidecar is unusable
@@ -529,7 +557,7 @@ func wrapEventLogStatusFn(statusFn iostream.StatusFunc, sidecarID string, active
 }
 
 // finishValidate reports the validate outcome and handles hook exit codes.
-func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start time.Time, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start time.Time, cfg *config.ProjectConfig, counter *commandCounter, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	maxAttempts := validate.DefaultMaxAttempts
 	if hook != nil {
 		if ma := cfg.StopHookMaxAttempts; ma > 0 {
@@ -537,22 +565,24 @@ func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start 
 		}
 	}
 
+	elapsed := ui.FormatDuration(time.Since(start))
+	summary := fmt.Sprintf("%d/%d passed", counter.passed, counter.total)
 	if execErr != nil {
 		if hook != nil {
 			attempt := validate.ReadAttempts(hook.sessionID) + 1
-			statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed, attempt %d/%d)", ui.FormatDuration(time.Since(start)), attempt, maxAttempts))
+			statusFn(iostream.LevelError, fmt.Sprintf("%s  %s (attempt %d/%d)", summary, elapsed, attempt, maxAttempts))
 		} else {
-			statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed)", ui.FormatDuration(time.Since(start))))
+			statusFn(iostream.LevelError, fmt.Sprintf("%s  %s", summary, elapsed))
 		}
 	} else {
-		statusFn(iostream.LevelDone, fmt.Sprintf("done in %s", ui.FormatDuration(time.Since(start))))
+		statusFn(iostream.LevelDone, fmt.Sprintf("%s  %s", summary, elapsed))
 	}
 	if hook == nil {
 		return execErr
 	}
 	hookErr := validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
 	if hookErr == nil && execErr == nil {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.Success(fmt.Sprintf("chunk validate passed (%s)", ui.FormatDuration(time.Since(start)))))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.Success(fmt.Sprintf("chunk validate passed (%s)", elapsed)))
 		return nil
 	}
 	return hookErr

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -405,7 +405,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			// A hit is a success, so it finishes the same way a real successful run
 			// does rather than repeating that bookkeeping here: clearing the failure
 			// counter, and whatever else the success branch grows later.
-			return finishValidate(cmd, hook, nil, start, opts.sidecarID, cfg, statusFn, streams)
+			return finishValidate(cmd, hook, nil, start, opts.sidecarID, cfg, wrapEventLogStatusFn(statusFn, "", nil, workDir, hook), streams)
 		}
 	}
 
@@ -441,11 +441,9 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return err
 	}
 
-	// Wire event log only when a sidecar is involved. The wrap goes here — after
-	// setupRemote fills opts.sidecarID but before loadSidecarEnvVars — so that
-	// sync and env-resolve status events are captured. Skipping when there is no
-	// sidecar avoids writing events with an empty sidecar_id that the TUI would
-	// filter out and never display.
+	// Wire event log for all runs (both local and remote). The wrap goes here —
+	// after setupRemote fills opts.sidecarID but before loadSidecarEnvVars — so
+	// that sync and env-resolve status events are captured.
 	// Kept unwrapped so a replacement sidecar can be rewrapped against its own ID
 	// rather than logging its events under the sidecar it replaced.
 	baseStatusFn := statusFn
@@ -512,14 +510,10 @@ func loadEnvVarsWithRetry(
 	return envVars, statusFn, freshlyCreated, nil
 }
 
-// wrapEventLogStatusFn wraps statusFn with event log recording when a sidecar
-// is active. Returns statusFn unchanged when no sidecar is involved, so callers
-// with empty sidecar IDs never write events with a blank sidecar_id.
+// wrapEventLogStatusFn wraps statusFn with event log recording for all runs,
+// both remote (sidecarID set) and local (sidecarID empty).
 func wrapEventLogStatusFn(statusFn iostream.StatusFunc, sidecarID string, activeSidecar *sidecar.ActiveSidecar, workDir string, hook *hookContext) iostream.StatusFunc {
-	if sidecarID == "" {
-		return statusFn
-	}
-	dataDir, err := sidecar.StateDir()
+	dataDir, err := config.ProjectDataDir(workDir)
 	if err != nil {
 		return statusFn
 	}
@@ -542,29 +536,28 @@ func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start 
 			maxAttempts = ma
 		}
 	}
+
+	location := "local"
+	if sidecarID != "" {
+		location = "remote"
+	}
+
 	if execErr != nil {
 		if hook != nil {
 			attempt := validate.ReadAttempts(hook.sessionID) + 1
-			statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed, attempt %d/%d)", ui.FormatDuration(time.Since(start)), attempt, maxAttempts))
+			statusFn(iostream.LevelError, fmt.Sprintf("done in %s (%s, failed, attempt %d/%d)", ui.FormatDuration(time.Since(start)), location, attempt, maxAttempts))
 		} else {
-			statusFn(iostream.LevelError, fmt.Sprintf("done in %s (failed)", ui.FormatDuration(time.Since(start))))
+			statusFn(iostream.LevelError, fmt.Sprintf("done in %s (%s, failed)", ui.FormatDuration(time.Since(start)), location))
 		}
-	} else if hook == nil {
-		statusFn(iostream.LevelStep, fmt.Sprintf("done in %s", ui.FormatDuration(time.Since(start))))
-	}
-	if sidecarID != "" {
-		if execErr != nil {
-			statusFn(iostream.LevelError, "validate failed")
-		} else {
-			statusFn(iostream.LevelDone, "validate passed")
-		}
+	} else {
+		statusFn(iostream.LevelDone, fmt.Sprintf("done in %s (%s)", ui.FormatDuration(time.Since(start)), location))
 	}
 	if hook == nil {
 		return execErr
 	}
 	hookErr := validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
 	if hookErr == nil && execErr == nil {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.Success(fmt.Sprintf("chunk validate passed (%s)", ui.FormatDuration(time.Since(start)))))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.Success(fmt.Sprintf("chunk validate passed (%s · %s)", ui.FormatDuration(time.Since(start)), location)))
 		return nil
 	}
 	return hookErr
@@ -680,6 +673,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 	}
 
 	// Run all
+	statusFn(iostream.LevelInfo, "running locally")
 	return mapValidateError(validate.RunAll(ctx, workDir, cfg, statusFn, streams))
 }
 

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -48,25 +48,6 @@ func newStatusFunc(streams iostream.Streams) iostream.StatusFunc {
 	}
 }
 
-// commandCounter counts per-command pass/fail events emitted by the validate
-// runner. It detects command results by the "(local)" or "(remote)" suffix that
-// RunRemote and runCommand append to every per-command status line.
-type commandCounter struct {
-	passed int
-	total  int
-}
-
-func (c *commandCounter) wrap(fn iostream.StatusFunc) iostream.StatusFunc {
-	return func(level iostream.Level, msg string) {
-		if strings.HasSuffix(msg, "(local)") || strings.HasSuffix(msg, "(remote)") {
-			if level == iostream.LevelDone {
-				c.passed++
-			}
-		}
-		fn(level, msg)
-	}
-}
-
 // hookContext holds the Claude Code Stop hook payload fields.
 type hookContext struct {
 	sessionID      string
@@ -424,7 +405,8 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			// A hit is a success, so it finishes the same way a real successful run
 			// does rather than repeating that bookkeeping here: clearing the failure
 			// counter, and whatever else the success branch grows later.
-			return finishValidate(cmd, hook, nil, start, cfg, &commandCounter{}, wrapEventLogStatusFn(statusFn, "", nil, workDir, hook), streams)
+			n := len(cfg.Commands)
+			return finishValidate(cmd, hook, nil, start, cfg, validate.Result{Passed: n, Total: n}, wrapEventLogStatusFn(statusFn, "", nil, workDir, hook), streams)
 		}
 	}
 
@@ -476,22 +458,13 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return err
 	}
 
-	counter := &commandCounter{}
-	switch {
-	case opts.inlineCmd != "", name != "":
-		counter.total = 1
-	default:
-		counter.total = len(cfg.Commands)
-	}
-	statusFn = counter.wrap(statusFn)
-
-	execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
+	result, execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
 	if execErr == nil && resultCache != nil {
 		if err := resultCache.Put(cacheKey, validate.CachedResult{CachedAt: time.Now()}); err != nil {
 			streams.ErrPrintf("  %s\n", ui.ErrDim(fmt.Sprintf("chunk validate: cache write failed: %v", err)))
 		}
 	}
-	return finishValidate(cmd, hook, execErr, start, cfg, counter, statusFn, streams)
+	return finishValidate(cmd, hook, execErr, start, cfg, result, statusFn, streams)
 }
 
 // loadEnvVarsWithRetry loads sidecar env vars, and if the sidecar is unusable
@@ -557,7 +530,7 @@ func wrapEventLogStatusFn(statusFn iostream.StatusFunc, sidecarID string, active
 }
 
 // finishValidate reports the validate outcome and handles hook exit codes.
-func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start time.Time, cfg *config.ProjectConfig, counter *commandCounter, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start time.Time, cfg *config.ProjectConfig, result validate.Result, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	maxAttempts := validate.DefaultMaxAttempts
 	if hook != nil {
 		if ma := cfg.StopHookMaxAttempts; ma > 0 {
@@ -566,7 +539,7 @@ func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start 
 	}
 
 	elapsed := ui.FormatDuration(time.Since(start))
-	summary := fmt.Sprintf("%d/%d passed", counter.passed, counter.total)
+	summary := fmt.Sprintf("%d/%d passed", result.Passed, result.Total)
 	if execErr != nil {
 		if hook != nil {
 			attempt := validate.ReadAttempts(hook.sessionID) + 1
@@ -604,14 +577,15 @@ func runValidateDryRun(name, inlineCmd string, cfg *config.ProjectConfig, status
 		statusFn(iostream.LevelInfo, fmt.Sprintf("%s: %s", cmdName, inlineCmd))
 		return nil
 	}
-	return mapValidateError(validate.RunDryRun(cfg, name, statusFn))
+	_, err := mapValidateError(validate.Result{}, validate.RunDryRun(cfg, name, statusFn))
+	return err
 }
 
 // runValidate dispatches to the appropriate Run* function based on the
 // provided options. It is shared by both direct and hook invocations.
 // allRemote is true when --remote is passed explicitly (all commands run on the
 // sidecar); false means only commands with Remote:true are routed to the sidecar.
-func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, freshlyCreated bool, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, freshlyCreated bool, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) (validate.Result, error) {
 	// --cmd: inline command (always local in per-command mode)
 	if inlineCmd != "" {
 		cmdName := name
@@ -620,14 +594,14 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 		}
 		if save {
 			if err := config.SaveCommand(workDir, cmdName, inlineCmd); err != nil {
-				return &userError{msg: "Could not save command to .chunk/config.json.", err: err}
+				return validate.Result{}, &userError{msg: "Could not save command to .chunk/config.json.", err: err}
 			}
 			streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", cmdName)))
 		}
 		if sidecarID != "" && allRemote {
 			execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, streams)
 			if err != nil {
-				return err
+				return validate.Result{}, err
 			}
 			return validate.RunRemoteInline(ctx, execFn, cmdName, inlineCmd, dest, statusFn, streams)
 		}
@@ -638,7 +612,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 	if sidecarID != "" && allRemote {
 		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, streams)
 		if err != nil {
-			return err
+			return validate.Result{}, err
 		}
 		return validate.RunRemote(ctx, execFn, cfg, name, dest, workDir, statusFn, streams)
 	}
@@ -651,7 +625,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 				statusFn(iostream.LevelInfo, fmt.Sprintf("running %s on sidecar %s", name, sidecarID))
 				execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, streams)
 				if err != nil {
-					return err
+					return validate.Result{}, err
 				}
 				return validate.RunRemote(ctx, execFn, cfg, name, dest, workDir, statusFn, streams)
 			}
@@ -666,7 +640,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 	if name != "" {
 		if cfg.FindCommand(name) == nil {
 			if !term.IsTerminal(int(os.Stdin.Fd())) {
-				return &userError{
+				return validate.Result{}, &userError{
 					msg:        fmt.Sprintf("Command %q is not configured.", name),
 					suggestion: "Add it to .chunk/config.json.",
 					errMsg:     fmt.Sprintf("command %q is not configured", name),
@@ -677,21 +651,21 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 			streams.ErrPrintf("What command should %s run? ", ui.Bold(name))
 			scanner := bufio.NewScanner(os.Stdin)
 			if !scanner.Scan() {
-				return &userError{msg: "No command entered.", errMsg: "no input received"}
+				return validate.Result{}, &userError{msg: "No command entered.", errMsg: "no input received"}
 			}
 			input := strings.TrimSpace(scanner.Text())
 			if input == "" {
 				streams.ErrPrintln(ui.Dim("No command entered, aborting."))
-				return &userError{msg: "No command entered.", errMsg: "no command entered"}
+				return validate.Result{}, &userError{msg: "No command entered.", errMsg: "no command entered"}
 			}
 			if err := config.SaveCommand(workDir, name, input); err != nil {
-				return &userError{msg: "Could not save command to .chunk/config.json.", err: err}
+				return validate.Result{}, &userError{msg: "Could not save command to .chunk/config.json.", err: err}
 			}
 			streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", name)))
 			var err error
 			cfg, err = config.LoadProjectConfig(workDir)
 			if err != nil {
-				return err
+				return validate.Result{}, err
 			}
 		}
 		return mapValidateError(validate.RunNamed(ctx, workDir, name, cfg, statusFn, streams))
@@ -847,7 +821,7 @@ func hostForwardEnv(token string) map[string]string {
 // When freshlyCreated is true, exec failures are hard errors rather than
 // silent local fallbacks (a newly provisioned sidecar that can't be reached
 // indicates a real problem, not temporary unavailability).
-func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) (validate.Result, error) {
 	remoteCfg, localCfg := splitByRemote(cfg)
 	if len(remoteCfg.Commands) > 0 {
 		statusFn(iostream.LevelInfo, fmt.Sprintf("running on sidecar %s: %s", sidecarID, commandNames(remoteCfg.Commands)))
@@ -855,12 +829,13 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 	if len(localCfg.Commands) > 0 {
 		statusFn(iostream.LevelInfo, fmt.Sprintf("running locally: %s", commandNames(localCfg.Commands)))
 	}
+	var combined validate.Result
 	var runErr error
 	if len(remoteCfg.Commands) > 0 {
 		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, streams)
 		if err != nil {
 			if freshlyCreated {
-				return newUserError(fmt.Sprintf("Could not reach newly created sidecar %s.", sidecarID)).
+				return validate.Result{}, newUserError(fmt.Sprintf("Could not reach newly created sidecar %s.", sidecarID)).
 					withCode("sidecar.unreachable").
 					withSuggestion("The sidecar may still be starting. Try again in a moment.").
 					withExitCode(ExitAPIError).
@@ -870,7 +845,7 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 			localCfg.Commands = append(remoteCfg.Commands, localCfg.Commands...)
 		} else if wsErr := validate.WorkspaceExists(ctx, execFn, dest); wsErr != nil {
 			if freshlyCreated {
-				return newUserError(fmt.Sprintf("Workspace not found on newly created sidecar %s.", sidecarID)).
+				return validate.Result{}, newUserError(fmt.Sprintf("Workspace not found on newly created sidecar %s.", sidecarID)).
 					withCode("sidecar.workspace_missing").
 					withSuggestion("Run 'chunk sidecar env build' to prepare the workspace.").
 					withExitCode(ExitNotFound).
@@ -879,15 +854,21 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 			streams.ErrPrintf("warning: %v (%q); run 'chunk sidecar env build' to set up the workspace; running %s locally instead\n", wsErr, dest, commandNames(remoteCfg.Commands))
 			localCfg.Commands = append(remoteCfg.Commands, localCfg.Commands...)
 		} else {
-			runErr = validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, statusFn, streams)
+			r, err := validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, statusFn, streams)
+			combined.Passed += r.Passed
+			combined.Total += r.Total
+			runErr = err
 		}
 	}
 	if len(localCfg.Commands) > 0 {
-		if err := mapValidateError(validate.RunAll(ctx, workDir, localCfg, statusFn, streams)); err != nil {
+		r, err := mapValidateError(validate.RunAll(ctx, workDir, localCfg, statusFn, streams))
+		combined.Passed += r.Passed
+		combined.Total += r.Total
+		if err != nil {
 			runErr = errors.Join(runErr, err)
 		}
 	}
-	return runErr
+	return combined, runErr
 }
 
 // splitByRemote partitions cfg.Commands into two configs: one containing only
@@ -1114,14 +1095,14 @@ func execTarget(opts *validateOpts, cfg *config.ProjectConfig, active *sidecar.A
 	return id + "\x00" + image
 }
 
-func mapValidateError(err error) error {
+func mapValidateError(r validate.Result, err error) (validate.Result, error) {
 	if errors.Is(err, validate.ErrNotConfigured) {
-		return &userError{
+		return r, &userError{
 			msg:        msgValidateNotConfigured,
 			suggestion: suggestionValidateNotConfigured,
 			hideDetail: true,
 			err:        err,
 		}
 	}
-	return err
+	return r, err
 }

--- a/internal/tui/watch/model.go
+++ b/internal/tui/watch/model.go
@@ -86,11 +86,13 @@ type ProjectEntry struct {
 	ProjectRoot string
 }
 
-// sidecarInfo holds display state for one sidecar.
+// sidecarInfo holds display state for one sidecar or the local runner.
+// id == "" identifies the local (non-sidecar) runner for a project.
 type sidecarInfo struct {
 	id            string
 	name          string
 	projectName   string
+	projectIdx    int       // index into Model.projects
 	snapshotName  string    // name of the active snapshot for this project, if any
 	fileMtime     time.Time // mtime of the sidecar state file (fallback when no events yet)
 	lastSyncedRef string
@@ -98,6 +100,7 @@ type sidecarInfo struct {
 	running       bool
 	lastActivity  time.Time
 	lastOp        eventlog.Op
+	lastLevel     string // level of the most recent event ("done", "error", etc.)
 }
 
 type tickMsg struct{}
@@ -105,7 +108,7 @@ type spinMsg struct{}
 
 type dataMsg struct {
 	sidecars []sidecarInfo
-	events   [][]eventlog.Event
+	events   [][]eventlog.Event // per-project; index matches Model.projects
 	offsets  []int64
 	branches []string
 	headRefs []string
@@ -121,7 +124,7 @@ type Model struct {
 	sidecars    []sidecarInfo
 	selectedIdx int
 	selectedID  string             // id of the selected sidecar, so selection survives reordering
-	events      [][]eventlog.Event // per project, capped independently
+	events      [][]eventlog.Event // per-project; index matches projects
 
 	width      int
 	height     int
@@ -216,8 +219,14 @@ func (m Model) render() string {
 }
 
 func (m Model) renderHeader() string {
-	count := fmt.Sprintf("%d sidecar", len(m.sidecars))
-	if len(m.sidecars) != 1 {
+	n := 0
+	for _, sc := range m.sidecars {
+		if sc.id != "" {
+			n++
+		}
+	}
+	count := fmt.Sprintf("%d sidecar", n)
+	if n != 1 {
 		count += "s"
 	}
 
@@ -321,6 +330,15 @@ func (m Model) renderSidecarPane(maxLines int) []string {
 		case sc.running:
 			frame := spinFrames[m.spinIdx%len(spinFrames)]
 			add("  " + blue(frame+" "+string(sc.lastOp)+"..."))
+		case sc.id == "": // local runner — no sync state
+			switch sc.lastLevel {
+			case levelDone:
+				add("  " + green("✓ passed"))
+			case levelError:
+				add("  " + red("✗ failed"))
+			default:
+				add("  " + muted("no runs yet"))
+			}
 		case sc.inSync:
 			add("  " + green("✓ in sync"))
 		case sc.lastSyncedRef == "":
@@ -360,10 +378,10 @@ func (m Model) renderActivityPane(maxLines int) []string {
 
 	var filtered []eventlog.Event
 	if m.selectedIdx < len(m.sidecars) {
-		id := m.sidecars[m.selectedIdx].id
-		for _, evs := range m.events {
-			for _, e := range evs {
-				if e.SidecarID == id {
+		sc := m.sidecars[m.selectedIdx]
+		if sc.projectIdx < len(m.events) {
+			for _, e := range m.events[sc.projectIdx] {
+				if e.SidecarID == sc.id {
 					filtered = append(filtered, e)
 				}
 			}
@@ -493,7 +511,15 @@ func (m Model) renderFooter() string {
 // loadData reads sidecar state files and new event log entries from all projects.
 func (m Model) loadData() tea.Msg {
 	var allSidecars []sidecarInfo
-	newEvents := make([][]eventlog.Event, len(m.projects))
+
+	// Build per-project event slices, preserving existing events across polls.
+	allEventsByProject := make([][]eventlog.Event, len(m.projects))
+	for i := range allEventsByProject {
+		if i < len(m.events) {
+			allEventsByProject[i] = m.events[i]
+		}
+	}
+
 	newOffsets := make([]int64, len(m.projects))
 	copy(newOffsets, m.offsets)
 	newBranches := make([]string, len(m.projects))
@@ -502,27 +528,33 @@ func (m Model) loadData() tea.Msg {
 	for i, p := range m.projects {
 		newBranches[i] = sidecar.CurrentBranch(p.ProjectRoot)
 		newHeadRefs[i] = headRef(p.ProjectRoot)
+		snapName := loadSnapshotName(p.DataDir)
+		sidecars := loadSidecars(p.DataDir, p.ProjectRoot, snapName, newHeadRefs[i], i)
+		allSidecars = append(allSidecars, sidecars...)
 
-		// Events are read before the sidecars they annotate.
-		if i < len(m.events) {
-			newEvents[i] = m.events[i]
+		// Synthesize a local entry for this project; filtered out later if no activity.
+		allSidecars = append(allSidecars, sidecarInfo{
+			id:          "",
+			name:        "local",
+			projectName: filepath.Base(p.ProjectRoot),
+			projectIdx:  i,
+		})
+
+		if p.Log == nil {
+			continue
 		}
-		if p.Log != nil {
+		if i < len(m.offsets) {
 			fresh, newOff, _ := p.Log.TailFrom(m.offsets[i])
-			newEvents[i] = capEvents(newEvents[i], fresh)
+			allEventsByProject[i] = capEvents(allEventsByProject[i], fresh)
 			newOffsets[i] = newOff
 		}
-
-		snapName := loadSnapshotName(p.DataDir)
-		sidecars := loadSidecars(p.DataDir, p.ProjectRoot, snapName, newHeadRefs[i])
-		annotateActivity(sidecars, newEvents[i])
-		allSidecars = append(allSidecars, sidecars...)
 	}
 
+	annotateActivity(allSidecars, allEventsByProject)
 	sortByActivity(allSidecars)
 	allSidecars = filterSidecars(allSidecars, m.sidecarCapacity())
 
-	return dataMsg{sidecars: allSidecars, events: newEvents, offsets: newOffsets, branches: newBranches, headRefs: newHeadRefs}
+	return dataMsg{sidecars: allSidecars, events: allEventsByProject, offsets: newOffsets, branches: newBranches, headRefs: newHeadRefs}
 }
 
 // capEvents appends fresh to prior, keeping at most recentEvents. The cap is
@@ -538,11 +570,15 @@ func capEvents(prior, fresh []eventlog.Event) []eventlog.Event {
 	return merged
 }
 
-// annotateActivity fills lastActivity, lastOp and running from the newest event
-// belonging to each sidecar.
-func annotateActivity(sidecars []sidecarInfo, events []eventlog.Event) {
+// annotateActivity fills lastActivity, lastOp, lastLevel and running from the
+// newest event belonging to each sidecar.
+func annotateActivity(sidecars []sidecarInfo, eventsByProject [][]eventlog.Event) {
 	for i := range sidecars {
 		sc := &sidecars[i]
+		if sc.projectIdx >= len(eventsByProject) {
+			continue
+		}
+		events := eventsByProject[sc.projectIdx]
 		for j := len(events) - 1; j >= 0; j-- {
 			e := events[j]
 			if e.SidecarID != sc.id {
@@ -550,6 +586,7 @@ func annotateActivity(sidecars []sidecarInfo, events []eventlog.Event) {
 			}
 			sc.lastActivity = e.Ts
 			sc.lastOp = e.Op
+			sc.lastLevel = e.Level
 			if e.Level != levelDone && e.Level != levelError && time.Since(e.Ts) < runningTimeout {
 				sc.running = true
 			}
@@ -605,7 +642,7 @@ func selectedSidecarID(sidecars []sidecarInfo, idx int) string {
 }
 
 // loadSidecars reads all sidecar*.json files from dataDir, deduplicates by ID.
-func loadSidecars(dataDir, projectRoot string, snapshotName string, head string) []sidecarInfo {
+func loadSidecars(dataDir, projectRoot string, snapshotName string, head string, projectIdx int) []sidecarInfo {
 	matches, _ := filepath.Glob(filepath.Join(dataDir, "sidecar*.json"))
 	projectName := filepath.Base(projectRoot)
 	seen := map[string]bool{}
@@ -632,6 +669,7 @@ func loadSidecars(dataDir, projectRoot string, snapshotName string, head string)
 			id:            as.SidecarID,
 			name:          as.Name,
 			projectName:   projectName,
+			projectIdx:    projectIdx,
 			snapshotName:  snapshotName,
 			fileMtime:     mtime,
 			lastSyncedRef: as.LastSyncedRef,

--- a/internal/tui/watch/model_test.go
+++ b/internal/tui/watch/model_test.go
@@ -199,7 +199,7 @@ func TestLoadSidecars_deduplicatesIDs(t *testing.T) {
 	// Duplicate id1 — should be deduplicated.
 	writeSidecarJSON(t, dir, "sidecar.sess2.json", `{"sidecar_id":"id1","name":"sc1"}`)
 
-	result := loadSidecars(dir, root, "", "abc123")
+	result := loadSidecars(dir, root, "", "abc123", 0)
 	if len(result) != 2 {
 		t.Fatalf("want 2 unique sidecars, got %d", len(result))
 	}
@@ -211,7 +211,7 @@ func TestLoadSidecars_inSyncWhenHeadMatches(t *testing.T) {
 
 	writeSidecarJSON(t, dir, "sidecar.json", `{"sidecar_id":"id1","name":"sc1","last_synced_ref":"abc123"}`)
 
-	result := loadSidecars(dir, root, "", "abc123")
+	result := loadSidecars(dir, root, "", "abc123", 0)
 	if len(result) != 1 {
 		t.Fatalf("want 1, got %d", len(result))
 	}
@@ -226,7 +226,7 @@ func TestLoadSidecars_notInSyncWhenHeadDiffers(t *testing.T) {
 
 	writeSidecarJSON(t, dir, "sidecar.json", `{"sidecar_id":"id1","last_synced_ref":"oldref"}`)
 
-	result := loadSidecars(dir, root, "", "newref")
+	result := loadSidecars(dir, root, "", "newref", 0)
 	if len(result) != 1 {
 		t.Fatalf("want 1, got %d", len(result))
 	}
@@ -238,7 +238,7 @@ func TestLoadSidecars_notInSyncWhenHeadDiffers(t *testing.T) {
 func TestLoadSidecars_emptyDir(t *testing.T) {
 	dir := t.TempDir()
 	root := t.TempDir()
-	if result := loadSidecars(dir, root, "", ""); len(result) != 0 {
+	if result := loadSidecars(dir, root, "", "", 0); len(result) != 0 {
 		t.Errorf("want 0, got %d", len(result))
 	}
 }
@@ -249,7 +249,7 @@ func TestLoadSidecars_skipsEmptySidecarID(t *testing.T) {
 
 	writeSidecarJSON(t, dir, "sidecar.json", `{"sidecar_id":"","name":"empty"}`)
 
-	if result := loadSidecars(dir, root, "", ""); len(result) != 0 {
+	if result := loadSidecars(dir, root, "", "", 0); len(result) != 0 {
 		t.Errorf("want 0 (skipped empty ID), got %d", len(result))
 	}
 }
@@ -260,7 +260,7 @@ func TestLoadSidecars_snapshotName(t *testing.T) {
 
 	writeSidecarJSON(t, dir, "sidecar.json", `{"sidecar_id":"id1","name":"sc1"}`)
 
-	result := loadSidecars(dir, root, "my-snap", "")
+	result := loadSidecars(dir, root, "my-snap", "", 0)
 	if len(result) != 1 {
 		t.Fatalf("want 1, got %d", len(result))
 	}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -167,7 +167,7 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 		stdout, stderr, exitCode, err := execFn(ctx, script)
 		elapsed := time.Since(start)
 		if err != nil {
-			status(iostream.LevelError, fmt.Sprintf("%-*s  exec error", maxWidth, c.Name))
+			status(iostream.LevelError, fmt.Sprintf("%-*s  exec error (remote)", maxWidth, c.Name))
 			skipRemaining(status, commands[i+1:], maxWidth)
 			return fmt.Errorf("remote %s: %w", c.Name, err)
 		}
@@ -181,11 +181,11 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 			_, _ = fmt.Fprint(streams.Err, stderr)
 		}
 		if exitCode != 0 {
-			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, formatElapsed(elapsed)))
+			status(iostream.LevelError, fmt.Sprintf("%-*s  %s (remote)", maxWidth, c.Name, formatElapsed(elapsed)))
 			skipRemaining(status, commands[i+1:], maxWidth)
 			return fmt.Errorf("remote %s failed with exit code %d", c.Name, exitCode)
 		}
-		status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", maxWidth, c.Name, formatElapsed(elapsed)))
+		status(iostream.LevelDone, fmt.Sprintf("%-*s  %s (remote)", maxWidth, c.Name, formatElapsed(elapsed)))
 	}
 	return nil
 }
@@ -209,10 +209,10 @@ func RunRemoteInline(ctx context.Context, execFn func(ctx context.Context, scrip
 		_, _ = fmt.Fprint(streams.Err, stderr)
 	}
 	if exitCode != 0 {
-		status(iostream.LevelError, fmt.Sprintf("%s  %s", name, formatElapsed(elapsed)))
+		status(iostream.LevelError, fmt.Sprintf("%s  %s (remote)", name, formatElapsed(elapsed)))
 		return fmt.Errorf("remote %s failed with exit code %d", name, exitCode)
 	}
-	status(iostream.LevelDone, fmt.Sprintf("%s  %s", name, formatElapsed(elapsed)))
+	status(iostream.LevelDone, fmt.Sprintf("%s  %s (remote)", name, formatElapsed(elapsed)))
 	return nil
 }
 
@@ -276,17 +276,17 @@ func runCommand(ctx context.Context, workDir, name, command string, timeoutSec, 
 
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			status(iostream.LevelError, fmt.Sprintf("%-*s  timed out after %ds  %s", nameWidth, name, timeoutSec, formatElapsed(elapsed)))
+			status(iostream.LevelError, fmt.Sprintf("%-*s  timed out after %ds  %s (local)", nameWidth, name, timeoutSec, formatElapsed(elapsed)))
 			return fmt.Errorf("%s command timed out after %ds", name, timeoutSec)
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() != 0 {
-			status(iostream.LevelError, fmt.Sprintf("%-*s  %s", nameWidth, name, formatElapsed(elapsed)))
+			status(iostream.LevelError, fmt.Sprintf("%-*s  %s (local)", nameWidth, name, formatElapsed(elapsed)))
 			return fmt.Errorf("%s command failed with exit code %d", name, exitErr.ExitCode())
 		}
 		return fmt.Errorf("%s: %w", name, err)
 	}
-	status(iostream.LevelDone, fmt.Sprintf("%-*s  %s", nameWidth, name, formatElapsed(elapsed)))
+	status(iostream.LevelDone, fmt.Sprintf("%-*s  %s (local)", nameWidth, name, formatElapsed(elapsed)))
 	return nil
 }
 

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -28,6 +28,12 @@ func formatElapsed(d time.Duration) string {
 // ErrNotConfigured indicates no validate commands are configured.
 var ErrNotConfigured = errors.New("no validate commands configured")
 
+// Result holds the pass/fail counts from a validate run.
+type Result struct {
+	Passed int
+	Total  int
+}
+
 // ErrWorkspaceNotFound is returned when the remote workspace directory does not exist.
 var ErrWorkspaceNotFound = errors.New("workspace directory not found on sidecar")
 
@@ -79,17 +85,23 @@ func commandTags(c config.Command) string {
 }
 
 // RunInline runs an inline command string.
-func RunInline(ctx context.Context, workDir, name, command string, status iostream.StatusFunc, streams iostream.Streams) error {
-	return runCommand(ctx, workDir, name, command, 0, 0, status, streams)
+func RunInline(ctx context.Context, workDir, name, command string, status iostream.StatusFunc, streams iostream.Streams) (Result, error) {
+	if err := runCommand(ctx, workDir, name, command, 0, 0, status, streams); err != nil {
+		return Result{Total: 1}, err
+	}
+	return Result{Passed: 1, Total: 1}, nil
 }
 
 // RunNamed runs a single named command from config.
-func RunNamed(ctx context.Context, workDir, name string, cfg *config.ProjectConfig, status iostream.StatusFunc, streams iostream.Streams) error {
+func RunNamed(ctx context.Context, workDir, name string, cfg *config.ProjectConfig, status iostream.StatusFunc, streams iostream.Streams) (Result, error) {
 	c := cfg.FindCommand(name)
 	if c == nil {
-		return fmt.Errorf("command %q not configured", name)
+		return Result{}, fmt.Errorf("command %q not configured", name)
 	}
-	return runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, 0, status, streams)
+	if err := runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, 0, status, streams); err != nil {
+		return Result{Total: 1}, err
+	}
+	return Result{Passed: 1, Total: 1}, nil
 }
 
 func skipRemaining(status iostream.StatusFunc, remaining []config.Command, width int) {
@@ -109,19 +121,20 @@ func nameWidth(commands []config.Command) int {
 }
 
 // RunAll runs all configured commands, stopping at the first failure.
-func RunAll(ctx context.Context, workDir string, cfg *config.ProjectConfig, status iostream.StatusFunc, streams iostream.Streams) error {
+func RunAll(ctx context.Context, workDir string, cfg *config.ProjectConfig, status iostream.StatusFunc, streams iostream.Streams) (Result, error) {
 	if !cfg.HasCommands() {
-		return ErrNotConfigured
+		return Result{}, ErrNotConfigured
 	}
 
 	maxWidth := nameWidth(cfg.Commands)
+	total := len(cfg.Commands)
 	for i, c := range cfg.Commands {
 		if err := runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, maxWidth, status, streams); err != nil {
 			skipRemaining(status, cfg.Commands[i+1:], maxWidth)
-			return err
+			return Result{Passed: i, Total: total}, err
 		}
 	}
-	return nil
+	return Result{Passed: total, Total: total}, nil
 }
 
 // RunDryRun prints commands without executing them.
@@ -148,16 +161,17 @@ func RunDryRun(cfg *config.ProjectConfig, name string, status iostream.StatusFun
 // RunRemote runs commands on a remote sidecar via SSH.
 // If name is non-empty, only the named command is run.
 // workDir is the local repository root used to expand {{CHANGED_PACKAGES}}.
-func RunRemote(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), cfg *config.ProjectConfig, name, dest, workDir string, status iostream.StatusFunc, streams iostream.Streams) error {
+func RunRemote(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), cfg *config.ProjectConfig, name, dest, workDir string, status iostream.StatusFunc, streams iostream.Streams) (Result, error) {
 	commands := cfg.Commands
 	if name != "" {
 		c := cfg.FindCommand(name)
 		if c == nil {
-			return fmt.Errorf("command %q not configured", name)
+			return Result{}, fmt.Errorf("command %q not configured", name)
 		}
 		commands = []config.Command{*c}
 	}
 
+	total := len(commands)
 	maxWidth := nameWidth(commands)
 	for i, c := range commands {
 		run := ExpandCommand(workDir, c.Run)
@@ -169,7 +183,7 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 		if err != nil {
 			status(iostream.LevelError, fmt.Sprintf("%-*s  exec error (remote)", maxWidth, c.Name))
 			skipRemaining(status, commands[i+1:], maxWidth)
-			return fmt.Errorf("remote %s: %w", c.Name, err)
+			return Result{Passed: i, Total: total}, fmt.Errorf("remote %s: %w", c.Name, err)
 		}
 		if exitCode != 0 && (stdout != "" || stderr != "") {
 			status(iostream.LevelInfo, c.Name+":")
@@ -183,21 +197,21 @@ func RunRemote(ctx context.Context, execFn func(ctx context.Context, script stri
 		if exitCode != 0 {
 			status(iostream.LevelError, fmt.Sprintf("%-*s  %s (remote)", maxWidth, c.Name, formatElapsed(elapsed)))
 			skipRemaining(status, commands[i+1:], maxWidth)
-			return fmt.Errorf("remote %s failed with exit code %d", c.Name, exitCode)
+			return Result{Passed: i, Total: total}, fmt.Errorf("remote %s failed with exit code %d", c.Name, exitCode)
 		}
 		status(iostream.LevelDone, fmt.Sprintf("%-*s  %s (remote)", maxWidth, c.Name, formatElapsed(elapsed)))
 	}
-	return nil
+	return Result{Passed: total, Total: total}, nil
 }
 
 // RunRemoteInline runs a single inline command on a remote sidecar via SSH.
-func RunRemoteInline(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), name, command, dest string, status iostream.StatusFunc, streams iostream.Streams) error {
+func RunRemoteInline(ctx context.Context, execFn func(ctx context.Context, script string) (stdout, stderr string, exitCode int, err error), name, command, dest string, status iostream.StatusFunc, streams iostream.Streams) (Result, error) {
 	script := "cd " + shellEscape(dest) + " && " + command
 	start := time.Now()
 	stdout, stderr, exitCode, err := execFn(ctx, script)
 	elapsed := time.Since(start)
 	if err != nil {
-		return fmt.Errorf("remote %s: %w", name, err)
+		return Result{Total: 1}, fmt.Errorf("remote %s: %w", name, err)
 	}
 	if exitCode != 0 && (stdout != "" || stderr != "") {
 		status(iostream.LevelInfo, name+":")
@@ -210,10 +224,10 @@ func RunRemoteInline(ctx context.Context, execFn func(ctx context.Context, scrip
 	}
 	if exitCode != 0 {
 		status(iostream.LevelError, fmt.Sprintf("%s  %s (remote)", name, formatElapsed(elapsed)))
-		return fmt.Errorf("remote %s failed with exit code %d", name, exitCode)
+		return Result{Total: 1}, fmt.Errorf("remote %s failed with exit code %d", name, exitCode)
 	}
 	status(iostream.LevelDone, fmt.Sprintf("%s  %s (remote)", name, formatElapsed(elapsed)))
-	return nil
+	return Result{Passed: 1, Total: 1}, nil
 }
 
 // ExpandCommand replaces template variables in command before execution.

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -202,7 +202,8 @@ func TestRunAll(t *testing.T) {
 		streams, out, _ := newStreams()
 		var statusBuf bytes.Buffer
 
-		assert.NilError(t, RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams))
+		_, err := RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams)
+		assert.NilError(t, err)
 		assert.Assert(t, strings.Contains(out.String(), "installed"), "got: %s", out.String())
 		assert.Assert(t, strings.Contains(out.String(), "tested"), "got: %s", out.String())
 		assert.Assert(t, strings.Contains(statusBuf.String(), "[done] install"), "got: %s", statusBuf.String())
@@ -214,7 +215,7 @@ func TestRunAll(t *testing.T) {
 		streams, _, _ := newStreams()
 		var statusBuf bytes.Buffer
 
-		err := RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams)
+		_, err := RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams)
 		assert.ErrorContains(t, err, "no validate commands")
 	})
 
@@ -225,7 +226,7 @@ func TestRunAll(t *testing.T) {
 		streams, _, _ := newStreams()
 		var statusBuf bytes.Buffer
 
-		err := RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams)
+		_, err := RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams)
 		assert.ErrorContains(t, err, "test command failed")
 	})
 
@@ -238,7 +239,7 @@ func TestRunAll(t *testing.T) {
 		streams, out, _ := newStreams()
 		var statusBuf bytes.Buffer
 
-		err := RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams)
+		_, err := RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams)
 		assert.Assert(t, err != nil, "expected error")
 		assert.Assert(t, !strings.Contains(out.String(), "should-not-run"), "skipped command should not produce output, got: %s", out.String())
 		assert.Assert(t, strings.Contains(statusBuf.String(), "[error] install"), "got: %s", statusBuf.String())
@@ -254,7 +255,8 @@ func TestRunAll(t *testing.T) {
 		streams, out, _ := newStreams()
 		var statusBuf bytes.Buffer
 
-		assert.NilError(t, RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams))
+		_, err := RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams)
+		assert.NilError(t, err)
 		assert.Assert(t, strings.Contains(out.String(), "ok"), "got: %s", out.String())
 		assert.Assert(t, strings.Contains(statusBuf.String(), "[done] test"), "got: %s", statusBuf.String())
 	})
@@ -313,7 +315,8 @@ func TestRunRemote(t *testing.T) {
 		streams, out, _ := newStreams()
 		var statusBuf bytes.Buffer
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), testStatus(&statusBuf), streams))
+		_, err := RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), testStatus(&statusBuf), streams)
+		assert.NilError(t, err)
 		assert.Assert(t, strings.Contains(out.String(), "remote output"), "got: %s", out.String())
 		assert.Assert(t, strings.Contains(statusBuf.String(), "[done] install"), "got: %s", statusBuf.String())
 		assert.Assert(t, strings.Contains(statusBuf.String(), "[done] test"), "got: %s", statusBuf.String())
@@ -330,7 +333,7 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		err := RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams)
+		_, err := RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, "remote test failed")
 	})
 
@@ -344,7 +347,8 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, out, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams))
+		_, err := RunRemote(context.Background(), execFn, cfg, "", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams)
+		assert.NilError(t, err)
 		assert.Equal(t, out.Len(), 0)
 	})
 
@@ -361,7 +365,8 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "test", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams))
+		_, err := RunRemote(context.Background(), execFn, cfg, "test", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams)
+		assert.NilError(t, err)
 		assert.Equal(t, len(capturedScripts), 1)
 		assert.Assert(t, strings.Contains(capturedScripts[0], "echo test"), "got: %s", capturedScripts[0])
 	})
@@ -376,7 +381,7 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		err := RunRemote(context.Background(), execFn, cfg, "lint", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams)
+		_, err := RunRemote(context.Background(), execFn, cfg, "lint", "/workspace", t.TempDir(), func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, `"lint" not configured`)
 	})
 
@@ -392,7 +397,8 @@ func TestRunRemote(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		assert.NilError(t, RunRemote(context.Background(), execFn, cfg, "", "/custom/path", t.TempDir(), func(iostream.Level, string) {}, streams))
+		_, err := RunRemote(context.Background(), execFn, cfg, "", "/custom/path", t.TempDir(), func(iostream.Level, string) {}, streams)
+		assert.NilError(t, err)
 		assert.Assert(t, strings.HasPrefix(capturedScript, "cd '/custom/path' &&"), "got: %s", capturedScript)
 	})
 }
@@ -439,7 +445,8 @@ func TestRunRemoteSSH(t *testing.T) {
 		streams, out, _ := newStreams()
 
 		var statusBuf bytes.Buffer
-		assert.NilError(t, RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), testStatus(&statusBuf), streams))
+		_, runErr := RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), testStatus(&statusBuf), streams)
+		assert.NilError(t, runErr)
 		assert.Assert(t, strings.Contains(out.String(), "hello from remote"), "got: %s", out.String())
 		assert.Assert(t, strings.Contains(statusBuf.String(), "[done] test"), "got: %s", statusBuf.String())
 		assert.Equal(t, len(sshSrv.Commands()), 1)
@@ -465,7 +472,7 @@ func TestRunRemoteSSH(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		err = RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), func(iostream.Level, string) {}, streams)
+		_, err = RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, "remote test failed")
 	})
 
@@ -490,7 +497,7 @@ func TestRunRemoteSSH(t *testing.T) {
 		}}
 		streams, _, _ := newStreams()
 
-		err = RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), func(iostream.Level, string) {}, streams)
+		_, err = RunRemote(context.Background(), execCallback(t, session), cfg, "", "/workspace/repo", t.TempDir(), func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, "remote install failed")
 		assert.Equal(t, len(sshSrv.Commands()), 1)
 	})
@@ -506,7 +513,8 @@ func TestRunRemoteInline(t *testing.T) {
 		streams, out, _ := newStreams()
 		var statusBuf bytes.Buffer
 
-		assert.NilError(t, RunRemoteInline(context.Background(), execFn, "custom", "echo hello", "/workspace/repo", testStatus(&statusBuf), streams))
+		_, err := RunRemoteInline(context.Background(), execFn, "custom", "echo hello", "/workspace/repo", testStatus(&statusBuf), streams)
+		assert.NilError(t, err)
 		assert.Assert(t, strings.Contains(out.String(), "inline output"), "got: %s", out.String())
 		assert.Assert(t, strings.Contains(statusBuf.String(), "[done] custom"), "got: %s", statusBuf.String())
 		assert.Assert(t, strings.HasPrefix(capturedScript, "cd '/workspace/repo' &&"), "got: %s", capturedScript)
@@ -518,7 +526,7 @@ func TestRunRemoteInline(t *testing.T) {
 		}
 		streams, _, _ := newStreams()
 
-		err := RunRemoteInline(context.Background(), execFn, "custom", "false", "/workspace", func(iostream.Level, string) {}, streams)
+		_, err := RunRemoteInline(context.Background(), execFn, "custom", "false", "/workspace", func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, "remote custom failed")
 	})
 
@@ -528,7 +536,7 @@ func TestRunRemoteInline(t *testing.T) {
 		}
 		streams, _, _ := newStreams()
 
-		err := RunRemoteInline(context.Background(), execFn, "custom", "echo hi", "/workspace", func(iostream.Level, string) {}, streams)
+		_, err := RunRemoteInline(context.Background(), execFn, "custom", "echo hi", "/workspace", func(iostream.Level, string) {}, streams)
 		assert.ErrorContains(t, err, "remote custom")
 		assert.ErrorContains(t, err, "connection lost")
 	})


### PR DESCRIPTION
## Summary

- Validate output now includes `(local)` or `(remote)` on each individual command result line (e.g. `✓ lint  5.6s (remote)`), so users can tell at a glance which runner produced each result when commands are split across executors
- The validate summary line now shows `n/m passed  Xs` instead of `done in Xs`, making it immediately clear how many commands succeeded alongside the elapsed time
- The watch TUI now shows a local runner entry per project alongside remote sidecars — it displays pass/fail state and activity feed for local runs using the same event log infrastructure
- Event log recording is now wired for all runs (not just sidecar runs), writing events to the project data dir so both the TUI and local runs share the same log path

<img width="900" height="420" alt="demo" src="https://github.com/user-attachments/assets/1c3afd3d-0864-4fcc-b04e-69d4efec00c5" />

<img width="900" height="520" alt="demo-watch" src="https://github.com/user-attachments/assets/b7d33f9a-3b70-4e9c-844d-1bd8452014e3" />

## Test plan

- [ ] Run `chunk validate` locally — each command result shows `(local)` (e.g. `✓ lint  5.6s (local)`)
- [ ] Run `chunk validate` with a sidecar — each command result shows `(remote)`
- [ ] Summary line reads `n/m passed  Xs` (not `done in Xs`)
- [ ] Open `chunk watch` with no sidecars configured — local runner entry appears after first run, showing pass/fail
- [ ] Open `chunk watch` with sidecars — local and remote entries both appear; header sidecar count excludes the local entry
- [x] Existing tests pass: `task test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
