### PR TITLE
Select a sidecar snapshot when a repo has no image configured

### DIFF
--- a/acceptance/sidecar_snapshot_select_test.go
+++ b/acceptance/sidecar_snapshot_select_test.go
@@ -1,0 +1,119 @@
+package acceptance
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/binary"
+	testenv "github.com/CircleCI-Public/chunk-cli/internal/testing/env"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/gitrepo"
+)
+
+// writeRemoteCommandConfig writes a .chunk/config.json with one remote command
+// and no validation.sidecarImage — the "repo with no sidecar image" case.
+func writeRemoteCommandConfig(t *testing.T, workDir string) {
+	t.Helper()
+	chunkDir := filepath.Join(workDir, ".chunk")
+	assert.NilError(t, os.MkdirAll(chunkDir, 0o755))
+	cfg := map[string]any{
+		"commands": []map[string]any{
+			{"name": "test", "run": "echo test-output", "remote": true},
+		},
+	}
+	data, err := json.Marshal(cfg)
+	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), data, 0o644))
+}
+
+// createdSidecarImage returns the image attribute of the single create-sidecar
+// request recorded by cci.
+func createdSidecarImage(t *testing.T, cci *fakes.FakeCircleCI) any {
+	t.Helper()
+	createReqs := filterByPath(cci.Recorder.AllRequests(), "/api/v3/sidecar/instances")
+	assert.Equal(t, len(createReqs), 1, "expected exactly 1 create-sidecar request")
+
+	var body map[string]any
+	assert.NilError(t, json.Unmarshal(createReqs[0].Body, &body))
+	envelope, ok := body["data"].(map[string]any)
+	assert.Assert(t, ok, "expected data envelope in request body")
+	attrs, ok := envelope["attributes"].(map[string]any)
+	assert.Assert(t, ok, "expected attributes in data envelope")
+	return attrs["image"]
+}
+
+// runValidateForSnapshotSelection runs `chunk validate` in a fresh repo with no
+// configured sidecar image, against the given org snapshots. seedFiles are
+// written into the working tree first so stack detection has something to read.
+// Sync fails because no SSH server is listening, which is fine: sidecar
+// creation happens first and is all these tests assert on.
+func runValidateForSnapshotSelection(t *testing.T, snapshots []fakes.Snapshot, seedFiles map[string]string) *fakes.FakeCircleCI {
+	t.Helper()
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = "127.0.0.1"
+	cci.Snapshots = snapshots
+	srv := httptest.NewServer(cci)
+	t.Cleanup(srv.Close)
+
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	for name, content := range seedFiles {
+		assert.NilError(t, os.WriteFile(filepath.Join(workDir, name), []byte(content), 0o644))
+	}
+	writeRemoteCommandConfig(t, workDir)
+
+	sshDir := filepath.Join(t.TempDir(), ".ssh")
+	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
+	identityFile := filepath.Join(sshDir, "chunk_ai")
+	assert.NilError(t, generateTestSSHKey(t, identityFile))
+
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
+	env.Extra["CIRCLECI_ORG_ID"] = "org-aaa"
+
+	binary.RunCLI(t, []string{"validate", "--identity-file", identityFile}, env, workDir)
+	return cci
+}
+
+// A repo with no validation.sidecarImage should still land on the org snapshot
+// built for it, rather than on the bare default image.
+func TestValidateSelectsSnapshotMatchingRepo(t *testing.T) {
+	cci := runValidateForSnapshotSelection(t, []fakes.Snapshot{
+		{ID: "snap-unrelated", OrgID: "org-aaa", Name: "billing-service"},
+		{ID: "snap-repo", OrgID: "org-aaa", Name: "test-repo"},
+	}, nil)
+	assert.Equal(t, createdSidecarImage(t, cci), "snap-repo")
+}
+
+// With no repo-specific snapshot, the stack detected from the working tree is
+// the next best signal.
+func TestValidateFallsBackToStackSnapshot(t *testing.T) {
+	cci := runValidateForSnapshotSelection(t, []fakes.Snapshot{
+		{ID: "snap-python", OrgID: "org-aaa", Name: "python-base"},
+		{ID: "snap-go", OrgID: "org-aaa", Name: "go-base"},
+	}, map[string]string{"go.mod": "module example.com/test-repo\n"})
+	assert.Equal(t, createdSidecarImage(t, cci), "snap-go")
+}
+
+// Nothing related to the repo means no image: guessing wrong is worse than
+// falling back to the default, which is what the CLI did before selection.
+func TestValidateKeepsDefaultImageWhenNoSnapshotMatches(t *testing.T) {
+	cci := runValidateForSnapshotSelection(t, []fakes.Snapshot{
+		{ID: "snap-unrelated", OrgID: "org-aaa", Name: "billing-service"},
+	}, nil)
+	image := createdSidecarImage(t, cci)
+	assert.Assert(t, image == nil || image == "", "expected no image, got %v", image)
+}
+
+// A snapshot in another org must never be selected.
+func TestValidateIgnoresSnapshotsFromOtherOrgs(t *testing.T) {
+	cci := runValidateForSnapshotSelection(t, []fakes.Snapshot{
+		{ID: "snap-other-org", OrgID: "org-bbb", Name: "test-repo"},
+	}, nil)
+	image := createdSidecarImage(t, cci)
+	assert.Assert(t, image == nil || image == "", "expected no image, got %v", image)
+}

--- a/acceptance/sidecar_snapshot_select_test.go
+++ b/acceptance/sidecar_snapshot_select_test.go
@@ -32,8 +32,8 @@ func writeRemoteCommandConfig(t *testing.T, workDir string) {
 }
 
 // createdSidecarImage returns the image attribute of the single create-sidecar
-// request recorded by cci.
-func createdSidecarImage(t *testing.T, cci *fakes.FakeCircleCI) any {
+// request recorded by cci, or "" when the request carried no image.
+func createdSidecarImage(t *testing.T, cci *fakes.FakeCircleCI) string {
 	t.Helper()
 	createReqs := filterByPath(cci.Recorder.AllRequests(), "/api/v3/sidecar/instances")
 	assert.Equal(t, len(createReqs), 1, "expected exactly 1 create-sidecar request")
@@ -44,7 +44,14 @@ func createdSidecarImage(t *testing.T, cci *fakes.FakeCircleCI) any {
 	assert.Assert(t, ok, "expected data envelope in request body")
 	attrs, ok := envelope["attributes"].(map[string]any)
 	assert.Assert(t, ok, "expected attributes in data envelope")
-	return attrs["image"]
+
+	raw, ok := attrs["image"]
+	if !ok || raw == nil {
+		return ""
+	}
+	image, ok := raw.(string)
+	assert.Assert(t, ok, "expected image to be a string, got %T", raw)
+	return image
 }
 
 // runValidateForSnapshotSelection runs `chunk validate` in a fresh repo with no
@@ -105,8 +112,7 @@ func TestValidateKeepsDefaultImageWhenNoSnapshotMatches(t *testing.T) {
 	cci := runValidateForSnapshotSelection(t, []fakes.Snapshot{
 		{ID: "snap-unrelated", OrgID: "org-aaa", Name: "billing-service"},
 	}, nil)
-	image := createdSidecarImage(t, cci)
-	assert.Assert(t, image == nil || image == "", "expected no image, got %v", image)
+	assert.Equal(t, createdSidecarImage(t, cci), "")
 }
 
 // A snapshot in another org must never be selected.
@@ -114,6 +120,5 @@ func TestValidateIgnoresSnapshotsFromOtherOrgs(t *testing.T) {
 	cci := runValidateForSnapshotSelection(t, []fakes.Snapshot{
 		{ID: "snap-other-org", OrgID: "org-bbb", Name: "test-repo"},
 	}, nil)
-	image := createdSidecarImage(t, cci)
-	assert.Assert(t, image == nil || image == "", "expected no image, got %v", image)
+	assert.Equal(t, createdSidecarImage(t, cci), "")
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -187,6 +187,17 @@ chunk
   Since `sidecar snapshot create` is normally followed by recording that key, a
   project on a snapshot runs everything remotely and `remote: true` becomes a
   no-op.
+- **Snapshot selection.** When a sidecar has to be created and no
+  `validation.sidecarImage` is recorded (project-level or per-command), `chunk`
+  picks one of the org's snapshots instead of booting the bare default image.
+  A snapshot matches on its name and tag, split into tokens: the repo name
+  (from the git remote, then `vcs.repo`, then the directory name) outranks the
+  detected stack, and the org's own snapshot outranks an equivalent system one.
+  Matching is token-based, so `go` matches `go-base` but not `mongo-api`. When
+  nothing matches, the default image is used and the reason is printed —
+  guessing the wrong prepared environment produces failures that look like the
+  repo's own. Selection never fails a run: an unreachable snapshot API is
+  warned about and treated as no match.
 - Telemetry is anonymous and opt-out. It's disabled by the
   `CHUNK_NO_TELEMETRY` / `NO_ANALYTICS` / `DO_NOT_TRACK` / `CI` environment
   variables (first match wins, in that order), or `chunk config set telemetry false`.
@@ -267,7 +278,7 @@ chunk
 | `model` | user config (`~/.config/chunk/config.json`) | Claude model override |
 | `telemetry` | user config (`~/.config/chunk/config.json`) | Anonymous usage telemetry (`true`/`false`, default: `true`) |
 | `orgID` | `.chunk/config.json` | CircleCI organization ID for sidecar subcommands |
-| `validation.sidecarImage` | `.chunk/config.json` | Snapshot or image ID for sidecar bootstrap and validate |
+| `validation.sidecarImage` | `.chunk/config.json` | Snapshot or image ID for sidecar bootstrap and validate (unset: a matching org snapshot is selected automatically) |
 
 `chunk config show` displays resolved user credentials and, when run from a
 project directory, the resolved `orgID` (env var takes precedence over project

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -172,6 +172,8 @@ chunk sidecar forget         # unset the active sidecar (does not delete it)
 
 Per-command routing only applies while `validation.sidecarImage` is unset. Once you record a snapshot ID there, `chunk validate` sends every command to the sidecar regardless of its `remote` flag — run formatters directly if you need them rewriting local files.
 
+With no `validation.sidecarImage` recorded, a sidecar that has to be created is started from whichever of your org's snapshots best fits the repo — one named after the repo first, then one built for the detected stack. The chosen snapshot and the reason are printed. If no snapshot fits, the default image is used, which has none of your dependencies on it; record a snapshot ID to pin the environment instead of relying on the match.
+
 The active sidecar and snapshot state are stored in `$XDG_DATA_HOME/chunk/<project>/` (default: `~/.local/share/chunk/<project>/`) — never inside the repo. The project key is derived from the git root path.
 
 Or hand this off to the `chunk-sidecar` skill:

--- a/envbuilder/envbuilder.go
+++ b/envbuilder/envbuilder.go
@@ -1984,6 +1984,18 @@ func parseJavaVersionFromText(content string) int {
 	return -1
 }
 
+// StackUnknown is the stack name reported when nothing in a directory
+// identifies a supported tech stack.
+const StackUnknown = stackUnknown
+
+// DetectStack identifies the dominant tech stack in dir. It is the first step
+// of DetectEnvironment, exported separately for callers that need only the
+// stack name: unlike DetectEnvironment it never touches the network, so it is
+// cheap enough to run on paths that must not block on Docker Hub.
+func DetectStack(dir string) (string, error) {
+	return detectStack(dir)
+}
+
 // DetectEnvironment analyses the repository at dir and returns a detected Environment.
 func DetectEnvironment(ctx context.Context, dir string) (*Environment, error) {
 	stack, err := detectStack(dir)

--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -482,8 +482,9 @@ func (c *Client) GetCommand(ctx context.Context, commandID string) (*Command, er
 }
 
 type snapshotAttrs struct {
-	Name string `json:"name"`
-	Tag  string `json:"tag,omitempty"`
+	Name     string `json:"name"`
+	Tag      string `json:"tag,omitempty"`
+	IsSystem bool   `json:"is_system,omitempty"`
 }
 
 func (c *Client) CreateSnapshot(ctx context.Context, sidecarID, name string) (*Snapshot, error) {
@@ -520,10 +521,11 @@ func (c *Client) GetSnapshot(ctx context.Context, id string) (*Snapshot, error) 
 		return nil, mapErr("get snapshot", err)
 	}
 	return &Snapshot{
-		ID:    env.Data.ID,
-		OrgID: refs.Org.ID,
-		Name:  attrs.Name,
-		Tag:   attrs.Tag,
+		ID:       env.Data.ID,
+		OrgID:    refs.Org.ID,
+		Name:     attrs.Name,
+		Tag:      attrs.Tag,
+		IsSystem: attrs.IsSystem,
 	}, nil
 }
 
@@ -545,6 +547,9 @@ func (c *Client) ListSnapshots(ctx context.Context, orgID string) ([]Snapshot, e
 			}
 			if tag, ok := attrs["tag"].(string); ok {
 				s.Tag = tag
+			}
+			if isSystem, ok := attrs["is_system"].(bool); ok {
+				s.IsSystem = isSystem
 			}
 		}
 		if refs, ok := item.References.(map[string]any); ok {

--- a/internal/circleci/types.go
+++ b/internal/circleci/types.go
@@ -58,6 +58,10 @@ type Snapshot struct {
 	OrgID string `json:"org_id"`
 	Name  string `json:"name"`
 	Tag   string `json:"tag,omitempty"`
+	// IsSystem marks a CircleCI-provided base snapshot rather than one an org
+	// captured itself. Snapshot selection prefers an org's own snapshot when
+	// both match a repo equally well.
+	IsSystem bool `json:"is_system,omitempty"`
 }
 
 type Command struct {

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -232,13 +232,24 @@ func newSidecarCreateCmd() *cobra.Command {
 					image = cfg.Validation.SidecarImage
 				}
 			}
+			// Still unset: fall back to whichever of the org's snapshots fits
+			// this repo, so an unconfigured project gets a prepared environment
+			// instead of a bare image.
+			//
+			// Tracked separately from a user-supplied image: a rejected image the
+			// caller chose is a mistake worth explaining, while a rejected one
+			// chunk chose is not something the caller can act on.
+			imageChosenByUser := image != ""
+			if image == "" {
+				image = autoSelectSnapshotImage(cmd.Context(), client, resolvedOrgID, cwd, newStatusFunc(io), io)
+			}
 			sb, err := sidecar.Create(cmd.Context(), client, resolvedOrgID, name, image)
 			if err != nil {
 				if err := notAuthorized("create sidecars", err); err != nil {
 					return err
 				}
 				var se *circleci.StatusError
-				if image != "" && errors.As(err, &se) && (se.StatusCode == 400 || se.StatusCode == 404) {
+				if imageChosenByUser && errors.As(err, &se) && (se.StatusCode == 400 || se.StatusCode == 404) {
 					return newUserError("Could not create the sidecar.").
 						withSuggestion("--image requires a snapshot ID. Create one with 'chunk sidecar snapshot create'.").
 						wrap(err)

--- a/internal/cmd/snapshotpick.go
+++ b/internal/cmd/snapshotpick.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/CircleCI-Public/chunk-cli/envbuilder"
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
+)
+
+// snapshotCriteria describes workDir's repository for snapshot selection.
+//
+// Both signals prefer recorded facts over inference: the repo name comes from
+// the git remote (what the snapshot's author would have named it after) before
+// the directory name, and the stack comes from the environment `sidecar setup`
+// already saved before re-deriving it by walking the tree.
+func snapshotCriteria(workDir string, cfg *config.ProjectConfig) sidecar.SnapshotCriteria {
+	c := sidecar.SnapshotCriteria{}
+
+	if _, repo, err := gitremote.DetectOrgAndRepo(workDir); err == nil && repo != "" {
+		c.Repo = repo
+	} else if cfg != nil && cfg.VCS != nil && cfg.VCS.Repo != "" {
+		c.Repo = cfg.VCS.Repo
+	} else if abs, err := filepath.Abs(workDir); err == nil {
+		c.Repo = filepath.Base(abs)
+	}
+
+	if cfg != nil && cfg.Environment != nil && cfg.Environment.Stack != "" {
+		c.Stack = cfg.Environment.Stack
+	} else if stack, err := envbuilder.DetectStack(workDir); err == nil {
+		c.Stack = stack
+	}
+	if c.Stack == envbuilder.StackUnknown {
+		c.Stack = ""
+	}
+	return c
+}
+
+// autoSelectSnapshotImage returns the ID of the org snapshot that best fits the
+// repo in workDir, for projects that have no validation.sidecarImage recorded.
+//
+// Creating the sidecar from a matching snapshot is what makes an unconfigured
+// repo usable: the plain default image has none of the repo's dependencies, so
+// every command run against it fails on a missing toolchain rather than on the
+// code. Returns "" when the org has no snapshot related to this repo, which
+// leaves the caller on that default image — the previous behaviour, and still
+// the right one when guessing would be worse than not guessing.
+//
+// Selection is never fatal: any failure to reach the API is reported and then
+// treated as "no match", because losing a snapshot is a worse outcome for the
+// user than losing the whole validate run.
+func autoSelectSnapshotImage(
+	ctx context.Context,
+	client *circleci.Client,
+	orgID, workDir string,
+	statusFn iostream.StatusFunc,
+	streams iostream.Streams,
+) string {
+	if client == nil || orgID == "" {
+		return ""
+	}
+	cfg, err := config.LoadProjectConfig(workDir)
+	if err != nil {
+		cfg = nil
+	}
+	criteria := snapshotCriteria(workDir, cfg)
+
+	match, ok, err := sidecar.ResolveSnapshot(ctx, client, orgID, criteria)
+	if err != nil {
+		streams.ErrPrintf("warning: could not list snapshots to pick a sidecar image: %v\n", err)
+		return ""
+	}
+	if !ok {
+		statusFn(iostream.LevelInfo, snapshotMissHint(criteria))
+		return ""
+	}
+	statusFn(iostream.LevelInfo, fmt.Sprintf(
+		"using snapshot %s (%s) — %s", match.Snapshot.Name, match.Snapshot.ID, match.Reason))
+	return match.Snapshot.ID
+}
+
+// snapshotMissHint explains a no-match in terms of what was searched for, so
+// the user can tell a missing snapshot apart from a mis-detected stack.
+func snapshotMissHint(c sidecar.SnapshotCriteria) string {
+	switch {
+	case c.Repo != "" && c.Stack != "":
+		return fmt.Sprintf("no snapshot matches %s or %s; using the default image", c.Repo, c.Stack)
+	case c.Repo != "":
+		return fmt.Sprintf("no snapshot matches %s; using the default image", c.Repo)
+	case c.Stack != "":
+		return fmt.Sprintf("no snapshot matches %s; using the default image", c.Stack)
+	default:
+		return "no snapshot to match against; using the default image"
+	}
+}

--- a/internal/cmd/snapshotpick_test.go
+++ b/internal/cmd/snapshotpick_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/envspec"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/gitrepo"
+)
+
+func TestSnapshotCriteriaFromGitRemote(t *testing.T) {
+	dir := gitrepo.SetupGitRepo(t, "CircleCI-Public", "chunk-cli")
+
+	got := snapshotCriteria(dir, nil)
+	assert.Equal(t, got.Repo, "chunk-cli")
+}
+
+func TestSnapshotCriteriaFallsBackToDirectoryName(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "my-project")
+	assert.NilError(t, os.Mkdir(dir, 0o755))
+
+	got := snapshotCriteria(dir, nil)
+	assert.Equal(t, got.Repo, "my-project")
+}
+
+func TestSnapshotCriteriaFallsBackToConfiguredRepo(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "checkout")
+	assert.NilError(t, os.Mkdir(dir, 0o755))
+
+	cfg := &config.ProjectConfig{VCS: &config.VCSConfig{Repo: "chunk-cli"}}
+	got := snapshotCriteria(dir, cfg)
+	assert.Equal(t, got.Repo, "chunk-cli")
+}
+
+// The saved environment is authoritative: re-walking the tree can disagree with
+// what setup actually provisioned, and the snapshot was built from the latter.
+func TestSnapshotCriteriaPrefersSavedStack(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0o644))
+
+	cfg := &config.ProjectConfig{Environment: &envspec.Environment{Stack: "python"}}
+	got := snapshotCriteria(dir, cfg)
+	assert.Equal(t, got.Stack, "python")
+}
+
+func TestSnapshotCriteriaDetectsStackWhenUnsaved(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/x\n"), 0o644))
+
+	got := snapshotCriteria(dir, nil)
+	assert.Equal(t, got.Stack, "go")
+}
+
+// An undetectable stack must not become the literal string "unknown", which
+// would then be matched against snapshot names.
+func TestSnapshotCriteriaBlanksUnknownStack(t *testing.T) {
+	dir := t.TempDir()
+
+	got := snapshotCriteria(dir, nil)
+	assert.Equal(t, got.Stack, "")
+}
+
+// Without a client or an org there is nothing to list, and the caller must be
+// left on the default image rather than erroring out.
+func TestAutoSelectSnapshotImageNoOpWithoutOrg(t *testing.T) {
+	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
+	noopStatus := func(iostream.Level, string) {}
+
+	assert.Equal(t, autoSelectSnapshotImage(context.Background(), nil, "org-abc", t.TempDir(), noopStatus, streams), "")
+	assert.Equal(t, autoSelectSnapshotImage(context.Background(), nil, "", t.TempDir(), noopStatus, streams), "")
+}
+
+func TestSnapshotMissHint(t *testing.T) {
+	tests := []struct {
+		criteria sidecar.SnapshotCriteria
+		want     string
+	}{
+		{sidecar.SnapshotCriteria{Repo: "chunk-cli", Stack: "go"}, "no snapshot matches chunk-cli or go; using the default image"},
+		{sidecar.SnapshotCriteria{Repo: "chunk-cli"}, "no snapshot matches chunk-cli; using the default image"},
+		{sidecar.SnapshotCriteria{Stack: "go"}, "no snapshot matches go; using the default image"},
+		{sidecar.SnapshotCriteria{}, "no snapshot to match against; using the default image"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, snapshotMissHint(tt.criteria), tt.want)
+	}
+}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -957,6 +957,13 @@ func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, side
 	if err != nil {
 		return false, err
 	}
+	// No image configured means no snapshot was ever recorded for this repo.
+	// Rather than boot the bare default image, look for one of the org's
+	// snapshots that fits this repo; autoSelectSnapshotImage returns "" (the
+	// old behaviour) when none does.
+	if image == "" {
+		image = autoSelectSnapshotImage(ctx, client, resolvedOrgID, workDir, newStatusFunc(streams), streams)
+	}
 	sandboxName := sidecarAutoName(ctx, workDir)
 	sc, err := sidecar.Create(ctx, client, resolvedOrgID, sandboxName, image)
 	if err != nil {

--- a/internal/sidecar/snapshotselect.go
+++ b/internal/sidecar/snapshotselect.go
@@ -136,19 +136,16 @@ func scoreSnapshot(s circleci.Snapshot, c SnapshotCriteria) (int, string) {
 }
 
 // containsAll reports whether every part is present in tokens. Empty parts are
-// ignored so a trailing separator in a repo name does not fail the match.
+// ignored so a doubled separator in a repo name does not fail the match, which
+// leaves an all-empty parts list vacuously true — the sole caller only reaches
+// here with a normalized name that has at least one real token.
 func containsAll(tokens map[string]bool, parts []string) bool {
-	found := false
 	for _, p := range parts {
-		if p == "" {
-			continue
-		}
-		if !tokens[p] {
+		if p != "" && !tokens[p] {
 			return false
 		}
-		found = true
 	}
-	return found
+	return true
 }
 
 // SelectSnapshot picks the snapshot that best fits criteria, reporting false

--- a/internal/sidecar/snapshotselect.go
+++ b/internal/sidecar/snapshotselect.go
@@ -1,0 +1,188 @@
+package sidecar
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+)
+
+// SnapshotCriteria describes the repository a sidecar is being created for.
+// Both fields are optional: an empty Repo or Stack simply contributes no score.
+type SnapshotCriteria struct {
+	// Repo is the repository name, e.g. "chunk-cli".
+	Repo string
+	// Stack is the detected tech stack as envbuilder names it, e.g. "go" or
+	// "typescript". Callers pass "" or "unknown" when detection failed.
+	Stack string
+}
+
+// SnapshotMatch is a selected snapshot together with why it was selected.
+type SnapshotMatch struct {
+	Snapshot circleci.Snapshot
+	// Reason is a short human-readable justification, e.g. "matches repo
+	// chunk-cli". Callers surface it so the choice is never silent.
+	Reason string
+}
+
+// Scores are spread an order of magnitude apart so a weaker signal can never
+// outrank a stronger one, however many weak signals a name accumulates.
+const (
+	scoreRepoExact = 1000 // whole name is the repo name
+	scoreRepoToken = 100  // repo name appears as a token, e.g. "chunk-cli-go"
+	scoreStack     = 10   // stack (or a known alias) appears as a token
+	scoreOwned     = 1    // tiebreak: the org's own snapshot over a system one
+)
+
+// stackAliases maps an envbuilder stack name to the tokens a snapshot name
+// plausibly uses for it. The stack name itself is always matched, so entries
+// here list only the extra spellings — including the cimg image names, since
+// snapshots are frequently named after the image they were built from.
+var stackAliases = map[string][]string{
+	"go":         {"golang"},
+	"javascript": {"js", "node", "nodejs"},
+	"typescript": {"ts", "node", "nodejs"},
+	"python":     {"py"},
+	"ruby":       {"rb"},
+	"java":       {"jvm", "openjdk", "jdk"},
+	"scala":      {"jvm", "openjdk", "jdk", "sbt"},
+	"dotnet":     {"net", "csharp", "dot-net"},
+	"cpp":        {"c++", "cplusplus"},
+	"php":        {"php"},
+	"rust":       {"rs", "cargo"},
+	"elixir":     {"ex", "beam"},
+	"haskell":    {"hs", "ghc"},
+	"dart":       {"flutter"},
+}
+
+// nameTokens splits a snapshot name and tag into lowercase alphanumeric tokens.
+// Matching is token-based rather than substring-based on purpose: a substring
+// test makes "go" match "mongo-api" and "django", which is exactly the kind of
+// accidental hit that picks the wrong environment.
+func nameTokens(s circleci.Snapshot) map[string]bool {
+	tokens := map[string]bool{}
+	for _, field := range []string{s.Name, s.Tag} {
+		for _, tok := range strings.FieldsFunc(strings.ToLower(field), isSeparator) {
+			tokens[tok] = true
+		}
+	}
+	return tokens
+}
+
+// isSeparator reports whether r ends a token. '+' is kept so "c++" survives as
+// one token rather than splitting into an empty string.
+func isSeparator(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '+':
+		return false
+	default:
+		return true
+	}
+}
+
+// normalizeName lowercases a snapshot name and collapses separators so that
+// "Chunk CLI" and "chunk-cli" compare equal.
+func normalizeName(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// scoreSnapshot rates how well a snapshot fits the criteria, returning the
+// score and the reason for the strongest signal that contributed to it. A
+// score of zero means nothing about the snapshot ties it to this repo.
+func scoreSnapshot(s circleci.Snapshot, c SnapshotCriteria) (int, string) {
+	tokens := nameTokens(s)
+	score, reason := 0, ""
+
+	if repo := normalizeName(c.Repo); repo != "" {
+		switch {
+		case normalizeName(s.Name) == repo:
+			score += scoreRepoExact
+			reason = fmt.Sprintf("named for repo %s", c.Repo)
+		case containsAll(tokens, strings.Split(repo, "-")):
+			score += scoreRepoToken
+			reason = fmt.Sprintf("mentions repo %s", c.Repo)
+		}
+	}
+
+	if stack := strings.ToLower(c.Stack); stack != "" && stack != "unknown" {
+		for _, alias := range append([]string{stack}, stackAliases[stack]...) {
+			if tokens[alias] {
+				score += scoreStack
+				if reason == "" {
+					reason = fmt.Sprintf("built for %s", c.Stack)
+				}
+				break
+			}
+		}
+	}
+
+	// Only a tiebreak, and only among snapshots that already matched:
+	// preferring an owned snapshot must never promote an unrelated one.
+	if score > 0 && !s.IsSystem {
+		score += scoreOwned
+	}
+	return score, reason
+}
+
+// containsAll reports whether every part is present in tokens. Empty parts are
+// ignored so a trailing separator in a repo name does not fail the match.
+func containsAll(tokens map[string]bool, parts []string) bool {
+	found := false
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		if !tokens[p] {
+			return false
+		}
+		found = true
+	}
+	return found
+}
+
+// SelectSnapshot picks the snapshot that best fits criteria, reporting false
+// when none of them relate to the repository at all. Returning false rather
+// than an arbitrary snapshot is deliberate: booting the wrong prepared
+// environment is more confusing than booting the plain default image, because
+// the failures it produces look like the repo's own.
+func SelectSnapshot(snapshots []circleci.Snapshot, c SnapshotCriteria) (SnapshotMatch, bool) {
+	// Sort by ID first so the winner is stable when two snapshots tie and the
+	// API returns them in a different order between runs.
+	ranked := make([]circleci.Snapshot, len(snapshots))
+	copy(ranked, snapshots)
+	sort.Slice(ranked, func(i, j int) bool { return ranked[i].ID < ranked[j].ID })
+
+	best, bestScore, bestReason := circleci.Snapshot{}, 0, ""
+	for _, s := range ranked {
+		score, reason := scoreSnapshot(s, c)
+		if score > bestScore {
+			best, bestScore, bestReason = s, score, reason
+		}
+	}
+	if bestScore == 0 {
+		return SnapshotMatch{}, false
+	}
+	return SnapshotMatch{Snapshot: best, Reason: bestReason}, true
+}
+
+// ResolveSnapshot lists the org's snapshots and selects the one that best fits
+// criteria. It reports false when the org has no suitable snapshot.
+func ResolveSnapshot(ctx context.Context, client *circleci.Client, orgID string, c SnapshotCriteria) (SnapshotMatch, bool, error) {
+	snapshots, err := client.ListSnapshots(ctx, orgID)
+	if err != nil {
+		return SnapshotMatch{}, false, fmt.Errorf("list snapshots: %w", err)
+	}
+	match, ok := SelectSnapshot(snapshots, c)
+	return match, ok, nil
+}

--- a/internal/sidecar/snapshotselect.go
+++ b/internal/sidecar/snapshotselect.go
@@ -15,7 +15,7 @@ type SnapshotCriteria struct {
 	// Repo is the repository name, e.g. "chunk-cli".
 	Repo string
 	// Stack is the detected tech stack as envbuilder names it, e.g. "go" or
-	// "typescript". Callers pass "" or "unknown" when detection failed.
+	// "typescript". Callers pass "" when detection failed.
 	Stack string
 }
 
@@ -50,7 +50,6 @@ var stackAliases = map[string][]string{
 	"scala":      {"jvm", "openjdk", "jdk", "sbt"},
 	"dotnet":     {"net", "csharp", "dot-net"},
 	"cpp":        {"c++", "cplusplus"},
-	"php":        {"php"},
 	"rust":       {"rs", "cargo"},
 	"elixir":     {"ex", "beam"},
 	"haskell":    {"hs", "ghc"},
@@ -83,16 +82,17 @@ func isSeparator(r rune) bool {
 }
 
 // normalizeName lowercases a snapshot name and collapses separators so that
-// "Chunk CLI" and "chunk-cli" compare equal.
+// "Chunk CLI" and "chunk-cli" compare equal. It defers to isSeparator for what
+// counts as a separator: the two must agree, or a name normalizes into parts
+// that nameTokens can never produce and the token match silently fails.
 func normalizeName(s string) string {
 	var b strings.Builder
 	for _, r := range strings.ToLower(s) {
-		switch {
-		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
-			b.WriteRune(r)
-		default:
+		if isSeparator(r) {
 			b.WriteRune('-')
+			continue
 		}
+		b.WriteRune(r)
 	}
 	return strings.Trim(b.String(), "-")
 }
@@ -115,7 +115,7 @@ func scoreSnapshot(s circleci.Snapshot, c SnapshotCriteria) (int, string) {
 		}
 	}
 
-	if stack := strings.ToLower(c.Stack); stack != "" && stack != "unknown" {
+	if stack := strings.ToLower(c.Stack); stack != "" {
 		for _, alias := range append([]string{stack}, stackAliases[stack]...) {
 			if tokens[alias] {
 				score += scoreStack

--- a/internal/sidecar/snapshotselect_test.go
+++ b/internal/sidecar/snapshotselect_test.go
@@ -61,6 +61,32 @@ func TestSelectSnapshot(t *testing.T) {
 			wantID:   "s2",
 		},
 		{
+			// normalizeName feeds the token path, so it has to agree with
+			// isSeparator on '+'. Collapsing it to a dash would split "c++"
+			// into a "c" token that nameTokens never produces, so this
+			// snapshot would score zero and the repo would get no match.
+			name: "plus survives normalization for a repo token match",
+			snapshots: []circleci.Snapshot{
+				{ID: "s1", Name: "unrelated"},
+				{ID: "s2", Name: "c++-base"},
+			},
+			// Stack is empty on purpose: with it set to "cpp" the c++ alias
+			// matches this snapshot on its own and hides a broken repo match.
+			criteria: SnapshotCriteria{Repo: "c++", Stack: ""},
+			wantID:   "s2",
+		},
+		{
+			// The same disagreement in reverse: with '+' collapsed,
+			// "notify++" and "notify" both normalize to "notify" and this
+			// unrelated snapshot takes a match it has no claim to.
+			name: "plus is not collapsed into a shorter name",
+			snapshots: []circleci.Snapshot{
+				{ID: "s1", Name: "notify"},
+			},
+			criteria: SnapshotCriteria{Repo: "notify++", Stack: ""},
+			wantID:   "",
+		},
+		{
 			name: "stack alias matches when the repo does not",
 			snapshots: []circleci.Snapshot{
 				{ID: "s1", Name: "python-base"},

--- a/internal/sidecar/snapshotselect_test.go
+++ b/internal/sidecar/snapshotselect_test.go
@@ -138,14 +138,6 @@ func TestSelectSnapshot(t *testing.T) {
 			wantID:   "s1",
 		},
 		{
-			name: "unknown stack contributes nothing",
-			snapshots: []circleci.Snapshot{
-				{ID: "s1", Name: "unknown-base"},
-			},
-			criteria: SnapshotCriteria{Repo: "chunk-cli", Stack: "unknown"},
-			wantID:   "",
-		},
-		{
 			name: "names are compared case- and separator-insensitively",
 			snapshots: []circleci.Snapshot{
 				{ID: "s1", Name: "Chunk CLI"},

--- a/internal/sidecar/snapshotselect_test.go
+++ b/internal/sidecar/snapshotselect_test.go
@@ -1,0 +1,260 @@
+package sidecar
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+)
+
+func TestSelectSnapshot(t *testing.T) {
+	tests := []struct {
+		name      string
+		snapshots []circleci.Snapshot
+		criteria  SnapshotCriteria
+		wantID    string
+	}{
+		{
+			name:      "no snapshots",
+			snapshots: nil,
+			criteria:  SnapshotCriteria{Repo: "chunk-cli", Stack: "go"},
+			wantID:    "",
+		},
+		{
+			name: "nothing relates to the repo",
+			snapshots: []circleci.Snapshot{
+				{ID: "s1", Name: "billing-service"},
+				{ID: "s2", Name: "frontend-node"},
+			},
+			criteria: SnapshotCriteria{Repo: "chunk-cli", Stack: "go"},
+			wantID:   "",
+		},
+		{
+			name: "exact repo name wins over stack match",
+			snapshots: []circleci.Snapshot{
+				{ID: "s1", Name: "go-base"},
+				{ID: "s2", Name: "chunk-cli"},
+			},
+			criteria: SnapshotCriteria{Repo: "chunk-cli", Stack: "go"},
+			wantID:   "s2",
+		},
+		{
+			name: "repo tokens match a decorated name",
+			snapshots: []circleci.Snapshot{
+				{ID: "s1", Name: "go-base"},
+				{ID: "s2", Name: "chunk-cli-uv-lint"},
+			},
+			criteria: SnapshotCriteria{Repo: "chunk-cli", Stack: "go"},
+			wantID:   "s2",
+		},
+		{
+			name: "exact repo name beats a decorated one",
+			snapshots: []circleci.Snapshot{
+				{ID: "s1", Name: "chunk-cli-uv-lint"},
+				{ID: "s2", Name: "chunk-cli"},
+			},
+			criteria: SnapshotCriteria{Repo: "chunk-cli", Stack: "go"},
+			wantID:   "s2",
+		},
+		{
+			name: "stack alias matches when the repo does not",
+			snapshots: []circleci.Snapshot{
+				{ID: "s1", Name: "python-base"},
+				{ID: "s2", Name: "golang-base"},
+			},
+			criteria: SnapshotCriteria{Repo: "chunk-cli", Stack: "go"},
+			wantID:   "s2",
+		},
+		{
+			name: "node snapshot matches a typescript repo",
+			snapshots: []circleci.Snapshot{
+				{ID: "s1", Name: "node-20"},
+			},
+			criteria: SnapshotCriteria{Repo: "webapp", Stack: "typescript"},
+			wantID:   "s1",
+		},
+		{
+			name: "stack is matched on tokens, not substrings",
+			snapshots: []circleci.Snapshot{
+				{ID: "s1", Name: "mongo-api"},
+				{ID: "s2", Name: "django-worker"},
+			},
+			criteria: SnapshotCriteria{Repo: "chunk-cli", Stack: "go"},
+			wantID:   "",
+		},
+		{
+			name: "the org's own snapshot beats an equivalent system one",
+			snapshots: []circleci.Snapshot{
+				{ID: "s1", Name: "go", IsSystem: true},
+				{ID: "s2", Name: "go", IsSystem: false},
+			},
+			criteria: SnapshotCriteria{Repo: "chunk-cli", Stack: "go"},
+			wantID:   "s2",
+		},
+		{
+			name: "an owned but unrelated snapshot is still not selected",
+			snapshots: []circleci.Snapshot{
+				{ID: "s1", Name: "billing-service", IsSystem: false},
+			},
+			criteria: SnapshotCriteria{Repo: "chunk-cli", Stack: "go"},
+			wantID:   "",
+		},
+		{
+			name: "the tag is matched as well as the name",
+			snapshots: []circleci.Snapshot{
+				{ID: "s1", Name: "team-base", Tag: "go"},
+			},
+			criteria: SnapshotCriteria{Repo: "chunk-cli", Stack: "go"},
+			wantID:   "s1",
+		},
+		{
+			name: "unknown stack contributes nothing",
+			snapshots: []circleci.Snapshot{
+				{ID: "s1", Name: "unknown-base"},
+			},
+			criteria: SnapshotCriteria{Repo: "chunk-cli", Stack: "unknown"},
+			wantID:   "",
+		},
+		{
+			name: "names are compared case- and separator-insensitively",
+			snapshots: []circleci.Snapshot{
+				{ID: "s1", Name: "Chunk CLI"},
+			},
+			criteria: SnapshotCriteria{Repo: "chunk-cli"},
+			wantID:   "s1",
+		},
+		{
+			name: "ties resolve to the lowest ID regardless of order",
+			snapshots: []circleci.Snapshot{
+				{ID: "s2", Name: "go-base"},
+				{ID: "s1", Name: "go-base"},
+			},
+			criteria: SnapshotCriteria{Repo: "chunk-cli", Stack: "go"},
+			wantID:   "s1",
+		},
+		{
+			name: "empty criteria match nothing",
+			snapshots: []circleci.Snapshot{
+				{ID: "s1", Name: "go-base"},
+			},
+			criteria: SnapshotCriteria{},
+			wantID:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match, ok := SelectSnapshot(tt.snapshots, tt.criteria)
+			if tt.wantID == "" {
+				assert.Assert(t, !ok, "expected no match, got %q", match.Snapshot.ID)
+				return
+			}
+			assert.Assert(t, ok, "expected a match")
+			assert.Equal(t, match.Snapshot.ID, tt.wantID)
+			assert.Assert(t, match.Reason != "", "a match must explain itself")
+		})
+	}
+}
+
+// A repo whose name is a superset of a snapshot's must not match it: "chunk"
+// and "chunk-cli" are different projects.
+func TestSelectSnapshotRequiresEveryRepoToken(t *testing.T) {
+	snapshots := []circleci.Snapshot{{ID: "s1", Name: "chunk"}}
+	_, ok := SelectSnapshot(snapshots, SnapshotCriteria{Repo: "chunk-cli"})
+	assert.Assert(t, !ok)
+}
+
+func TestSelectSnapshotReasonNamesTheSignal(t *testing.T) {
+	match, ok := SelectSnapshot(
+		[]circleci.Snapshot{{ID: "s1", Name: "go-base"}},
+		SnapshotCriteria{Repo: "chunk-cli", Stack: "go"},
+	)
+	assert.Assert(t, ok)
+	assert.Equal(t, match.Reason, "built for go")
+
+	match, ok = SelectSnapshot(
+		[]circleci.Snapshot{{ID: "s1", Name: "chunk-cli"}},
+		SnapshotCriteria{Repo: "chunk-cli", Stack: "go"},
+	)
+	assert.Assert(t, ok)
+	assert.Equal(t, match.Reason, "named for repo chunk-cli")
+}
+
+func TestResolveSnapshot(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.Snapshots = []fakes.Snapshot{
+		{ID: "snap-1", OrgID: "org-abc", Name: "billing-service"},
+		{ID: "snap-2", OrgID: "org-abc", Name: "chunk-cli"},
+		// Belongs to a different org, so it must never be considered even
+		// though it is the strongest possible name match.
+		{ID: "snap-3", OrgID: "org-other", Name: "chunk-cli"},
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	cl, err := circleci.NewClient(circleci.Config{Token: "fake-token", BaseURL: srv.URL})
+	assert.NilError(t, err)
+
+	match, ok, err := ResolveSnapshot(context.Background(), cl, "org-abc",
+		SnapshotCriteria{Repo: "chunk-cli", Stack: "go"})
+	assert.NilError(t, err)
+	assert.Assert(t, ok)
+	assert.Equal(t, match.Snapshot.ID, "snap-2")
+}
+
+func TestResolveSnapshotNoMatch(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.Snapshots = []fakes.Snapshot{
+		{ID: "snap-1", OrgID: "org-abc", Name: "billing-service"},
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	cl, err := circleci.NewClient(circleci.Config{Token: "fake-token", BaseURL: srv.URL})
+	assert.NilError(t, err)
+
+	_, ok, err := ResolveSnapshot(context.Background(), cl, "org-abc",
+		SnapshotCriteria{Repo: "chunk-cli", Stack: "go"})
+	assert.NilError(t, err)
+	assert.Assert(t, !ok)
+}
+
+func TestResolveSnapshotAPIError(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.ListSnapshotsStatusCode = 500
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	cl, err := circleci.NewClient(circleci.Config{Token: "fake-token", BaseURL: srv.URL})
+	assert.NilError(t, err)
+
+	_, ok, err := ResolveSnapshot(context.Background(), cl, "org-abc",
+		SnapshotCriteria{Repo: "chunk-cli", Stack: "go"})
+	assert.Assert(t, err != nil)
+	assert.Assert(t, !ok)
+}
+
+// IsSystem must survive the round trip through the list API, since selection
+// uses it to prefer an org's own snapshot.
+func TestResolveSnapshotPrefersOwnedOverSystem(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.Snapshots = []fakes.Snapshot{
+		{ID: "snap-1", OrgID: "org-abc", Name: "go-base", IsSystem: true},
+		{ID: "snap-2", OrgID: "org-abc", Name: "go-base"},
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	cl, err := circleci.NewClient(circleci.Config{Token: "fake-token", BaseURL: srv.URL})
+	assert.NilError(t, err)
+
+	match, ok, err := ResolveSnapshot(context.Background(), cl, "org-abc",
+		SnapshotCriteria{Repo: "webapp", Stack: "go"})
+	assert.NilError(t, err)
+	assert.Assert(t, ok)
+	assert.Equal(t, match.Snapshot.ID, "snap-2")
+}

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -36,10 +36,11 @@ type Sidecar struct {
 }
 
 type Snapshot struct {
-	ID    string `json:"id"`
-	OrgID string `json:"org_id"`
-	Name  string `json:"name"`
-	Tag   string `json:"tag,omitempty"`
+	ID       string `json:"id"`
+	OrgID    string `json:"org_id"`
+	Name     string `json:"name"`
+	Tag      string `json:"tag,omitempty"`
+	IsSystem bool   `json:"is_system,omitempty"`
 }
 
 type RunResponse struct {
@@ -656,7 +657,7 @@ func (f *FakeCircleCI) handleListSnapshots(c *gin.Context) {
 	var items []gin.H
 	for _, s := range f.Snapshots {
 		if s.OrgID == orgID {
-			attrs := gin.H{"name": s.Name, "is_system": false}
+			attrs := gin.H{"name": s.Name, "is_system": s.IsSystem}
 			if s.Tag != "" {
 				attrs["tag"] = s.Tag
 			}


### PR DESCRIPTION
Problem: a repo with no <validation.sidecarImage> got the bare default image - no toolchain, so every command failed on the environment instead of the code.

Fix: pick from the org's own snapshots instead, matching on a snapshot's name and tag.

Ranking, strongest first:
1. Rep name - git remote, then <vcs.repo>, then the directory name
2. Detected stack
3. Tiebreak: the org's own snapshot over an equivalent system one

Matching is token-based, not substring: <go> matches <go-base> but not <mongo-api>.  The wrong prepared environment fails in ways that look like repo's own, so a loose match is worse than no match.

Fallback: no match means the default image and a printed reason. selection never fails a run - an unreachable snapshot API is warned about and treated as no match.

Main Changes: split the ranking out of the prose paragraph so it's scannable, promoted "Problem / Fix / Fallback" to labels, and moved the "why token-based" justification to follow the rule it explains rather than interrupting it.