### PR TITLE
Record a terminal event when validate fails before running

### DIFF
--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -569,7 +569,7 @@ func newSidecarSyncCmd() *cobra.Command {
 				if as, _ := sidecar.LoadActive(cmd.Context()); as != nil && as.SidecarID == sidecarID {
 					scName = as.Name
 				}
-				syncFn = eventlog.WrapFromDir(dataDir, syncFn, eventlog.OpSync, sidecarID, scName, sidecar.CurrentBranch(cwd))
+				syncFn = eventlog.Record(dataDir, syncFn, eventlog.OpSync, sidecarID, scName, sidecar.CurrentBranch(cwd)).Status
 			}
 			err = sidecar.RsyncSync(cmd.Context(), client, sidecarID, identityFile, authSock, workdir, cwd, syncFn)
 			if err != nil {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -467,7 +467,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 
 	envVars, statusFn, _, err := loadEnvVarsWithRetry(ctx, circleCIClient, opts, image, rc.CircleCITokenSource, freshlyCreated, baseStatusFn, statusFn, workDir, hook, streams)
 	if err != nil {
-		return err
+		return failBeforeRun(statusFn, start, err)
 	}
 
 	result, execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
@@ -539,6 +539,28 @@ func wrapEventLogStatusFn(statusFn iostream.StatusFunc, sidecarID string, active
 		op = eventlog.OpHook
 	}
 	return eventlog.WrapFromDir(dataDir, statusFn, op, sidecarID, scName, sidecar.CurrentBranch(workDir))
+}
+
+// maxSetupFailReason caps the error text folded into the terminal event so the
+// event log keeps one line per event.
+const maxSetupFailReason = 120
+
+// failBeforeRun records a terminal event for a failure that happened after the
+// event log was wired but before any command ran — a sync, secrets or env
+// resolve failure. finishValidate writes the only other terminal event and is
+// unreachable from these paths, so without this the invocation stays open in
+// the log and chunk watch reads it as still running. The message keeps the
+// "N/M passed" shape the log reader uses to close an invocation.
+func failBeforeRun(statusFn iostream.StatusFunc, start time.Time, err error) error {
+	reason := err.Error()
+	if i := strings.IndexByte(reason, '\n'); i >= 0 {
+		reason = reason[:i]
+	}
+	if r := []rune(reason); len(r) > maxSetupFailReason {
+		reason = string(r[:maxSetupFailReason]) + "…"
+	}
+	statusFn(iostream.LevelError, fmt.Sprintf("0/0 passed  %s  setup failed: %s", ui.FormatDuration(time.Since(start)), reason))
+	return err
 }
 
 // notifyFunc returns notify.Send when enabled is true, or nil to skip notifications.

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -424,7 +424,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			// does rather than repeating that bookkeeping here: clearing the failure
 			// counter, and whatever else the success branch grows later.
 			n := len(cfg.Commands)
-			return finishValidate(cmd, hook, nil, start, cfg, validate.Result{Passed: n, Total: n}, wrapEventLogStatusFn(statusFn, "", nil, workDir, hook), streams, notifyFunc(rc.Notifications))
+			return finishValidate(cmd, hook, nil, start, cfg, validate.Result{Passed: n, Total: n}, newValidateRecorder(statusFn, "", nil, workDir, hook), streams, notifyFunc(rc.Notifications))
 		}
 	}
 
@@ -457,26 +457,28 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return err
 	}
 
-	// Wire event log for all runs (both local and remote). The wrap goes here —
-	// after setupRemote fills opts.sidecarID but before loadSidecarEnvVars — so
-	// that sync and env-resolve status events are captured.
-	// Kept unwrapped so a replacement sidecar can be rewrapped against its own ID
-	// rather than logging its events under the sidecar it replaced.
-	baseStatusFn := statusFn
-	statusFn = wrapEventLogStatusFn(statusFn, opts.sidecarID, activeSidecar, workDir, hook)
+	// Wire the event log for all runs (both local and remote). The recorder is
+	// built here — after setupRemote fills opts.sidecarID but before
+	// loadSidecarEnvVars — so that sync and env-resolve events are captured.
+	// statusFn is kept so a replacement sidecar can get its own recorder rather
+	// than logging its events under the sidecar it replaced.
+	rec := newValidateRecorder(statusFn, opts.sidecarID, activeSidecar, workDir, hook)
 
-	envVars, statusFn, _, err := loadEnvVarsWithRetry(ctx, circleCIClient, opts, image, rc.CircleCITokenSource, freshlyCreated, baseStatusFn, statusFn, workDir, hook, streams)
+	// Only load env vars and resolve secrets when a sidecar is actually
+	// being used — avoids parsing .env.local or hitting secrets APIs on
+	// purely local runs.
+	envVars, rec, _, err := loadEnvVarsWithRetry(ctx, circleCIClient, opts, image, rc.CircleCITokenSource, freshlyCreated, statusFn, rec, workDir, hook, streams)
 	if err != nil {
-		return failBeforeRun(statusFn, start, err)
+		return failBeforeRun(rec, start, err)
 	}
 
-	result, execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, opts.workdir, allRemote, envVars, cfg, statusFn, streams)
+	result, execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, opts.workdir, allRemote, envVars, cfg, rec.Status, streams)
 	if execErr == nil && resultCache != nil {
 		if err := resultCache.Put(cacheKey, validate.CachedResult{CachedAt: time.Now()}); err != nil {
 			streams.ErrPrintf("  %s\n", ui.ErrDim(fmt.Sprintf("chunk validate: cache write failed: %v", err)))
 		}
 	}
-	return finishValidate(cmd, hook, execErr, start, cfg, result, statusFn, streams, notifyFunc(rc.Notifications))
+	return finishValidate(cmd, hook, execErr, start, cfg, result, rec, streams, notifyFunc(rc.Notifications))
 }
 
 // loadEnvVarsWithRetry loads sidecar env vars, and if the sidecar is unusable
@@ -487,49 +489,47 @@ func loadEnvVarsWithRetry(
 	opts *validateOpts,
 	image, tokenSource string,
 	freshlyCreated bool,
-	baseStatusFn, statusFn iostream.StatusFunc,
+	statusFn iostream.StatusFunc,
+	rec *eventlog.Recorder,
 	workDir string,
 	hook *hookContext,
 	streams iostream.Streams,
-) (map[string]string, iostream.StatusFunc, bool, error) {
-	envVars, err := loadSidecarEnvVars(ctx, circleCIClient, opts, workDir, statusFn, streams)
+) (map[string]string, *eventlog.Recorder, bool, error) {
+	envVars, err := loadSidecarEnvVars(ctx, circleCIClient, opts, workDir, rec.Status, streams)
 	if errors.Is(err, errSidecarUnusable) {
 		// The sidecar could not be used and its state has been dropped, so replace
 		// it here rather than failing and asking for the same command again. The
 		// reap cannot prevent this on its own: a sidecar can go away between the
 		// listing and the sync, and one the API rejects as out of date is listed
 		// like any other.
-		statusFn(iostream.LevelWarn, "sidecar was unusable, provisioning a replacement")
+		rec.Status(iostream.LevelWarn, "sidecar was unusable, provisioning a replacement")
 		opts.sidecarID = ""
 		if _, createErr := resolveOrCreateSidecarID(ctx, circleCIClient, &opts.sidecarID, opts.orgID, image, workDir, tokenSource, streams); createErr != nil {
-			return nil, statusFn, freshlyCreated, createErr
+			return nil, rec, freshlyCreated, createErr
 		}
 		// A replacement has none of the setup the old one had, so exec failures on
 		// it are real failures rather than grounds for falling back to local.
 		freshlyCreated = true
-		statusFn = wrapEventLogStatusFn(baseStatusFn, opts.sidecarID, nil, workDir, hook)
-		envVars, err = loadSidecarEnvVars(ctx, circleCIClient, opts, workDir, statusFn, streams)
+		rec = newValidateRecorder(statusFn, opts.sidecarID, nil, workDir, hook)
+		envVars, err = loadSidecarEnvVars(ctx, circleCIClient, opts, workDir, rec.Status, streams)
 	}
 	if err != nil {
 		if errors.Is(err, errSidecarUnusable) {
 			// Twice in one run is not a stale sidecar, so stop rather than churn.
-			return nil, statusFn, freshlyCreated, newUserError("Could not get a usable sidecar.").
+			return nil, rec, freshlyCreated, newUserError("Could not get a usable sidecar.").
 				withCode("sidecar.unusable").
 				withSuggestion("Create one explicitly with: chunk sidecar create").
 				wrap(err)
 		}
-		return nil, statusFn, freshlyCreated, err
+		return nil, rec, freshlyCreated, err
 	}
-	return envVars, statusFn, freshlyCreated, nil
+	return envVars, rec, freshlyCreated, nil
 }
 
-// wrapEventLogStatusFn wraps statusFn with event log recording for all runs,
-// both remote (sidecarID set) and local (sidecarID empty).
-func wrapEventLogStatusFn(statusFn iostream.StatusFunc, sidecarID string, activeSidecar *sidecar.ActiveSidecar, workDir string, hook *hookContext) iostream.StatusFunc {
-	dataDir, err := config.ProjectDataDir(workDir)
-	if err != nil {
-		return statusFn
-	}
+// newValidateRecorder returns the recorder that reports validate progress and
+// records it in the event log, for all runs both remote (sidecarID set) and
+// local (sidecarID empty).
+func newValidateRecorder(statusFn iostream.StatusFunc, sidecarID string, activeSidecar *sidecar.ActiveSidecar, workDir string, hook *hookContext) *eventlog.Recorder {
 	scName := ""
 	if activeSidecar != nil && activeSidecar.SidecarID == sidecarID {
 		scName = activeSidecar.Name
@@ -538,28 +538,18 @@ func wrapEventLogStatusFn(statusFn iostream.StatusFunc, sidecarID string, active
 	if hook != nil && hook.stopHookActive {
 		op = eventlog.OpHook
 	}
-	return eventlog.WrapFromDir(dataDir, statusFn, op, sidecarID, scName, sidecar.CurrentBranch(workDir))
+	// A missing data dir leaves the recorder reporting without recording.
+	dataDir, _ := config.ProjectDataDir(workDir)
+	return eventlog.Record(dataDir, statusFn, op, sidecarID, scName, sidecar.CurrentBranch(workDir))
 }
 
-// maxSetupFailReason caps the error text folded into the terminal event so the
-// event log keeps one line per event.
-const maxSetupFailReason = 120
-
-// failBeforeRun records a terminal event for a failure that happened after the
-// event log was wired but before any command ran — a sync, secrets or env
-// resolve failure. finishValidate writes the only other terminal event and is
-// unreachable from these paths, so without this the invocation stays open in
-// the log and chunk watch reads it as still running. The message keeps the
-// "N/M passed" shape the log reader uses to close an invocation.
-func failBeforeRun(statusFn iostream.StatusFunc, start time.Time, err error) error {
-	reason := err.Error()
-	if i := strings.IndexByte(reason, '\n'); i >= 0 {
-		reason = reason[:i]
-	}
-	if r := []rune(reason); len(r) > maxSetupFailReason {
-		reason = string(r[:maxSetupFailReason]) + "…"
-	}
-	statusFn(iostream.LevelError, fmt.Sprintf("0/0 passed  %s  setup failed: %s", ui.FormatDuration(time.Since(start)), reason))
+// failBeforeRun closes the run after a failure that happened once the recorder
+// was wired but before any command ran — a sync, secrets or env resolve
+// failure. finishValidate reports the only other closing event and is
+// unreachable from these paths, so without this the run stays open in the event
+// log and chunk watch reads it as still running.
+func failBeforeRun(rec *eventlog.Recorder, start time.Time, err error) error {
+	rec.Final(iostream.LevelError, fmt.Sprintf("setup failed  %s: %s", ui.FormatDuration(time.Since(start)), err), 0, 0)
 	return err
 }
 
@@ -574,7 +564,7 @@ func notifyFunc(enabled bool) func(title, body string) {
 // finishValidate reports the validate outcome and handles hook exit codes.
 // notifyFn, when non-nil, is called with the notification title and body;
 // pass notify.Send for real desktop notifications, or a capturing closure in tests.
-func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start time.Time, cfg *config.ProjectConfig, result validate.Result, statusFn iostream.StatusFunc, streams iostream.Streams, notifyFn func(title, body string)) error {
+func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start time.Time, cfg *config.ProjectConfig, result validate.Result, rec *eventlog.Recorder, streams iostream.Streams, notifyFn func(title, body string)) error {
 	maxAttempts := validate.DefaultMaxAttempts
 	if hook != nil {
 		if ma := cfg.StopHookMaxAttempts; ma > 0 {
@@ -584,15 +574,14 @@ func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start 
 
 	elapsed := ui.FormatDuration(time.Since(start))
 	summary := fmt.Sprintf("%d/%d passed", result.Passed, result.Total)
-	if execErr != nil {
-		if hook != nil {
-			attempt := validate.ReadAttempts(hook.sessionID) + 1
-			statusFn(iostream.LevelError, fmt.Sprintf("%s  %s (attempt %d/%d)", summary, elapsed, attempt, maxAttempts))
-		} else {
-			statusFn(iostream.LevelError, fmt.Sprintf("%s  %s", summary, elapsed))
-		}
-	} else {
-		statusFn(iostream.LevelDone, fmt.Sprintf("%s  %s", summary, elapsed))
+	switch {
+	case execErr != nil && hook != nil:
+		attempt := validate.ReadAttempts(hook.sessionID) + 1
+		rec.Final(iostream.LevelError, fmt.Sprintf("%s  %s (attempt %d/%d)", summary, elapsed, attempt, maxAttempts), result.Passed, result.Total)
+	case execErr != nil:
+		rec.Final(iostream.LevelError, fmt.Sprintf("%s  %s", summary, elapsed), result.Passed, result.Total)
+	default:
+		rec.Final(iostream.LevelDone, fmt.Sprintf("%s  %s", summary, elapsed), result.Passed, result.Total)
 	}
 	if notifyFn != nil {
 		if execErr != nil {

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 
@@ -834,4 +835,32 @@ func TestValidateListShowsRoutingAndRole(t *testing.T) {
 	for _, want := range []string{"test [remote, gate]", "format [local, autofix]", "bare [local]"} {
 		assert.Assert(t, strings.Contains(out, want), "missing %q in:\n%s", want, out)
 	}
+}
+
+func TestFailBeforeRunEmitsTerminalEvent(t *testing.T) {
+	var gotLevel iostream.Level
+	var gotMsg string
+	statusFn := func(level iostream.Level, msg string) {
+		gotLevel, gotMsg = level, msg
+	}
+
+	inErr := errors.New("bundle sync: agent: failed to sign challenge\nmore detail")
+	outErr := failBeforeRun(statusFn, time.Now(), inErr)
+
+	assert.Equal(t, outErr, inErr)
+	assert.Equal(t, gotLevel, iostream.LevelError)
+	// The "N/M passed" prefix is what chunk watch reads to close an invocation.
+	assert.Assert(t, strings.HasPrefix(gotMsg, "0/0 passed  "), "got %q", gotMsg)
+	assert.Assert(t, strings.Contains(gotMsg, "setup failed: bundle sync: agent: failed to sign challenge"), "got %q", gotMsg)
+	assert.Assert(t, !strings.Contains(gotMsg, "\n"), "got %q", gotMsg)
+}
+
+func TestFailBeforeRunTruncatesLongReason(t *testing.T) {
+	var gotMsg string
+	statusFn := func(_ iostream.Level, msg string) { gotMsg = msg }
+
+	failBeforeRun(statusFn, time.Now(), errors.New(strings.Repeat("x", maxSetupFailReason+50)))
+
+	assert.Assert(t, strings.Contains(gotMsg, strings.Repeat("x", maxSetupFailReason)+"…"), "got %q", gotMsg)
+	assert.Assert(t, !strings.Contains(gotMsg, strings.Repeat("x", maxSetupFailReason+1)), "got %q", gotMsg)
 }

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
@@ -837,30 +838,28 @@ func TestValidateListShowsRoutingAndRole(t *testing.T) {
 	}
 }
 
-func TestFailBeforeRunEmitsTerminalEvent(t *testing.T) {
-	var gotLevel iostream.Level
-	var gotMsg string
-	statusFn := func(level iostream.Level, msg string) {
-		gotLevel, gotMsg = level, msg
-	}
+func TestFailBeforeRunClosesTheRun(t *testing.T) {
+	dir := t.TempDir()
+	log, err := eventlog.Open(dir)
+	assert.NilError(t, err)
 
-	inErr := errors.New("bundle sync: agent: failed to sign challenge\nmore detail")
-	outErr := failBeforeRun(statusFn, time.Now(), inErr)
+	var reported string
+	rec := log.Recorder(func(_ iostream.Level, msg string) { reported = msg }, eventlog.OpValidate, "", "", "")
 
-	assert.Equal(t, outErr, inErr)
-	assert.Equal(t, gotLevel, iostream.LevelError)
-	// The "N/M passed" prefix is what chunk watch reads to close an invocation.
-	assert.Assert(t, strings.HasPrefix(gotMsg, "0/0 passed  "), "got %q", gotMsg)
-	assert.Assert(t, strings.Contains(gotMsg, "setup failed: bundle sync: agent: failed to sign challenge"), "got %q", gotMsg)
-	assert.Assert(t, !strings.Contains(gotMsg, "\n"), "got %q", gotMsg)
-}
+	inErr := errors.New("bundle sync: agent: failed to sign challenge")
+	assert.Equal(t, failBeforeRun(rec, time.Now(), inErr), inErr)
 
-func TestFailBeforeRunTruncatesLongReason(t *testing.T) {
-	var gotMsg string
-	statusFn := func(_ iostream.Level, msg string) { gotMsg = msg }
+	events, err := log.Recent(10)
+	assert.NilError(t, err)
+	assert.Equal(t, len(events), 1)
+	assert.Equal(t, events[0].Level, "error")
+	assert.Assert(t, strings.Contains(events[0].Msg, "setup failed"), "got %q", events[0].Msg)
+	assert.Assert(t, strings.Contains(events[0].Msg, inErr.Error()), "got %q", events[0].Msg)
+	assert.Equal(t, reported, events[0].Msg)
 
-	failBeforeRun(statusFn, time.Now(), errors.New(strings.Repeat("x", maxSetupFailReason+50)))
-
-	assert.Assert(t, strings.Contains(gotMsg, strings.Repeat("x", maxSetupFailReason)+"…"), "got %q", gotMsg)
-	assert.Assert(t, !strings.Contains(gotMsg, strings.Repeat("x", maxSetupFailReason+1)), "got %q", gotMsg)
+	// Nothing ran, so the run closes on a 0/0 tally.
+	passed, total, ok := events[0].Outcome()
+	assert.Assert(t, ok)
+	assert.Equal(t, passed, 0)
+	assert.Equal(t, total, 0)
 }

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -35,6 +37,42 @@ type Event struct {
 	Op          Op        `json:"op"`
 	Level       string    `json:"level"` // "step", "info", "warn", "done", "error"
 	Msg         string    `json:"msg"`
+
+	// Final marks the one event that closes an operation, with Passed and Total
+	// carrying its tally. A reader tells a finished operation from one still in
+	// flight by this, never by reading Msg.
+	Final  bool `json:"final,omitempty"`
+	Passed int  `json:"passed,omitempty"`
+	Total  int  `json:"total,omitempty"`
+}
+
+// Outcome reports whether e is the event that closes an operation, and the
+// tally to show for it.
+func (e Event) Outcome() (passed, total int, ok bool) {
+	if e.Final {
+		return e.Passed, e.Total, true
+	}
+	return legacyOutcome(e)
+}
+
+// legacyOutcome recognises the closing events written before Final existed,
+// which carried the tally in the message as "N/M passed  Xs". Logs are trimmed
+// as they grow, so this can go once the existing ones have rolled over.
+func legacyOutcome(e Event) (int, int, bool) {
+	if e.Op != OpValidate || (e.Level != levelDone && e.Level != levelError) {
+		return 0, 0, false
+	}
+	first, _, _ := strings.Cut(e.Msg, " ")
+	p, t, found := strings.Cut(first, "/")
+	if !found {
+		return 0, 0, false
+	}
+	passed, passedErr := strconv.Atoi(p)
+	total, totalErr := strconv.Atoi(t)
+	if passedErr != nil || totalErr != nil {
+		return 0, 0, false
+	}
+	return passed, total, true
 }
 
 const logFile = "events.jsonl"
@@ -113,33 +151,66 @@ func (l *Log) Append(e Event) error {
 	return errors.Join(encErr, f.Close())
 }
 
-// Wrap returns a StatusFunc that calls inner and also appends each call to the
-// log. All events will be tagged with op, sidecarID, sidecarName, and branch.
-func (l *Log) Wrap(inner iostream.StatusFunc, op Op, sidecarID, sidecarName, branch string) iostream.StatusFunc {
-	return func(level iostream.Level, msg string) {
-		if inner != nil {
-			inner(level, msg)
-		}
-		_ = l.Append(Event{
-			Ts:          time.Now(),
+// Recorder reports status through inner and records it in the log, tagging
+// every event with the operation it belongs to. Status records an ordinary
+// event; Final records the one that closes the operation.
+type Recorder struct {
+	log   *Log
+	inner iostream.StatusFunc
+	tag   Event
+}
+
+// Recorder returns a Recorder that reports through inner and appends each call
+// to the log, tagged with op, sidecarID, sidecarName, and branch.
+func (l *Log) Recorder(inner iostream.StatusFunc, op Op, sidecarID, sidecarName, branch string) *Recorder {
+	return &Recorder{
+		log:   l,
+		inner: inner,
+		tag: Event{
 			SidecarID:   sidecarID,
 			SidecarName: sidecarName,
 			Branch:      branch,
 			Op:          op,
-			Level:       levelStr(level),
-			Msg:         msg,
-		})
+		},
 	}
 }
 
-// WrapFromDir wraps fn with event-log appending using the log in dataDir.
-// Errors opening the log are silently ignored (best-effort; never blocks).
-func WrapFromDir(dataDir string, fn iostream.StatusFunc, op Op, sidecarID, sidecarName, branch string) iostream.StatusFunc {
+// Record returns a Recorder writing to the log in dataDir. Errors opening the
+// log are silently ignored (best-effort; never blocks) and the Recorder then
+// only reports through fn.
+func Record(dataDir string, fn iostream.StatusFunc, op Op, sidecarID, sidecarName, branch string) *Recorder {
 	el, err := Open(dataDir)
 	if err != nil {
-		return fn
+		return &Recorder{inner: fn, tag: Event{Op: op}}
 	}
-	return el.Wrap(fn, op, sidecarID, sidecarName, branch)
+	return el.Recorder(fn, op, sidecarID, sidecarName, branch)
+}
+
+// Status reports an ordinary event, one that leaves the operation open.
+func (r *Recorder) Status(level iostream.Level, msg string) {
+	r.record(level, msg, false, 0, 0)
+}
+
+// Final reports the event that closes the operation, tallying the commands that
+// passed out of those attempted. Both are zero when the operation failed before
+// running anything.
+func (r *Recorder) Final(level iostream.Level, msg string, passed, total int) {
+	r.record(level, msg, true, passed, total)
+}
+
+func (r *Recorder) record(level iostream.Level, msg string, final bool, passed, total int) {
+	if r.inner != nil {
+		r.inner(level, msg)
+	}
+	if r.log == nil {
+		return
+	}
+	e := r.tag
+	e.Ts = time.Now()
+	e.Level = levelStr(level)
+	e.Msg = msg
+	e.Final, e.Passed, e.Total = final, passed, total
+	_ = r.log.Append(e)
 }
 
 // Recent returns up to n most recent events from the log.

--- a/internal/eventlog/eventlog_test.go
+++ b/internal/eventlog/eventlog_test.go
@@ -148,7 +148,7 @@ func TestTailFromNoNewEvents(t *testing.T) {
 	}
 }
 
-func TestWrapForwardsAndLogs(t *testing.T) {
+func TestRecorderForwardsAndLogs(t *testing.T) {
 	dir := t.TempDir()
 	l, err := Open(dir)
 	if err != nil {
@@ -160,9 +160,9 @@ func TestWrapForwardsAndLogs(t *testing.T) {
 		innerCalls = append(innerCalls, msg)
 	}
 
-	wrapped := l.Wrap(inner, OpExec, "sc-id", "my-sc", "main")
-	wrapped(iostream.LevelStep, "step1")
-	wrapped(iostream.LevelDone, "done1")
+	rec := l.Recorder(inner, OpExec, "sc-id", "my-sc", "main")
+	rec.Status(iostream.LevelStep, "step1")
+	rec.Status(iostream.LevelDone, "done1")
 
 	if len(innerCalls) != 2 {
 		t.Fatalf("want 2 inner calls, got %d", len(innerCalls))
@@ -183,14 +183,14 @@ func TestWrapForwardsAndLogs(t *testing.T) {
 	}
 }
 
-func TestWrapNilInner(t *testing.T) {
+func TestRecorderNilInner(t *testing.T) {
 	dir := t.TempDir()
 	l, err := Open(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	wrapped := l.Wrap(nil, OpSync, "", "", "")
-	wrapped(iostream.LevelInfo, "should not panic")
+	rec := l.Recorder(nil, OpSync, "", "", "")
+	rec.Status(iostream.LevelInfo, "should not panic")
 }
 
 func TestLevelStr(t *testing.T) {
@@ -208,5 +208,71 @@ func TestLevelStr(t *testing.T) {
 		if got := levelStr(tt.in); got != tt.want {
 			t.Errorf("levelStr(%v) = %q, want %q", tt.in, got, tt.want)
 		}
+	}
+}
+
+func TestFinalRecordsOutcome(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := l.Recorder(nil, OpValidate, "sc-id", "my-sc", "main")
+	rec.Status(iostream.LevelInfo, "$ task test")
+	rec.Final(iostream.LevelError, "1/2 passed  3s", 1, 2)
+
+	got, err := l.Recent(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, ok := got[0].Outcome(); ok {
+		t.Error("status event should not close the operation")
+	}
+	passed, total, ok := got[1].Outcome()
+	if !ok || passed != 1 || total != 2 {
+		t.Errorf("Outcome() = (%d, %d, %v), want (1, 2, true)", passed, total, ok)
+	}
+}
+
+// A Recorder with no log still reports, so a project without a data dir does
+// not lose its status output.
+func TestRecordWithoutLogStillReports(t *testing.T) {
+	var got []string
+	rec := Record("", func(_ iostream.Level, msg string) { got = append(got, msg) }, OpValidate, "", "", "")
+	rec.Status(iostream.LevelInfo, "syncing")
+	rec.Final(iostream.LevelDone, "1/1 passed", 1, 1)
+	if len(got) != 2 {
+		t.Fatalf("want 2 reported messages, got %d", len(got))
+	}
+}
+
+func TestOutcomeLegacyMessages(t *testing.T) {
+	cases := []struct {
+		msg    string
+		passed int
+		total  int
+		want   bool
+	}{
+		{"3/3 passed  5.2s", 3, 3, true},
+		{"0/4 passed  13.7s", 0, 4, true},
+		{"test    8.0s (remote)", 0, 0, false},
+		{"lint    0.4s (local)", 0, 0, false},
+		{"synced", 0, 0, false},
+		{"", 0, 0, false},
+		{"a/b passed", 0, 0, false},
+	}
+	for _, c := range cases {
+		e := Event{Op: OpValidate, Level: levelDone, Msg: c.msg}
+		passed, total, ok := e.Outcome()
+		if ok != c.want || passed != c.passed || total != c.total {
+			t.Errorf("Event{Msg: %q}.Outcome() = (%d, %d, %v), want (%d, %d, %v)", c.msg, passed, total, ok, c.passed, c.total, c.want)
+		}
+	}
+}
+
+func TestOutcomeLegacyIgnoresOtherOps(t *testing.T) {
+	e := Event{Op: OpSync, Level: levelDone, Msg: "1/1 passed  1s"}
+	if _, _, ok := e.Outcome(); ok {
+		t.Error("a sync event should not close a validate run")
 	}
 }

--- a/internal/ui/watch/model.go
+++ b/internal/ui/watch/model.go
@@ -671,7 +671,7 @@ func (m Model) buildCollapsibleLines(st watchStyles, groups []invocationGroup, r
 			g := groups[gi]
 			for ei := len(g.events) - 1; ei >= 0 && len(rendered) < maxLines; ei-- {
 				e := g.events[ei]
-				if isSummaryEvent(e) {
+				if closesRun(e) {
 					continue // already shown in header
 				}
 				add("  " + renderEvent(st, e))
@@ -808,13 +808,11 @@ type invocationGroup struct {
 func outcomeOf(g invocationGroup) (icon, label, level string) {
 	for i := len(g.events) - 1; i >= 0; i-- {
 		e := g.events[i]
-		if !isSummaryEvent(e) {
+		passed, total, ok := e.Outcome()
+		if !ok {
 			continue
 		}
-		count := extractCount(e.Msg)
-		if count == "" {
-			count = "passed"
-		}
+		count := fmt.Sprintf("%d/%d", passed, total)
 		if e.Level == levelDone {
 			return ui.IconOK, count, levelDone
 		}
@@ -824,19 +822,6 @@ func outcomeOf(g invocationGroup) (icon, label, level string) {
 		return "⊘", "abandoned", levelAbandoned
 	}
 	return "●", "running", ""
-}
-
-// extractCount pulls the "N/M" fraction from a summary message like "3/3 passed  5.2s".
-func extractCount(msg string) string {
-	i := strings.IndexByte(msg, ' ')
-	if i <= 0 {
-		return ""
-	}
-	part := msg[:i]
-	if strings.Contains(part, "/") {
-		return part
-	}
-	return ""
 }
 
 // renderInvocationHeader renders a one-line summary for an invocation group.
@@ -896,7 +881,7 @@ func groupByInvocation(events []eventlog.Event) []invocationGroup {
 	cur := make([]eventlog.Event, 0, len(events))
 	for _, e := range events {
 		cur = append(cur, e)
-		if isSummaryEvent(e) {
+		if closesRun(e) {
 			groups = append(groups, invocationGroup{events: cur})
 			cur = nil
 		}
@@ -907,23 +892,10 @@ func groupByInvocation(events []eventlog.Event) []invocationGroup {
 	return groups
 }
 
-// isSummaryEvent reports whether e is the overall validate summary that closes
-// an invocation. Summary messages are formatted "N/M passed  Xs" — only digits
-// precede the first "/", distinguishing them from per-command done events.
-func isSummaryEvent(e eventlog.Event) bool {
-	if e.Op != eventlog.OpValidate || (e.Level != levelDone && e.Level != levelError) {
-		return false
-	}
-	i := strings.IndexByte(e.Msg, '/')
-	if i <= 0 {
-		return false
-	}
-	for _, c := range e.Msg[:i] {
-		if c < '0' || c > '9' {
-			return false
-		}
-	}
-	return true
+// closesRun reports whether e is the event that closes an invocation.
+func closesRun(e eventlog.Event) bool {
+	_, _, ok := e.Outcome()
+	return ok
 }
 
 // eventGroup is a slice of events from a single op-run.
@@ -978,18 +950,21 @@ func opTag(st watchStyles, op eventlog.Op) string {
 }
 
 func iconAndMsg(st watchStyles, e eventlog.Event) (string, string) {
+	// One event is one line in the pane, whatever the writer put in it: a
+	// message can carry an error, and errors wrap.
+	msg := strings.ReplaceAll(e.Msg, "\n", " ")
 	switch e.Level {
 	case levelDone:
-		return st.success(ui.IconOK), st.success(e.Msg)
+		return st.success(ui.IconOK), st.success(msg)
 	case "warn":
-		return st.warning(ui.IconWarn), st.warning(e.Msg)
+		return st.warning(ui.IconWarn), st.warning(msg)
 	case levelError:
-		return st.err(ui.IconFail), st.err(e.Msg)
+		return st.err(ui.IconFail), st.err(msg)
 	default:
-		if strings.HasPrefix(e.Msg, "$ ") {
-			return st.muted("$"), st.muted(strings.TrimPrefix(e.Msg, "$ "))
+		if cmd, ok := strings.CutPrefix(msg, "$ "); ok {
+			return st.muted("$"), st.muted(cmd)
 		}
-		return st.vdim("›"), st.muted(e.Msg)
+		return st.vdim("›"), st.muted(msg)
 	}
 }
 

--- a/internal/ui/watch/model.go
+++ b/internal/ui/watch/model.go
@@ -32,6 +32,10 @@ const (
 	// localRunnerName labels the synthesised row for validate runs that happened
 	// locally rather than on a sidecar.
 	localRunnerName = "local"
+
+	// levelAbandoned is not an event level: it marks an invocation whose process
+	// died before writing a terminal event, so nothing will ever close it.
+	levelAbandoned = "abandoned"
 )
 
 var spinFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
@@ -797,7 +801,10 @@ type invocationGroup struct {
 
 // outcomeOf returns the icon, label, and terminal level of the invocation.
 // The label is the N/M count extracted from the summary event (e.g. "3/3").
-// Returns "" level when the invocation is still running.
+// Returns "" level when the invocation is still running, and levelAbandoned
+// when it has no summary and has been silent for longer than runningTimeout —
+// a process that died without reporting will never close its group, so without
+// this it would read as running forever.
 func outcomeOf(g invocationGroup) (icon, label, level string) {
 	for i := len(g.events) - 1; i >= 0; i-- {
 		e := g.events[i]
@@ -812,6 +819,9 @@ func outcomeOf(g invocationGroup) (icon, label, level string) {
 			return ui.IconOK, count, levelDone
 		}
 		return ui.IconFail, count, levelError
+	}
+	if n := len(g.events); n > 0 && time.Since(g.events[n-1].Ts) > runningTimeout {
+		return "⊘", "abandoned", levelAbandoned
 	}
 	return "●", "running", ""
 }
@@ -850,6 +860,8 @@ func renderInvocationHeader(st watchStyles, g invocationGroup, expanded, selecte
 		outcomeStr = st.success(icon + " " + label)
 	case levelError:
 		outcomeStr = st.err(icon + " " + label)
+	case levelAbandoned:
+		outcomeStr = st.warning(icon + " " + label)
 	default:
 		outcomeStr = st.running(icon + " " + label)
 	}

--- a/internal/ui/watch/model_test.go
+++ b/internal/ui/watch/model_test.go
@@ -100,14 +100,14 @@ func TestGroupEvents_doneFollowedByNewOp(t *testing.T) {
 	}
 }
 
-// groupByInvocation / isSummaryEvent tests
+// groupByInvocation / closesRun tests
 
 func TestGroupByInvocation_singleRun(t *testing.T) {
 	events := []eventlog.Event{
 		{Op: eventlog.OpSync, Level: "done", Msg: "synced"},
 		{Op: eventlog.OpValidate, Level: "done", Msg: "test    1.0s (remote)"},
 		{Op: eventlog.OpValidate, Level: "done", Msg: "lint    0.2s (remote)"},
-		{Op: eventlog.OpValidate, Level: "done", Msg: "2/2 passed  1.5s"},
+		{Op: eventlog.OpValidate, Level: "done", Msg: "2/2 passed  1.5s", Final: true, Passed: 2, Total: 2},
 	}
 	groups := groupByInvocation(events)
 	if len(groups) != 1 {
@@ -122,11 +122,11 @@ func TestGroupByInvocation_twoRuns(t *testing.T) {
 	events := []eventlog.Event{
 		{Op: eventlog.OpSync, Level: "done", Msg: "synced"},
 		{Op: eventlog.OpValidate, Level: "done", Msg: "test    1.0s (remote)"},
-		{Op: eventlog.OpValidate, Level: "error", Msg: "0/1 passed  1.0s"},
+		{Op: eventlog.OpValidate, Level: "error", Msg: "0/1 passed  1.0s", Final: true, Total: 1},
 		// second run
 		{Op: eventlog.OpSync, Level: "done", Msg: "synced"},
 		{Op: eventlog.OpValidate, Level: "done", Msg: "test    0.8s (remote)"},
-		{Op: eventlog.OpValidate, Level: "done", Msg: "1/1 passed  0.9s"},
+		{Op: eventlog.OpValidate, Level: "done", Msg: "1/1 passed  0.9s", Final: true, Passed: 1, Total: 1},
 	}
 	groups := groupByInvocation(events)
 	if len(groups) != 2 {
@@ -145,23 +145,20 @@ func TestGroupByInvocation_inProgress(t *testing.T) {
 	}
 }
 
-func TestIsSummaryEvent(t *testing.T) {
+func TestClosesRun(t *testing.T) {
 	cases := []struct {
-		msg  string
+		name string
+		e    eventlog.Event
 		want bool
 	}{
-		{"3/3 passed  5.2s", true},
-		{"0/4 passed  13.7s", true},
-		{"0/0 passed  3.1s  setup failed: agent: failed to sign challenge", true},
-		{"test    8.0s (remote)", false},
-		{"lint    0.4s (local)", false},
-		{"synced", false},
-		{"", false},
+		{"final event", eventlog.Event{Op: eventlog.OpValidate, Level: "done", Final: true, Passed: 3, Total: 3}, true},
+		{"per-command done", eventlog.Event{Op: eventlog.OpValidate, Level: "done", Msg: "test    8.0s (remote)"}, false},
+		{"sync done", eventlog.Event{Op: eventlog.OpSync, Level: "done", Msg: "Synced"}, false},
+		{"in flight", eventlog.Event{Op: eventlog.OpValidate, Level: "info", Msg: "Syncing workspace..."}, false},
 	}
 	for _, c := range cases {
-		e := eventlog.Event{Op: eventlog.OpValidate, Level: "done", Msg: c.msg}
-		if got := isSummaryEvent(e); got != c.want {
-			t.Errorf("isSummaryEvent(%q) = %v, want %v", c.msg, got, c.want)
+		if got := closesRun(c.e); got != c.want {
+			t.Errorf("closesRun(%s) = %v, want %v", c.name, got, c.want)
 		}
 	}
 }
@@ -1024,7 +1021,7 @@ func TestOutcomeOf(t *testing.T) {
 			name: "passed",
 			events: []eventlog.Event{
 				{Op: eventlog.OpValidate, Level: "info", Msg: "$ task test", Ts: now.Add(-8 * time.Hour)},
-				{Op: eventlog.OpValidate, Level: "done", Msg: "4/4 passed  32.4s", Ts: now.Add(-8 * time.Hour)},
+				{Op: eventlog.OpValidate, Level: "done", Msg: "4/4 passed  32.4s", Final: true, Passed: 4, Total: 4, Ts: now.Add(-8 * time.Hour)},
 			},
 			wantIcon:  "✓",
 			wantLabel: "4/4",
@@ -1032,7 +1029,7 @@ func TestOutcomeOf(t *testing.T) {
 		},
 		{
 			name:      "setup failure closes the invocation",
-			events:    []eventlog.Event{{Op: eventlog.OpValidate, Level: "error", Msg: "0/0 passed  3.1s  setup failed: agent: failed to sign challenge", Ts: now.Add(-8 * time.Hour)}},
+			events:    []eventlog.Event{{Op: eventlog.OpValidate, Level: "error", Msg: "setup failed  3.1s: agent: failed to sign challenge", Final: true, Ts: now.Add(-8 * time.Hour)}},
 			wantIcon:  "✗",
 			wantLabel: "0/0",
 			wantLevel: levelError,

--- a/internal/ui/watch/model_test.go
+++ b/internal/ui/watch/model_test.go
@@ -152,6 +152,7 @@ func TestIsSummaryEvent(t *testing.T) {
 	}{
 		{"3/3 passed  5.2s", true},
 		{"0/4 passed  13.7s", true},
+		{"0/0 passed  3.1s  setup failed: agent: failed to sign challenge", true},
 		{"test    8.0s (remote)", false},
 		{"lint    0.4s (local)", false},
 		{"synced", false},
@@ -992,4 +993,57 @@ func TestConvertSnapshot_localRowStaysSeparateWhenSessionsShareAWorktree(t *test
 	pane := strings.Join(m.renderSidecarPane(newWatchStyles(false), 40), "\n")
 	assert.Assert(t, strings.Contains(pane, "2 sessions"), pane)
 	assert.Assert(t, strings.Contains(pane, "this session"), pane)
+}
+
+// outcomeOf tests
+
+func TestOutcomeOf(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name      string
+		events    []eventlog.Event
+		wantIcon  string
+		wantLabel string
+		wantLevel string
+	}{
+		{
+			name:      "running while recent",
+			events:    []eventlog.Event{{Op: eventlog.OpValidate, Level: "info", Msg: "Syncing workspace...", Ts: now.Add(-time.Minute)}},
+			wantIcon:  "●",
+			wantLabel: "running",
+			wantLevel: "",
+		},
+		{
+			name:      "abandoned once past the running timeout",
+			events:    []eventlog.Event{{Op: eventlog.OpValidate, Level: "info", Msg: "Syncing workspace...", Ts: now.Add(-8 * time.Hour)}},
+			wantIcon:  "⊘",
+			wantLabel: "abandoned",
+			wantLevel: levelAbandoned,
+		},
+		{
+			name: "passed",
+			events: []eventlog.Event{
+				{Op: eventlog.OpValidate, Level: "info", Msg: "$ task test", Ts: now.Add(-8 * time.Hour)},
+				{Op: eventlog.OpValidate, Level: "done", Msg: "4/4 passed  32.4s", Ts: now.Add(-8 * time.Hour)},
+			},
+			wantIcon:  "✓",
+			wantLabel: "4/4",
+			wantLevel: levelDone,
+		},
+		{
+			name:      "setup failure closes the invocation",
+			events:    []eventlog.Event{{Op: eventlog.OpValidate, Level: "error", Msg: "0/0 passed  3.1s  setup failed: agent: failed to sign challenge", Ts: now.Add(-8 * time.Hour)}},
+			wantIcon:  "✗",
+			wantLabel: "0/0",
+			wantLevel: levelError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			icon, label, level := outcomeOf(invocationGroup{events: tt.events})
+			if icon != tt.wantIcon || label != tt.wantLabel || level != tt.wantLevel {
+				t.Errorf("outcomeOf() = (%q, %q, %q), want (%q, %q, %q)", icon, label, level, tt.wantIcon, tt.wantLabel, tt.wantLevel)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- A sync, secrets or env-resolve failure returned straight out of `runValidateCmdE`, and `finishValidate` reports the only closing event, so the event log was left ending on whatever info event came last. `chunk watch` has no way to tell that from a run still in flight, so the invocation showed `running` forever - one killed pre-commit hook left a sidecar reading as busy eight hours later.
- `failBeforeRun` now closes the run with an error event carrying the reason.
- Events carry `Final` plus the `Passed`/`Total` tally, and `Event.Outcome` reports both, so the reader no longer sniffs `N/M passed` out of the message and the writer no longer has to fake that shape. `eventlog.Recorder` replaces the wrapped `StatusFunc` so the one call that closes a run says so. Message parsing survives only as a shim for logs written before the field.
- Belt and braces for the events we still cannot write (a SIGKILL, a laptop sleeping mid-sync): `outcomeOf` reports an unclosed run that has been silent for longer than `runningTimeout` as abandoned rather than running, matching the timeout the sidecar list already applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)