### PR TITLE
Skip interactive org picker in non-interactive (CI) sessions

### DIFF
--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -114,6 +114,13 @@ func orgPicker(ctx context.Context, client *circleci.Client) func() (string, err
 		if len(collabs) == 1 {
 			return collabs[0].ID, nil
 		}
+		if nonInteractive() {
+			return "", &userError{
+				msg:        "No interactive terminal available to select an organization.",
+				suggestion: "Run 'chunk org list' to find your org ID, then set it with 'chunk config set orgID <id>' or pass --org-id.",
+				err:        tui.ErrNoTTY,
+			}
+		}
 		labels := make([]string, len(collabs))
 		for i, c := range collabs {
 			labels[i] = fmt.Sprintf("%s/%s", c.VcsType, c.Name)

--- a/internal/cmd/sidecar_test.go
+++ b/internal/cmd/sidecar_test.go
@@ -162,6 +162,20 @@ func TestOrgPicker_MultipleOrgs_NoTTY(t *testing.T) {
 	assert.Assert(t, errors.Is(err, tui.ErrNoTTY), "expected ErrNoTTY, got: %v", err)
 }
 
+func TestOrgPicker_MultipleOrgs_NonInteractive(t *testing.T) {
+	t.Setenv("CI", "true")
+
+	cci := fakes.NewFakeCircleCI()
+	cci.Collaborations = []fakes.Collaboration{
+		{ID: "org-1", Name: "first"},
+		{ID: "org-2", Name: "second"},
+	}
+	client := newOrgPickerClient(t, cci)
+
+	_, err := orgPicker(context.Background(), client)()
+	assert.Assert(t, errors.Is(err, tui.ErrNoTTY), "expected ErrNoTTY in non-interactive mode, got: %v", err)
+}
+
 func TestSnapshotCreateNameAtLimit(t *testing.T) {
 	cmd := newSidecarSnapshotCreateCmd()
 


### PR DESCRIPTION
## Problem

In agent and CI sessions the \`CI\` environment variable is set, but a PTY may still be allocated — so \`term.IsTerminal\` returns true. When \`chunk\` needs to resolve an org ID and neither \`--org-id\` nor a stored \`orgID\` is found, it falls through to the interactive org picker. With \`CI=true\` the picker is rendered by bubbletea and then waits indefinitely for keyboard input that never arrives, **hanging the session**.

## Fix

Added a \`nonInteractive()\` guard in \`orgPicker\` (\`internal/cmd/sidecar.go\`) immediately before the call to \`tui.SelectFromList\`. This mirrors the same pattern already used in \`auth.go\`. When \`CI=true\` the function returns immediately with a clear \`userError\` wrapping \`tui.ErrNoTTY\`, directing the user to run \`chunk org list\` and set their org ID.

Single-org auto-selection is unaffected — the guard only fires when multiple orgs are found and interactive selection would be required.

## Test plan

- [x] \`task build\` passes
- [x] \`task test\` passes — new test \`TestOrgPicker_MultipleOrgs_NonInteractive\` verifies the fix
- [x] Existing \`TestOrgPicker_MultipleOrgs_NoTTY\` and \`TestOrgPicker_SingleOrg\` continue to pass