### PR TITLE
Fix sidecars stuck on "needs sync" in the watch TUI

### DIFF
--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -164,12 +164,37 @@ func SaveActiveTo(ctx context.Context, dir string, a ActiveSidecar) error {
 	}
 	root, _ := projectRoot()
 	branch := CurrentBranch(root)
-	if err := os.WriteFile(filepath.Join(dir, sidecarFileName(session.IDFromCtx(ctx), branch)), data, 0o644); err != nil {
+	path := filepath.Join(dir, sidecarFileName(session.IDFromCtx(ctx), branch))
+	if err := os.WriteFile(path, data, 0o644); err != nil {
 		return err
 	}
+	pruneRekeyedState(dir, path, a.SidecarID)
 	// Write a breadcrumb so chunk watch --all can discover this project.
 	_ = os.WriteFile(filepath.Join(dir, "project-root"), []byte(root), 0o644)
 	return nil
+}
+
+// pruneRekeyedState removes state files other than keep that name sidecarID.
+//
+// LoadAnyActive reuses one sidecar across sessions and branches, and the next
+// SaveActive re-keys it under the current session+branch. Without this the file
+// it was read from is left behind holding an out-of-date synced ref, so readers
+// that pick the wrong file report a sidecar as permanently needing a sync.
+// Best-effort: a file that cannot be removed is left for Reap to clean up.
+func pruneRekeyedState(dir, keep, sidecarID string) {
+	if sidecarID == "" {
+		return
+	}
+	entries, err := loadStateEntries(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.path == keep || e.active.SidecarID != sidecarID {
+			continue
+		}
+		_ = removeState(e.path)
+	}
 }
 
 // AllProjectRoots returns the roots of all projects that have ever saved a

--- a/internal/sidecar/active_test.go
+++ b/internal/sidecar/active_test.go
@@ -294,3 +294,29 @@ func TestSidecarFileNameHashUniquenessAcrossBranches(t *testing.T) {
 	f2 := sidecarFileName("sess-abc", "feature/my-branch")
 	assert.Assert(t, f1 != f2, "different branches must produce different file names")
 }
+
+func TestSaveActivePrunesRekeyedStateFiles(t *testing.T) {
+	setupXDGData(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	stateDir, err := config.ProjectDataDir(dir)
+	assert.NilError(t, err)
+	assert.NilError(t, os.MkdirAll(stateDir, 0o755))
+
+	// A file another session left behind naming the same sidecar, plus one naming
+	// a different sidecar that must survive.
+	stale := filepath.Join(stateDir, "sidecar.other-session.json")
+	assert.NilError(t, os.WriteFile(stale, []byte(`{"sidecar_id":"sb-1","last_synced_ref":"oldref"}`), 0o644))
+	keep := filepath.Join(stateDir, "sidecar.unrelated.json")
+	assert.NilError(t, os.WriteFile(keep, []byte(`{"sidecar_id":"sb-2"}`), 0o644))
+
+	assert.NilError(t, SaveActive(context.Background(), ActiveSidecar{SidecarID: "sb-1", LastSyncedRef: "newref"}))
+
+	_, err = os.Stat(stale)
+	assert.Assert(t, os.IsNotExist(err), "state file re-keyed to a new name must be removed")
+	_, err = os.Stat(keep)
+	assert.NilError(t, err, "state for a different sidecar must survive")
+	_, err = os.Stat(filepath.Join(stateDir, "sidecar.json"))
+	assert.NilError(t, err)
+}

--- a/internal/tui/watch/model.go
+++ b/internal/tui/watch/model.go
@@ -1126,11 +1126,16 @@ func projectRepoName(projectRoot string) string {
 	return filepath.Base(mainRoot)
 }
 
-// loadSidecars reads all sidecar*.json files from dataDir, deduplicates by ID.
+// loadSidecars reads all sidecar*.json files from dataDir, keeping one entry per
+// sidecar ID. State accumulates one file per session and branch, and several of
+// them can name the same sidecar because LoadAnyActive reuses it across sessions
+// and branches. Only the most recently written file holds the current synced ref,
+// so entries are deduplicated by newest mtime rather than by glob order — reading
+// an older file reports a stale ref and the sidecar looks permanently out of sync.
 func loadSidecars(dataDir, projectRoot string, snapshotName string, head string, projectIdx int, repoName, branch string) []sidecarInfo {
 	matches, _ := filepath.Glob(filepath.Join(dataDir, "sidecar*.json"))
 	projectName := filepath.Base(projectRoot)
-	seen := map[string]bool{}
+	idx := map[string]int{}
 	var result []sidecarInfo
 	for _, path := range matches {
 		data, err := os.ReadFile(path)
@@ -1141,16 +1146,15 @@ func loadSidecars(dataDir, projectRoot string, snapshotName string, head string,
 		if json.Unmarshal(data, &as) != nil || as.SidecarID == "" {
 			continue
 		}
-		if seen[as.SidecarID] {
-			continue
-		}
-		seen[as.SidecarID] = true
-		inSync := head != "" && as.LastSyncedRef != "" && head == as.LastSyncedRef
 		var mtime time.Time
 		if fi, err := os.Stat(path); err == nil {
 			mtime = fi.ModTime()
 		}
-		result = append(result, sidecarInfo{
+		at, dup := idx[as.SidecarID]
+		if dup && !mtime.After(result[at].fileMtime) {
+			continue
+		}
+		info := sidecarInfo{
 			id:            as.SidecarID,
 			sidecarIDs:    []string{as.SidecarID},
 			name:          as.Name,
@@ -1161,8 +1165,15 @@ func loadSidecars(dataDir, projectRoot string, snapshotName string, head string,
 			snapshotName:  snapshotName,
 			fileMtime:     mtime,
 			lastSyncedRef: as.LastSyncedRef,
-			inSync:        inSync,
-		})
+			inSync:        head != "" && as.LastSyncedRef != "" && head == as.LastSyncedRef,
+		}
+		// Replace in place so output order still follows the first sighting of an ID.
+		if dup {
+			result[at] = info
+			continue
+		}
+		idx[as.SidecarID] = len(result)
+		result = append(result, info)
 	}
 	return result
 }

--- a/internal/tui/watch/model_test.go
+++ b/internal/tui/watch/model_test.go
@@ -614,3 +614,29 @@ func TestUpdate_unknownSelectionFallsBackToFreshest(t *testing.T) {
 		t.Errorf("want fallback to idx 0 (fresh), got idx %d id %q", m.selectedIdx, m.selectedID)
 	}
 }
+
+func TestLoadSidecars_prefersNewestFileForDuplicateID(t *testing.T) {
+	dir := t.TempDir()
+	root := t.TempDir()
+
+	// Both files name the same sidecar. The stale one sorts first under Glob, so
+	// glob order would report the old ref and the sidecar would look out of sync.
+	writeSidecarJSON(t, dir, "sidecar.aaa.json", `{"sidecar_id":"id1","name":"sc1","last_synced_ref":"oldref"}`)
+	writeSidecarJSON(t, dir, "sidecar.json", `{"sidecar_id":"id1","name":"sc1","last_synced_ref":"newref"}`)
+
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(filepath.Join(dir, "sidecar.aaa.json"), old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	result := loadSidecars(dir, root, "", "newref", 0, "root", "main")
+	if len(result) != 1 {
+		t.Fatalf("want 1 sidecar, got %d", len(result))
+	}
+	if result[0].lastSyncedRef != "newref" {
+		t.Errorf("want newest file's ref newref, got %q", result[0].lastSyncedRef)
+	}
+	if !result[0].inSync {
+		t.Error("sidecar should be in sync when the newest state file matches head")
+	}
+}


### PR DESCRIPTION
## Summary
- Sidecar state accumulates one file per session and branch, and several files can name the same sidecar because `LoadAnyActive` reuses one across sessions and branches. Only the newest file holds the current synced ref.
- `loadSidecars` deduplicated by glob order, so it read whichever filename sorted first and reported a stale ref, leaving the sidecar shown as permanently needing a sync. It now dedupes by newest mtime, matching `LoadAnyActive`.
- `SaveActive` now removes other state files naming the same sidecar when it re-keys, so stale refs stop accumulating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)