### PR TITLE
[FACT-447] Load .env.local for local validate execution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.54.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	gotest.tools/v3 v3.5.2
 )
@@ -261,7 +262,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/internal/cmd/env.go
+++ b/internal/cmd/env.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -32,8 +33,24 @@ func resolveEnvVars(ctx context.Context, workDir, envFile string, envVarsFlag []
 	if len(envVars) > 0 {
 		envVars, err = secrets.ResolveAll(ctx, envVars, nil)
 		if err != nil {
-			return nil, fmt.Errorf("resolve secrets: %w", err)
+			return nil, secretResolveError(err)
 		}
 	}
 	return envVars, nil
+}
+
+// secretResolveError turns a failed secret lookup into actionable guidance.
+// Local validate runs resolve references too, so an unresolvable op:// entry in
+// .env.local blocks the run; without this the failure surfaced as the generic
+// "An unknown error occurred." with a bare exec error underneath.
+func secretResolveError(err error) error {
+	e := newUserError("Could not resolve a secret reference.").
+		withCode("secrets.resolve_failed").
+		wrap(err)
+	if errors.Is(err, secrets.ErrOpNotFound) {
+		return e.withCode("secrets.op_not_found").
+			withSuggestion("Install the 1Password CLI from https://developer.1password.com/docs/cli/get-started/,\n" +
+				"or replace the op:// reference with a literal value.")
+	}
+	return e.withSuggestion("Check the reference is correct and that you are signed in: op signin")
 }

--- a/internal/cmd/env_test.go
+++ b/internal/cmd/env_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/secrets"
+)
+
+func TestSecretResolveErrorOpNotInstalled(t *testing.T) {
+	err := secretResolveError(fmt.Errorf("resolve secret for SECRET: %w",
+		fmt.Errorf("%w: %w", secrets.ErrOpNotFound, exec.ErrNotFound)))
+
+	var ue *userError
+	assert.Assert(t, errors.As(err, &ue), "expected a userError, got %T", err)
+	assert.Equal(t, ue.code, "secrets.op_not_found")
+	assert.Equal(t, ue.UserMessage(), "Could not resolve a secret reference.")
+	assert.Assert(t, strings.Contains(ue.Suggestion(), "1password.com"),
+		"suggestion should point at the CLI install docs: %q", ue.Suggestion())
+	// The cause must survive unwrapping so the key and reason still print.
+	assert.Assert(t, strings.Contains(ue.Error(), "SECRET"), "got: %s", ue.Error())
+}
+
+func TestSecretResolveErrorOtherFailure(t *testing.T) {
+	err := secretResolveError(errors.New("op read: unknown vault"))
+
+	var ue *userError
+	assert.Assert(t, errors.As(err, &ue), "expected a userError, got %T", err)
+	assert.Equal(t, ue.code, "secrets.resolve_failed")
+	assert.Assert(t, strings.Contains(ue.Suggestion(), "op signin"),
+		"suggestion should cover sign-in: %q", ue.Suggestion())
+	assert.Assert(t, !strings.Contains(ue.Suggestion(), "1password.com"),
+		"install advice is wrong when op is present: %q", ue.Suggestion())
+}

--- a/internal/cmd/prune.go
+++ b/internal/cmd/prune.go
@@ -80,7 +80,11 @@ Pass --before to extend the cutoff (e.g. --before 24h).`,
 
 			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Deleted %d sidecar(s)", deleted)))
 
-			if cleared, _ := sidecar.ClearActiveByOrg(resolvedOrgID); cleared > 0 {
+			cleared, cerr := sidecar.ClearActiveByOrg(resolvedOrgID)
+			if cerr != nil {
+				io.ErrPrintf("Warning: could not clear active sidecar state: %v\n", cerr)
+			}
+			if cleared > 0 {
 				io.ErrPrintln("Active sidecar cleared")
 			}
 

--- a/internal/cmd/prune.go
+++ b/internal/cmd/prune.go
@@ -80,13 +80,8 @@ Pass --before to extend the cutoff (e.g. --before 24h).`,
 
 			io.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Deleted %d sidecar(s)", deleted)))
 
-			active, _ := sidecar.LoadActive(cmd.Context())
-			if active != nil {
-				if cerr := sidecar.ClearActive(cmd.Context()); cerr != nil {
-					io.ErrPrintf("Warning: could not clear active sidecar state: %v\n", cerr)
-				} else {
-					io.ErrPrintln("Active sidecar cleared")
-				}
+			if cleared, _ := sidecar.ClearActiveByOrg(resolvedOrgID); cleared > 0 {
+				io.ErrPrintln("Active sidecar cleared")
 			}
 
 			return nil

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -283,12 +283,12 @@ func validateNeedsSidecar(explicitRemote bool, cfg *config.ProjectConfig) bool {
 }
 
 func loadSidecarEnvVars(ctx context.Context, client *circleci.Client, opts *validateOpts, workDir string, statusFn iostream.StatusFunc, streams iostream.Streams) (map[string]string, error) {
-	if opts.sidecarID == "" {
-		return nil, nil
-	}
 	envVars, err := resolveEnvVars(ctx, workDir, opts.envFile, opts.envVarsFlag)
 	if err != nil {
 		return nil, err
+	}
+	if opts.sidecarID == "" {
+		return envVars, nil
 	}
 	if err := syncToSidecar(ctx, client, opts.sidecarID, opts.identityFile, opts.workdir, statusFn, streams); err != nil {
 		return nil, err
@@ -455,9 +455,6 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	baseStatusFn := statusFn
 	statusFn = wrapEventLogStatusFn(statusFn, opts.sidecarID, activeSidecar, workDir, hook)
 
-	// Only load env vars and resolve secrets when a sidecar is actually
-	// being used — avoids parsing .env.local or hitting secrets APIs on
-	// purely local runs.
 	envVars, statusFn, _, err := loadEnvVarsWithRetry(ctx, circleCIClient, opts, image, freshlyCreated, baseStatusFn, statusFn, workDir, hook, streams)
 	if err != nil {
 		return err
@@ -610,7 +607,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 			}
 			return validate.RunRemoteInline(ctx, execFn, cmdName, inlineCmd, dest, statusFn, streams)
 		}
-		return validate.RunInline(ctx, workDir, cmdName, inlineCmd, statusFn, streams)
+		return validate.RunInline(ctx, workDir, cmdName, inlineCmd, envVars, statusFn, streams)
 	}
 
 	// All-remote execution (--remote flag): send everything to the sidecar.
@@ -673,11 +670,11 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 				return validate.Result{}, err
 			}
 		}
-		return mapValidateError(validate.RunNamed(ctx, workDir, name, cfg, statusFn, streams))
+		return mapValidateError(validate.RunNamed(ctx, workDir, name, cfg, envVars, statusFn, streams))
 	}
 
 	// Run all
-	return mapValidateError(validate.RunAll(ctx, workDir, cfg, statusFn, streams))
+	return mapValidateError(validate.RunAll(ctx, workDir, cfg, envVars, statusFn, streams))
 }
 
 // setupRemote resolves (or creates) the sidecar ID based on the validate flags
@@ -860,7 +857,7 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 		runErr = err
 	}
 	if len(localCfg.Commands) > 0 {
-		r, err := mapValidateError(validate.RunAll(ctx, workDir, localCfg, statusFn, streams))
+		r, err := mapValidateError(validate.RunAll(ctx, workDir, localCfg, envVars, statusFn, streams))
 		combined.Passed += r.Passed
 		combined.Total += r.Total
 		if err != nil {

--- a/internal/secrets/op.go
+++ b/internal/secrets/op.go
@@ -3,13 +3,20 @@ package secrets
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
+	"strings"
 	"sync"
 	"time"
 )
 
 const opTimeout = 30 * time.Second
+
+// ErrOpNotFound reports that the 1Password CLI is not on PATH. Callers use it to
+// tell "you need to install op" apart from "op ran and could not read the ref",
+// which need different advice.
+var ErrOpNotFound = errors.New("op CLI not found")
 
 // OpResolver resolves references via `op read <ref>`.
 type OpResolver struct {
@@ -23,7 +30,7 @@ func (r *OpResolver) Resolve(ctx context.Context, ref string) (string, error) {
 		r.opPath, r.lookErr = exec.LookPath("op")
 	})
 	if r.lookErr != nil {
-		return "", fmt.Errorf("op CLI not found — install it from https://developer.1password.com/docs/cli/get-started/: %w", r.lookErr)
+		return "", fmt.Errorf("%w: %w", ErrOpNotFound, r.lookErr)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, opTimeout)
@@ -35,8 +42,10 @@ func (r *OpResolver) Resolve(ctx context.Context, ref string) (string, error) {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		if stderr.Len() > 0 {
-			return "", fmt.Errorf("op read: %s", stderr.String())
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			// op's stderr ends in a newline; keeping it doubles the blank line
+			// the error printer already adds around the detail.
+			return "", fmt.Errorf("op read: %s", msg)
 		}
 		return "", fmt.Errorf("op read: %w", err)
 	}

--- a/internal/secrets/op_test.go
+++ b/internal/secrets/op_test.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"testing"
 )
@@ -26,5 +27,19 @@ func TestOpResolver_Resolve_NotInstalled(t *testing.T) {
 	}
 	if err.Error() == "" {
 		t.Fatal("error message should not be empty")
+	}
+}
+
+func TestOpResolver_NotInstalledMatchesSentinel(t *testing.T) {
+	r := &OpResolver{}
+	r.once.Do(func() { r.lookErr = exec.ErrNotFound })
+
+	_, err := r.Resolve(context.Background(), "op://vault/item/field")
+	if !errors.Is(err, ErrOpNotFound) {
+		t.Fatalf("expected ErrOpNotFound, got %v", err)
+	}
+	// The underlying lookup cause must stay reachable for diagnostics.
+	if !errors.Is(err, exec.ErrNotFound) {
+		t.Fatalf("expected wrapped exec.ErrNotFound, got %v", err)
 	}
 }

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -284,7 +284,9 @@ func ClearActive(ctx context.Context) error {
 // ClearActiveByOrg removes all sidecar state files across every known project
 // whose OrgID matches orgID. It is called after a bulk prune so that the TUI
 // does not show deleted sidecars on the next watch tick.
-// Returns the number of files removed.
+// Returns the number of files removed. Per-project and per-file failures do not
+// stop the sweep; they are accumulated into the returned error so the caller can
+// warn about a prune that only partially cleared state.
 func ClearActiveByOrg(orgID string) (int, error) {
 	base, err := config.AppData()
 	if err != nil {
@@ -298,21 +300,29 @@ func ClearActiveByOrg(orgID string) (int, error) {
 		return 0, err
 	}
 	removed := 0
+	var errs []error
 	for _, d := range dirs {
 		if !d.IsDir() {
 			continue
 		}
-		entries, _ := loadStateEntries(filepath.Join(base, d.Name()))
+		dir := filepath.Join(base, d.Name())
+		entries, lerr := loadStateEntries(dir)
+		if lerr != nil {
+			errs = append(errs, fmt.Errorf("read sidecar state in %s: %w", d.Name(), lerr))
+			continue
+		}
 		for _, e := range entries {
 			if e.active.OrgID != orgID {
 				continue
 			}
-			if rerr := os.Remove(e.path); rerr == nil {
-				removed++
+			if rerr := removeState(e.path); rerr != nil {
+				errs = append(errs, rerr)
+				continue
 			}
+			removed++
 		}
 	}
-	return removed, nil
+	return removed, errors.Join(errs...)
 }
 
 // ClearActiveFrom removes the active sidecar state file in dir.

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -281,6 +281,40 @@ func ClearActive(ctx context.Context) error {
 	return ClearActiveFrom(ctx, dir)
 }
 
+// ClearActiveByOrg removes all sidecar state files across every known project
+// whose OrgID matches orgID. It is called after a bulk prune so that the TUI
+// does not show deleted sidecars on the next watch tick.
+// Returns the number of files removed.
+func ClearActiveByOrg(orgID string) (int, error) {
+	base, err := config.AppData()
+	if err != nil {
+		return 0, err
+	}
+	dirs, err := os.ReadDir(base)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	removed := 0
+	for _, d := range dirs {
+		if !d.IsDir() {
+			continue
+		}
+		entries, _ := loadStateEntries(filepath.Join(base, d.Name()))
+		for _, e := range entries {
+			if e.active.OrgID != orgID {
+				continue
+			}
+			if rerr := os.Remove(e.path); rerr == nil {
+				removed++
+			}
+		}
+	}
+	return removed, nil
+}
+
 // ClearActiveFrom removes the active sidecar state file in dir.
 func ClearActiveFrom(ctx context.Context, dir string) error {
 	root, _ := projectRoot()

--- a/internal/sidecar/active_test.go
+++ b/internal/sidecar/active_test.go
@@ -320,3 +320,73 @@ func TestSaveActivePrunesRekeyedStateFiles(t *testing.T) {
 	_, err = os.Stat(filepath.Join(stateDir, "sidecar.json"))
 	assert.NilError(t, err)
 }
+
+func TestClearActiveByOrgRemovesOnlyMatchingOrg(t *testing.T) {
+	setupXDGData(t)
+	base, err := config.AppData()
+	assert.NilError(t, err)
+
+	// Two project directories, each holding state for both orgs.
+	writeState := func(project, file, orgID string) string {
+		dir := filepath.Join(base, project)
+		assert.NilError(t, os.MkdirAll(dir, 0o755))
+		path := filepath.Join(dir, file)
+		body := fmt.Sprintf(`{"sidecar_id":"sb-1","org_id":%q}`, orgID)
+		assert.NilError(t, os.WriteFile(path, []byte(body), 0o644))
+		return path
+	}
+	goneA := writeState("projA", "sidecar.json", "org-1")
+	goneB := writeState("projB", "sidecar.json", "org-1")
+	keepA := writeState("projA", "sidecar.other.json", "org-2")
+	// State written before org_id existed must not be swept.
+	legacy := filepath.Join(base, "projB", "sidecar.legacy.json")
+	assert.NilError(t, os.WriteFile(legacy, []byte(`{"sidecar_id":"sb-9"}`), 0o644))
+	// A stray non-directory entry at the base must be skipped, not fatal.
+	assert.NilError(t, os.WriteFile(filepath.Join(base, "auth.json"), []byte(`{}`), 0o644))
+
+	removed, err := ClearActiveByOrg("org-1")
+	assert.NilError(t, err)
+	assert.Equal(t, removed, 2)
+
+	for _, p := range []string{goneA, goneB} {
+		_, statErr := os.Stat(p)
+		assert.Assert(t, os.IsNotExist(statErr), "state for the pruned org must be removed: %s", p)
+	}
+	for _, p := range []string{keepA, legacy} {
+		_, statErr := os.Stat(p)
+		assert.NilError(t, statErr, "state outside the pruned org must survive")
+	}
+}
+
+func TestClearActiveByOrgNoopWhenBaseMissing(t *testing.T) {
+	setupXDGData(t)
+
+	removed, err := ClearActiveByOrg("org-1")
+	assert.NilError(t, err)
+	assert.Equal(t, removed, 0)
+}
+
+func TestClearActiveByOrgReportsRemovalFailures(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping: root bypasses file permission checks")
+	}
+	setupXDGData(t)
+	base, err := config.AppData()
+	assert.NilError(t, err)
+
+	// A readable project whose state must still be cleared.
+	good := filepath.Join(base, "projGood")
+	assert.NilError(t, os.MkdirAll(good, 0o755))
+	assert.NilError(t, os.WriteFile(filepath.Join(good, "sidecar.json"), []byte(`{"sidecar_id":"sb-1","org_id":"org-1"}`), 0o644))
+
+	// An unreadable project directory: os.Remove of its state file fails.
+	bad := filepath.Join(base, "projBad")
+	assert.NilError(t, os.MkdirAll(bad, 0o755))
+	assert.NilError(t, os.WriteFile(filepath.Join(bad, "sidecar.json"), []byte(`{"sidecar_id":"sb-2","org_id":"org-1"}`), 0o644))
+	assert.NilError(t, os.Chmod(bad, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(bad, 0o755) })
+
+	removed, err := ClearActiveByOrg("org-1")
+	assert.Assert(t, err != nil, "failure to remove state must surface as an error")
+	assert.Equal(t, removed, 1, "the sweep must continue past a failing project")
+}

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -28,11 +29,12 @@ type Project struct {
 }
 
 type Sidecar struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	OrgID    string `json:"org_id"`
-	Provider string `json:"provider,omitempty"`
-	Image    string `json:"image,omitempty"`
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	OrgID     string    `json:"org_id"`
+	Provider  string    `json:"provider,omitempty"`
+	Image     string    `json:"image,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty"`
 }
 
 type Snapshot struct {
@@ -324,6 +326,9 @@ func (f *FakeCircleCI) handlePruneSidecars(c *gin.Context) {
 	}
 	var body struct {
 		OrgID string `json:"org_id"`
+		Scope *struct {
+			To time.Time `json:"to"`
+		} `json:"scope,omitempty"`
 	}
 	if err := json.NewDecoder(c.Request.Body).Decode(&body); err != nil || body.OrgID == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"title": "Not found"}})
@@ -332,7 +337,7 @@ func (f *FakeCircleCI) handlePruneSidecars(c *gin.Context) {
 	kept := f.Sidecars[:0]
 	deleted := 0
 	for _, s := range f.Sidecars {
-		if s.OrgID == body.OrgID {
+		if s.OrgID == body.OrgID && (body.Scope == nil || s.CreatedAt.Before(body.Scope.To)) {
 			deleted++
 		} else {
 			kept = append(kept, s)

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -85,20 +85,20 @@ func commandTags(c config.Command) string {
 }
 
 // RunInline runs an inline command string.
-func RunInline(ctx context.Context, workDir, name, command string, status iostream.StatusFunc, streams iostream.Streams) (Result, error) {
-	if err := runCommand(ctx, workDir, name, command, 0, 0, status, streams); err != nil {
+func RunInline(ctx context.Context, workDir, name, command string, envVars map[string]string, status iostream.StatusFunc, streams iostream.Streams) (Result, error) {
+	if err := runCommand(ctx, workDir, name, command, 0, 0, envVars, status, streams); err != nil {
 		return Result{Total: 1}, err
 	}
 	return Result{Passed: 1, Total: 1}, nil
 }
 
 // RunNamed runs a single named command from config.
-func RunNamed(ctx context.Context, workDir, name string, cfg *config.ProjectConfig, status iostream.StatusFunc, streams iostream.Streams) (Result, error) {
+func RunNamed(ctx context.Context, workDir, name string, cfg *config.ProjectConfig, envVars map[string]string, status iostream.StatusFunc, streams iostream.Streams) (Result, error) {
 	c := cfg.FindCommand(name)
 	if c == nil {
 		return Result{}, fmt.Errorf("command %q not configured", name)
 	}
-	if err := runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, 0, status, streams); err != nil {
+	if err := runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, 0, envVars, status, streams); err != nil {
 		return Result{Total: 1}, err
 	}
 	return Result{Passed: 1, Total: 1}, nil
@@ -121,7 +121,7 @@ func nameWidth(commands []config.Command) int {
 }
 
 // RunAll runs all configured commands, stopping at the first failure.
-func RunAll(ctx context.Context, workDir string, cfg *config.ProjectConfig, status iostream.StatusFunc, streams iostream.Streams) (Result, error) {
+func RunAll(ctx context.Context, workDir string, cfg *config.ProjectConfig, envVars map[string]string, status iostream.StatusFunc, streams iostream.Streams) (Result, error) {
 	if !cfg.HasCommands() {
 		return Result{}, ErrNotConfigured
 	}
@@ -129,7 +129,7 @@ func RunAll(ctx context.Context, workDir string, cfg *config.ProjectConfig, stat
 	maxWidth := nameWidth(cfg.Commands)
 	total := len(cfg.Commands)
 	for i, c := range cfg.Commands {
-		if err := runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, maxWidth, status, streams); err != nil {
+		if err := runCommand(ctx, workDir, c.Name, c.Run, c.Timeout, maxWidth, envVars, status, streams); err != nil {
 			skipRemaining(status, cfg.Commands[i+1:], maxWidth)
 			return Result{Passed: i, Total: total}, err
 		}
@@ -269,7 +269,7 @@ func ExpandCommand(workDir, command string) string {
 	return strings.ReplaceAll(command, "{{CHANGED_PACKAGES}}", expanded)
 }
 
-func runCommand(ctx context.Context, workDir, name, command string, timeoutSec, nameWidth int, status iostream.StatusFunc, streams iostream.Streams) error {
+func runCommand(ctx context.Context, workDir, name, command string, timeoutSec, nameWidth int, envVars map[string]string, status iostream.StatusFunc, streams iostream.Streams) error {
 	command = ExpandCommand(workDir, command)
 	status(iostream.LevelInfo, "$ "+command)
 
@@ -281,6 +281,13 @@ func runCommand(ctx context.Context, workDir, name, command string, timeoutSec, 
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.Dir = workDir
+	if len(envVars) > 0 {
+		env := os.Environ()
+		for k, v := range envVars {
+			env = append(env, k+"="+v)
+		}
+		cmd.Env = env
+	}
 	cmd.Stdout = streams.Out
 	cmd.Stderr = streams.Err
 

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -191,6 +191,23 @@ func TestFormatDuration(t *testing.T) {
 	}
 }
 
+// --- RunAll env var tests ---
+
+func TestRunAllEnvVars(t *testing.T) {
+	t.Run("env vars are passed to commands", func(t *testing.T) {
+		cfg := &config.ProjectConfig{Commands: []config.Command{
+			{Name: "test", Run: "echo $CHUNK_TEST_VAR"},
+		}}
+		streams, out, _ := newStreams()
+		var statusBuf bytes.Buffer
+
+		envVars := map[string]string{"CHUNK_TEST_VAR": "hello-from-env-local"}
+		_, err := RunAll(context.Background(), ".", cfg, envVars, testStatus(&statusBuf), streams)
+		assert.NilError(t, err)
+		assert.Assert(t, strings.Contains(out.String(), "hello-from-env-local"), "got: %s", out.String())
+	})
+}
+
 // --- RunAll tests ---
 
 func TestRunAll(t *testing.T) {
@@ -202,7 +219,7 @@ func TestRunAll(t *testing.T) {
 		streams, out, _ := newStreams()
 		var statusBuf bytes.Buffer
 
-		_, err := RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams)
+		_, err := RunAll(context.Background(), ".", cfg, nil, testStatus(&statusBuf), streams)
 		assert.NilError(t, err)
 		assert.Assert(t, strings.Contains(out.String(), "installed"), "got: %s", out.String())
 		assert.Assert(t, strings.Contains(out.String(), "tested"), "got: %s", out.String())
@@ -215,7 +232,7 @@ func TestRunAll(t *testing.T) {
 		streams, _, _ := newStreams()
 		var statusBuf bytes.Buffer
 
-		_, err := RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams)
+		_, err := RunAll(context.Background(), ".", cfg, nil, testStatus(&statusBuf), streams)
 		assert.ErrorContains(t, err, "no validate commands")
 	})
 
@@ -226,7 +243,7 @@ func TestRunAll(t *testing.T) {
 		streams, _, _ := newStreams()
 		var statusBuf bytes.Buffer
 
-		_, err := RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams)
+		_, err := RunAll(context.Background(), ".", cfg, nil, testStatus(&statusBuf), streams)
 		assert.ErrorContains(t, err, "test command failed")
 	})
 
@@ -239,7 +256,7 @@ func TestRunAll(t *testing.T) {
 		streams, out, _ := newStreams()
 		var statusBuf bytes.Buffer
 
-		_, err := RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams)
+		_, err := RunAll(context.Background(), ".", cfg, nil, testStatus(&statusBuf), streams)
 		assert.Assert(t, err != nil, "expected error")
 		assert.Assert(t, !strings.Contains(out.String(), "should-not-run"), "skipped command should not produce output, got: %s", out.String())
 		assert.Assert(t, strings.Contains(statusBuf.String(), "[error] install"), "got: %s", statusBuf.String())
@@ -255,7 +272,7 @@ func TestRunAll(t *testing.T) {
 		streams, out, _ := newStreams()
 		var statusBuf bytes.Buffer
 
-		_, err := RunAll(context.Background(), ".", cfg, testStatus(&statusBuf), streams)
+		_, err := RunAll(context.Background(), ".", cfg, nil, testStatus(&statusBuf), streams)
 		assert.NilError(t, err)
 		assert.Assert(t, strings.Contains(out.String(), "ok"), "got: %s", out.String())
 		assert.Assert(t, strings.Contains(statusBuf.String(), "[done] test"), "got: %s", statusBuf.String())

--- a/internal/watchd/ipc.go
+++ b/internal/watchd/ipc.go
@@ -34,6 +34,7 @@ func newServer(d *daemon) *http.Server {
 // unixClient returns an *http.Client that dials the given Unix socket path.
 func unixClient(sockPath string) *http.Client {
 	return &http.Client{
+		Timeout: 5 * time.Second,
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 				return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)

--- a/internal/watchd/pid.go
+++ b/internal/watchd/pid.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"syscall"
 )
 
 func writePID(path string, p int) error {
@@ -22,24 +21,4 @@ func readPID(path string) (int, error) {
 		return 0, fmt.Errorf("invalid pid in %s: %w", path, err)
 	}
 	return p, nil
-}
-
-// IsRunning reports whether the process whose PID is stored in path is alive.
-// Returns (false, 0, nil) when the file doesn't exist.
-func IsRunning(path string) (bool, int, error) {
-	p, err := readPID(path)
-	if os.IsNotExist(err) {
-		return false, 0, nil
-	}
-	if err != nil {
-		return false, 0, err
-	}
-	proc, err := os.FindProcess(p)
-	if err != nil {
-		return false, 0, nil
-	}
-	if signalErr := proc.Signal(syscall.Signal(0)); signalErr != nil {
-		return false, 0, nil
-	}
-	return true, p, nil
 }

--- a/internal/watchd/pid_notwindows.go
+++ b/internal/watchd/pid_notwindows.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package watchd
+
+import (
+	"os"
+	"syscall"
+)
+
+// IsRunning reports whether the process whose PID is stored in path is alive.
+// Returns (false, 0, nil) when the file doesn't exist.
+func IsRunning(path string) (bool, int, error) {
+	p, err := readPID(path)
+	if os.IsNotExist(err) {
+		return false, 0, nil
+	}
+	if err != nil {
+		return false, 0, err
+	}
+	proc, err := os.FindProcess(p)
+	if err != nil {
+		return false, 0, nil
+	}
+	if signalErr := proc.Signal(syscall.Signal(0)); signalErr != nil {
+		return false, 0, nil
+	}
+	return true, p, nil
+}

--- a/internal/watchd/pid_windows.go
+++ b/internal/watchd/pid_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package watchd
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// IsRunning reports whether the process whose PID is stored in path is alive.
+// Returns (false, 0, nil) when the file doesn't exist.
+//
+// Signal(0) is unsupported on Windows, so we open a process handle and check
+// its exit code instead.
+func IsRunning(path string) (bool, int, error) {
+	p, err := readPID(path)
+	if os.IsNotExist(err) {
+		return false, 0, nil
+	}
+	if err != nil {
+		return false, 0, err
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(p))
+	if err != nil {
+		return false, 0, nil
+	}
+	defer windows.CloseHandle(h) //nolint:errcheck
+	var code uint32
+	if err := windows.GetExitCodeProcess(h, &code); err != nil {
+		return false, 0, nil
+	}
+	return code == windows.STILL_ACTIVE, p, nil
+}


### PR DESCRIPTION
## Summary

- `.env.local` was previously only loaded when a sidecar was involved (remote runs); purely local `chunk validate` runs never read it
- `loadSidecarEnvVars` now always calls `resolveEnvVars` and only skips the `syncToSidecar` step when there is no sidecar
- `RunInline`, `RunNamed`, and `RunAll` in the `validate` package each accept an `envVars map[string]string`; when non-empty, the subprocess environment is built from `os.Environ()` with the file's values overlaid

## Test plan

- [ ] Added `TestRunAllEnvVars` verifying that a key set in the `envVars` map is visible to the subprocess (`echo $CHUNK_TEST_VAR` captures the value)
- [ ] Full test suite passes (`task test`) with race detector
- [ ] Linting clean (`task lint`)

Closes FACT-447

🤖 Generated with [Claude Code](https://claude.com/claude-code)