### PR TITLE
Make remote the default for validate; add --local to opt out

### DIFF
--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -85,7 +85,7 @@ func TestValidateHookMode_DirtyTree(t *testing.T) {
 	writeProjectConfig(t, workDir, "", "false")
 
 	env := testenv.NewTestEnv(t)
-	result := binary.RunCLIWithStdin(t, []string{"validate"}, env, workDir,
+	result := binary.RunCLIWithStdin(t, []string{"validate", "--local"}, env, workDir,
 		hookStdin(t, "test-session-dirty", false))
 
 	assert.Equal(t, result.ExitCode, 2,
@@ -161,60 +161,73 @@ func TestValidateRunDryRunNoConfig(t *testing.T) {
 		"expected no-commands-configured error, got: %s", combined)
 }
 
-func TestValidateRunLocal(t *testing.T) {
-	// Local-only commands (no remote:true) are now blocked — users must configure
-	// remote validation before running chunk validate.
+// TestValidateDefaultsToRemote confirms that running without --local always
+// attempts remote execution. Without a valid token the attempt fails with an
+// auth error, proving commands never silently ran locally.
+func TestValidateDefaultsToRemote(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	writeProjectConfig(t, workDir, "echo should-not-run-locally", "echo should-not-run-locally")
+
+	env := testenv.NewTestEnv(t)
+	env.CircleToken = "" // no auth → sidecar creation fails
+
+	result := binary.RunCLI(t, []string{"validate"}, env, workDir)
+
+	assert.Assert(t, result.ExitCode != 0, "expected failure: remote attempted without valid token")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, !strings.Contains(combined, "should-not-run-locally"),
+		"commands must not have run locally, got: %s", combined)
+}
+
+// TestValidateLocalFlagRunsLocally confirms that --local executes commands in
+// the local process and succeeds without a sidecar or token.
+func TestValidateRunLocalFlag(t *testing.T) {
 	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
 	writeProjectConfig(t, workDir, "echo installed", "echo tested")
 
 	env := testenv.NewTestEnv(t)
 
 	result := binary.RunCLI(t, []string{
-		"validate",
+		"validate", "--local",
 	}, env, workDir)
 
-	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit when remote is not configured")
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "Remote validation is not configured"),
-		"expected remote-not-configured message, got: %s", combined)
-	assert.Assert(t, strings.Contains(combined, "sidecar setup") || strings.Contains(combined, "mark-remote"),
-		"expected actionable suggestion in output, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "installed") || strings.Contains(combined, "tested"),
+		"expected local command output, got: %s", combined)
 }
 
-func TestValidateRunLocalFailure(t *testing.T) {
-	// Local-only commands are blocked regardless of whether they would pass or fail.
+// TestValidateRunLocalFlagFailure confirms that --local with a failing command
+// exits non-zero.
+func TestValidateRunLocalFlagFailure(t *testing.T) {
 	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
 	writeProjectConfig(t, workDir, "true", "false")
 
 	env := testenv.NewTestEnv(t)
 
 	result := binary.RunCLI(t, []string{
-		"validate",
+		"validate", "--local",
 	}, env, workDir)
 
-	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit when remote is not configured")
-	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "Remote validation is not configured"),
-		"expected remote-not-configured message, got: %s", combined)
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit for failing command")
 }
 
-func TestValidateRunLocalSkipsAfterFailure(t *testing.T) {
-	// Local-only commands are blocked before any execution — no "skipped" output.
+// TestValidateRunLocalFlagStopsOnFirstFailure confirms that --local stops
+// running commands after the first failure.
+func TestValidateRunLocalFlagStopsOnFirstFailure(t *testing.T) {
 	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
 	writeProjectConfig(t, workDir, "false", "echo should-not-run")
 
 	env := testenv.NewTestEnv(t)
 
 	result := binary.RunCLI(t, []string{
-		"validate",
+		"validate", "--local",
 	}, env, workDir)
 
-	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit when remote is not configured")
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit")
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "Remote validation is not configured"),
-		"expected remote-not-configured message, got: %s", combined)
 	assert.Assert(t, !strings.Contains(combined, "should-not-run"),
-		"blocked run must not execute any command, got: %s", combined)
+		"must stop on first failure, got: %s", combined)
 }
 
 // generateTestSSHKey writes an ed25519 keypair to identityFile and identityFile+".pub".
@@ -240,21 +253,22 @@ func generateTestSSHKey(t *testing.T, identityFile string) error {
 
 // --- Named command execution ---
 
-func TestValidateRunNamed(t *testing.T) {
-	// Named local commands are also blocked — remote must be configured first.
+// TestValidateRunNamedLocalFlag confirms that --local runs a named command
+// in the local process.
+func TestValidateRunNamedLocalFlag(t *testing.T) {
 	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
 	writeProjectConfig(t, workDir, "echo installed", "echo tested")
 
 	env := testenv.NewTestEnv(t)
 
 	result := binary.RunCLI(t, []string{
-		"validate", "test",
+		"validate", "--local", "test",
 	}, env, workDir)
 
-	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit when remote is not configured")
+	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "Remote validation is not configured"),
-		"expected remote-not-configured message, got: %s", combined)
+	assert.Assert(t, strings.Contains(combined, "tested"),
+		"expected named command output, got: %s", combined)
 }
 
 func TestValidateRunNamedNotConfiguredNonTTY(t *testing.T) {
@@ -264,7 +278,7 @@ func TestValidateRunNamedNotConfiguredNonTTY(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 
 	result := binary.RunCLI(t, []string{
-		"validate", "nonexistent",
+		"validate", "--local", "nonexistent",
 	}, env, workDir)
 
 	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit code for unknown command")
@@ -281,7 +295,7 @@ func TestValidateInlineCmd(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 
 	result := binary.RunCLI(t, []string{
-		"validate", "--cmd", "echo inline-output",
+		"validate", "--local", "--cmd", "echo inline-output",
 	}, env, workDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
@@ -314,7 +328,7 @@ func TestValidateInlineCmdSave(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 
 	result := binary.RunCLI(t, []string{
-		"validate", "lint", "--cmd", "echo linting", "--save",
+		"validate", "--local", "lint", "--cmd", "echo linting", "--save",
 	}, env, workDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
@@ -562,7 +576,7 @@ func TestValidateHookMode_SuccessLine(t *testing.T) {
 	writeProjectConfig(t, workDir, "", "true")
 
 	env := testenv.NewTestEnv(t)
-	result := binary.RunCLIWithStdin(t, []string{"validate"}, env, workDir,
+	result := binary.RunCLIWithStdin(t, []string{"validate", "--local"}, env, workDir,
 		hookStdin(t, "test-session-success-line", false))
 
 	assert.Equal(t, result.ExitCode, 0, "expected exit 0 for passing hook; stderr: %s", result.Stderr)

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -418,8 +418,10 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		}
 	}
 
-	// allRemote is true unless --local is passed explicitly.
-	allRemote := !opts.local && (explicitRemote || cfg.HasSidecarImage())
+	// allRemote is true unless --local is passed explicitly. opts.remote is
+	// already set to true above, so explicitRemote is always true here; the
+	// expression simplifies to the local flag check.
+	allRemote := !opts.local
 
 	image := resolveImage(name, cfg)
 
@@ -456,12 +458,12 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	// Only load env vars and resolve secrets when a sidecar is actually
 	// being used — avoids parsing .env.local or hitting secrets APIs on
 	// purely local runs.
-	envVars, statusFn, freshlyCreated, err := loadEnvVarsWithRetry(ctx, circleCIClient, opts, image, freshlyCreated, baseStatusFn, statusFn, workDir, hook, streams)
+	envVars, statusFn, _, err := loadEnvVarsWithRetry(ctx, circleCIClient, opts, image, freshlyCreated, baseStatusFn, statusFn, workDir, hook, streams)
 	if err != nil {
 		return err
 	}
 
-	result, execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, freshlyCreated, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
+	result, execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
 	if execErr == nil && resultCache != nil {
 		if err := resultCache.Put(cacheKey, validate.CachedResult{CachedAt: time.Now()}); err != nil {
 			streams.ErrPrintf("  %s\n", ui.ErrDim(fmt.Sprintf("chunk validate: cache write failed: %v", err)))
@@ -588,7 +590,7 @@ func runValidateDryRun(name, inlineCmd string, cfg *config.ProjectConfig, status
 // provided options. It is shared by both direct and hook invocations.
 // allRemote is true when --remote is passed explicitly (all commands run on the
 // sidecar); false means only commands with Remote:true are routed to the sidecar.
-func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, freshlyCreated bool, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) (validate.Result, error) {
+func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) (validate.Result, error) {
 	// --cmd: inline command (always local in per-command mode)
 	if inlineCmd != "" {
 		cmdName := name
@@ -635,7 +637,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 			statusFn(iostream.LevelInfo, fmt.Sprintf("running %s locally (not marked remote)", name))
 			// Named command is not marked remote; fall through to local execution.
 		} else {
-			return runSplitCommands(ctx, client, sidecarID, freshlyCreated, workdir, workDir, envVars, rc, cfg, statusFn, streams)
+			return runSplitCommands(ctx, client, sidecarID, workdir, workDir, envVars, rc, cfg, statusFn, streams)
 		}
 	}
 
@@ -826,7 +828,7 @@ func hostForwardEnv(token string) map[string]string {
 // name is given: remote-tagged commands go to the sidecar, the rest run locally.
 // Any error reaching or using the sidecar is returned immediately — there is no
 // local fallback.
-func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) (validate.Result, error) {
+func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) (validate.Result, error) {
 	remoteCfg, localCfg := splitByRemote(cfg)
 	if len(remoteCfg.Commands) > 0 {
 		statusFn(iostream.LevelInfo, fmt.Sprintf("running on sidecar %s: %s", sidecarID, commandNames(remoteCfg.Commands)))

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -824,9 +824,8 @@ func hostForwardEnv(token string) map[string]string {
 
 // runSplitCommands handles per-command remote routing when no specific command
 // name is given: remote-tagged commands go to the sidecar, the rest run locally.
-// When freshlyCreated is true, exec failures are hard errors rather than
-// silent local fallbacks (a newly provisioned sidecar that can't be reached
-// indicates a real problem, not temporary unavailability).
+// Any error reaching or using the sidecar is returned immediately — there is no
+// local fallback.
 func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) (validate.Result, error) {
 	remoteCfg, localCfg := splitByRemote(cfg)
 	if len(remoteCfg.Commands) > 0 {
@@ -840,31 +839,23 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 	if len(remoteCfg.Commands) > 0 {
 		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, streams)
 		if err != nil {
-			if freshlyCreated {
-				return validate.Result{}, newUserError(fmt.Sprintf("Could not reach newly created sidecar %s.", sidecarID)).
-					withCode("sidecar.unreachable").
-					withSuggestion("The sidecar may still be starting. Try again in a moment.").
-					withExitCode(ExitAPIError).
-					wrap(err)
-			}
-			streams.ErrPrintf("warning: could not reach sidecar (%v); running %s locally instead\n", err, commandNames(remoteCfg.Commands))
-			localCfg.Commands = append(remoteCfg.Commands, localCfg.Commands...)
-		} else if wsErr := validate.WorkspaceExists(ctx, execFn, dest); wsErr != nil {
-			if freshlyCreated {
-				return validate.Result{}, newUserError(fmt.Sprintf("Workspace not found on newly created sidecar %s.", sidecarID)).
-					withCode("sidecar.workspace_missing").
-					withSuggestion("Run 'chunk sidecar env build' to prepare the workspace.").
-					withExitCode(ExitNotFound).
-					wrap(wsErr)
-			}
-			streams.ErrPrintf("warning: %v (%q); run 'chunk sidecar env build' to set up the workspace; running %s locally instead\n", wsErr, dest, commandNames(remoteCfg.Commands))
-			localCfg.Commands = append(remoteCfg.Commands, localCfg.Commands...)
-		} else {
-			r, err := validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, statusFn, streams)
-			combined.Passed += r.Passed
-			combined.Total += r.Total
-			runErr = err
+			return validate.Result{}, newUserError(fmt.Sprintf("Could not reach sidecar %s.", sidecarID)).
+				withCode("sidecar.unreachable").
+				withSuggestion("The sidecar may still be starting. Try again in a moment.").
+				withExitCode(ExitAPIError).
+				wrap(err)
 		}
+		if wsErr := validate.WorkspaceExists(ctx, execFn, dest); wsErr != nil {
+			return validate.Result{}, newUserError(fmt.Sprintf("Workspace not found on sidecar %s.", sidecarID)).
+				withCode("sidecar.workspace_missing").
+				withSuggestion("Run 'chunk sidecar env build' to prepare the workspace.").
+				withExitCode(ExitNotFound).
+				wrap(wsErr)
+		}
+		r, err := validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, statusFn, streams)
+		combined.Passed += r.Passed
+		combined.Total += r.Total
+		runErr = err
 	}
 	if len(localCfg.Commands) > 0 {
 		r, err := mapValidateError(validate.RunAll(ctx, workDir, localCfg, statusFn, streams))

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -157,6 +157,7 @@ type validateOpts struct {
 	list         bool
 	save         bool
 	remote       bool
+	local        bool
 	markRemote   bool
 	jsonOut      bool
 	inlineCmd    string
@@ -186,7 +187,8 @@ func newValidateCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.remote, "remote", false, "Run on active sidecar, or create one if none is set")
+	cmd.Flags().BoolVar(&opts.remote, "remote", false, "Run on active sidecar, or create one if none is set (default behavior)")
+	cmd.Flags().BoolVar(&opts.local, "local", false, "Run commands locally instead of on sidecar")
 	cmd.Flags().StringVar(&opts.sidecarID, "sidecar-id", "", "Sidecar ID for remote execution")
 	cmd.Flags().StringVar(&opts.orgID, "org-id", "", "Organization ID (used when creating a new sidecar)")
 	cmd.Flags().StringVar(&opts.identityFile, "identity-file", "", "SSH identity file (uses ssh-agent or ~/.ssh/chunk_ai when omitted)")
@@ -242,10 +244,11 @@ func initHook(ctx context.Context, hook *hookContext, workDir string, tree gitut
 }
 
 // checkRemoteConfigured returns an error when an interactive run would fall
-// back to local execution because no commands are marked remote. Hooks and
-// explicit override flags (--remote, --sidecar-id, --cmd) bypass this gate.
+// back to local execution because no commands are marked remote. Hooks,
+// --local, and explicit override flags (--remote, --sidecar-id, --cmd) bypass
+// this gate.
 func checkRemoteConfigured(hook *hookContext, opts *validateOpts, cfg *config.ProjectConfig) error {
-	if hook != nil || opts.inlineCmd != "" || opts.remote || opts.sidecarID != "" {
+	if hook != nil || opts.local || opts.inlineCmd != "" || opts.remote || opts.sidecarID != "" {
 		return nil
 	}
 	if cfg == nil || !cfg.HasCommands() || cfg.HasRemoteCommands() || cfg.HasSidecarImage() {
@@ -382,6 +385,11 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return runValidateDryRun(name, opts.inlineCmd, cfg, statusFn)
 	}
 
+	// Remote is the default; --local is the only opt-out.
+	if !opts.local {
+		opts.remote = true
+	}
+
 	if err := checkRemoteConfigured(hook, opts, cfg); err != nil {
 		return err
 	}
@@ -392,7 +400,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	rc, _ := config.ResolveCircleCI(insecureStorage)
 
 	explicitRemote := opts.remote || opts.sidecarID != ""
-	needsSidecar := validateNeedsSidecar(explicitRemote, cfg)
+	needsSidecar := !opts.local && validateNeedsSidecar(explicitRemote, cfg)
 	if hookMissingAuth(hook, needsSidecar, rc.CircleCIToken, streams) {
 		return errSilentExit
 	}
@@ -410,13 +418,8 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		}
 	}
 
-	// allRemote is true when the caller explicitly targets the sidecar
-	// (--remote or --sidecar-id), meaning every command runs there.
-	// Per-command routing only applies when the sidecar is resolved implicitly.
-	allRemote := explicitRemote
-	if cfg.HasSidecarImage() {
-		allRemote = true
-	}
+	// allRemote is true unless --local is passed explicitly.
+	allRemote := !opts.local && (explicitRemote || cfg.HasSidecarImage())
 
 	image := resolveImage(name, cfg)
 
@@ -678,6 +681,9 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 // setupRemote resolves (or creates) the sidecar ID based on the validate flags
 // and config, then returns whether a new sidecar was provisioned.
 func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpts, image string, cfg *config.ProjectConfig, activeSidecar *sidecar.ActiveSidecar, statusFn iostream.StatusFunc, workDir string, streams iostream.Streams) (bool, error) {
+	if opts.local {
+		return false, nil
+	}
 	if validateNeedsSidecar(opts.remote || opts.sidecarID != "", cfg) {
 		if opts.remote {
 			created, err := resolveOrCreateSidecarID(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, streams)

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -96,12 +96,14 @@ func TestValidateHookExitsOneWhenCircleCITokenMissingAndSidecarImage(t *testing.
 		"expected auth message in stderr, got: %q", stderr)
 }
 
-func TestValidateHookSkipsAuthCheckWhenNoRemoteCommands(t *testing.T) {
+// TestValidateHookRequiresAuthByDefault verifies that hook invocations now
+// always require CircleCI auth — even when no commands are explicitly marked
+// Remote:true — because remote is the default execution mode.
+func TestValidateHookRequiresAuthByDefault(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv(config.EnvCircleToken, "")
 	t.Setenv(config.EnvCircleCIToken, "")
 
-	// Local-only commands: auth check must not fire.
 	dir := t.TempDir()
 	projCfg := &config.ProjectConfig{
 		Commands: []config.Command{
@@ -112,10 +114,9 @@ func TestValidateHookSkipsAuthCheckWhenNoRemoteCommands(t *testing.T) {
 
 	_, stderr, err := runValidateHook(t, dir)
 
-	// May fail for other reasons (no git repo), but must not be an auth error.
-	assert.Assert(t, !strings.Contains(stderr, "CircleCI auth is not configured"),
-		"auth check must not fire for local-only commands, stderr: %q", stderr)
-	_ = err
+	assert.Assert(t, err != nil)
+	assert.Assert(t, strings.Contains(stderr, "CircleCI auth is not configured"),
+		"auth check must fire because remote is the default, stderr: %q", stderr)
 }
 
 func TestValidateNeedsSidecarSidecarImage(t *testing.T) {
@@ -191,12 +192,19 @@ func TestValidateNoConfigShowsSkillHint(t *testing.T) {
 		"expected suggestion to mention chunk-sidecar skill, got: %q", ue.Suggestion())
 }
 
-func TestValidateRequiresRemoteConfiguration(t *testing.T) {
+// TestValidateDefaultsToRemote confirms that running without --local always
+// attempts remote execution, even when no commands are marked Remote:true.
+// Without a valid CircleCI token the attempt fails with an auth error — proving
+// it never silently fell back to running the commands locally.
+func TestValidateDefaultsToRemote(t *testing.T) {
 	isolateConfig(t)
+	t.Setenv(config.EnvCircleToken, "")
+	t.Setenv(config.EnvCircleCIToken, "")
+
 	dir := t.TempDir()
 	assert.NilError(t, config.SaveProjectConfig(dir, &config.ProjectConfig{
 		Commands: []config.Command{
-			{Name: "test", Run: "go test ./..."},
+			{Name: "test", Run: "echo should-not-run-locally"},
 		},
 	}))
 
@@ -207,37 +215,64 @@ func TestValidateRequiresRemoteConfiguration(t *testing.T) {
 	root.SetArgs([]string{"validate", "--project", dir})
 	err := root.Execute()
 
-	assert.Assert(t, err != nil, "expected error when no remote commands configured")
-	var ue *userError
-	assert.Assert(t, errors.As(err, &ue), "expected userError, got %T: %v", err, err)
-	assert.Assert(t, strings.Contains(ue.UserMessage(), "Remote validation is not configured"),
-		"expected remote-not-configured message, got: %q", ue.UserMessage())
-	assert.Assert(t, strings.Contains(ue.Suggestion(), "sidecar setup") || strings.Contains(ue.Suggestion(), "mark-remote"),
-		"expected suggestion to mention sidecar setup or mark-remote, got: %q", ue.Suggestion())
+	assert.Assert(t, err != nil, "expected error: remote should be attempted and fail without a token")
+	combined := outBuf.String() + errBuf.String()
+	assert.Assert(t, !strings.Contains(combined, "should-not-run-locally"),
+		"command must not have run locally, got: %q", combined)
 }
 
-func TestValidateRequiresRemoteConfigurationSkipsInHookContext(t *testing.T) {
+// TestValidateLocalFlagRunsLocally confirms that --local executes commands in
+// the local process without touching a sidecar.
+func TestValidateLocalFlagRunsLocally(t *testing.T) {
 	isolateConfig(t)
+	t.Setenv(config.EnvCircleToken, "")
+	t.Setenv(config.EnvCircleCIToken, "")
+
 	dir := t.TempDir()
-	gitSetup(t, dir, "main")
 	assert.NilError(t, config.SaveProjectConfig(dir, &config.ProjectConfig{
 		Commands: []config.Command{
-			{Name: "test", Run: "exit 0"},
+			{Name: "test", Run: "echo ran-locally"},
 		},
 	}))
 
-	_, _, err := runValidateHook(t, dir)
+	var outBuf, errBuf bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"validate", "--local", "--project", dir})
+	err := root.Execute()
 
-	// Hook must not be blocked by the remote-not-configured gate.
-	// (It may fail for other reasons like a dirty tree that can't be fingerprinted,
-	// but it must not return the remote-not-configured userError.)
-	if err != nil {
-		var ue *userError
-		if errors.As(err, &ue) {
-			assert.Assert(t, !strings.Contains(ue.Error(), "Remote validation is not configured"),
-				"hook must not be blocked by remote-not-configured gate, got: %q", ue.Error())
-		}
-	}
+	assert.NilError(t, err)
+	combined := outBuf.String() + errBuf.String()
+	assert.Assert(t, strings.Contains(combined, "ran-locally"),
+		"--local must execute commands in the local process, got: %q", combined)
+}
+
+// TestValidateLocalFlagOverridesRemoteConfig confirms that --local wins over
+// Remote:true in config — the flag is the explicit opt-out from remote-first.
+func TestValidateLocalFlagOverridesRemoteConfig(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv(config.EnvCircleToken, "")
+	t.Setenv(config.EnvCircleCIToken, "")
+
+	dir := t.TempDir()
+	assert.NilError(t, config.SaveProjectConfig(dir, &config.ProjectConfig{
+		Commands: []config.Command{
+			{Name: "test", Run: "echo ran-locally", Remote: true},
+		},
+	}))
+
+	var outBuf, errBuf bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"validate", "--local", "--project", dir})
+	err := root.Execute()
+
+	assert.NilError(t, err, "--local must bypass Remote:true config and run locally")
+	combined := outBuf.String() + errBuf.String()
+	assert.Assert(t, strings.Contains(combined, "ran-locally"),
+		"--local must execute commands locally even when Remote:true, got: %q", combined)
 }
 
 func TestValidateEnvFlagBadValue(t *testing.T) {
@@ -274,6 +309,8 @@ const skipMsg = "skipped (no changes since last successful run)"
 // runActiveStopHook fires a re-signalled Stop hook against dir and returns what
 // the agent would see, along with the exit error. Unlike runValidateHook it does
 // not assert on the error, so failing runs can be exercised too.
+// --local is passed so the tests focus on hook caching semantics rather than
+// remote routing — caching is orthogonal to where commands run.
 func runActiveStopHook(t *testing.T, dir string) (stderr string, err error) {
 	t.Helper()
 	var outBuf, errBuf bytes.Buffer
@@ -281,7 +318,7 @@ func runActiveStopHook(t *testing.T, dir string) (stderr string, err error) {
 	root.SetOut(&outBuf)
 	root.SetErr(&errBuf)
 	root.SetIn(strings.NewReader(activeStopHookPayload))
-	root.SetArgs([]string{"validate", "--project", dir})
+	root.SetArgs([]string{"validate", "--local", "--project", dir})
 	err = root.Execute()
 	return errBuf.String(), err
 }


### PR DESCRIPTION
## Summary

- `chunk validate` now routes to a sidecar by default — no flags required
- Added `--local` flag as the explicit opt-out for local execution
- Remote errors are surfaced directly; no silent fallback to local under any circumstances

## Test plan

- [x] `TestValidateDefaultsToRemote` — running without `--local` attempts remote (fails with auth error when no token, proving no local fallback)
- [x] `TestValidateLocalFlagRunsLocally` / `TestValidateRunLocalFlag` — `--local` executes commands in the local process
- [x] `TestValidateLocalFlagOverridesRemoteConfig` — `--local` wins even when commands have `Remote: true` in config
- [x] `TestValidateHookRequiresAuthByDefault` — hook invocations now require auth regardless of whether commands are marked `Remote: true`
- [x] All existing sidecar/remote tests continue to pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)