### PR TITLE
Fail instead of running locally when no sidecar is found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ test-fetch-on-stale-sidecar.log
 # toolchain installers downloaded into the repo root
 *.pkg
 *.tar.gz
+
+# Test and lint reports written by Taskfile (RESULTS_DIR).
+test-reports/

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -91,6 +91,18 @@ func resolveOrgID(orgID, workDir string, pickOrg func() (string, error)) (string
 	return pickOrg()
 }
 
+// orgSource names where resolveOrgID would have taken the org ID from, for use
+// in error messages. It mirrors resolveOrgID's precedence and must be kept in
+// step with it. An empty result means the picker supplied the value, which for
+// a single-collaboration account happens without prompting.
+func orgSource(orgID, workDir string) string {
+	if orgID != "" {
+		return "--org-id"
+	}
+	_, source := config.ResolveOrgID(workDir)
+	return source
+}
+
 func orgPicker(ctx context.Context, client *circleci.Client) func() (string, error) {
 	return func() (string, error) {
 		collabs, err := client.ListCollaborations(ctx)
@@ -121,10 +133,13 @@ func orgPicker(ctx context.Context, client *circleci.Client) func() (string, err
 		idx, err := tui.SelectFromList("Select an organization:", labels)
 		if err != nil {
 			if errors.Is(err, tui.ErrNoTTY) {
+				// hideDetail: the wrapped error is "no interactive terminal
+				// available", which the message already says in full.
 				return "", &userError{
 					msg:        "No interactive terminal available to select an organization.",
 					suggestion: "Run 'chunk org list' to find your org ID, then set it with 'chunk config set orgID <id>' or pass --org-id.",
 					err:        err,
+					hideDetail: true,
 				}
 			}
 			return "", &userError{msg: "Could not select an organization.", suggestion: "Pass --org-id instead.", err: err}

--- a/internal/cmd/usererr.go
+++ b/internal/cmd/usererr.go
@@ -74,6 +74,47 @@ func cannotCreateSidecar(orgID, source string, err error) error {
 		wrap(err)
 }
 
+// unreachableSidecar and missingWorkspace phrase the two ways a sidecar that
+// already exists can fail to run the commands routed to it. Both return an
+// error rather than letting those commands run locally: a command is marked
+// remote because a local result does not answer the question it was written to
+// answer, so running it here reports a pass the sidecar never gave. That is the
+// same false green as a refused creation, reached one step later — and it costs
+// the full suite's runtime before saying so. Naming the commands that did not
+// run keeps the skipped work visible rather than implied.
+//
+// freshlyCreated changes only the advice. A sidecar this run provisioned may
+// genuinely still be starting, so retrying is sound; a pre-existing one that has
+// gone unreachable will not fix itself on a retry, so the suggestion points at
+// inspecting or replacing it instead.
+func unreachableSidecar(sidecarID string, freshlyCreated bool, cmds string, err error) error {
+	msg := fmt.Sprintf("Could not reach sidecar %s.", sidecarID)
+	suggestion := "Check its state with 'chunk sidecar list', or provision a replacement with 'chunk sidecar create'."
+	if freshlyCreated {
+		msg = fmt.Sprintf("Could not reach newly created sidecar %s.", sidecarID)
+		suggestion = "The sidecar may still be starting. Try again in a moment."
+	}
+	return newUserError(msg).
+		withCode("sidecar.unreachable").
+		withDetail(fmt.Sprintf("Did not run: %s. Commands marked remote are not run locally.", cmds)).
+		withSuggestion(suggestion).
+		withExitCode(ExitAPIError).
+		wrap(err)
+}
+
+func missingWorkspace(sidecarID, dest string, freshlyCreated bool, cmds string, err error) error {
+	msg := fmt.Sprintf("Workspace not found on sidecar %s.", sidecarID)
+	if freshlyCreated {
+		msg = fmt.Sprintf("Workspace not found on newly created sidecar %s.", sidecarID)
+	}
+	return newUserError(msg).
+		withCode("sidecar.workspace_missing").
+		withDetail(fmt.Sprintf("Expected it at %q. Did not run: %s. Commands marked remote are not run locally.", dest, cmds)).
+		withSuggestion("Run 'chunk sidecar env build' to prepare the workspace.").
+		withExitCode(ExitNotFound).
+		wrap(err)
+}
+
 // outdatedSidecarAPI maps an unsupported output format to guidance that points
 // the right way. The API is behind this binary, not ahead of it, so telling
 // someone to upgrade chunk would send them in exactly the wrong direction —

--- a/internal/cmd/usererr.go
+++ b/internal/cmd/usererr.go
@@ -47,6 +47,33 @@ func notAuthorized(action string, err error) error {
 		wrap(err)
 }
 
+// cannotCreateSidecar phrases a rejected sidecar creation, or returns nil when
+// err is not an authorization failure.
+//
+// The generic notAuthorized() says to check the token, which is the wrong lead
+// here: the token is usually fine and the org is the problem. An org ID reaches
+// Create from four places — a flag, an env var, .chunk/config.json, or a silent
+// auto-pick when the account has exactly one collaboration — and nothing on
+// screen says which one was used. Naming the org and its source makes "chunk
+// tried the wrong org" a visible possibility rather than a guess.
+func cannotCreateSidecar(orgID, source string, err error) error {
+	if !errors.Is(err, circleci.ErrNotAuthorized) {
+		return nil
+	}
+	detail := fmt.Sprintf("Org %s rejected the request", orgID)
+	if source != "" {
+		detail += " (org ID from " + source + ")"
+	}
+	return newUserError("Not authorized to create sidecars in this organization.").
+		withCode("sidecar.not_authorized").
+		withDetail(detail + ".").
+		withSuggestion("Confirm this is the right org: 'chunk org list' shows the ones you belong to, and " +
+			"'chunk config set orgID <id>' records the one this repo should use.\n" +
+			"If the org is correct, it may not have sidecars enabled yet, or your token may lack access to it.").
+		withExitCode(ExitAuthError).
+		wrap(err)
+}
+
 // outdatedSidecarAPI maps an unsupported output format to guidance that points
 // the right way. The API is behind this binary, not ahead of it, so telling
 // someone to upgrade chunk would send them in exactly the wrong direction —

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -687,7 +687,7 @@ func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpt
 			statusFn(iostream.LevelInfo, fmt.Sprintf("running all commands on sidecar %s", opts.sidecarID))
 			return created, nil
 		}
-		return resolveSidecar(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, activeSidecar, streams), nil
+		return resolveSidecar(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, activeSidecar, streams)
 	}
 	return false, nil
 }
@@ -914,18 +914,23 @@ func resolveImage(name string, cfg *config.ProjectConfig) string {
 // sidecarImage is configured). It uses the active sidecar when available,
 // and auto-creates one otherwise.
 // Returns true when a brand-new sidecar was provisioned in this call.
-func resolveSidecar(ctx context.Context, client *circleci.Client, sidecarID *string, orgID, image, workDir string, active *sidecar.ActiveSidecar, streams iostream.Streams) bool {
+//
+// A failure here is returned rather than downgraded to a local run. Commands
+// marked remote are marked that way because local results do not answer the
+// question they were written to answer, so quietly running them here reports a
+// pass the sidecar never gave. The three ways this fails in practice — no org
+// ID, no TTY to pick one, a token that cannot create sidecars — are all
+// configuration, so a retry without user action fails identically; falling
+// back only spends the full suite's runtime before saying so. This matches
+// --remote, which has always returned the error from this same call.
+func resolveSidecar(ctx context.Context, client *circleci.Client, sidecarID *string, orgID, image, workDir string, active *sidecar.ActiveSidecar, streams iostream.Streams) (bool, error) {
 	statusFn := newStatusFunc(streams)
 	if active != nil {
 		*sidecarID = active.SidecarID
 		statusFn(iostream.LevelInfo, fmt.Sprintf("using sidecar %s for remote commands", *sidecarID))
-		return false
+		return false, nil
 	}
-	created, err := resolveOrCreateSidecarID(ctx, client, sidecarID, orgID, image, workDir, streams)
-	if err != nil {
-		streams.ErrPrintf("warning: could not create sidecar (%v); running commands locally instead\n", err)
-	}
-	return created
+	return resolveOrCreateSidecarID(ctx, client, sidecarID, orgID, image, workDir, streams)
 }
 
 // resolveOrCreateSidecarID fills sidecarID from the active sidecar, or creates
@@ -952,7 +957,11 @@ func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, side
 		*sidecarID = existing.SidecarID
 		return false, nil
 	}
-	streams.ErrPrintf("No active sidecar found, creating a new sidecar...\n")
+	// A status line, not stderr prose: having no sidecar yet is the normal state
+	// of a first run, and printing it raw made it the headline of the hook's
+	// "Stop hook error:" banner even when everything then went fine.
+	statusFn := newStatusFunc(streams)
+	statusFn(iostream.LevelInfo, "no active sidecar; creating one")
 	resolvedOrgID, err := resolveOrgID(orgID, workDir, orgPicker(ctx, client))
 	if err != nil {
 		return false, err
@@ -960,7 +969,7 @@ func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, side
 	sandboxName := sidecarAutoName(ctx, workDir)
 	sc, err := sidecar.Create(ctx, client, resolvedOrgID, sandboxName, image)
 	if err != nil {
-		if authErr := notAuthorized("create sidecars", err); authErr != nil {
+		if authErr := cannotCreateSidecar(resolvedOrgID, orgSource(orgID, workDir), err); authErr != nil {
 			return false, authErr
 		}
 		return false, &userError{

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -720,6 +720,15 @@ func sidecarSyncError(ctx context.Context, client *circleci.Client, sidecarID st
 	case circleci.SidecarGone(err):
 		pruneSidecarState(ctx, client, sidecarID, false, streams)
 	default:
+		// Ask sshSessionError first. The SSH failures have specific, actionable
+		// phrasing — a missing key names the ssh-keygen command that creates it —
+		// and it is only reached by asking. Wrapping bare drops that suggestion and
+		// shows the cause alone, which is how "ssh key not found" reached a user
+		// with nothing saying how to fix it. Five call sites in sidecar.go already
+		// classify this way; the validate path was the one that did not.
+		if sshErr := sshSessionError(err); sshErr != nil {
+			return sshErr
+		}
 		return &userError{msg: "Could not sync to sidecar.", err: err}
 	}
 	// Both wrapped, not replaced: the caller replaces the sidecar and retries, and
@@ -818,9 +827,14 @@ func hostForwardEnv(token string) map[string]string {
 
 // runSplitCommands handles per-command remote routing when no specific command
 // name is given: remote-tagged commands go to the sidecar, the rest run locally.
-// When freshlyCreated is true, exec failures are hard errors rather than
-// silent local fallbacks (a newly provisioned sidecar that can't be reached
-// indicates a real problem, not temporary unavailability).
+//
+// A sidecar that cannot be reached, or that has no workspace, is an error here
+// rather than grounds for running the remote-marked commands locally. Those
+// commands are marked remote because a local result does not answer the
+// question they were written to answer, so running them here reports a pass the
+// sidecar never gave — the same false green as a failed creation, arrived at one
+// step later. freshlyCreated only selects the wording: on a sidecar this run
+// provisioned, "try again" is sound advice, and on a pre-existing one it is not.
 func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, freshlyCreated bool, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) (validate.Result, error) {
 	remoteCfg, localCfg := splitByRemote(cfg)
 	if len(remoteCfg.Commands) > 0 {
@@ -834,31 +848,15 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 	if len(remoteCfg.Commands) > 0 {
 		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, streams)
 		if err != nil {
-			if freshlyCreated {
-				return validate.Result{}, newUserError(fmt.Sprintf("Could not reach newly created sidecar %s.", sidecarID)).
-					withCode("sidecar.unreachable").
-					withSuggestion("The sidecar may still be starting. Try again in a moment.").
-					withExitCode(ExitAPIError).
-					wrap(err)
-			}
-			streams.ErrPrintf("warning: could not reach sidecar (%v); running %s locally instead\n", err, commandNames(remoteCfg.Commands))
-			localCfg.Commands = append(remoteCfg.Commands, localCfg.Commands...)
-		} else if wsErr := validate.WorkspaceExists(ctx, execFn, dest); wsErr != nil {
-			if freshlyCreated {
-				return validate.Result{}, newUserError(fmt.Sprintf("Workspace not found on newly created sidecar %s.", sidecarID)).
-					withCode("sidecar.workspace_missing").
-					withSuggestion("Run 'chunk sidecar env build' to prepare the workspace.").
-					withExitCode(ExitNotFound).
-					wrap(wsErr)
-			}
-			streams.ErrPrintf("warning: %v (%q); run 'chunk sidecar env build' to set up the workspace; running %s locally instead\n", wsErr, dest, commandNames(remoteCfg.Commands))
-			localCfg.Commands = append(remoteCfg.Commands, localCfg.Commands...)
-		} else {
-			r, err := validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, statusFn, streams)
-			combined.Passed += r.Passed
-			combined.Total += r.Total
-			runErr = err
+			return validate.Result{}, unreachableSidecar(sidecarID, freshlyCreated, commandNames(remoteCfg.Commands), err)
 		}
+		if wsErr := validate.WorkspaceExists(ctx, execFn, dest); wsErr != nil {
+			return validate.Result{}, missingWorkspace(sidecarID, dest, freshlyCreated, commandNames(remoteCfg.Commands), wsErr)
+		}
+		r, err := validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, statusFn, streams)
+		combined.Passed += r.Passed
+		combined.Total += r.Total
+		runErr = err
 	}
 	if len(localCfg.Commands) > 0 {
 		r, err := mapValidateError(validate.RunAll(ctx, workDir, localCfg, statusFn, streams))

--- a/internal/cmd/validate_sidecar_fallback_test.go
+++ b/internal/cmd/validate_sidecar_fallback_test.go
@@ -157,3 +157,90 @@ func TestCannotCreateSidecarNamesOrgSource(t *testing.T) {
 			"only authorization failures are this function's business")
 	})
 }
+
+// TestUnreachableSidecarDoesNotDegradeToLocal covers the second half of
+// FACT-426. Creation was only the first way to end up running remote-marked
+// commands locally; a sidecar that already existed but could not be reached
+// took the same warn-and-continue path and produced the same false green.
+func TestUnreachableSidecarDoesNotDegradeToLocal(t *testing.T) {
+	t.Run("a pre-existing sidecar is not worth retrying", func(t *testing.T) {
+		err := unreachableSidecar("sc-1", false, "test, lint", io.EOF)
+
+		ue, ok := errors.AsType[*userError](err)
+		assert.Assert(t, ok, "want a structured userError, got %T: %v", err, err)
+		assert.Equal(t, ue.ErrorCode(), "sidecar.unreachable")
+		assert.Equal(t, ue.UserExitCode(), ExitAPIError)
+		assert.Assert(t, strings.Contains(ue.Detail(), "test, lint"),
+			"the detail must name the commands that did not run, got %q", ue.Detail())
+		// A sidecar that has gone unreachable will not fix itself, so "try
+		// again" would send the user in a circle.
+		assert.Assert(t, !strings.Contains(ue.Suggestion(), "Try again"),
+			"got %q", ue.Suggestion())
+		assert.Assert(t, strings.Contains(ue.Suggestion(), "chunk sidecar"),
+			"the suggestion must point at a next step, got %q", ue.Suggestion())
+	})
+
+	// One this run provisioned may genuinely still be booting, which is the one
+	// case where waiting is the right advice.
+	t.Run("a fresh sidecar may still be starting", func(t *testing.T) {
+		err := unreachableSidecar("sc-1", true, "test", io.EOF)
+		ue, ok := errors.AsType[*userError](err)
+		assert.Assert(t, ok)
+		assert.Assert(t, strings.Contains(ue.UserMessage(), "newly created"), "got %q", ue.UserMessage())
+		assert.Assert(t, strings.Contains(ue.Suggestion(), "Try again"), "got %q", ue.Suggestion())
+	})
+}
+
+// TestMissingWorkspaceDoesNotDegradeToLocal covers the most reachable of the
+// two: a sidecar that syncs fine but never had 'chunk sidecar env build' run
+// still has no workspace to execute in.
+func TestMissingWorkspaceDoesNotDegradeToLocal(t *testing.T) {
+	err := missingWorkspace("sc-1", "/home/circleci/project", false, "test", io.EOF)
+
+	ue, ok := errors.AsType[*userError](err)
+	assert.Assert(t, ok, "want a structured userError, got %T: %v", err, err)
+	assert.Equal(t, ue.ErrorCode(), "sidecar.workspace_missing")
+	assert.Equal(t, ue.UserExitCode(), ExitNotFound)
+	assert.Assert(t, strings.Contains(ue.Detail(), "/home/circleci/project"),
+		"the detail must say where the workspace was expected, got %q", ue.Detail())
+	assert.Assert(t, strings.Contains(ue.Detail(), "test"),
+		"the detail must name the commands that did not run, got %q", ue.Detail())
+	assert.Assert(t, strings.Contains(ue.Suggestion(), "env build"),
+		"the suggestion must name the command that builds it, got %q", ue.Suggestion())
+}
+
+// TestSidecarSyncErrorKeepsSSHGuidance covers the other half of what made
+// Claire's report hard to act on. sshSessionError already phrases a missing key
+// with the ssh-keygen command that creates it, but the sync path wrapped the
+// cause bare, so the suggestion was dropped and only "ssh key not found: <path>"
+// reached the user.
+func TestSidecarSyncErrorKeepsSSHGuidance(t *testing.T) {
+	keyErr := &sidecar.KeyNotFoundError{Path: "/home/dev/.ssh/chunk_ai"}
+
+	err := sidecarSyncError(
+		context.Background(), nil, "sc-1", keyErr,
+		iostream.Streams{Out: io.Discard, Err: io.Discard},
+	)
+
+	ue, ok := errors.AsType[*userError](err)
+	assert.Assert(t, ok, "want a structured userError, got %T: %v", err, err)
+	assert.Equal(t, ue.ErrorCode(), "ssh.key_not_found")
+	assert.Assert(t, strings.Contains(ue.Suggestion(), "ssh-keygen"),
+		"the suggestion must name the command that creates the key, got %q", ue.Suggestion())
+	assert.Assert(t, strings.Contains(ue.Suggestion(), "/home/dev/.ssh/chunk_ai"),
+		"the suggestion must name the path it expected, got %q", ue.Suggestion())
+}
+
+// A sync failure that is not an SSH problem must keep the sync framing rather
+// than be forced through the SSH classifier.
+func TestSidecarSyncErrorKeepsSyncFramingForOtherFailures(t *testing.T) {
+	err := sidecarSyncError(
+		context.Background(), nil, "sc-1", io.ErrUnexpectedEOF,
+		iostream.Streams{Out: io.Discard, Err: io.Discard},
+	)
+
+	ue, ok := errors.AsType[*userError](err)
+	assert.Assert(t, ok, "want a structured userError, got %T: %v", err, err)
+	assert.Assert(t, strings.Contains(ue.UserMessage(), "sync"),
+		"got %q", ue.UserMessage())
+}

--- a/internal/cmd/validate_sidecar_fallback_test.go
+++ b/internal/cmd/validate_sidecar_fallback_test.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+)
+
+// fallbackEnv gives a project rooted in a temp dir with its own state and
+// config directories, so nothing here reads or writes the developer's real
+// sidecar state.
+func fallbackEnv(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
+	t.Setenv(config.EnvCircleCIOrgID, "")
+
+	stateDir, err := sidecar.StateDir()
+	assert.NilError(t, err)
+	assert.NilError(t, os.MkdirAll(stateDir, 0o755))
+	return dir
+}
+
+func fallbackClient(t *testing.T, cci *fakes.FakeCircleCI) *circleci.Client {
+	t.Helper()
+	srv := httptest.NewServer(cci)
+	t.Cleanup(srv.Close)
+	client, err := circleci.NewClient(circleci.Config{Token: "test-token", BaseURL: srv.URL})
+	assert.NilError(t, err)
+	return client
+}
+
+// TestResolveSidecarReportsCreateRejection is the regression test for FACT-426.
+//
+// A token that cannot create sidecars used to produce a one-line warning and
+// then a full local run: the commands the config marked remote were executed
+// on the developer's machine and reported as if they had passed on a sidecar.
+// The rejection must reach the caller instead.
+func TestResolveSidecarReportsCreateRejection(t *testing.T) {
+	workDir := fallbackEnv(t)
+	cci := fakes.NewFakeCircleCI()
+	cci.CreateStatusCode = http.StatusForbidden
+
+	var sidecarID string
+	created, err := resolveSidecar(
+		context.Background(), fallbackClient(t, cci), &sidecarID,
+		"org-1", "", workDir, nil,
+		iostream.Streams{Out: io.Discard, Err: io.Discard},
+	)
+
+	assert.Assert(t, err != nil, "a rejected create must fail the run, not fall back to a local one")
+	assert.Assert(t, !created)
+	assert.Equal(t, sidecarID, "", "no sidecar ID may be reported when creation was refused")
+
+	// The old code printed only the wrapped cause ("create sidecar: not
+	// authorized"), discarding the message and suggestion that say what to do.
+	ue, ok := errors.AsType[*userError](err)
+	assert.Assert(t, ok, "want a structured userError, got %T: %v", err, err)
+	assert.Equal(t, ue.ErrorCode(), "sidecar.not_authorized")
+	assert.Assert(t, strings.Contains(ue.Detail(), "org-1"),
+		"the detail must name the org that refused, got %q", ue.Detail())
+	assert.Assert(t, strings.Contains(ue.Suggestion(), "chunk org list"),
+		"the suggestion must point at a next step, got %q", ue.Suggestion())
+	assert.Equal(t, ue.UserExitCode(), ExitAuthError)
+}
+
+// TestResolveSidecarReportsUnpickableOrg covers the no-org-ID case: a fresh
+// repo with nothing in .chunk/config.json, more than one collaboration to
+// choose from, and no TTY to choose with. The picker's suggestion is the
+// useful part and used to be swallowed with the error.
+func TestResolveSidecarReportsUnpickableOrg(t *testing.T) {
+	workDir := fallbackEnv(t)
+	cci := fakes.NewFakeCircleCI()
+	cci.Collaborations = []fakes.Collaboration{
+		{ID: "org-aaa", Name: "circleci", VCSType: "github"},
+		{ID: "org-bbb", Name: "circleci-public", VCSType: "github"},
+	}
+
+	var sidecarID string
+	created, err := resolveSidecar(
+		context.Background(), fallbackClient(t, cci), &sidecarID,
+		"", "", workDir, nil,
+		iostream.Streams{Out: io.Discard, Err: io.Discard},
+	)
+
+	assert.Assert(t, err != nil, "an unresolvable org must fail the run, not fall back to a local one")
+	assert.Assert(t, !created)
+
+	ue, ok := errors.AsType[*userError](err)
+	assert.Assert(t, ok, "want a structured userError, got %T: %v", err, err)
+	assert.Assert(t, strings.Contains(ue.Suggestion(), "orgID"),
+		"the suggestion must name the setting that fixes this, got %q", ue.Suggestion())
+}
+
+// TestResolveSidecarUsesActiveSidecar guards the path that must stay quiet:
+// when state already names a sidecar there is nothing to create and no error
+// to report.
+func TestResolveSidecarUsesActiveSidecar(t *testing.T) {
+	workDir := fallbackEnv(t)
+	cci := fakes.NewFakeCircleCI()
+	cci.CreateStatusCode = http.StatusForbidden // must never be reached
+
+	var sidecarID string
+	created, err := resolveSidecar(
+		context.Background(), fallbackClient(t, cci), &sidecarID,
+		"org-1", "", workDir, &sidecar.ActiveSidecar{SidecarID: "sc-existing"},
+		iostream.Streams{Out: io.Discard, Err: io.Discard},
+	)
+
+	assert.NilError(t, err)
+	assert.Assert(t, !created, "reusing state is not a fresh provision")
+	assert.Equal(t, sidecarID, "sc-existing")
+}
+
+// TestCannotCreateSidecarNamesOrgSource covers the ambiguity that made Claire's
+// report hard to act on: four different places can supply the org ID, and the
+// error never said which one had been used.
+func TestCannotCreateSidecarNamesOrgSource(t *testing.T) {
+	rejected := circleci.ErrNotAuthorized
+
+	t.Run("names an explicit source", func(t *testing.T) {
+		err := cannotCreateSidecar("org-1", "--org-id", rejected)
+		assert.Assert(t, err != nil)
+		ue, ok := errors.AsType[*userError](err)
+		assert.Assert(t, ok)
+		assert.Assert(t, strings.Contains(ue.Detail(), "--org-id"),
+			"got %q", ue.Detail())
+	})
+
+	// An empty source means the org was auto-picked from a single
+	// collaboration, which is exactly the case where the user never chose it.
+	t.Run("omits the clause when auto-picked", func(t *testing.T) {
+		err := cannotCreateSidecar("org-1", "", rejected)
+		ue, ok := errors.AsType[*userError](err)
+		assert.Assert(t, ok)
+		assert.Assert(t, strings.Contains(ue.Detail(), "org-1"), "got %q", ue.Detail())
+		assert.Assert(t, !strings.Contains(ue.Detail(), "org ID from"),
+			"no source clause when there is no source, got %q", ue.Detail())
+	})
+
+	t.Run("passes through non-auth errors", func(t *testing.T) {
+		assert.Assert(t, cannotCreateSidecar("org-1", "--org-id", io.EOF) == nil,
+			"only authorization failures are this function's business")
+	})
+}


### PR DESCRIPTION
## Summary
- `chunk validate` was silently passing: when sidecar creation failed, it warned once, ran `remote`-marked commands locally instead, and exited `0` — so the Stop hook saw success and said nothing.
- The real fix suggestion (e.g. `chunk org list`) was getting swallowed by `%v` formatting, leaving users with a bare `create sidecar: not authorized` instead.
- `resolveSidecar` and `runSplitCommands` no longer degrade to local runs on failure — they return errors. This covers all three creation failures and the two post-creation cases (unreachable sidecar, no workspace), so `remote` commands are never silently run locally (`grep -c "locally instead"` → `0`).
- New errors are more actionable: `cannotCreateSidecar` names the org and where its ID came from (flag/env/config/auto-pick); `sidecarSyncError` checks for missing SSH keys and surfaces the `ssh-keygen` fix instead of a bare "not found."
- "No active sidecar" is now a proper status line instead of a raw first-line banner in the hook's `Stop hook error:` output.
- Both new errors list the commands that got skipped. `.gitignore` also now excludes `test-reports/`.

## Notes

- **Sharp edge:** if a repo has both remote and local commands and the sidecar is unavailable, nothing runs now — not even the local ones. Intentional, since a half-run reporting a pass is the same false green in a smaller package.
- `chunk init` does not install a `Stop` hook; repos get it from a checked-in `.claude/settings.json` (ours came from #272). Exposure was narrower than "every repo that ran `init`."
- The missing-workspace path is covered by unit tests on the error helper, not an end-to-end repro — that needs a live sidecar with no workspace built.

## Test Plan

- [ ] `task test` passes (1366 tests, 2 env-gated skips)
- [ ] `task lint` passes (0 issues)
- [ ] Against a fake API refusing `POST /api/v3/sidecar/instances`, `chunk validate` with a `remote`-marked command fails non-zero and runs nothing locally — verified for all three creation failures
- [ ] Same three cases on released 0.7.156 run locally and exit `0`, confirming the regression
- [ ] Control: `orgID` set correctly and creation refused still fails closed, and the error names `Project config (.chunk/config.json)` as the source
- [ ] Happy path: sidecar is still created and commands still run remotely
- [ ] `chunk validate --identity-file /nonexistent` surfaces `SSH key not found` with the `ssh-keygen` suggestion
- [ ] Full `chunk validate` against a real sidecar: 4/4 passed, all remote

Fixes FACT-426.
