### PR TITLE
review and update landing / instruction pages to focus on current sidecar approach

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # AGENTS.md
 
-`chunk` is a Go CLI (built with cobra) that mines PR review comments from GitHub, analyzes them with Claude, and outputs a markdown prompt file tuned to a team's review patterns. Generated context goes in `.chunk/context/` for AI coding agents to pick up automatically.
+`chunk` is a Go CLI (built with cobra) for inner loop validation. Its primary capability is **sidecars** — ephemeral Linux environments on CircleCI that a developer's working tree is synced to so quality checks (test, lint, format) run there instead of locally, catching environment-specific failures before they reach CI.
+
+It also provides `build-prompt`, a secondary tool that mines PR review comments from GitHub, analyzes them with Claude, and outputs a markdown prompt file tuned to a team's review patterns. Generated context goes in `.chunk/context/` for AI coding agents to pick up automatically.
 
 ## Common Commands
 
@@ -16,7 +18,7 @@ task fmt                # Format code
 
 Read these when working in the relevant area:
 
-- **[docs/GETTING_STARTED.md](docs/GETTING_STARTED.md)** — user guide: auth, init, build-prompt, skills, sidecar workflow
+- **[docs/GETTING_STARTED.md](docs/GETTING_STARTED.md)** — user guide: auth, init, sidecar setup, dev loop, skills, build-prompt
 - **[docs/SKILLS.md](docs/SKILLS.md)** — skills reference: installing and using agent skills
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — module layering, dependency rules, data flow, environment variables
 - **[docs/CLI.md](docs/CLI.md)** — complete command tree, flag conventions, behavior decisions

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 # chunk
 
-CLI for [Chunk](https://chunk.ai/) — inner loop validation and AI-ready code review context for software teams building with AI agents. The chunk CLI currently has two main capabilities:
+CLI for [Chunk](https://chunk.ai/) — inner loop validation for software teams building with AI agents.
 
-- **Chunk sidecars** — lightweight microVM environments that run alongside your AI agent and validate changes in the inner loop before they reach CI
-- **build-prompt** — mines PR review comments from your GitHub org and uses Claude to generate a context file tuned to your team's code review standards
+**Chunk sidecars** are lightweight microVM environments that run alongside your AI agent and validate changes in the inner loop, before they reach CI.
 
 ## Why chunk?
 
 As AI churns out more and more code, CI pipelines get flooded with commits that haven't been well validated. Failures surface late, forcing expensive re-prompting cycles and slowing delivery.
 
 Chunk sidecars fix this by running lightweight microbuilds to validate inside the inner loop — while the agent is still working — ensuring basic checks pass before anything hits CI. Save the CI for the integration and release work that gets code to production.
-
-The build-prompt command complements this by capturing your team's real review patterns and turning them into agent context, so the code agents write reflects your standards from the start.
 
 ## Requirements
 
@@ -42,6 +39,11 @@ chunk validate --list       # list configured commands
 ### Agent Onboarding for Sidecars (Preferred method)
 
 Chunk init will install skills for working with Chunk sidecars. After the init, start a claude session and run `/chunk-sidecar` and your agent will create a sidecar and configure it for use running tests and creating snapshots of good Chunk sidecars.
+
+```bash
+# Install or update the agent skills (Claude Code, Codex, Cursor)
+chunk skill install
+```
 
 ### Manual setup
 
@@ -106,9 +108,9 @@ chunk sidecar create --name new-sidecar --image <snapshot-id>
 
 **Note:** `snapshot create` consumes the source sidecar — it is deleted once the snapshot is captured and cannot be reused. To resume work, launch a new sidecar from the snapshot with `chunk sidecar create --image <snapshot-id>`. Use `chunk sidecar snapshot list` to look up snapshot IDs for your org.
 
-### Context Generation
+## Also included: team review context
 
-Generate a review context prompt from your org's GitHub PR comments:
+An additional tool, independent of the sidecar workflow. `chunk build-prompt` mines PR review comments from your GitHub org and uses Claude to generate a context file tuned to your team's review standards, so the code agents write reflects those standards from the start.
 
 ```bash
 # From inside a git repo — org and repos are auto-detected
@@ -118,10 +120,9 @@ chunk build-prompt
 chunk build-prompt --org myorg --repos api,backend --top 10
 
 # Output lands in .chunk/context/review-prompt.md
-
-# Install review skills for Claude Code, Codex, and Cursor
-chunk skill install
 ```
+
+See [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md#team-review-context) for details.
 
 ## Commands
 
@@ -149,7 +150,7 @@ See [docs/CLI.md](docs/CLI.md) for the full command and flag reference.
 
 | Doc | Purpose |
 |-----|---------|
-| [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) | Step-by-step guide: auth, init, build-prompt, skills, sidecar workflow |
+| [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) | Step-by-step guide: auth, init, sidecar setup, dev loop, skills |
 | [docs/SKILLS.md](docs/SKILLS.md) | Skills reference: installing, triggering, and troubleshooting agent skills |
 | [docs/CLI.md](docs/CLI.md) | Full command and flag reference |
 | [docs/HOOKS.md](docs/HOOKS.md) | Pre-commit and Stop hook configuration |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,10 +1,10 @@
 # Getting Started with chunk
 
-`chunk` is a CLI that does two related things:
+`chunk` runs your quality checks (tests, lint, format) on a **sidecar** — a clean cloud environment on CircleCI — while your AI agent is still working. Failures surface in the inner loop instead of in CI, so you catch what only reproduces outside your machine before you ever push.
 
-1. **Generates team review context** — mines real PR review comments from GitHub, analyzes them with Claude, and produces a `.chunk/context/review-prompt.md` file that encodes how your team actually reviews code. AI coding agents pick this file up automatically and apply your team's standards.
+This guide sets that up: authenticate, initialize your project, create a sidecar, and run the dev loop against it.
 
-2. **Validates changes remotely** — runs your quality checks (tests, lint, format) in a clean cloud environment on CircleCI before you push, so you catch failures that only reproduce outside your machine.
+It also covers **team review context** ([below](#team-review-context)) — an additional tool that mines your PR review history into a prompt file your agents read automatically. Useful, but independent of the sidecar workflow; skip it until the loop above is working.
 
 ---
 
@@ -24,17 +24,6 @@ chunk --version
 
 ## Concepts
 
-### .chunk/ directory
-
-The `.chunk/` directory lives at the root of your project and holds configuration that should be version-controlled. After running `chunk init` and `chunk build-prompt`, it looks like:
-
-```
-.chunk/
-├── config.json              # Configured validation commands
-└── context/
-    └── review-prompt.md     # Generated team review standards
-```
-
 ### Sidecars
 
 A **sidecar** is an ephemeral Linux environment running on CircleCI. Instead of running tests locally, you sync your working tree to a sidecar and run checks there. This catches failures caused by local environment differences (different OS, missing dependencies, port conflicts) before they reach CI.
@@ -43,7 +32,18 @@ Sidecars are available to all CircleCI customers, including the free plans.
 
 ### Skills
 
-**Skills** are instructions for AI coding agents (Claude Code, Cursor, Codex). Running `chunk skill install` copies skill files into your agent's configuration directory, teaching it commands like `/chunk-review` and how to run the sidecar dev loop.
+**Skills** are instructions for AI coding agents (Claude Code, Cursor, Codex). Running `chunk skill install` copies skill files into your agent's configuration directory, teaching it how to run the sidecar dev loop and commands like `/chunk-review`.
+
+### .chunk/ directory
+
+The `.chunk/` directory lives at the root of your project and holds configuration that should be version-controlled. After `chunk init` it holds your validation commands; `chunk build-prompt` adds the review context file if you generate one:
+
+```
+.chunk/
+├── config.json              # Configured validation commands
+└── context/
+    └── review-prompt.md     # Generated team review standards (optional)
+```
 
 ---
 
@@ -52,15 +52,15 @@ Sidecars are available to all CircleCI customers, including the free plans.
 Store credentials for the services you plan to use:
 
 ```bash
-chunk auth set anthropic   # required for build-prompt and init
-chunk auth set github      # required for build-prompt
-
-# For CircleCI (required for sidecars and task runs), browser OAuth is recommended:
+# CircleCI — required for sidecars. Browser OAuth is recommended:
 chunk auth login           # existing CircleCI account
 chunk auth signup          # new CircleCI account
 
 # Or set a personal API token directly:
 chunk auth set circleci
+
+chunk auth set anthropic   # required for init (command detection) and build-prompt
+chunk auth set github      # only needed for build-prompt
 ```
 
 Check status at any time:
@@ -122,67 +122,7 @@ chunk validate --dry-run # print commands without executing
 
 ---
 
-## Step 3: Generate team review context
-
-This step mines your GitHub PR history and generates a prompt that captures how your team reviews code. Run it once and commit the output.
-
-```bash
-# Auto-detects org and repos from your git remote
-chunk build-prompt
-
-# Or specify explicitly
-chunk build-prompt --org myorg --repos api,backend --top 10 --since 2024-01-01
-```
-
-The pipeline runs three steps:
-
-1. **Discover** — fetches PR review comments from GitHub, identifies top reviewers
-2. **Analyze** — sends comments to Claude Sonnet to extract patterns
-3. **Generate** — sends patterns to Claude Opus to produce a focused prompt
-
-Output lands at `.chunk/context/review-prompt.md`. Commit this file — your team's AI agents will read it automatically.
-
----
-
-## Step 4: Install skills
-
-Skills install slash commands into your AI coding agents so they can run reviews and use sidecars.
-
-```bash
-chunk skill install     # install or update all skills
-chunk skill list        # check installation status
-```
-
-After installing, your agent gains these skills:
-
-| Skill | Trigger | What it does |
-|---|---|---|
-| `chunk-review` | "review my changes" / "chunk review" | Applies your team's review standards to the current diff |
-| `chunk-sidecar` | "validate on the sidecar" / "sidecar dev loop" | Syncs and validates changes on a remote CircleCI environment |
-| `chunk-testing-gaps` | "find testing gaps" / "mutation test" | Runs mutation testing on parallel sidecars to find undertested code |
-| `debug-ci-failures` | "debug CI" / "why is CI failing" | Analyzes CircleCI build failures and flaky tests |
-
-See [docs/SKILLS.md](SKILLS.md) for full details on each skill.
-
----
-
-## Step 5: Review changes
-
-Once `.chunk/context/review-prompt.md` exists and skills are installed, ask your agent to review:
-
-```
-chunk review
-review my changes
-review PR #123
-```
-
-The agent loads your team's prompt, diffs the changes, and returns filtered findings (Critical/High issues, capped at 10 comments).
-
----
-
-## Sidecar workflow (preview)
-
-### First-time sidecar setup
+## Step 3: Create your first sidecar
 
 Sidecar commands need a CircleCI org ID. The recommended path is to authenticate and run `chunk init` before using sidecars — init captures the org ID automatically and saves it to `.chunk/config.json`. After that, `chunk sidecar create` just works.
 
@@ -201,9 +141,11 @@ chunk config set orgID <your-org-id>
 See [docs/CLI.md](CLI.md) for the full resolution order (`--org-id` → env →
 project config → interactive picker).
 
-### Dev loop
+---
 
-Sidecars let you run validations in a clean cloud environment. The typical loop:
+## Step 4: Run the dev loop
+
+This is the core workflow — sync your working tree to the sidecar, then run your validation commands there:
 
 ```bash
 # Create a sidecar (--name is optional; a random name is generated if omitted)
@@ -240,6 +182,37 @@ run the tests on the sidecar
 ```
 
 The skill handles the full loop: auth checks → find active sidecar → sync → validate → interpret failures → fix locally → repeat.
+
+---
+
+## Step 5: Install skills
+
+Skills let your AI coding agent drive the loop above itself, instead of you running each command by hand.
+
+```bash
+chunk skill install     # install or update all skills
+chunk skill list        # check installation status
+```
+
+After installing, your agent gains these skills:
+
+| Skill | Trigger | What it does |
+|---|---|---|
+| `chunk-sidecar` | "validate on the sidecar" / "sidecar dev loop" | Syncs and validates changes on a sidecar |
+| `chunk-sidecar-setup` | "set up chunk sidecar" / "walk me through sidecar setup" | Interactive first-time onboarding: auth, orgID, create, install deps, snapshot |
+| `chunk-testing-gaps` | "find testing gaps" / "mutation test" | Runs mutation testing on parallel sidecars to find undertested code |
+| `debug-ci-failures` | "debug CI" / "why is CI failing" | Analyzes CircleCI build failures and flaky tests |
+| `chunk-review` | "review my changes" / "chunk review" | Applies your team's review standards to the current diff |
+
+See [docs/SKILLS.md](SKILLS.md) for full details on each skill.
+
+**Shortcut:** rather than doing Steps 3–4 by hand, you can hand them to your agent. Say "set up chunk sidecar" and the `chunk-sidecar-setup` wizard walks through auth, orgID, creation, dependency installation, and snapshotting — then hands off to `chunk-sidecar` for the dev loop.
+
+---
+
+## Sidecar reference
+
+The sections below cover the sidecar workflow in more detail. Skip them until you need something specific.
 
 ### Syncing
 
@@ -453,23 +426,58 @@ See [docs/HOOKS.md](HOOKS.md) for configuration details and [Result Caching](HOO
 
 ---
 
+## Team review context
+
+An additional tool, independent of the sidecar workflow above. `chunk build-prompt` mines your GitHub PR history and generates a prompt that captures how your team reviews code. Run it once and commit the output.
+
+```bash
+# Auto-detects org and repos from your git remote
+chunk build-prompt
+
+# Or specify explicitly
+chunk build-prompt --org myorg --repos api,backend --top 10 --since 2024-01-01
+```
+
+The pipeline runs three steps:
+
+1. **Discover** — fetches PR review comments from GitHub, identifies top reviewers
+2. **Analyze** — sends comments to Claude Sonnet to extract patterns
+3. **Generate** — sends patterns to Claude Opus to produce a focused prompt
+
+Output lands at `.chunk/context/review-prompt.md`. Commit this file — your team's AI agents will read it automatically.
+
+Requires `chunk auth set anthropic` and `chunk auth set github`.
+
+Once that file exists and skills are installed, ask your agent to review:
+
+```
+chunk review
+review my changes
+review PR #123
+```
+
+The agent loads your team's prompt, diffs the changes, and returns filtered findings (Critical/High issues, capped at 10 comments).
+
+---
+
 ## Typical day-to-day workflow
 
 ```
-Start coding session
-    └─ Agent picks up .chunk/context/review-prompt.md automatically
-
 Make changes
+
+Validate on a sidecar
     └─ chunk sidecar sync + chunk validate --remote   (or locally: chunk validate)
+    └─ or hand it to the agent: "validate on the sidecar"
     └─ chunk watch   (optional: live dashboard to see sync/validate progress)
 
 Before committing
     └─ Hook runs chunk validate automatically
 
-Ask for a review
-    └─ "chunk review" → agent applies team standards → filtered findings
-
 Push
+
+Optionally, if you generated review context
+    └─ Agent picks up .chunk/context/review-prompt.md automatically
+    └─ "chunk review" → agent applies team standards → filtered findings
 ```
 
 ---

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -1,6 +1,8 @@
 # Skills
 
-Skills are instruction files for AI coding agents. Installing them teaches agents how to use `chunk` commands — code review, remote validation, test gap analysis, and CI debugging — through natural-language triggers.
+Skills are instruction files for AI coding agents. Installing them teaches agents how to use `chunk` commands — sidecar setup and the remote validation dev loop, plus test gap analysis, CI debugging, and code review — through natural-language triggers.
+
+Skills below are listed alphabetically. If you are setting up for the first time, start with [`chunk-sidecar-setup`](#chunk-sidecar-setup), then use [`chunk-sidecar`](#chunk-sidecar) for the day-to-day loop.
 
 ## Installing skills
 


### PR DESCRIPTION
## Summary
- Lead README, getting-started, skills, and AGENTS.md with sidecars as the primary path
- Move `build-prompt` / team review context to an optional extra, not a setup step
- Drop the leftover "sidecar workflow (preview)" framing so the inner-loop sidecar loop is the documented default

## Test plan
- [ ] Read README from the top: sidecars are the product; review is under "Also included"
- [ ] Walk `docs/GETTING_STARTED.md` as a new user: auth → init → create sidecar → dev loop, with review only after that
- [ ] Confirm `docs/SKILLS.md` points first-time setup at `chunk-sidecar-setup` / `chunk-sidecar`
- [ ] Confirm `AGENTS.md` describes sidecars first and `build-prompt` as secondary