### PR TITLE
Make chunk watch default to --all

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -143,7 +143,7 @@ chunk
 │           --json                  # Output as JSON
 │
 ├── watch [dir...]                  # Live TUI dashboard for active sidecars and recent activity
-│   --all                           # Watch all known projects, not just the current directory
+│   --focus                         # Watch only the current directory instead of all known projects
 │
 ├── hook                            # Manage chunk hook execution
 │   --project <path>                # Override project directory
@@ -206,7 +206,7 @@ chunk
   env var → `orgID` in `.chunk/config.json` → interactive org picker (TTY only).
   Non-interactive sessions (agents, CI) should set `orgID` in project config or
   pass `--org-id` / `CIRCLECI_ORG_ID`.
-- `watch` requires a TTY — it exits with an error if stdout is not a terminal. It polls sidecar state every 5 seconds and keeps an in-memory window of the 300 most recent event log entries. Use `j`/`k` or `↑`/`↓` to select a sidecar, `q` or `Esc` to quit. Running `watch` in a project also registers that project so `--all` finds it in future runs.
+- `watch` requires a TTY — it exits with an error if stdout is not a terminal. It polls sidecar state every 5 seconds and keeps an in-memory window of the 300 most recent event log entries. Use `j`/`k` or `↑`/`↓` to select a sidecar, `q` or `Esc` to quit. By default it watches every project it knows about; pass `--focus` to watch only the current directory. Running `watch` in a project also registers that project so future runs find it. `--all` is deprecated — it is now the default.
 - `chunk init` uses Claude to auto-detect the test command for the project.
   It generates `.claude/settings.json` with pre-commit hooks. It never touches
   CircleCI — tokens are prompted inline only when a command actually needs them.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -281,12 +281,12 @@ chunk watch  1 sidecar  main@a3f9e12                      15:04:32
   ↑/↓ j/k  select  ·  q  quit
 ```
 
-To watch multiple projects at once:
+`watch` shows every project you've watched before, not just the current one:
 
 ```bash
-chunk watch                   # current directory only
+chunk watch                   # all projects you've watched before
+chunk watch --focus           # current directory only
 chunk watch /path/to/other    # add another project
-chunk watch --all             # all projects you've watched before
 ```
 
 `watch` requires a TTY — it will not run in a non-interactive shell (CI, pipes).

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -19,7 +19,10 @@ import (
 )
 
 func newWatchCmd() *cobra.Command {
-	var all bool
+	var (
+		focus bool
+		all   bool
+	)
 
 	cmd := &cobra.Command{
 		Use:          "watch [dir...]",
@@ -39,15 +42,10 @@ func newWatchCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("watch: could not determine working directory: %w", err)
 			}
-			roots := []string{cwd}
-			if all {
-				known, err := sidecar.AllProjectRoots()
-				if err != nil {
-					return fmt.Errorf("watch: could not list projects: %w", err)
-				}
-				roots = append(roots, known...)
+			roots, err := watchRoots(cwd, focus, args)
+			if err != nil {
+				return err
 			}
-			roots = append(roots, args...)
 
 			seen := map[string]bool{}
 			var entries []watch.ProjectEntry
@@ -72,7 +70,7 @@ func newWatchCmd() *cobra.Command {
 					return fmt.Errorf("watch: data dir for %s: %w", abs, err)
 				}
 
-				// Register this project so future --all runs find it.
+				// Register this project so future runs discover it.
 				if err := os.MkdirAll(dataDir, 0o755); err == nil {
 					_ = os.WriteFile(filepath.Join(dataDir, "project-root"), []byte(abs), 0o644)
 				}
@@ -89,14 +87,32 @@ func newWatchCmd() *cobra.Command {
 				})
 			}
 
-			m := watch.New(entries, all)
+			m := watch.New(entries, !focus)
 			p := tea.NewProgram(m, tea.WithContext(cmd.Context()))
 			_, err = p.Run()
 			return err
 		},
 	}
 
-	cmd.Flags().BoolVar(&all, "all", false, "Watch all known projects, not just the current directory")
+	cmd.Flags().BoolVar(&focus, "focus", false, "Watch only the current directory instead of all known projects")
+	// --all is now the default; keep the flag so existing invocations keep working.
+	cmd.Flags().BoolVar(&all, "all", false, "Watch all known projects (default)")
+	_ = cmd.Flags().MarkDeprecated("all", "watching all known projects is now the default; use --focus to watch only the current directory")
 	cmd.AddCommand(newWatchDaemonCmd())
 	return cmd
+}
+
+// watchRoots returns the directories the dashboard should watch: the current
+// directory plus any explicitly named ones, and — unless focus is set — every
+// project chunk has seen before.
+func watchRoots(cwd string, focus bool, args []string) ([]string, error) {
+	roots := []string{cwd}
+	if !focus {
+		known, err := sidecar.AllProjectRoots()
+		if err != nil {
+			return nil, fmt.Errorf("watch: could not list projects: %w", err)
+		}
+		roots = append(roots, known...)
+	}
+	return append(roots, args...), nil
 }

--- a/internal/cmd/watch_test.go
+++ b/internal/cmd/watch_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+)
+
+// registerProject writes the project-root breadcrumb chunk drops for every
+// project it has seen, so AllProjectRoots discovers root.
+func registerProject(t *testing.T, root string) {
+	t.Helper()
+	dataDir, err := config.ProjectDataDir(root)
+	assert.NilError(t, err)
+	assert.NilError(t, os.MkdirAll(dataDir, 0o755))
+	assert.NilError(t, os.WriteFile(filepath.Join(dataDir, "project-root"), []byte(root), 0o644))
+}
+
+func TestWatchRootsDefaultsToAllKnownProjects(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
+
+	cwd, other := t.TempDir(), t.TempDir()
+	registerProject(t, other)
+
+	roots, err := watchRoots(cwd, false, nil)
+	assert.NilError(t, err)
+	assert.Assert(t, slices.Contains(roots, cwd), "cwd should always be watched: %v", roots)
+	assert.Assert(t, slices.Contains(roots, other), "known project should be watched by default: %v", roots)
+}
+
+func TestWatchRootsFocusLimitsToCwdAndArgs(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
+
+	cwd, other, explicit := t.TempDir(), t.TempDir(), t.TempDir()
+	registerProject(t, other)
+
+	roots, err := watchRoots(cwd, true, []string{explicit})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, roots, []string{cwd, explicit})
+}
+
+func TestWatchAllFlagIsDeprecatedButAccepted(t *testing.T) {
+	cmd := newWatchCmd()
+
+	focus := cmd.Flags().Lookup("focus")
+	assert.Assert(t, focus != nil, "--focus should be registered")
+	assert.Equal(t, focus.DefValue, "false")
+
+	all := cmd.Flags().Lookup("all")
+	assert.Assert(t, all != nil, "--all should still parse for existing invocations")
+	assert.Assert(t, all.Deprecated != "", "--all should be marked deprecated")
+}

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -169,7 +169,7 @@ func SaveActiveTo(ctx context.Context, dir string, a ActiveSidecar) error {
 		return err
 	}
 	pruneRekeyedState(dir, path, a.SidecarID)
-	// Write a breadcrumb so chunk watch --all can discover this project.
+	// Write a breadcrumb so chunk watch can discover this project.
 	_ = os.WriteFile(filepath.Join(dir, "project-root"), []byte(root), 0o644)
 	return nil
 }

--- a/internal/tui/watch/model.go
+++ b/internal/tui/watch/model.go
@@ -157,10 +157,11 @@ type Model struct {
 // always falls back to index 0 — the most recently active sidecar.
 const noSelection = "\x00"
 
-// New creates a Model ready to run. When watchAll is true, each poll also
-// checks for projects that have saved a sidecar since the dashboard started
-// and adds them, so a sidecar started after `chunk watch --all` launches
-// still shows up without a restart.
+// New creates a Model ready to run. When watchAll is true (the default for
+// `chunk watch`; `--focus` turns it off), each poll also checks for projects
+// that have saved a sidecar since the dashboard started and adds them, so a
+// sidecar started after the dashboard launches still shows up without a
+// restart.
 func New(projects []ProjectEntry, watchAll bool) Model {
 	return Model{
 		loadFn:        loadFromDaemon,


### PR DESCRIPTION
## Summary

`chunk watch` watched only the current working directory unless you passed `--all`. Watching everything is the more useful default for a dashboard:

- **Default** - discovers and watches every project `chunk` has seen before (via the `project-root` breadcrumbs each project registers).
- **`--focus`** (new) - narrows back to the current directory only.
- **`--all`** - kept and still parses, but mark deprecated: it prints a one-line pointer to `--focus` and is hidden from `--help`. Existing invocations, aliases, and script's don't break.

Root selection moved out of `RunE` into a `watchRoots(cwd, focus, args)` helper so it can be tested without a TTY.

## Test plan

- [x] `task test` - 1369 pass, 2 skipped (the usual env-gated `CHUNK_ENV_BUILDER_ACCEPTANCE` / `op` CLI ones)
- [x] `task lint` - 0 issues
- [x] New unit tests in `internal/cmd/watch_test_go`:
    - default mode picks up a project registered via its breadcrumb
    - `--focus' yields exactly `[cwd, args...]` and ignores known projects
    - `--all` is still registered and carries a deprecation message
- [x] `chunk watch --help` shows `--focus`, hides `--all`
- [x] `chunk watch --all` prints `Flag --all has been deprecated, watching all known projects is now the default; use --focus...` and still proceeds
- [x]  Manual: run `chunk watch` in a real terminal with sidecars in two projects, confirm both appear; then `chunk watch --focus` and confirm only the current one does