### PR TITLE
Fall back to the most recent sidecars when nothing is active

### DIFF
--- a/internal/tui/watch/model.go
+++ b/internal/tui/watch/model.go
@@ -279,12 +279,12 @@ func (m Model) renderSidecarPane(maxLines int) []string {
 	add("")
 
 	if len(m.sidecars) == 0 {
-		// Idle is now the common empty state: sidecars may well exist, they just
-		// haven't done anything within activeWindow.
-		add(muted("nothing active"))
+		// Sidecars may well exist, they just haven't done anything recent
+		// enough to be worth showing.
+		add(muted("nothing recent"))
 		add("")
 		add(dim("no sidecar activity"))
-		add(dim("in the last hour"))
+		add(dim("in the last day"))
 		return lines
 	}
 
@@ -520,7 +520,7 @@ func (m Model) loadData() tea.Msg {
 	}
 
 	sortByActivity(allSidecars)
-	allSidecars = filterSidecars(allSidecars)
+	allSidecars = filterSidecars(allSidecars, m.sidecarCapacity())
 
 	return dataMsg{sidecars: allSidecars, events: newEvents, offsets: newOffsets, branches: newBranches, headRefs: newHeadRefs}
 }
@@ -641,8 +641,18 @@ func loadSidecars(dataDir, projectRoot string, snapshotName string, head string)
 	return result
 }
 
-// activeWindow is how recently a sidecar must have been active to be shown.
-const activeWindow = time.Hour
+const (
+	// activeWindow is how recently a sidecar must have been active to be shown.
+	activeWindow = time.Hour
+	// fallbackWindow bounds how far back the pane reaches when nothing has been
+	// active within activeWindow.
+	fallbackWindow = 24 * time.Hour
+	// linesPerSidecar is the worst-case row cost of one sidecar in the sidecar
+	// pane: project header, name, status, age, and the gap between projects.
+	linesPerSidecar = 5
+	// defaultCapacity is used until the first WindowSizeMsg gives a real height.
+	defaultCapacity = 5
+)
 
 // loadSnapshotName returns the Name field from any snapshot*.json in dataDir,
 // or "" if none is found or the name is not set.
@@ -663,20 +673,57 @@ func loadSnapshotName(dataDir string) string {
 	return ""
 }
 
-// filterSidecars keeps only sidecars active within activeWindow. There is no
-// per-project cap: every sidecar you have touched in the last hour is shown,
-// however many that is.
-func filterSidecars(sidecars []sidecarInfo) []sidecarInfo {
+// filterSidecars keeps every sidecar active within activeWindow, with no
+// per-project cap, however many that is. When nothing has been active that
+// recently it falls back to the most recent sidecars, enough to fill the pane
+// and reaching back no further than fallbackWindow, so an idle dashboard still
+// shows you where you left off. sidecars must already be sorted by recency.
+func filterSidecars(sidecars []sidecarInfo, capacity int) []sidecarInfo {
 	now := time.Now()
-	result := sidecars[:0]
+
+	var active []sidecarInfo
 	for _, sc := range sidecars {
-		eff := effectiveActivity(sc)
-		if eff.IsZero() || now.Sub(eff) > activeWindow {
-			continue
+		if within(now, sc, activeWindow) {
+			active = append(active, sc)
 		}
-		result = append(result, sc)
 	}
-	return result
+	if len(active) > 0 {
+		return active
+	}
+
+	if capacity < 1 {
+		capacity = 1
+	}
+	var recent []sidecarInfo
+	for _, sc := range sidecars {
+		if len(recent) >= capacity {
+			break
+		}
+		if within(now, sc, fallbackWindow) {
+			recent = append(recent, sc)
+		}
+	}
+	return recent
+}
+
+// within reports whether the sidecar was active no longer than window ago.
+func within(now time.Time, sc sidecarInfo, window time.Duration) bool {
+	eff := effectiveActivity(sc)
+	return !eff.IsZero() && now.Sub(eff) <= window
+}
+
+// sidecarCapacity is how many sidecars the left pane can render at the current
+// terminal height. It mirrors renderBody's content height, less the pane title
+// and the blank line under it.
+func (m Model) sidecarCapacity() int {
+	if m.height <= 0 {
+		return defaultCapacity
+	}
+	paneHeight := m.height - 4 - 2
+	if paneHeight < linesPerSidecar {
+		return 1
+	}
+	return paneHeight / linesPerSidecar
 }
 
 func anyRunning(sidecars []sidecarInfo) bool {

--- a/internal/tui/watch/model_test.go
+++ b/internal/tui/watch/model_test.go
@@ -1,6 +1,7 @@
 package watch
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -317,7 +318,7 @@ func TestFilterSidecars_noPerProjectCap(t *testing.T) {
 	}
 
 	sortByActivity(sidecars)
-	got := filterSidecars(sidecars)
+	got := filterSidecars(sidecars, 2)
 
 	if len(got) != 4 {
 		t.Fatalf("want all 4 sidecars, got %d", len(got))
@@ -339,7 +340,7 @@ func TestFilterSidecars_dropsInactive(t *testing.T) {
 		{id: "no-activity-at-all", projectName: "r"},
 	}
 
-	got := filterSidecars(sidecars)
+	got := filterSidecars(sidecars, 10)
 
 	want := []string{"recent", "mtime-recent"}
 	if len(got) != len(want) {
@@ -349,6 +350,80 @@ func TestFilterSidecars_dropsInactive(t *testing.T) {
 		if got[i].id != id {
 			t.Errorf("position %d: want %s, got %s", i, id, got[i].id)
 		}
+	}
+}
+
+func TestFilterSidecars_fallsBackToPaneFullOfRecent(t *testing.T) {
+	now := time.Now()
+	// Nothing inside the hour, so the fallback fills the pane by recency.
+	sidecars := []sidecarInfo{
+		{id: "h2", projectName: "a", lastActivity: now.Add(-2 * time.Hour)},
+		{id: "h3", projectName: "b", lastActivity: now.Add(-3 * time.Hour)},
+		{id: "h4", projectName: "c", lastActivity: now.Add(-4 * time.Hour)},
+		{id: "yesterday", projectName: "d", lastActivity: now.Add(-25 * time.Hour)},
+	}
+
+	got := filterSidecars(sidecars, 2)
+
+	if len(got) != 2 {
+		t.Fatalf("want 2 sidecars (pane capacity), got %d", len(got))
+	}
+	for i, id := range []string{"h2", "h3"} {
+		if got[i].id != id {
+			t.Errorf("position %d: want %s, got %s", i, id, got[i].id)
+		}
+	}
+}
+
+func TestFilterSidecars_fallbackStopsAtOneDay(t *testing.T) {
+	now := time.Now()
+	sidecars := []sidecarInfo{
+		{id: "just-inside", projectName: "a", lastActivity: now.Add(-23 * time.Hour)},
+		{id: "too-old", projectName: "b", lastActivity: now.Add(-25 * time.Hour)},
+	}
+
+	got := filterSidecars(sidecars, 10)
+
+	if len(got) != 1 || got[0].id != "just-inside" {
+		t.Fatalf("want only just-inside, got %v", got)
+	}
+}
+
+func TestFilterSidecars_activeSetIgnoresCapacity(t *testing.T) {
+	now := time.Now()
+	var sidecars []sidecarInfo
+	for i := range 8 {
+		sidecars = append(sidecars, sidecarInfo{
+			id: fmt.Sprintf("s%d", i), projectName: "p",
+			lastActivity: now.Add(-time.Duration(i) * time.Minute),
+		})
+	}
+
+	// All eight are inside the hour, so none are dropped to fit the pane.
+	if got := filterSidecars(sidecars, 2); len(got) != 8 {
+		t.Fatalf("want all 8 active sidecars, got %d", len(got))
+	}
+}
+
+func TestSidecarCapacity(t *testing.T) {
+	tests := []struct {
+		name   string
+		height int
+		want   int
+	}{
+		{"unset height", 0, defaultCapacity},
+		{"tiny terminal", 8, 1},
+		{"40 rows", 40, 6},
+		{"80 rows", 80, 14},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := New(nil)
+			m.height = tt.height
+			if got := m.sidecarCapacity(); got != tt.want {
+				t.Errorf("height %d: want %d, got %d", tt.height, tt.want, got)
+			}
+		})
 	}
 }
 
@@ -406,7 +481,8 @@ func TestLoadData_busyProjectDoesNotEvictRecentValidate(t *testing.T) {
 	if !ok {
 		t.Fatalf("want dataMsg, got %T", msg)
 	}
-	// The noisy sidecar's events are 2h old, so it falls outside activeWindow.
+	// The quiet project just validated, so only it is inside activeWindow; the
+	// noisy sidecar's events are 2h old and the fallback does not apply.
 	if len(msg.sidecars) != 1 {
 		t.Fatalf("want 1 active sidecar, got %d", len(msg.sidecars))
 	}


### PR DESCRIPTION
## Summary

Follow-up to #507. That PR narrowed `chunk watch` to sidecars active in the last hour, which leaves the dashboard blank whenever you step away and loses the "where did I leave off" view.

- When nothing has been active within the hour, fall back to the most recent sidecars: enough to fill the left pane at the current terminal height, reaching back no further than a day.
- Pane capacity is derived from the live terminal height, `(height - 6) / 5`, 5 rows being the worst case cost of one sidecar. It defaults to 5 until the first `WindowSizeMsg` arrives and self-corrects on the next poll.
- The active set is still uncapped, so a busy hour shows every sidecar that ran regardless of pane height.
- Empty state now reads "nothing recent", since it only appears when a full day is dry.