### PR TITLE
Require remote configuration before running chunk validate

### DIFF
--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -162,6 +162,8 @@ func TestValidateRunDryRunNoConfig(t *testing.T) {
 }
 
 func TestValidateRunLocal(t *testing.T) {
+	// Local-only commands (no remote:true) are now blocked — users must configure
+	// remote validation before running chunk validate.
 	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
 	writeProjectConfig(t, workDir, "echo installed", "echo tested")
 
@@ -171,17 +173,18 @@ func TestValidateRunLocal(t *testing.T) {
 		"validate",
 	}, env, workDir)
 
-	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit when remote is not configured")
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "installed"),
-		"expected install command output in result, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "tested"),
-		"expected test command output in result, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "Remote validation is not configured"),
+		"expected remote-not-configured message, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "sidecar setup") || strings.Contains(combined, "mark-remote"),
+		"expected actionable suggestion in output, got: %s", combined)
 }
 
 func TestValidateRunLocalFailure(t *testing.T) {
+	// Local-only commands are blocked regardless of whether they would pass or fail.
 	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
-	writeProjectConfig(t, workDir, "true", "false") // false exits non-zero
+	writeProjectConfig(t, workDir, "true", "false")
 
 	env := testenv.NewTestEnv(t)
 
@@ -189,12 +192,15 @@ func TestValidateRunLocalFailure(t *testing.T) {
 		"validate",
 	}, env, workDir)
 
-	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit code for failing test command")
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit when remote is not configured")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "Remote validation is not configured"),
+		"expected remote-not-configured message, got: %s", combined)
 }
 
 func TestValidateRunLocalSkipsAfterFailure(t *testing.T) {
+	// Local-only commands are blocked before any execution — no "skipped" output.
 	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
-	// install fails, so test should be skipped
 	writeProjectConfig(t, workDir, "false", "echo should-not-run")
 
 	env := testenv.NewTestEnv(t)
@@ -203,10 +209,12 @@ func TestValidateRunLocalSkipsAfterFailure(t *testing.T) {
 		"validate",
 	}, env, workDir)
 
-	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit code")
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit when remote is not configured")
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "skipped"),
-		"expected skipped indicator for test command, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "Remote validation is not configured"),
+		"expected remote-not-configured message, got: %s", combined)
+	assert.Assert(t, !strings.Contains(combined, "should-not-run"),
+		"blocked run must not execute any command, got: %s", combined)
 }
 
 // generateTestSSHKey writes an ed25519 keypair to identityFile and identityFile+".pub".
@@ -233,6 +241,7 @@ func generateTestSSHKey(t *testing.T, identityFile string) error {
 // --- Named command execution ---
 
 func TestValidateRunNamed(t *testing.T) {
+	// Named local commands are also blocked — remote must be configured first.
 	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
 	writeProjectConfig(t, workDir, "echo installed", "echo tested")
 
@@ -242,12 +251,10 @@ func TestValidateRunNamed(t *testing.T) {
 		"validate", "test",
 	}, env, workDir)
 
-	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit when remote is not configured")
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "tested"),
-		"expected test command output in result, got: %s", combined)
-	assert.Assert(t, !strings.Contains(combined, "installed"),
-		"install command must not run when only 'test' is requested, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "Remote validation is not configured"),
+		"expected remote-not-configured message, got: %s", combined)
 }
 
 func TestValidateRunNamedNotConfiguredNonTTY(t *testing.T) {

--- a/internal/cmd/errmsg.go
+++ b/internal/cmd/errmsg.go
@@ -10,6 +10,10 @@ const (
 	errMsgHomeNotSet            = "HOME not set"
 	msgValidateNotConfigured    = "No validate commands configured."
 
+	msgRemoteNotConfigured        = "Remote validation is not configured."
+	suggestionRemoteNotConfigured = "Set up remote validation with: chunk sidecar setup\n" +
+		"Or mark commands as remote with: chunk validate --mark-remote"
+
 	suggestionCheckPerms   = "Check file permissions."
 	suggestionNetworkRetry = "Check your network connection and try again."
 	suggestionGitRepo      = "Run this command from inside a git repo."

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -241,6 +241,37 @@ func initHook(ctx context.Context, hook *hookContext, workDir string, tree gitut
 	return ctx, streams, false, nil
 }
 
+// checkRemoteConfigured returns an error when an interactive run would fall
+// back to local execution because no commands are marked remote. Hooks and
+// explicit override flags (--remote, --sidecar-id, --cmd) bypass this gate.
+func checkRemoteConfigured(hook *hookContext, opts *validateOpts, cfg *config.ProjectConfig) error {
+	if hook != nil || opts.inlineCmd != "" || opts.remote || opts.sidecarID != "" {
+		return nil
+	}
+	if cfg == nil || !cfg.HasCommands() || cfg.HasRemoteCommands() || cfg.HasSidecarImage() {
+		return nil
+	}
+	return &userError{
+		msg:        msgRemoteNotConfigured,
+		suggestion: suggestionRemoteNotConfigured,
+		errMsg:     "remote not configured",
+		hideDetail: true,
+	}
+}
+
+// hookMissingAuth reports whether a hook run should be aborted because the
+// CircleCI token is missing. It also prints the actionable message. Returns
+// false (do not abort) for non-hook runs — those prompt interactively instead.
+func hookMissingAuth(hook *hookContext, needsSidecar bool, token string, streams iostream.Streams) bool {
+	if hook == nil || !needsSidecar || token != "" {
+		return false
+	}
+	streams.ErrPrintln("CircleCI auth is not configured.")
+	streams.ErrPrintln("Suggestion: " + suggestionCircleCIAuth)
+	streams.ErrPrintln("Don't have an account? Sign up at https://app.circleci.com/signup")
+	return true
+}
+
 func validateNeedsSidecar(explicitRemote bool, cfg *config.ProjectConfig) bool {
 	if explicitRemote || cfg.HasRemoteCommands() {
 		return true
@@ -351,6 +382,10 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return runValidateDryRun(name, opts.inlineCmd, cfg, statusFn)
 	}
 
+	if err := checkRemoteConfigured(hook, opts, cfg); err != nil {
+		return err
+	}
+
 	// Hook: fail early when CircleCI auth is missing and remote commands need it.
 	// In non-hook context ensureCircleCIClient prompts interactively; hooks have
 	// no TTY so we surface a clear message here instead of a confusing fallback.
@@ -358,10 +393,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 
 	explicitRemote := opts.remote || opts.sidecarID != ""
 	needsSidecar := validateNeedsSidecar(explicitRemote, cfg)
-	if hook != nil && needsSidecar && rc.CircleCIToken == "" {
-		streams.ErrPrintln("CircleCI auth is not configured.")
-		streams.ErrPrintln("Suggestion: " + suggestionCircleCIAuth)
-		streams.ErrPrintln("Don't have an account? Sign up at https://app.circleci.com/signup")
+	if hookMissingAuth(hook, needsSidecar, rc.CircleCIToken, streams) {
 		return errSilentExit
 	}
 

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -191,6 +191,55 @@ func TestValidateNoConfigShowsSkillHint(t *testing.T) {
 		"expected suggestion to mention chunk-sidecar skill, got: %q", ue.Suggestion())
 }
 
+func TestValidateRequiresRemoteConfiguration(t *testing.T) {
+	isolateConfig(t)
+	dir := t.TempDir()
+	assert.NilError(t, config.SaveProjectConfig(dir, &config.ProjectConfig{
+		Commands: []config.Command{
+			{Name: "test", Run: "go test ./..."},
+		},
+	}))
+
+	var outBuf, errBuf bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"validate", "--project", dir})
+	err := root.Execute()
+
+	assert.Assert(t, err != nil, "expected error when no remote commands configured")
+	var ue *userError
+	assert.Assert(t, errors.As(err, &ue), "expected userError, got %T: %v", err, err)
+	assert.Assert(t, strings.Contains(ue.UserMessage(), "Remote validation is not configured"),
+		"expected remote-not-configured message, got: %q", ue.UserMessage())
+	assert.Assert(t, strings.Contains(ue.Suggestion(), "sidecar setup") || strings.Contains(ue.Suggestion(), "mark-remote"),
+		"expected suggestion to mention sidecar setup or mark-remote, got: %q", ue.Suggestion())
+}
+
+func TestValidateRequiresRemoteConfigurationSkipsInHookContext(t *testing.T) {
+	isolateConfig(t)
+	dir := t.TempDir()
+	gitSetup(t, dir, "main")
+	assert.NilError(t, config.SaveProjectConfig(dir, &config.ProjectConfig{
+		Commands: []config.Command{
+			{Name: "test", Run: "exit 0"},
+		},
+	}))
+
+	_, _, err := runValidateHook(t, dir)
+
+	// Hook must not be blocked by the remote-not-configured gate.
+	// (It may fail for other reasons like a dirty tree that can't be fingerprinted,
+	// but it must not return the remote-not-configured userError.)
+	if err != nil {
+		var ue *userError
+		if errors.As(err, &ue) {
+			assert.Assert(t, !strings.Contains(ue.Error(), "Remote validation is not configured"),
+				"hook must not be blocked by remote-not-configured gate, got: %q", ue.Error())
+		}
+	}
+}
+
 func TestValidateEnvFlagBadValue(t *testing.T) {
 	isolateConfig(t)
 	dir := t.TempDir()


### PR DESCRIPTION
**Summary**

- chunk validate now fails with a clear message when no commands are marked remote and no sidecar image is configured, rather than silently running locally
- Directs users to chunk sidecar setup (preferred) or chunk validate --mark-remote to configure remote before proceeding
- Hooks are exempt — existing hook setups are unaffected. Explicit flags (--remote, --sidecar-id, --cmd, --dry-run) also bypass the gate

**Implementation**

- checkRemoteConfigured — new helper that enforces the gate; returns early for hooks and override flags
- hookMissingAuth — extracted from runValidateCmdE to keep cyclomatic complexity under the linter limit
- 4 acceptance tests updated: local-only chunk validate now expects the remote-not-configured error instead of successful execution
- 2 unit tests added: one for the gate firing, one confirming hooks are exempt

**Test plan**

- [ ] chunk validate in a project with local-only commands shows Remote validation is not configured. with actionable suggestion
- [ ] chunk validate --dry-run still works (bypasses gate)
- [ ] chunk validate --mark-remote still works (bypasses gate, fixes config)
- [ ] After marking remote, chunk validate attempts sidecar as expected
- [ ] Stop hook with local-only commands is not blocked
- [ ] All tests pass: task test