### PR TITLE
Say what the sidecar API said when a command fails

### DIFF
--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -580,11 +580,14 @@ func mapErr(op string, err error) error {
 	if he.StatusCode == http.StatusUnauthorized || he.StatusCode == http.StatusForbidden {
 		return fmt.Errorf("%s: %w", op, ErrNotAuthorized)
 	}
-	se := &StatusError{Op: op, StatusCode: he.StatusCode}
-	if he.StatusCode == http.StatusGone {
-		se.ServerMessage = extractServerMessage(he.Body)
+	// Every status carries the server's own explanation, not just 410. The API
+	// says things like "sidecar is paused" that no status text can convey, and
+	// dropping them left users with a bare "409 Conflict" to interpret.
+	return &StatusError{
+		Op:            op,
+		StatusCode:    he.StatusCode,
+		ServerMessage: extractServerMessage(he.Body),
 	}
-	return se
 }
 
 // extractServerMessage pulls the human-readable message out of a JSON error

--- a/internal/circleci/staleness.go
+++ b/internal/circleci/staleness.go
@@ -33,8 +33,31 @@ func SidecarOutOfDate(err error) bool {
 // else means a missing route, not a missing sidecar.
 func SidecarGone(err error) bool {
 	var se *StatusError
-	if !errors.As(err, &se) {
+	if !errors.As(err, &se) || se.StatusCode != http.StatusNotFound {
 		return false
 	}
-	return se.StatusCode == http.StatusNotFound
+	// The gateway answers an unknown route with 404 "Route Not Found.", which
+	// means an API too old for this command, not a sidecar that has gone away.
+	// Reporting it as a missing sidecar would prune healthy local state and send
+	// people off recreating a sidecar that was never the problem.
+	return !strings.Contains(strings.ToLower(se.ServerMessage), "route not found")
+}
+
+// SidecarPaused reports whether err is the API refusing an operation because the
+// sidecar is suspended. Sidecars pause themselves when left idle.
+//
+// The underlying sandbox can be resumed: the provider has an API for it, and
+// resume-on-connect is enabled. But the exec path checks the paused state and
+// declines rather than waking it, and no route exposes a resume. So a
+// replacement is the only remedy a caller can act on, however recoverable the
+// sidecar itself may be.
+//
+// Matched on the server's wording for the same reason as SidecarOutOfDate: the
+// V3 error envelope carries no machine-readable code.
+func SidecarPaused(err error) bool {
+	var se *StatusError
+	if !errors.As(err, &se) || se.StatusCode != http.StatusConflict {
+		return false
+	}
+	return strings.Contains(strings.ToLower(se.ServerMessage), "paused")
 }

--- a/internal/circleci/staleness_test.go
+++ b/internal/circleci/staleness_test.go
@@ -1,0 +1,136 @@
+package circleci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+)
+
+func TestSidecarGone(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "404 naming the sidecar",
+			err:  &StatusError{Op: "exec", StatusCode: http.StatusNotFound, ServerMessage: "Not found"},
+			want: true,
+		},
+		{
+			// The gateway's wording for an unknown route. Treating it as a
+			// missing sidecar would prune healthy local state.
+			name: "404 from a missing route",
+			err:  &StatusError{Op: "exec", StatusCode: http.StatusNotFound, ServerMessage: "Route Not Found."},
+			want: false,
+		},
+		{
+			name: "404 with no message at all",
+			err:  &StatusError{Op: "exec", StatusCode: http.StatusNotFound},
+			want: true,
+		},
+		{
+			name: "wrapped 404 still matches",
+			err:  fmt.Errorf("sync: %w", &StatusError{Op: "sync", StatusCode: http.StatusNotFound}),
+			want: true,
+		},
+		{
+			name: "409 is not gone",
+			err:  &StatusError{Op: "exec", StatusCode: http.StatusConflict, ServerMessage: "sidecar is paused"},
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("dial tcp: connection refused"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, SidecarGone(tt.err), tt.want)
+		})
+	}
+}
+
+func TestSidecarPaused(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "409 naming the condition",
+			err:  &StatusError{Op: "exec", StatusCode: http.StatusConflict, ServerMessage: "sidecar is paused"},
+			want: true,
+		},
+		{
+			name: "wording is matched case-insensitively",
+			err:  &StatusError{Op: "exec", StatusCode: http.StatusConflict, ServerMessage: "Sidecar Is Paused"},
+			want: true,
+		},
+		{
+			// A conflict the CLI has no specific advice for must fall through to
+			// the generic path rather than claim the sidecar is asleep.
+			name: "409 for some other conflict",
+			err:  &StatusError{Op: "exec", StatusCode: http.StatusConflict, ServerMessage: "command already running"},
+			want: false,
+		},
+		{
+			name: "paused wording on a different status",
+			err:  &StatusError{Op: "exec", StatusCode: http.StatusGone, ServerMessage: "sidecar is paused"},
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("dial tcp: connection refused"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, SidecarPaused(tt.err), tt.want)
+		})
+	}
+}
+
+// mapErr used to attach the server's message only for 410, so every other
+// status reached users as bare status text. These check it for the statuses the
+// sidecar routes actually return, in both body shapes the API uses.
+func TestExecSurfacesServerMessage(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		message    string
+	}{
+		{name: "paused sidecar", statusCode: http.StatusConflict, message: "sidecar is paused"},
+		{name: "missing sidecar", statusCode: http.StatusNotFound, message: "Not found"},
+		{name: "out of date sidecar", statusCode: http.StatusGone, message: "sidecar is out of date"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := fakes.NewFakeCircleCI()
+			fake.ExecStatusCode = tt.statusCode
+			fake.ExecMessage = tt.message
+			srv := httptest.NewServer(fake)
+			defer srv.Close()
+
+			client := newTestClient(t, srv.URL)
+			_, err := client.Exec(context.Background(), "sb-1", "w", nil, nil, nil)
+
+			var se *StatusError
+			assert.Assert(t, errors.As(err, &se), "expected StatusError, got %v", err)
+			assert.Equal(t, se.StatusCode, tt.statusCode)
+			assert.Equal(t, se.ServerMessage, tt.message)
+		})
+	}
+}

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -287,6 +287,9 @@ func newSidecarDeleteCmd() *cobra.Command {
 				if err := notAuthorized("delete sidecars", err); err != nil {
 					return err
 				}
+				if err := sidecarUnavailable(sidecarID, err); err != nil {
+					return err
+				}
 				return &userError{
 					msg:        "Could not delete the sidecar.",
 					suggestion: suggestionNetworkRetry,
@@ -359,6 +362,9 @@ or via the repeatable --args flag. Positional arguments are appended after any
 				if err := notAuthorized("execute commands", err); err != nil {
 					return err
 				}
+				if err := sidecarUnavailable(sidecarID, err); err != nil {
+					return err
+				}
 				if err := outdatedSidecarAPI(err); err != nil {
 					return err
 				}
@@ -405,6 +411,9 @@ func newSidecarAddSSHKeyCmd() *cobra.Command {
 			resp, err := sidecar.AddSSHKey(cmd.Context(), client, sidecarID, publicKey, publicKeyFile)
 			if err != nil {
 				if err := notAuthorized("add SSH keys", err); err != nil {
+					return err
+				}
+				if err := sidecarUnavailable(sidecarID, err); err != nil {
 					return err
 				}
 				switch {
@@ -478,6 +487,9 @@ func newSidecarSSHCmd() *cobra.Command {
 					return err
 				}
 				if err := notAuthorized("connect via SSH", err); err != nil {
+					return err
+				}
+				if err := sidecarUnavailable(sidecarID, err); err != nil {
 					return err
 				}
 				return err
@@ -554,6 +566,9 @@ func newSidecarSyncCmd() *cobra.Command {
 					return err
 				}
 				if err := notAuthorized("sync files", err); err != nil {
+					return err
+				}
+				if err := sidecarUnavailable(sidecarID, err); err != nil {
 					return err
 				}
 				return &userError{

--- a/internal/cmd/usererr.go
+++ b/internal/cmd/usererr.go
@@ -63,6 +63,34 @@ func outdatedSidecarAPI(err error) error {
 		wrap(err)
 }
 
+// sidecarUnavailable maps the two conditions the API reports about a sidecar
+// itself, rather than about the request, into guidance that names it: the
+// sidecar no longer exists, or it is paused. Both leave a bare status code
+// otherwise, and "409 Conflict" tells nobody that their sidecar went to sleep.
+//
+// Only call this on errors from requests addressed at a specific sidecar; see
+// circleci.SidecarGone.
+func sidecarUnavailable(sidecarID string, err error) error {
+	switch {
+	case circleci.SidecarGone(err):
+		return newUserError(fmt.Sprintf("Sidecar %s no longer exists.", sidecarID)).
+			withCode("sidecar.not_found").
+			withSuggestion("See what you have with: chunk sidecar list\nOr create a new one with: chunk sidecar create").
+			withExitCode(ExitNotFound).
+			withoutDetail().
+			wrap(err)
+	case circleci.SidecarPaused(err):
+		return newUserError(fmt.Sprintf("Sidecar %s is paused.", sidecarID)).
+			withCode("sidecar.paused").
+			withSuggestion("Sidecars pause when left idle, and the API exposes no way to resume one. " +
+				"Create a replacement with: chunk sidecar create").
+			withExitCode(ExitAPIError).
+			withoutDetail().
+			wrap(err)
+	}
+	return nil
+}
+
 func sshSessionError(err error) error {
 	if e, ok := errors.AsType[*sidecar.KeyNotFoundError](err); ok {
 		return newUserError(fmt.Sprintf("SSH key not found: %s", e.Path)).

--- a/internal/cmd/usererr_test.go
+++ b/internal/cmd/usererr_test.go
@@ -80,3 +80,49 @@ func TestGoneErrorDistinguishesStaleSidecarFromStaleCLI(t *testing.T) {
 		assert.Check(t, GoneError(errors.New("nope")) == nil)
 	})
 }
+
+// A 404 or 409 from a sidecar-scoped call used to reach users as bare status
+// text under "An unknown error occurred", which named neither the sidecar nor
+// what to do about it.
+func TestSidecarUnavailableNamesTheSidecarAndTheRemedy(t *testing.T) {
+	const id = "ba600ef3-907b-412d-bd01-57752350836f"
+
+	t.Run("a deleted sidecar", func(t *testing.T) {
+		err := sidecarUnavailable(id, &circleci.StatusError{
+			Op: "exec", StatusCode: http.StatusNotFound, ServerMessage: "Not found",
+		})
+		assert.Assert(t, err != nil, "a 404 must be recognised")
+		var ue *userError
+		assert.Assert(t, errors.As(err, &ue), "expected *userError, got %T", err)
+		assert.Assert(t, strings.Contains(ue.UserMessage(), id), "the message must name the sidecar: %q", ue.UserMessage())
+		assert.Assert(t, strings.Contains(ue.Suggestion(), "chunk sidecar list"))
+		assert.Equal(t, ue.UserExitCode(), ExitNotFound)
+	})
+
+	t.Run("a paused sidecar", func(t *testing.T) {
+		err := sidecarUnavailable(id, &circleci.StatusError{
+			Op: "exec", StatusCode: http.StatusConflict, ServerMessage: "sidecar is paused",
+		})
+		assert.Assert(t, err != nil, "a paused 409 must be recognised")
+		var ue *userError
+		assert.Assert(t, errors.As(err, &ue), "expected *userError, got %T", err)
+		assert.Assert(t, strings.Contains(ue.UserMessage(), "paused"), "got %q", ue.UserMessage())
+		// No route resumes a sidecar, so a replacement is the only remedy the
+		// caller can act on.
+		assert.Assert(t, strings.Contains(ue.Suggestion(), "chunk sidecar create"))
+		assert.Equal(t, ue.UserExitCode(), ExitAPIError)
+	})
+
+	t.Run("anything else falls through", func(t *testing.T) {
+		cases := []error{
+			errors.New("dial tcp: connection refused"),
+			// An unknown route, not a missing sidecar.
+			&circleci.StatusError{Op: "exec", StatusCode: http.StatusNotFound, ServerMessage: "Route Not Found."},
+			// A conflict this helper has no advice for.
+			&circleci.StatusError{Op: "exec", StatusCode: http.StatusConflict, ServerMessage: "command already running"},
+		}
+		for _, c := range cases {
+			assert.Assert(t, sidecarUnavailable(id, c) == nil, "must not claim to handle %v", c)
+		}
+	})
+}

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -90,6 +90,7 @@ type FakeCircleCI struct {
 	CreateStatusCode         int    // override for POST /sidecar/instances
 	DeleteStatusCode         int    // override for DELETE /sidecar/instances/:id
 	ExecStatusCode           int    // override for POST /sidecar/instances/:id/exec
+	ExecMessage              string // V3 error title when ExecStatusCode is set
 	CommandOutputStatusCode  int    // override for GET /sidecar/commands/:id/output
 	CommandOutputMessage     string // error message body when CommandOutputStatusCode is set
 	// DropStreamsBeforeExit ends this many output streams after delivering their
@@ -334,10 +335,16 @@ func (f *FakeCircleCI) handleExec(c *gin.Context) {
 	f.mu.RLock()
 	resp := f.ExecResponse
 	statusCode := f.ExecStatusCode
+	msg := f.ExecMessage
 	f.mu.RUnlock()
 
 	if statusCode != 0 {
-		c.JSON(statusCode, gin.H{"message": "API error"})
+		if msg == "" {
+			msg = "API error"
+		}
+		// The V3 envelope shape, which is what this route really returns; the
+		// client has to dig the title out of it to say anything useful.
+		c.JSON(statusCode, gin.H{"error": gin.H{"id": "trace-1", "title": msg}})
 		return
 	}
 


### PR DESCRIPTION
## Summary

- `mapErr` attached the server's message only for 410, so every other status reached users as bare status text under "An unknown error occurred". `chunk sidecar exec` against a deleted sidecar said `404 Not Found`, and against a paused one `409 Conflict`, naming neither the sidecar nor the remedy. It now extracts the message for every status - `extractServerMessage` already parsed all three body shapes the API uses, it was just gated behind `StatusGone`.
- New `circleci.SidecarPaused` for the 409, plus a `sidecarUnavailable` helper turning both conditions into guidance that names the sidecar, wired into all five sidecar-scoped commands: `exec`, `delete`, `add-ssh-key`, `ssh`, `sync`.
- `SidecarGone` now excludes the gateway's 404 `Route Not Found.`, which means an API too old for the command rather than a missing sidecar. Treating the two alike had `sidecarSyncError` prune local state for a perfectly healthy sidecar.

Before and after, against the real API:

```
$ chunk sidecar exec --sidecar-id ba600ef3-... --command w
- ✗ Error: An unknown error occurred.   exec: 404 Not Found   exit 1
+ ✗ Error: Sidecar ba600ef3-... no longer exists.
+   Suggestion: See what you have with: chunk sidecar list
+   Or create a new one with: chunk sidecar create             exit 5

$ chunk sidecar exec --sidecar-id 32981cc3-... --command w
- ✗ Error: An unknown error occurred.   exec: 409 Conflict    exit 1
+ ✗ Error: Sidecar 32981cc3-... is paused.
+   Suggestion: Sidecars pause when left idle, and the API exposes no
+   way to resume one. Create a replacement with: chunk sidecar create
                                                                exit 4
```

On the paused wording: sandbox-provisioner creates sidecars with `AutoPause` and a 300s timeout, so they suspend themselves when idle. The sandbox is recoverable - the provider exposes a resume and resume-on-connect is enabled - but `prepareExec` checks the paused state and declines rather than waking it, and the v3 route table has no resume endpoint. So a replacement is the only remedy a caller can act on, and the message says that rather than claiming resumption is impossible.

`ExecMessage` on the CircleCI fake makes the exec route return the V3 error envelope it really returns, so the message extraction is exercised end to end.

Note for reviewers: 5xx is deliberately not covered by the new tests - it gets retried and surfaces as a retry error, not a `StatusError`.