### PR TITLE
Unify chunk CLI command telemetry event (CF2-900)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -212,13 +212,12 @@ in `config.Resolve` and makes clients testable.
 ## Telemetry (`internal/telemetry/`)
 
 Modeled on circleci-cli's `internal/telemetry` package. Every command reports
-a single `chunk_command_invocation` event containing the command path and the
-names (never values) of flags the user set — no flag values, argument
-values, file paths, or other PII. The event is named `chunk_command_invocation`
-rather than the generic `command_invocation` circleci-cli's own telemetry
-package uses, because both tools currently share the same Segment write
-key/workspace; the `chunk_` prefix keeps chunk-cli's events unambiguous in
-the event stream.
+a single `command_invocation` event containing the command path and the names
+(never values) of flags the user set — no flag values, argument values, file
+paths, or other PII. chunk-cli events are distinguished from circleci-cli
+events via `context_app_name` (`chunk-cli` vs `circleci-cli`). The install
+UUID is sent as `AnonymousId` (not `UserId`) to avoid mixing machine
+identifiers with real user IDs in shared event counts.
 
 Every event's `Context` also carries the operating system (`runtime.GOOS`)
 and, if detected, the AI coding agent chunk-cli was invoked from (e.g.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -214,10 +214,11 @@ in `config.Resolve` and makes clients testable.
 Modeled on circleci-cli's `internal/telemetry` package. Every command reports
 a single `command_invocation` event containing the command path and the names
 (never values) of flags the user set — no flag values, argument values, file
-paths, or other PII. chunk-cli events are distinguished from circleci-cli
-events via `context_app_name` (`chunk-cli` vs `circleci-cli`). The install
-UUID is sent as `AnonymousId` (not `UserId`) to avoid mixing machine
-identifiers with real user IDs in shared event counts.
+paths, or other PII. chunk-cli and circleci-cli share the same Segment write key/workspace; events
+are distinguished by `context_app_name` (`chunk-cli` vs `circleci-cli`). The
+install UUID is sent as `AnonymousId` (not `UserId`) to avoid mixing machine
+identifiers with real user IDs in shared event counts. When the user has
+authenticated, their CircleCI user UUID is also sent as `UserId`.
 
 Every event's `Context` also carries the operating system (`runtime.GOOS`)
 and, if detected, the AI coding agent chunk-cli was invoked from (e.g.

--- a/internal/authprompt/authprompt.go
+++ b/internal/authprompt/authprompt.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/google/uuid"
+
 	"github.com/CircleCI-Public/chunk-cli/internal/anthropic"
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
@@ -20,9 +22,10 @@ import (
 // the user interactively.
 var ErrNeedsAuth = errors.New("authentication required")
 
-// ValidateCircleCIToken calls GET /api/v2/me to confirm the token is accepted.
-// A 429 response is treated as valid (rate-limited but authenticated).
-func ValidateCircleCIToken(ctx context.Context, token, baseURL string) error {
+// ValidateCircleCIToken calls GET /api/v2/me to confirm the token is accepted
+// and returns the authenticated user's UUID. A 429 response is treated as
+// valid (rate-limited but authenticated); uuid.Nil is returned in that case.
+func ValidateCircleCIToken(ctx context.Context, token, baseURL string) (uuid.UUID, error) {
 	if baseURL == "" {
 		baseURL = "https://circleci.com"
 	}
@@ -32,14 +35,21 @@ func ValidateCircleCIToken(ctx context.Context, token, baseURL string) error {
 		AuthHeader: "Circle-Token",
 		UserAgent:  version.UserAgent(),
 	})
-	_, err := cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v2/me"))
+	var me struct {
+		ID string `json:"id"`
+	}
+	_, err := cl.Call(ctx, hc.NewRequest(http.MethodGet, "/api/v2/me", hc.JSONDecoder(&me)))
 	if err != nil {
 		if hc.HasStatusCode(err, http.StatusTooManyRequests) {
-			return nil
+			return uuid.Nil, nil
 		}
-		return err
+		return uuid.Nil, err
 	}
-	return nil
+	id, parseErr := uuid.Parse(me.ID)
+	if parseErr != nil {
+		return uuid.Nil, nil
+	}
+	return id, nil
 }
 
 // ValidateAPIKey calls POST /v1/messages/count_tokens to confirm the Anthropic

--- a/internal/authprompt/authprompt_test.go
+++ b/internal/authprompt/authprompt_test.go
@@ -36,8 +36,9 @@ func TestValidateCircleCIToken_OK(t *testing.T) {
 	srv := httptest.NewServer(cci)
 	defer srv.Close()
 
-	err := authprompt.ValidateCircleCIToken(context.Background(), randToken("cci-"), srv.URL)
+	userID, err := authprompt.ValidateCircleCIToken(context.Background(), randToken("cci-"), srv.URL)
 	assert.NilError(t, err)
+	assert.Equal(t, userID.String(), "00000000-0000-0000-0000-000000000123")
 }
 
 func TestValidateAPIKey_OK(t *testing.T) {

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -300,8 +300,10 @@ func saveCircleCIToken(ctx context.Context, token string, streams iostream.Strea
 			err:        fmt.Errorf("save token: %w", err),
 		}
 	}
-	if userID != (uuid.UUID{}) {
-		_ = config.SaveUserID(userID)
+	if userID != uuid.Nil {
+		if err := config.SaveUserID(userID); err != nil {
+			streams.ErrPrintln(ui.Dim(fmt.Sprintf("note: could not persist CircleCI user ID for telemetry: %v", err)))
+		}
 	}
 
 	streams.ErrPrintln("")

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/authprompt"
@@ -283,7 +284,8 @@ func authSetAnthropic(ctx context.Context, io iostream.Streams, baseURL string, 
 
 func saveCircleCIToken(ctx context.Context, token string, streams iostream.Streams, circleCIBaseURL string, insecureStorage bool) error {
 	streams.ErrPrintln(ui.Dim("Validating CircleCI token..."))
-	if err := authprompt.ValidateCircleCIToken(ctx, token, circleCIBaseURL); err != nil {
+	userID, err := authprompt.ValidateCircleCIToken(ctx, token, circleCIBaseURL)
+	if err != nil {
 		return &userError{
 			msg:        "CircleCI token validation failed.",
 			suggestion: "Check that your token is correct.",
@@ -297,6 +299,9 @@ func saveCircleCIToken(ctx context.Context, token string, streams iostream.Strea
 			suggestion: "Check that your config file is writable.",
 			err:        fmt.Errorf("save token: %w", err),
 		}
+	}
+	if userID != (uuid.UUID{}) {
+		_ = config.SaveUserID(userID)
 	}
 
 	streams.ErrPrintln("")
@@ -331,7 +336,7 @@ func newAuthStatusCmd() *cobra.Command {
 				io.Printf("  Source: %s\n", rc.CircleCITokenSource)
 				io.Printf("  Token:  %s\n", config.MaskKey(rc.CircleCIToken))
 				io.ErrPrintln(ui.Dim("Validating CircleCI token..."))
-				if err := authprompt.ValidateCircleCIToken(cmd.Context(), rc.CircleCIToken, rc.CircleCIBaseURL); err != nil {
+				if _, err := authprompt.ValidateCircleCIToken(cmd.Context(), rc.CircleCIToken, rc.CircleCIBaseURL); err != nil {
 					io.ErrPrintln(ui.FormatError(
 						"CircleCI token validation failed.",
 						"",

--- a/internal/cmd/authhelper.go
+++ b/internal/cmd/authhelper.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/anthropic"
@@ -120,7 +121,8 @@ func ensureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc config.Res
 	}
 
 	streams.ErrPrintln(ui.Dim("Validating CircleCI token..."))
-	if err := authprompt.ValidateCircleCIToken(ctx, token, rc.CircleCIBaseURL); err != nil {
+	userID, err := authprompt.ValidateCircleCIToken(ctx, token, rc.CircleCIBaseURL)
+	if err != nil {
 		if hc.HasStatusCode(err, http.StatusUnauthorized) {
 			return nil, fmt.Errorf("invalid CircleCI token: %w", err)
 		}
@@ -129,6 +131,9 @@ func ensureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc config.Res
 
 	if err := authprompt.SaveCircleCIToken(token, rc.CircleCIBaseURL, insecureStorage); err != nil {
 		return nil, err
+	}
+	if userID != (uuid.UUID{}) {
+		_ = config.SaveUserID(userID)
 	}
 	printSaved(streams, "CircleCI token", insecureStorage)
 	return circleci.NewClient(circleci.Config{

--- a/internal/cmd/authhelper.go
+++ b/internal/cmd/authhelper.go
@@ -132,8 +132,12 @@ func ensureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc config.Res
 	if err := authprompt.SaveCircleCIToken(token, rc.CircleCIBaseURL, insecureStorage); err != nil {
 		return nil, err
 	}
-	if userID != (uuid.UUID{}) {
-		_ = config.SaveUserID(userID)
+	if userID != uuid.Nil {
+		// Intentionally overwrites any previously saved user ID — account
+		// switching should reflect the newly authenticated user.
+		if err := config.SaveUserID(userID); err != nil {
+			streams.ErrPrintln(ui.Dim(fmt.Sprintf("note: could not persist CircleCI user ID for telemetry: %v", err)))
+		}
 	}
 	printSaved(streams, "CircleCI token", insecureStorage)
 	return circleci.NewClient(circleci.Config{

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -100,7 +100,7 @@ Configuration:
 
 // setupTelemetry resolves the user's telemetry preference and attaches a
 // telemetry.Sender to cmd's context so RecordNow can report a
-// chunk_command_invocation event once the command finishes.
+// command_invocation event once the command finishes.
 func setupTelemetry(cmd *cobra.Command, version string) error {
 	if telemetry.IsTelemetryDisabled(cmd) {
 		return nil
@@ -140,6 +140,7 @@ func setupTelemetry(cmd *cobra.Command, version string) error {
 		Metadata: telemetry.Meta{
 			Version:     version,
 			InstanceID:  instanceID,
+			UserID:      config.GetUserID(),
 			OS:          runtime.GOOS,
 			CodingAgent: telemetry.DetectCodingAgent(),
 		},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,6 +115,7 @@ func LoadEnv(ctx context.Context) (EnvVars, error) {
 type UserConfig struct {
 	AnthropicAPIKey    string `json:"anthropicAPIKey,omitempty"`
 	CircleCIToken      string `json:"circleCIToken,omitempty"`
+	CircleCIUserID     string `json:"circleCIUserID,omitempty"`
 	GitHubToken        string `json:"gitHubToken,omitempty"`
 	Model              string `json:"model,omitempty"`
 	UseSSHIdentityFile bool   `json:"useSSHIdentityFile,omitempty"`
@@ -294,6 +295,31 @@ func EnsureInstanceID() (uuid.UUID, error) {
 		return uuid.Nil, err
 	}
 	return id, nil
+}
+
+// SaveUserID persists the CircleCI user UUID for the current user so it can
+// be attached to telemetry events as the real UserId.
+func SaveUserID(id uuid.UUID) error {
+	cfg, err := Load()
+	if err != nil {
+		return err
+	}
+	cfg.CircleCIUserID = id.String()
+	return Save(cfg)
+}
+
+// GetUserID returns the persisted CircleCI user UUID, or uuid.Nil if none has
+// been saved yet (e.g. the user has not authenticated).
+func GetUserID() uuid.UUID {
+	cfg, err := Load()
+	if err != nil {
+		return uuid.Nil
+	}
+	id, err := uuid.Parse(cfg.CircleCIUserID)
+	if err != nil {
+		return uuid.Nil
+	}
+	return id
 }
 
 // Resolve computes the final config from flags, env, file, and keychain.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -299,6 +299,11 @@ func EnsureInstanceID() (uuid.UUID, error) {
 
 // SaveUserID persists the CircleCI user UUID for the current user so it can
 // be attached to telemetry events as the real UserId.
+//
+// Note: like EnsureInstanceID, this does a Load→Save cycle without a file
+// lock, so concurrent writes from two processes can race. In practice the
+// only caller is the auth flow, which runs once interactively, making the
+// race window negligible.
 func SaveUserID(id uuid.UUID) error {
 	cfg, err := Load()
 	if err != nil {
@@ -309,7 +314,10 @@ func SaveUserID(id uuid.UUID) error {
 }
 
 // GetUserID returns the persisted CircleCI user UUID, or uuid.Nil if none has
-// been saved yet (e.g. the user has not authenticated).
+// been saved yet (e.g. the user has not authenticated) or the config cannot
+// be read. Errors are silently swallowed because this is a best-effort
+// telemetry helper — a missing user ID degrades gracefully to anonymous
+// attribution rather than blocking the command.
 func GetUserID() uuid.UUID {
 	cfg, err := Load()
 	if err != nil {

--- a/internal/telemetry/record.go
+++ b/internal/telemetry/record.go
@@ -44,8 +44,8 @@ func IsTelemetryDisabled(cmd *cobra.Command) bool {
 }
 
 // RecordForSubcommands wraps every descendant command's RunE so it reports a
-// chunk_command_invocation event after running, without requiring
-// per-command changes.
+// command_invocation event after running, without requiring per-command
+// changes.
 func RecordForSubcommands(cmd *cobra.Command) {
 	for _, c := range cmd.Commands() {
 		record(c)
@@ -67,16 +67,12 @@ func record(cmd *cobra.Command) {
 	}
 }
 
-// RecordNow reports a chunk_command_invocation event immediately: the full
-// command path, the sorted comma-joined names (never values) of flags the
-// user set, the outcome ("success" or "failure"), the wall-clock duration in
+// RecordNow reports a command_invocation event immediately: the full command
+// path, the sorted comma-joined names (never values) of flags the user set,
+// the outcome ("success" or "failure"), the wall-clock duration in
 // milliseconds, and — on failure — the Go type and message of the error.
-//
-// The event name is prefixed with "chunk_" (rather than the more generic
-// "command_invocation" that circleci-cli's own telemetry package uses)
-// because both tools currently send to the same Segment write key/workspace;
-// the prefix keeps chunk-cli's events unambiguous in the event stream
-// without requiring anyone to inspect the nested Context.App.Name field.
+// chunk-cli events are distinguished from circleci-cli events via
+// Context.App.Name ("chunk-cli").
 func RecordNow(cmd *cobra.Command, err error, duration time.Duration) {
 	tc := FromContext(cmd.Context())
 	if tc == nil {
@@ -105,5 +101,5 @@ func RecordNow(cmd *cobra.Command, err error, duration time.Duration) {
 		props["error_message"] = err.Error()
 	}
 
-	_ = tc.Track("chunk_command_invocation", props)
+	_ = tc.Track("command_invocation", props)
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -150,7 +150,7 @@ func (s *Sender) Track(eventName string, props map[string]any) error {
 		AnonymousId: s.meta.InstanceID.String(),
 		Context:     s.meta.toContext(),
 	}
-	if s.meta.UserID != (uuid.UUID{}) {
+	if s.meta.UserID != uuid.Nil {
 		track.UserId = s.meta.UserID.String()
 	}
 	return s.dest.Enqueue(track)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -63,6 +63,10 @@ type Config struct {
 type Meta struct {
 	Version    string
 	InstanceID uuid.UUID
+	// UserID is the authenticated CircleCI user UUID. When non-zero it is sent
+	// as UserId so events can be attributed to a real user. The install UUID
+	// (InstanceID) is always sent as AnonymousId regardless.
+	UserID uuid.UUID
 
 	// OS is the operating system chunk-cli is running on, e.g. runtime.GOOS.
 	OS string
@@ -139,12 +143,15 @@ func (s *Sender) Track(eventName string, props map[string]any) error {
 		p.Set(key, val)
 	}
 
-	return s.dest.Enqueue(analytics.Track{
-		Event:      eventName,
-		Timestamp:  time.Now(),
-		Properties: p,
-
-		UserId:  s.meta.InstanceID.String(),
-		Context: s.meta.toContext(),
-	})
+	track := analytics.Track{
+		Event:       eventName,
+		Timestamp:   time.Now(),
+		Properties:  p,
+		AnonymousId: s.meta.InstanceID.String(),
+		Context:     s.meta.toContext(),
+	}
+	if s.meta.UserID != (uuid.UUID{}) {
+		track.UserId = s.meta.UserID.String()
+	}
+	return s.dest.Enqueue(track)
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -51,13 +51,38 @@ func TestSender_Track(t *testing.T) {
 	assert.Equal(t, len(fake.tracks), 1)
 	tr := fake.tracks[0]
 	assert.Equal(t, tr.Event, "command_invocation")
-	assert.Equal(t, tr.UserId, instanceID.String())
+	assert.Equal(t, tr.AnonymousId, instanceID.String())
+	assert.Equal(t, tr.UserId, "")
 	assert.Equal(t, tr.Properties["command"], "chunk config show")
 	assert.Equal(t, tr.Properties["flags"], "json")
+	assert.Equal(t, tr.Context.App.Name, "chunk-cli")
 	assert.Equal(t, tr.Context.App.Version, "1.2.3")
 	assert.Equal(t, tr.Context.Device.Id, instanceID.String())
 	assert.Equal(t, tr.Context.OS.Name, "linux")
 	assert.Equal(t, tr.Context.Extra["codingAgent"], agentClaudeCode)
+}
+
+func TestSender_Track_WithUserID(t *testing.T) {
+	fake := &fakeDestination{}
+	instanceID := uuid.New()
+	userID := uuid.New()
+
+	s, err := NewSender(Config{
+		TestDestination: fake,
+		Metadata: Meta{
+			Version:    "1.2.3",
+			InstanceID: instanceID,
+			UserID:     userID,
+			OS:         "linux",
+		},
+	})
+	assert.NilError(t, err)
+
+	assert.NilError(t, s.Track("command_invocation", nil))
+
+	tr := fake.tracks[0]
+	assert.Equal(t, tr.AnonymousId, instanceID.String())
+	assert.Equal(t, tr.UserId, userID.String())
 }
 
 func TestMeta_ToContext_OmitsCodingAgentWhenUndetected(t *testing.T) {
@@ -113,7 +138,8 @@ func TestRecordForSubcommands_TracksCommandInvocation(t *testing.T) {
 	assert.NilError(t, root.Execute())
 
 	assert.Equal(t, len(fake.tracks), 1)
-	assert.Equal(t, fake.tracks[0].Event, "chunk_command_invocation")
+	assert.Equal(t, fake.tracks[0].Event, "command_invocation")
+	assert.Equal(t, fake.tracks[0].Context.App.Name, "chunk-cli")
 	assert.Equal(t, fake.tracks[0].Properties["command"], "chunk show")
 	assert.Equal(t, fake.tracks[0].Properties["flags"], "json")
 	assert.Equal(t, fake.tracks[0].Properties["outcome"], "success")

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -173,7 +173,7 @@ func (f *FakeCircleCI) handleGetCurrentUser(c *gin.Context) {
 	if !f.requireToken(c) {
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"id": "user-123", "login": "testuser"})
+	c.JSON(http.StatusOK, gin.H{"id": "00000000-0000-0000-0000-000000000123", "login": "testuser"})
 }
 
 func (f *FakeCircleCI) requireToken(c *gin.Context) bool {


### PR DESCRIPTION
## Summary
- Rename `chunk_command_invocation` → `command_invocation` to share one event name with circleci-cli, distinguished by context_app_name
- Move install UUID from UserId to AnonymousId to avoid mixing machine identifiers with real user IDs in shared event counts
- Capture CircleCI user UUID from /api/v2/me at auth time, persist it to config, and send it as UserId on subsequent runs. Based on circleci-cli way of saving user_id.

