### PR TITLE
Add opt in desktop notifications for validate results

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -170,7 +170,7 @@ chunk
 - `build-prompt` does not write intermediate files by default. Pass `--debug` to write the raw details JSON, analysis markdown, and PR rankings CSV alongside the prompt — useful when diagnosing unexpected prompt output.
 - `task run` defaults to pipeline-as-tool mode; use `--no-pipeline-as-tool`
   to disable.
-- `config set` user keys: `model`, `telemetry`. Project keys (`.chunk/config.json`):
+- `config set` user keys: `model`, `telemetry`, `notifications`. Project keys (`.chunk/config.json`):
   `orgID`, `validation.sidecarImage`. Credentials use `chunk auth set`, not `config set`.
 - `validate --mark-remote` sets `remote: true` on commands in `.chunk/config.json`
   and exits without running anything. With a `[name]` it marks that one command;
@@ -277,6 +277,7 @@ chunk
 |-----|-------|-------------|
 | `model` | user config (`~/.config/chunk/config.json`) | Claude model override |
 | `telemetry` | user config (`~/.config/chunk/config.json`) | Anonymous usage telemetry (`true`/`false`, default: `true`) |
+| `notifications` | user config (`~/.config/chunk/config.json`) | OS desktop notification after validate completes (`true`/`false`, default: `false`) |
 | `orgID` | `.chunk/config.json` | CircleCI organization ID for sidecar subcommands |
 | `validation.sidecarImage` | `.chunk/config.json` | Snapshot or image ID for sidecar bootstrap and validate (unset: a matching org snapshot is selected automatically) |
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -62,6 +62,7 @@ func newConfigShowCmd() *cobra.Command {
 					OrgID              configEntry `json:"orgID"`
 					UseSSHIdentityFile bool        `json:"useSSHIdentityFile"`
 					Telemetry          bool        `json:"telemetry"`
+					Notifications      bool        `json:"notifications"`
 				}
 				maskOrEmpty := func(key string) string {
 					if key == "" {
@@ -77,6 +78,7 @@ func newConfigShowCmd() *cobra.Command {
 					OrgID:              configEntry{Value: orgID, Source: orgIDSource},
 					UseSSHIdentityFile: rc.UseSSHIdentityFile,
 					Telemetry:          telemetryEnabled,
+					Notifications:      userCfg.Notifications,
 				})
 			}
 
@@ -109,6 +111,7 @@ func newConfigShowCmd() *cobra.Command {
 
 			io.Printf("%s %v\n", ui.Label("useSSHIdentityFile:", w), rc.UseSSHIdentityFile)
 			io.Printf("%s %v\n", ui.Label("telemetry:", w), telemetryEnabled)
+			io.Printf("%s %v\n", ui.Label("notifications:", w), userCfg.Notifications)
 
 			return nil
 		},
@@ -123,7 +126,7 @@ func newConfigSetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "set <key> <value>",
 		Short: "Set a config value",
-		Long:  "Set a config value. Use 'chunk auth set <provider>' to store credentials with validation.\n\nUser keys: model, useSSHIdentityFile, telemetry\nProject keys: orgID, validation.sidecarImage",
+		Long:  "Set a config value. Use 'chunk auth set <provider>' to store credentials with validation.\n\nUser keys: model, useSSHIdentityFile, telemetry, notifications\nProject keys: orgID, validation.sidecarImage",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
@@ -159,7 +162,7 @@ func newConfigSetCmd() *cobra.Command {
 			if !config.ValidConfigKeys[key] {
 				return &userError{
 					msg:    fmt.Sprintf("Unknown config key: %q.", key),
-					detail: "Supported keys: model, useSSHIdentityFile, telemetry, orgID, validation.sidecarImage.",
+					detail: "Supported keys: model, useSSHIdentityFile, telemetry, notifications, orgID, validation.sidecarImage.",
 					errMsg: fmt.Sprintf("unknown config key %q", key),
 				}
 			}
@@ -173,33 +176,23 @@ func newConfigSetCmd() *cobra.Command {
 			case "model":
 				cfg.Model = value
 			case "useSSHIdentityFile":
-				switch value {
-				case "true", "1":
-					cfg.UseSSHIdentityFile = true
-				case "false", "0":
-					cfg.UseSSHIdentityFile = false
-				default:
-					return &userError{
-						msg:    fmt.Sprintf("Invalid value %q for useSSHIdentityFile.", value),
-						detail: "Accepted values: true, false.",
-						errMsg: fmt.Sprintf("invalid boolean value %q", value),
-					}
+				b, err := parseBoolValue("useSSHIdentityFile", value)
+				if err != nil {
+					return err
 				}
+				cfg.UseSSHIdentityFile = b
 			case "telemetry":
-				switch value {
-				case "true", "1":
-					enabled := true
-					cfg.Telemetry = &enabled
-				case "false", "0":
-					enabled := false
-					cfg.Telemetry = &enabled
-				default:
-					return &userError{
-						msg:    fmt.Sprintf("Invalid value %q for telemetry.", value),
-						detail: "Accepted values: true, false.",
-						errMsg: fmt.Sprintf("invalid boolean value %q", value),
-					}
+				b, err := parseBoolValue("telemetry", value)
+				if err != nil {
+					return err
 				}
+				cfg.Telemetry = &b
+			case "notifications":
+				b, err := parseBoolValue("notifications", value)
+				if err != nil {
+					return err
+				}
+				cfg.Notifications = b
 			}
 
 			if err := config.Save(cfg); err != nil {
@@ -209,5 +202,20 @@ func newConfigSetCmd() *cobra.Command {
 			io.Printf("%s\n", ui.Success(fmt.Sprintf("Set %s to %s", key, value)))
 			return nil
 		},
+	}
+}
+
+func parseBoolValue(key, value string) (bool, error) {
+	switch value {
+	case "true", "1":
+		return true, nil
+	case "false", "0":
+		return false, nil
+	default:
+		return false, &userError{
+			msg:    fmt.Sprintf("Invalid value %q for %s.", value, key),
+			detail: "Accepted values: true, false.",
+			errMsg: fmt.Sprintf("invalid boolean value %q", value),
+		}
 	}
 }

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -415,7 +415,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			// does rather than repeating that bookkeeping here: clearing the failure
 			// counter, and whatever else the success branch grows later.
 			n := len(cfg.Commands)
-			return finishValidate(cmd, hook, nil, start, cfg, validate.Result{Passed: n, Total: n}, wrapEventLogStatusFn(statusFn, "", nil, workDir, hook), streams, rc.Notifications)
+			return finishValidate(cmd, hook, nil, start, cfg, validate.Result{Passed: n, Total: n}, wrapEventLogStatusFn(statusFn, "", nil, workDir, hook), streams, notifyFunc(rc.Notifications))
 		}
 	}
 
@@ -470,7 +470,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			streams.ErrPrintf("  %s\n", ui.ErrDim(fmt.Sprintf("chunk validate: cache write failed: %v", err)))
 		}
 	}
-	return finishValidate(cmd, hook, execErr, start, cfg, result, statusFn, streams, rc.Notifications)
+	return finishValidate(cmd, hook, execErr, start, cfg, result, statusFn, streams, notifyFunc(rc.Notifications))
 }
 
 // loadEnvVarsWithRetry loads sidecar env vars, and if the sidecar is unusable
@@ -535,8 +535,18 @@ func wrapEventLogStatusFn(statusFn iostream.StatusFunc, sidecarID string, active
 	return eventlog.WrapFromDir(dataDir, statusFn, op, sidecarID, scName, sidecar.CurrentBranch(workDir))
 }
 
+// notifyFunc returns notify.Send when enabled is true, or nil to skip notifications.
+func notifyFunc(enabled bool) func(title, body string) {
+	if enabled {
+		return notify.Send
+	}
+	return nil
+}
+
 // finishValidate reports the validate outcome and handles hook exit codes.
-func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start time.Time, cfg *config.ProjectConfig, result validate.Result, statusFn iostream.StatusFunc, streams iostream.Streams, notifyDesktop bool) error {
+// notifyFn, when non-nil, is called with the notification title and body;
+// pass notify.Send for real desktop notifications, or a capturing closure in tests.
+func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start time.Time, cfg *config.ProjectConfig, result validate.Result, statusFn iostream.StatusFunc, streams iostream.Streams, notifyFn func(title, body string)) error {
 	maxAttempts := validate.DefaultMaxAttempts
 	if hook != nil {
 		if ma := cfg.StopHookMaxAttempts; ma > 0 {
@@ -556,11 +566,11 @@ func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start 
 	} else {
 		statusFn(iostream.LevelDone, fmt.Sprintf("%s  %s", summary, elapsed))
 	}
-	if notifyDesktop {
+	if notifyFn != nil {
 		if execErr != nil {
-			notify.Send("chunk validate failed", fmt.Sprintf("%d/%d checks passed · %s", result.Passed, result.Total, elapsed))
+			notifyFn("chunk validate failed", fmt.Sprintf("%d/%d checks passed · %s", result.Passed, result.Total, elapsed))
 		} else {
-			notify.Send("chunk validate passed", fmt.Sprintf("%d/%d checks passed · %s", result.Passed, result.Total, elapsed))
+			notifyFn("chunk validate passed", fmt.Sprintf("%d/%d checks passed · %s", result.Passed, result.Total, elapsed))
 		}
 	}
 	if hook == nil {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -24,6 +24,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/notify"
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
 	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
 	"github.com/CircleCI-Public/chunk-cli/internal/tui"
@@ -414,7 +415,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			// does rather than repeating that bookkeeping here: clearing the failure
 			// counter, and whatever else the success branch grows later.
 			n := len(cfg.Commands)
-			return finishValidate(cmd, hook, nil, start, cfg, validate.Result{Passed: n, Total: n}, wrapEventLogStatusFn(statusFn, "", nil, workDir, hook), streams)
+			return finishValidate(cmd, hook, nil, start, cfg, validate.Result{Passed: n, Total: n}, wrapEventLogStatusFn(statusFn, "", nil, workDir, hook), streams, rc.Notifications)
 		}
 	}
 
@@ -469,7 +470,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			streams.ErrPrintf("  %s\n", ui.ErrDim(fmt.Sprintf("chunk validate: cache write failed: %v", err)))
 		}
 	}
-	return finishValidate(cmd, hook, execErr, start, cfg, result, statusFn, streams)
+	return finishValidate(cmd, hook, execErr, start, cfg, result, statusFn, streams, rc.Notifications)
 }
 
 // loadEnvVarsWithRetry loads sidecar env vars, and if the sidecar is unusable
@@ -535,7 +536,7 @@ func wrapEventLogStatusFn(statusFn iostream.StatusFunc, sidecarID string, active
 }
 
 // finishValidate reports the validate outcome and handles hook exit codes.
-func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start time.Time, cfg *config.ProjectConfig, result validate.Result, statusFn iostream.StatusFunc, streams iostream.Streams) error {
+func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start time.Time, cfg *config.ProjectConfig, result validate.Result, statusFn iostream.StatusFunc, streams iostream.Streams, notifyDesktop bool) error {
 	maxAttempts := validate.DefaultMaxAttempts
 	if hook != nil {
 		if ma := cfg.StopHookMaxAttempts; ma > 0 {
@@ -554,6 +555,13 @@ func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start 
 		}
 	} else {
 		statusFn(iostream.LevelDone, fmt.Sprintf("%s  %s", summary, elapsed))
+	}
+	if notifyDesktop {
+		if execErr != nil {
+			notify.Send("chunk validate failed", fmt.Sprintf("%d/%d checks passed · %s", result.Passed, result.Total, elapsed))
+		} else {
+			notify.Send("chunk validate passed", fmt.Sprintf("%d/%d checks passed · %s", result.Passed, result.Total, elapsed))
+		}
 	}
 	if hook == nil {
 		return execErr

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,6 +125,10 @@ type UserConfig struct {
 	// case telemetry defaults to enabled (it is opt-out).
 	Telemetry *bool `json:"telemetry,omitempty"`
 
+	// Notifications enables OS desktop notifications after validate completes.
+	// false (zero value) means disabled; true means enabled (opt-in).
+	Notifications bool `json:"notifications,omitempty"`
+
 	// LegacyAPIKey reads the pre-rename "apiKey" field so existing users don't
 	// silently lose their stored Anthropic key on upgrade. Migrated into
 	// AnthropicAPIKey by Load and dropped on the next Save (omitempty).
@@ -147,6 +151,7 @@ type ResolvedConfig struct {
 	AnalyzeModel          string
 	PromptModel           string
 	UseSSHIdentityFile    bool
+	Notifications         bool
 }
 
 func resolveCircleCIToken(env EnvVars, cfg UserConfig) (string, string) {
@@ -336,6 +341,7 @@ func Resolve(flagAPIKey, flagModel string, _ bool) (ResolvedConfig, error) {
 	rc.AnthropicBaseURL = env.AnthropicBaseURL
 	rc.GitHubAPIURL = env.GitHubAPIURL
 	rc.UseSSHIdentityFile = cfg.UseSSHIdentityFile
+	rc.Notifications = cfg.Notifications
 
 	return rc, err
 }
@@ -361,6 +367,7 @@ func ResolveCircleCI(_ bool) (ResolvedConfig, error) {
 		AnthropicBaseURL:   env.AnthropicBaseURL,
 		GitHubAPIURL:       env.GitHubAPIURL,
 		UseSSHIdentityFile: cfg.UseSSHIdentityFile,
+		Notifications:      cfg.Notifications,
 	}
 	rc.CircleCIToken, rc.CircleCITokenSource = resolveCircleCIToken(env, cfg)
 	return rc, nil
@@ -395,6 +402,7 @@ var ValidConfigKeys = map[string]bool{
 	"model":              true,
 	"useSSHIdentityFile": true,
 	"telemetry":          true,
+	"notifications":      true,
 }
 
 // ValidProjectConfigKeys are the keys accepted by "config set" that write to

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -5,52 +5,55 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
+	"strings"
 	"time"
 )
 
-// Sender fires a desktop notification.
-type Sender interface {
-	Send(title, body string)
-}
-
-// DefaultSender is the process-wide Sender. Replace in tests with a spy.
-var DefaultSender Sender = &osSender{}
-
-// Send fires a desktop notification via DefaultSender. Errors are silently
+// Send fires a desktop notification in the background. Errors are silently
 // discarded — notifications are best-effort and must not disrupt the caller.
 func Send(title, body string) {
-	DefaultSender.Send(title, body)
-}
-
-type osSender struct{}
-
-func (osSender) Send(title, body string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
-		if path, err := exec.LookPath("terminal-notifier"); err == nil {
-			cmd = exec.CommandContext(ctx, path, "-title", title, "-message", body)
-		} else {
-			script := fmt.Sprintf(`display notification %q with title %q`, body, title)
-			cmd = exec.CommandContext(ctx, "osascript", "-e", script)
-		}
+		script := fmt.Sprintf(`display notification %s with title %s`, asQuote(body), asQuote(title))
+		cmd = exec.Command("osascript", "-e", script)
 	case "linux":
-		cmd = exec.CommandContext(ctx, "notify-send", title, body)
+		cmd = exec.Command("notify-send", title, body)
 	case "windows":
 		ps := fmt.Sprintf(
 			`[System.Reflection.Assembly]::LoadWithPartialName('System.Windows.Forms') | Out-Null; `+
 				`$n = New-Object System.Windows.Forms.NotifyIcon; `+
 				`$n.Icon = [System.Drawing.SystemIcons]::Information; `+
-				`$n.BalloonTipTitle = %q; $n.BalloonTipText = %q; `+
+				`$n.BalloonTipTitle = %s; $n.BalloonTipText = %s; `+
 				`$n.Visible = $true; $n.ShowBalloonTip(5000)`,
-			title, body,
+			psQuote(title), psQuote(body),
 		)
-		cmd = exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", ps)
+		cmd = exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", ps)
 	default:
 		return
 	}
-	_ = cmd.Run()
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = cmd.Start()
+		done := make(chan error, 1)
+		go func() { done <- cmd.Wait() }()
+		select {
+		case <-ctx.Done():
+			_ = cmd.Process.Kill()
+		case <-done:
+		}
+	}()
+}
+
+// asQuote wraps s in an AppleScript double-quoted string literal, escaping
+// internal double quotes by doubling them.
+func asQuote(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
+// psQuote wraps s in a PowerShell single-quoted string literal, escaping
+// internal single quotes by doubling them.
+func psQuote(s string) string {
+	return `'` + strings.ReplaceAll(s, `'`, `''`) + `'`
 }

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -31,8 +31,12 @@ func (osSender) Send(title, body string) {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
-		script := fmt.Sprintf(`display notification %q with title %q`, body, title)
-		cmd = exec.CommandContext(ctx, "osascript", "-e", script)
+		if path, err := exec.LookPath("terminal-notifier"); err == nil {
+			cmd = exec.CommandContext(ctx, path, "-title", title, "-message", body)
+		} else {
+			script := fmt.Sprintf(`display notification %q with title %q`, body, title)
+			cmd = exec.CommandContext(ctx, "osascript", "-e", script)
+		}
 	case "linux":
 		cmd = exec.CommandContext(ctx, "notify-send", title, body)
 	case "windows":

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,52 @@
+package notify
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+// Sender fires a desktop notification.
+type Sender interface {
+	Send(title, body string)
+}
+
+// DefaultSender is the process-wide Sender. Replace in tests with a spy.
+var DefaultSender Sender = &osSender{}
+
+// Send fires a desktop notification via DefaultSender. Errors are silently
+// discarded — notifications are best-effort and must not disrupt the caller.
+func Send(title, body string) {
+	DefaultSender.Send(title, body)
+}
+
+type osSender struct{}
+
+func (osSender) Send(title, body string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		script := fmt.Sprintf(`display notification %q with title %q`, body, title)
+		cmd = exec.CommandContext(ctx, "osascript", "-e", script)
+	case "linux":
+		cmd = exec.CommandContext(ctx, "notify-send", title, body)
+	case "windows":
+		ps := fmt.Sprintf(
+			`[System.Reflection.Assembly]::LoadWithPartialName('System.Windows.Forms') | Out-Null; `+
+				`$n = New-Object System.Windows.Forms.NotifyIcon; `+
+				`$n.Icon = [System.Drawing.SystemIcons]::Information; `+
+				`$n.BalloonTipTitle = %q; $n.BalloonTipText = %q; `+
+				`$n.Visible = $true; $n.ShowBalloonTip(5000)`,
+			title, body,
+		)
+		cmd = exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", ps)
+	default:
+		return
+	}
+	_ = cmd.Run()
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -3,8 +3,9 @@ package notify_test
 import (
 	"testing"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/notify"
 	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/notify"
 )
 
 type spySender struct {

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,0 +1,45 @@
+package notify_test
+
+import (
+	"testing"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/notify"
+	"gotest.tools/v3/assert"
+)
+
+type spySender struct {
+	title, body string
+	calls       int
+}
+
+func (s *spySender) Send(title, body string) {
+	s.title = title
+	s.body = body
+	s.calls++
+}
+
+func TestSend_routesTitleAndBody(t *testing.T) {
+	spy := &spySender{}
+	orig := notify.DefaultSender
+	notify.DefaultSender = spy
+	t.Cleanup(func() { notify.DefaultSender = orig })
+
+	notify.Send("chunk validate", "Passed: 3/3  1.2s")
+
+	assert.Equal(t, spy.calls, 1)
+	assert.Equal(t, spy.title, "chunk validate")
+	assert.Equal(t, spy.body, "Passed: 3/3  1.2s")
+}
+
+func TestSend_failure(t *testing.T) {
+	spy := &spySender{}
+	orig := notify.DefaultSender
+	notify.DefaultSender = spy
+	t.Cleanup(func() { notify.DefaultSender = orig })
+
+	notify.Send("chunk validate", "Failed: 1/3  2.1s")
+
+	assert.Equal(t, spy.calls, 1)
+	assert.Equal(t, spy.title, "chunk validate")
+	assert.Equal(t, spy.body, "Failed: 1/3  2.1s")
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -8,39 +8,32 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/notify"
 )
 
-type spySender struct {
-	title, body string
-	calls       int
+// TestNotifyFn_closure verifies that a capturing closure passed as a notifyFn
+// receives the title and body without any global state. This mirrors how
+// finishValidate uses a func parameter for testability.
+func TestNotifyFn_closure(t *testing.T) {
+	t.Parallel()
+
+	var gotTitle, gotBody string
+	var calls int
+	fn := func(title, body string) {
+		gotTitle = title
+		gotBody = body
+		calls++
+	}
+
+	fn("chunk validate passed", "3/3 checks passed · 1.2s")
+
+	assert.Equal(t, calls, 1)
+	assert.Equal(t, gotTitle, "chunk validate passed")
+	assert.Equal(t, gotBody, "3/3 checks passed · 1.2s")
 }
 
-func (s *spySender) Send(title, body string) {
-	s.title = title
-	s.body = body
-	s.calls++
-}
-
-func TestSend_routesTitleAndBody(t *testing.T) {
-	spy := &spySender{}
-	orig := notify.DefaultSender
-	notify.DefaultSender = spy
-	t.Cleanup(func() { notify.DefaultSender = orig })
-
-	notify.Send("chunk validate", "Passed: 3/3  1.2s")
-
-	assert.Equal(t, spy.calls, 1)
-	assert.Equal(t, spy.title, "chunk validate")
-	assert.Equal(t, spy.body, "Passed: 3/3  1.2s")
-}
-
-func TestSend_failure(t *testing.T) {
-	spy := &spySender{}
-	orig := notify.DefaultSender
-	notify.DefaultSender = spy
-	t.Cleanup(func() { notify.DefaultSender = orig })
-
-	notify.Send("chunk validate", "Failed: 1/3  2.1s")
-
-	assert.Equal(t, spy.calls, 1)
-	assert.Equal(t, spy.title, "chunk validate")
-	assert.Equal(t, spy.body, "Failed: 1/3  2.1s")
+// TestSend_exists just ensures the package-level Send function compiles and
+// is callable; it will be a no-op on platforms with no notification tool.
+func TestSend_exists(t *testing.T) {
+	t.Parallel()
+	// We cannot observe the OS notification, but we verify Send does not panic.
+	// On most CI runners (Linux with no notify-send) this is a silent no-op.
+	notify.Send("test title", "test body")
 }


### PR DESCRIPTION
## Summary

Adds an opt-in notifications user config key that sends an os desktop notification when chunk validate finishes, reporting pass/fail, check counts, and the elapsed time. Disabled by default - enable it with `chunk config set notifications true`. 

<img width="385" height="220" alt="Screenshot 2026-08-25 at 2 56 13 PM" src="https://github.com/user-attachments/assets/995c4e39-fc71-4c4e-b4a3-e2e38dba441b" />

## Implementation 
- Adds Notifications bool to UserConfig/ResolvedConfig and propagates it through config resolution
- New internal/notify/ package wraps the OS notification call
- finishValidate accepts a notifyDesktop bool and fires notify.Send after reporting the outcome
- config show/config set supports the new key; extracts parseBoolValue to deduplicate boolean parsing

## Test Plan
- [ ] chunk config set notifications true → chunk config show reflects it
- [ ] chunk validate (passing) → desktop notification appears with correct counts and elapsed
- [ ] chunk validate (failing) → desktop notification shows failed message
- [ ] chunk config set notifications false → no notification sent
- [ ] chunk config set notifications invalid → user-facing error with accepted values hint