### PR TITLE
Show per-session sidecars separately in watch TUI

### DIFF
--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -231,7 +231,7 @@ func initHook(ctx context.Context, hook *hookContext, workDir string, tree gitut
 	if len(sessionLabel) > 8 {
 		sessionLabel = sessionLabel[:8]
 	}
-	if branch, err := gitutil.CurrentBranch(); err == nil && branch != "" {
+	if branch, err := gitutil.CurrentBranchIn(workDir); err == nil && branch != "" {
 		streams.ErrPrintln(ui.ErrBold(fmt.Sprintf("── validate · %s [%s]", branch, sessionLabel)))
 	} else {
 		streams.ErrPrintln(ui.ErrBold(fmt.Sprintf("── validate [%s]", sessionLabel)))

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -226,6 +226,16 @@ func initHook(ctx context.Context, hook *hookContext, workDir string, tree gitut
 	// Route stdout to stderr so all output appears in the Stop
 	// hook feedback block that Claude Code shows the agent.
 	streams = iostream.Streams{Out: streams.Err, Err: streams.Err}
+	// Print a header so concurrent stop-hook runs are distinguishable.
+	sessionLabel := hook.sessionID
+	if len(sessionLabel) > 8 {
+		sessionLabel = sessionLabel[:8]
+	}
+	if branch, err := gitutil.CurrentBranch(); err == nil && branch != "" {
+		streams.ErrPrintln(ui.ErrBold(fmt.Sprintf("── validate · %s [%s]", branch, sessionLabel)))
+	} else {
+		streams.ErrPrintln(ui.ErrBold(fmt.Sprintf("── validate [%s]", sessionLabel)))
+	}
 	if validate.HooksDisabled(workDir, os.Getenv(config.EnvChunkHooksDisabled) != "") {
 		streams.ErrPrintln("chunk validate: hooks are disabled — skipping validation")
 		return ctx, streams, false, validate.NewHookExitError(1)

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -32,7 +32,21 @@ func RepoRoot(from string) (string, error) {
 	}
 }
 
-// CurrentBranch returns the current git branch name.
+// CurrentBranchIn returns the current git branch name for the repo rooted at dir.
+// Returns an error if in detached HEAD state or not in a git repo.
+func CurrentBranchIn(dir string) (string, error) {
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--abbrev-ref", gitHEAD).Output()
+	if err != nil {
+		return "", fmt.Errorf("get current branch: %w", err)
+	}
+	branch := strings.TrimSpace(string(out))
+	if branch == gitHEAD {
+		return "", fmt.Errorf("detached HEAD state")
+	}
+	return branch, nil
+}
+
+// CurrentBranch returns the current git branch name resolved from the process CWD.
 // Returns an error if in detached HEAD state or not in a git repo.
 func CurrentBranch() (string, error) {
 	out, err := exec.Command("git", "rev-parse", "--abbrev-ref", gitHEAD).Output()

--- a/internal/tui/watch/model.go
+++ b/internal/tui/watch/model.go
@@ -416,6 +416,9 @@ func (m Model) renderSidecarPane(maxLines int) []string {
 		if sc.snapshotName != "" {
 			add("   " + vdim("◈ "+truncate(sc.snapshotName, leftPaneWidth-6)))
 		}
+		if sc.id != "" && sc.name != "" {
+			add("   " + vdim(truncate(sidecarDisplayName(sc.name, sc.id), leftPaneWidth-6)))
+		}
 
 		switch {
 		case sc.running:
@@ -444,9 +447,9 @@ func (m Model) renderSidecarPane(maxLines int) []string {
 			add("")
 		}
 
-		// Suppress dotted divider when next sidecar is in the same repo group.
+		// Divider between sidecars in the same repo group.
 		if i < len(m.sidecars)-1 && m.sidecars[i+1].repoName == sc.repoName {
-			add(vdim(strings.Repeat("·", leftPaneWidth)))
+			add(muted(strings.Repeat("─", leftPaneWidth)))
 		}
 	}
 	return lines
@@ -942,6 +945,14 @@ func mergeBranches(sidecars []sidecarInfo) []sidecarInfo {
 			result = append(result, sc)
 			seen[k] = len(result) - 1
 		} else {
+			// Only merge when one entry is a local runner (id == ""). Two real
+			// sidecars on the same branch belong to different sessions and must
+			// stay separate so they are distinguishable in the left pane.
+			if result[idx].id != "" && sc.id != "" {
+				result = append(result, sc)
+				seen[k] = len(result) - 1
+				continue
+			}
 			result[idx].sidecarIDs = append(result[idx].sidecarIDs, sc.sidecarIDs...)
 			// Promote a real sidecar over a local-only primary so the left pane
 			// shows sync state rather than a pass/fail badge.


### PR DESCRIPTION
- Don't collapse two real sidecars on the same branch; sessions that each created their own sidecar now appear as distinct left-pane entries
- Show sidecar name under snapshot name in left pane
- Print branch + session label header in stop-hook runs so concurrent invocations are distinguishable in the feedback block 

before:
<img width="744" height="762" alt="Screenshot 2026-08-25 at 11 09 00 AM" src="https://github.com/user-attachments/assets/4ceec5aa-45d8-4b7c-8c8d-341c9d474aa5" />
after:
<img width="886" height="409" alt="Screenshot 2026-08-25 at 1 51 38 PM" src="https://github.com/user-attachments/assets/82767a67-c1d8-4589-a814-80d860f92586" />
