### PR TITLE
Report token source in auth error messages

### DIFF
--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -71,8 +71,8 @@ func TestConfigShowFromConfigFile(t *testing.T) {
 	assert.Equal(t, result.ExitCode, 0, "stdout: %s\nstderr: %s", result.Stdout, result.Stderr)
 
 	combined := result.Stdout + result.Stderr
-	assert.Check(t, cmp.Contains(combined, "user config"),
-		"expected apiKey source to be 'user config'")
+	assert.Check(t, cmp.Contains(combined, "Config file ("),
+		"expected apiKey source to include config file path")
 	assert.Check(t, cmp.Contains(combined, "ZZZZ"),
 		"expected last 4 chars of stored key visible")
 }
@@ -217,8 +217,8 @@ func TestConfigShowCircleCITokenFromFile(t *testing.T) {
 	combined := result.Stdout + result.Stderr
 	assert.Check(t, cmp.Contains(combined, "FTOK"),
 		"expected file token last 4 chars")
-	assert.Check(t, cmp.Contains(combined, "user config"),
-		"expected config file source")
+	assert.Check(t, cmp.Contains(combined, "Config file ("),
+		"expected config file source to include path")
 }
 
 func TestConfigShowCircleTokenEnvPrecedenceOverCircleCIToken(t *testing.T) {
@@ -275,8 +275,8 @@ func TestConfigShowGitHubTokenFromFile(t *testing.T) {
 	combined := result.Stdout + result.Stderr
 	assert.Check(t, cmp.Contains(combined, "GHTK"),
 		"expected file token last 4 chars")
-	assert.Check(t, cmp.Contains(combined, "user config"),
-		"expected config file source")
+	assert.Check(t, cmp.Contains(combined, "Config file ("),
+		"expected config file source to include path")
 }
 
 func TestConfigShowModelFileOverDefault(t *testing.T) {

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -441,7 +441,7 @@ func detectOrgID(ctx context.Context, rc config.ResolvedConfig, streams iostream
 		}
 		return
 	}
-	orgID, err := orgPicker(ctx, client)()
+	orgID, err := orgPicker(ctx, client, rc.CircleCITokenSource)()
 	if err != nil {
 		if !errors.Is(err, tui.ErrNoTTY) && !errors.Is(err, tui.ErrCancelled) {
 			streams.ErrPrintf("%s\n", ui.Warning(fmt.Sprintf("Could not detect org ID: %v", err)))

--- a/internal/cmd/prune.go
+++ b/internal/cmd/prune.go
@@ -38,7 +38,7 @@ Pass --before to extend the cutoff (e.g. --before 24h).`,
 			if err != nil {
 				return fmt.Errorf("get working directory: %w", err)
 			}
-			resolvedOrgID, err := resolveOrgID(orgID, cwd, orgPicker(cmd.Context(), client))
+			resolvedOrgID, err := resolveOrgID(orgID, cwd, orgPicker(cmd.Context(), client, rc.CircleCITokenSource))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -110,11 +110,11 @@ func orgSource(orgID, workDir string) string {
 	return source
 }
 
-func orgPicker(ctx context.Context, client *circleci.Client) func() (string, error) {
+func orgPicker(ctx context.Context, client *circleci.Client, tokenSource string) func() (string, error) {
 	return func() (string, error) {
 		collabs, err := client.ListCollaborations(ctx)
 		if err != nil {
-			if err := notAuthorized("list organizations", err); err != nil {
+			if err := notAuthorized("list organizations", tokenSource, err); err != nil {
 				return "", err
 			}
 			return "", &userError{
@@ -182,7 +182,7 @@ func newSidecarListCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get working directory: %w", err)
 			}
-			resolvedOrgID, err := resolveOrgID(orgID, cwd, orgPicker(cmd.Context(), client))
+			resolvedOrgID, err := resolveOrgID(orgID, cwd, orgPicker(cmd.Context(), client, rc.CircleCITokenSource))
 			if err != nil {
 				return err
 			}
@@ -190,17 +190,14 @@ func newSidecarListCmd() *cobra.Command {
 			if err != nil {
 				if errors.Is(err, circleci.ErrNotAuthorized) {
 					if all {
-						return &userError{
-							msg:        "Not authorized to list all sidecars.",
-							suggestion: "Listing all sidecars requires org admin privileges.",
-							err:        err,
-						}
+						return newUserError("Not authorized to list all sidecars.").
+							withCode("auth.not_authorized").
+							withDetail(tokenSourceDetail(rc.CircleCITokenSource)).
+							withSuggestion("Listing all sidecars requires org admin privileges.").
+							withExitCode(ExitAuthError).
+							wrap(err)
 					}
-					return &userError{
-						msg:        "Not authorized to list sidecars.",
-						suggestion: suggestionReauth,
-						err:        err,
-					}
+					return notAuthorized("list sidecars", rc.CircleCITokenSource, err)
 				}
 				return &userError{
 					msg:        "Could not list sidecars.",
@@ -251,7 +248,7 @@ func newSidecarCreateCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get working directory: %w", err)
 			}
-			resolvedOrgID, err := resolveOrgID(orgID, cwd, orgPicker(cmd.Context(), client))
+			resolvedOrgID, err := resolveOrgID(orgID, cwd, orgPicker(cmd.Context(), client, rc.CircleCITokenSource))
 			if err != nil {
 				return err
 			}
@@ -274,7 +271,7 @@ func newSidecarCreateCmd() *cobra.Command {
 			}
 			sb, err := sidecar.Create(cmd.Context(), client, resolvedOrgID, name, image)
 			if err != nil {
-				if err := notAuthorized("create sidecars", err); err != nil {
+				if err := notAuthorized("create sidecars", rc.CircleCITokenSource, err); err != nil {
 					return err
 				}
 				var se *circleci.StatusError
@@ -324,7 +321,7 @@ func newSidecarDeleteCmd() *cobra.Command {
 				return err
 			}
 			if err := client.DeleteSidecar(cmd.Context(), sidecarID); err != nil {
-				if err := notAuthorized("delete sidecars", err); err != nil {
+				if err := notAuthorized("delete sidecars", rc.CircleCITokenSource, err); err != nil {
 					return err
 				}
 				if err := sidecarUnavailable(sidecarID, err); err != nil {
@@ -399,7 +396,7 @@ or via the repeatable --args flag. Positional arguments are appended after any
 			}
 			resp, err := sidecar.Exec(cmd.Context(), client, sidecarID, command, allArgs, onOutput)
 			if err != nil {
-				if err := notAuthorized("execute commands", err); err != nil {
+				if err := notAuthorized("execute commands", rc.CircleCITokenSource, err); err != nil {
 					return err
 				}
 				if err := sidecarUnavailable(sidecarID, err); err != nil {
@@ -450,7 +447,7 @@ func newSidecarAddSSHKeyCmd() *cobra.Command {
 			}
 			resp, err := sidecar.AddSSHKey(cmd.Context(), client, sidecarID, publicKey, publicKeyFile)
 			if err != nil {
-				if err := notAuthorized("add SSH keys", err); err != nil {
+				if err := notAuthorized("add SSH keys", rc.CircleCITokenSource, err); err != nil {
 					return err
 				}
 				if err := sidecarUnavailable(sidecarID, err); err != nil {
@@ -526,7 +523,7 @@ func newSidecarSSHCmd() *cobra.Command {
 				if err := sshSessionError(err); err != nil {
 					return err
 				}
-				if err := notAuthorized("connect via SSH", err); err != nil {
+				if err := notAuthorized("connect via SSH", rc.CircleCITokenSource, err); err != nil {
 					return err
 				}
 				if err := sidecarUnavailable(sidecarID, err); err != nil {
@@ -605,7 +602,7 @@ func newSidecarSyncCmd() *cobra.Command {
 				if err := sshSessionError(err); err != nil {
 					return err
 				}
-				if err := notAuthorized("sync files", err); err != nil {
+				if err := notAuthorized("sync files", rc.CircleCITokenSource, err); err != nil {
 					return err
 				}
 				if err := sidecarUnavailable(sidecarID, err); err != nil {
@@ -978,7 +975,7 @@ func newSidecarSnapshotListCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get working directory: %w", err)
 			}
-			resolvedOrgID, err := resolveOrgID(orgID, cwd, orgPicker(cmd.Context(), client))
+			resolvedOrgID, err := resolveOrgID(orgID, cwd, orgPicker(cmd.Context(), client, rc.CircleCITokenSource))
 			if err != nil {
 				return err
 			}
@@ -1081,7 +1078,7 @@ Example:
 				// Step 2: Resolve or create sidecar.
 				if sidecarID == "" {
 					var resolveErr error
-					sidecarID, _, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, name, dir, status, streams)
+					sidecarID, _, resolveErr = sidecarSetupResolveSidecar(cmd.Context(), client, orgID, name, dir, rc.CircleCITokenSource, status, streams)
 					if resolveErr != nil {
 						return resolveErr
 					}
@@ -1094,7 +1091,7 @@ Example:
 
 				// Step 4: Sync files to sidecar.
 				if !skipSync {
-					if err := sidecarSetupSync(cmd.Context(), client, sidecarID, identityFile, authSock, true, dir, status); err != nil {
+					if err := sidecarSetupSync(cmd.Context(), client, sidecarID, identityFile, authSock, true, dir, rc.CircleCITokenSource, status); err != nil {
 						return err
 					}
 				}
@@ -1175,6 +1172,7 @@ func sidecarSetupResolveSidecar(
 	ctx context.Context,
 	client *circleci.Client,
 	orgID, name, workDir string,
+	tokenSource string,
 	status iostream.StatusFunc,
 	streams iostream.Streams,
 ) (id, displayName string, err error) {
@@ -1189,14 +1187,14 @@ func sidecarSetupResolveSidecar(
 	if name == "" {
 		name = randomSidecarName()
 	}
-	resolvedOrgID, err := resolveOrgID(orgID, workDir, orgPicker(ctx, client))
+	resolvedOrgID, err := resolveOrgID(orgID, workDir, orgPicker(ctx, client, tokenSource))
 	if err != nil {
 		return "", "", err
 	}
 	status(iostream.LevelStep, fmt.Sprintf("Creating sidecar %q...", name))
 	sc, err := sidecar.Create(ctx, client, resolvedOrgID, name, "")
 	if err != nil {
-		if authErr := notAuthorized("create sidecars", err); authErr != nil {
+		if authErr := notAuthorized("create sidecars", tokenSource, err); authErr != nil {
 			return "", "", authErr
 		}
 		return "", "", &userError{
@@ -1236,6 +1234,7 @@ func sidecarSetupSync(
 	sidecarID, identityFile, authSock string,
 	useBundle bool,
 	cwd string,
+	tokenSource string,
 	status iostream.StatusFunc,
 ) error {
 	status(iostream.LevelStep, "Syncing files to sidecar...")
@@ -1269,7 +1268,7 @@ func sidecarSetupSync(
 	if authErr := sshSessionError(err); authErr != nil {
 		return authErr
 	}
-	if authErr := notAuthorized("sync files", err); authErr != nil {
+	if authErr := notAuthorized("sync files", tokenSource, err); authErr != nil {
 		return authErr
 	}
 	return err

--- a/internal/cmd/sidecar_test.go
+++ b/internal/cmd/sidecar_test.go
@@ -128,7 +128,7 @@ func TestOrgPicker_APIError(t *testing.T) {
 	cci.CollaborationsStatusCode = 500
 	client := newOrgPickerClient(t, cci)
 
-	_, err := orgPicker(context.Background(), client)()
+	_, err := orgPicker(context.Background(), client, "")()
 	assert.Assert(t, err != nil)
 }
 
@@ -136,7 +136,7 @@ func TestOrgPicker_NoOrgs(t *testing.T) {
 	cci := fakes.NewFakeCircleCI()
 	client := newOrgPickerClient(t, cci)
 
-	_, err := orgPicker(context.Background(), client)()
+	_, err := orgPicker(context.Background(), client, "")()
 	assert.ErrorContains(t, err, "no organizations found")
 }
 
@@ -145,7 +145,7 @@ func TestOrgPicker_SingleOrg(t *testing.T) {
 	cci.Collaborations = []fakes.Collaboration{{ID: "org-abc", Name: "myorg"}}
 	client := newOrgPickerClient(t, cci)
 
-	got, err := orgPicker(context.Background(), client)()
+	got, err := orgPicker(context.Background(), client, "")()
 	assert.NilError(t, err)
 	assert.Equal(t, got, "org-abc")
 }
@@ -158,7 +158,7 @@ func TestOrgPicker_MultipleOrgs_NoTTY(t *testing.T) {
 	}
 	client := newOrgPickerClient(t, cci)
 
-	_, err := orgPicker(context.Background(), client)()
+	_, err := orgPicker(context.Background(), client, "")()
 	assert.Assert(t, errors.Is(err, tui.ErrNoTTY), "expected ErrNoTTY, got: %v", err)
 }
 
@@ -172,7 +172,7 @@ func TestOrgPicker_MultipleOrgs_NonInteractive(t *testing.T) {
 	}
 	client := newOrgPickerClient(t, cci)
 
-	_, err := orgPicker(context.Background(), client)()
+	_, err := orgPicker(context.Background(), client, "")()
 	assert.Assert(t, errors.Is(err, tui.ErrNoTTY), "expected ErrNoTTY in non-interactive mode, got: %v", err)
 }
 

--- a/internal/cmd/usererr.go
+++ b/internal/cmd/usererr.go
@@ -36,15 +36,25 @@ func (e *silentExitError) ExitCode() int { return e.code }
 
 var errSilentExit error = &silentExitError{code: 1}
 
-func notAuthorized(action string, err error) error {
+func notAuthorized(action, tokenSource string, err error) error {
 	if !errors.Is(err, circleci.ErrNotAuthorized) {
 		return nil
 	}
 	return newUserError(fmt.Sprintf("Not authorized to %s.", action)).
 		withCode("auth.not_authorized").
+		withDetail(tokenSourceDetail(tokenSource)).
 		withSuggestion(suggestionReauth).
 		withExitCode(ExitAuthError).
 		wrap(err)
+}
+
+// tokenSourceDetail formats a token source string for use as an error detail.
+// Returns "" when source is empty, which leaves the detail field unset.
+func tokenSourceDetail(source string) string {
+	if source == "" {
+		return ""
+	}
+	return "Token from: " + source + "."
 }
 
 // cannotCreateSidecar phrases a rejected sidecar creation, or returns nil when

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -453,7 +453,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	}
 	activeSidecar, _ = sidecar.LoadActive(ctx)
 
-	freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, cfg, activeSidecar, statusFn, workDir, streams)
+	freshlyCreated, err := setupRemote(ctx, circleCIClient, opts, image, rc.CircleCITokenSource, cfg, activeSidecar, statusFn, workDir, streams)
 	if err != nil {
 		return err
 	}
@@ -466,7 +466,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	baseStatusFn := statusFn
 	statusFn = wrapEventLogStatusFn(statusFn, opts.sidecarID, activeSidecar, workDir, hook)
 
-	envVars, statusFn, _, err := loadEnvVarsWithRetry(ctx, circleCIClient, opts, image, freshlyCreated, baseStatusFn, statusFn, workDir, hook, streams)
+	envVars, statusFn, _, err := loadEnvVarsWithRetry(ctx, circleCIClient, opts, image, rc.CircleCITokenSource, freshlyCreated, baseStatusFn, statusFn, workDir, hook, streams)
 	if err != nil {
 		return err
 	}
@@ -486,7 +486,7 @@ func loadEnvVarsWithRetry(
 	ctx context.Context,
 	circleCIClient *circleci.Client,
 	opts *validateOpts,
-	image string,
+	image, tokenSource string,
 	freshlyCreated bool,
 	baseStatusFn, statusFn iostream.StatusFunc,
 	workDir string,
@@ -502,7 +502,7 @@ func loadEnvVarsWithRetry(
 		// like any other.
 		statusFn(iostream.LevelWarn, "sidecar was unusable, provisioning a replacement")
 		opts.sidecarID = ""
-		if _, createErr := resolveOrCreateSidecarID(ctx, circleCIClient, &opts.sidecarID, opts.orgID, image, workDir, streams); createErr != nil {
+		if _, createErr := resolveOrCreateSidecarID(ctx, circleCIClient, &opts.sidecarID, opts.orgID, image, workDir, tokenSource, streams); createErr != nil {
 			return nil, statusFn, freshlyCreated, createErr
 		}
 		// A replacement has none of the setup the old one had, so exec failures on
@@ -707,20 +707,20 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 
 // setupRemote resolves (or creates) the sidecar ID based on the validate flags
 // and config, then returns whether a new sidecar was provisioned.
-func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpts, image string, cfg *config.ProjectConfig, activeSidecar *sidecar.ActiveSidecar, statusFn iostream.StatusFunc, workDir string, streams iostream.Streams) (bool, error) {
+func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpts, image, tokenSource string, cfg *config.ProjectConfig, activeSidecar *sidecar.ActiveSidecar, statusFn iostream.StatusFunc, workDir string, streams iostream.Streams) (bool, error) {
 	if opts.local {
 		return false, nil
 	}
 	if validateNeedsSidecar(opts.remote || opts.sidecarID != "", cfg) {
 		if opts.remote {
-			created, err := resolveOrCreateSidecarID(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, streams)
+			created, err := resolveOrCreateSidecarID(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, tokenSource, streams)
 			if err != nil {
 				return false, err
 			}
 			statusFn(iostream.LevelInfo, fmt.Sprintf("running all commands on sidecar %s", opts.sidecarID))
 			return created, nil
 		}
-		return resolveSidecar(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, activeSidecar, streams)
+		return resolveSidecar(ctx, client, &opts.sidecarID, opts.orgID, image, workDir, tokenSource, activeSidecar, streams)
 	}
 	return false, nil
 }
@@ -953,20 +953,20 @@ func resolveImage(name string, cfg *config.ProjectConfig) string {
 // configuration, so a retry without user action fails identically; falling
 // back only spends the full suite's runtime before saying so. This matches
 // --remote, which has always returned the error from this same call.
-func resolveSidecar(ctx context.Context, client *circleci.Client, sidecarID *string, orgID, image, workDir string, active *sidecar.ActiveSidecar, streams iostream.Streams) (bool, error) {
+func resolveSidecar(ctx context.Context, client *circleci.Client, sidecarID *string, orgID, image, workDir, tokenSource string, active *sidecar.ActiveSidecar, streams iostream.Streams) (bool, error) {
 	statusFn := newStatusFunc(streams)
 	if active != nil {
 		*sidecarID = active.SidecarID
 		statusFn(iostream.LevelInfo, fmt.Sprintf("using sidecar %s for remote commands", *sidecarID))
 		return false, nil
 	}
-	return resolveOrCreateSidecarID(ctx, client, sidecarID, orgID, image, workDir, streams)
+	return resolveOrCreateSidecarID(ctx, client, sidecarID, orgID, image, workDir, tokenSource, streams)
 }
 
 // resolveOrCreateSidecarID fills sidecarID from the active sidecar, or creates
 // a new sidecar when none is configured. Returns true when a new sidecar was
 // provisioned (as opposed to loaded from the active state file).
-func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, sidecarID *string, orgID, image, workDir string, streams iostream.Streams) (created bool, err error) {
+func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, sidecarID *string, orgID, image, workDir, tokenSource string, streams iostream.Streams) (created bool, err error) {
 	if *sidecarID != "" {
 		return false, nil
 	}
@@ -983,7 +983,7 @@ func resolveOrCreateSidecarID(ctx context.Context, client *circleci.Client, side
 	// "Stop hook error:" banner even when everything then went fine.
 	statusFn := newStatusFunc(streams)
 	statusFn(iostream.LevelInfo, "no active sidecar; creating one")
-	resolvedOrgID, err := resolveOrgID(orgID, workDir, orgPicker(ctx, client))
+	resolvedOrgID, err := resolveOrgID(orgID, workDir, orgPicker(ctx, client, tokenSource))
 	if err != nil {
 		return false, err
 	}

--- a/internal/cmd/validate_sidecar_fallback_test.go
+++ b/internal/cmd/validate_sidecar_fallback_test.go
@@ -58,7 +58,7 @@ func TestResolveSidecarReportsCreateRejection(t *testing.T) {
 	var sidecarID string
 	created, err := resolveSidecar(
 		context.Background(), fallbackClient(t, cci), &sidecarID,
-		"org-1", "", workDir, nil,
+		"org-1", "", workDir, "", nil,
 		iostream.Streams{Out: io.Discard, Err: io.Discard},
 	)
 
@@ -93,7 +93,7 @@ func TestResolveSidecarReportsUnpickableOrg(t *testing.T) {
 	var sidecarID string
 	created, err := resolveSidecar(
 		context.Background(), fallbackClient(t, cci), &sidecarID,
-		"", "", workDir, nil,
+		"", "", workDir, "", nil,
 		iostream.Streams{Out: io.Discard, Err: io.Discard},
 	)
 
@@ -117,7 +117,7 @@ func TestResolveSidecarUsesActiveSidecar(t *testing.T) {
 	var sidecarID string
 	created, err := resolveSidecar(
 		context.Background(), fallbackClient(t, cci), &sidecarID,
-		"org-1", "", workDir, &sidecar.ActiveSidecar{SidecarID: "sc-existing"},
+		"org-1", "", workDir, "", &sidecar.ActiveSidecar{SidecarID: "sc-existing"},
 		iostream.Streams{Out: io.Discard, Err: io.Discard},
 	)
 

--- a/internal/cmd/validate_variants.go
+++ b/internal/cmd/validate_variants.go
@@ -97,7 +97,7 @@ func newValidateVariantsCmd() *cobra.Command {
 			if orgID == "" && cfg.OrgID != "" {
 				orgID = cfg.OrgID
 			}
-			resolvedOrgID, err := resolveOrgID(orgID, workDir, orgPicker(ctx, client))
+			resolvedOrgID, err := resolveOrgID(orgID, workDir, orgPicker(ctx, client, rc.CircleCITokenSource))
 			if err != nil {
 				return err
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,7 +38,8 @@ const (
 	dirPermission   = 0o700
 	filePermission  = 0o600
 
-	// SourceConfigFile is the source label used when a value comes from the user config file.
+	// SourceConfigFile is the fallback source label used when a value comes from the user config file
+	// and the path cannot be resolved. Callers should prefer configFileSource() for user-facing messages.
 	SourceConfigFile = "Config file (user config)"
 
 	// SourceProjectConfig is the source label for values from .chunk/config.json.
@@ -156,6 +157,16 @@ type ResolvedConfig struct {
 	Notifications         bool
 }
 
+// configFileSource returns a source label that includes the actual config file
+// path, e.g. "Config file (~/.config/chunk/config.json)". Falls back to
+// SourceConfigFile if the path cannot be resolved.
+func configFileSource() string {
+	if p, err := Path(); err == nil {
+		return "Config file (" + p + ")"
+	}
+	return SourceConfigFile
+}
+
 func resolveCircleCIToken(env EnvVars, cfg UserConfig) (string, string) {
 	switch {
 	case env.CircleToken != "":
@@ -163,7 +174,7 @@ func resolveCircleCIToken(env EnvVars, cfg UserConfig) (string, string) {
 	case env.CircleCIToken != "":
 		return env.CircleCIToken, "Environment variable (" + EnvCircleCIToken + ")"
 	case cfg.CircleCIToken != "":
-		return cfg.CircleCIToken, SourceConfigFile
+		return cfg.CircleCIToken, configFileSource()
 	default:
 		if token, err := keyring.Get(keyring.ServiceCircleCI(env.CircleCIBaseURL)); err == nil {
 			return token, keyring.SourceKeychain
@@ -179,7 +190,7 @@ func resolveAnthropicAPIKey(flagAPIKey string, env EnvVars, cfg UserConfig) (str
 	case env.AnthropicAPIKey != "":
 		return env.AnthropicAPIKey, "Environment variable"
 	case cfg.AnthropicAPIKey != "":
-		return cfg.AnthropicAPIKey, SourceConfigFile
+		return cfg.AnthropicAPIKey, configFileSource()
 	default:
 		if apiKey, err := keyring.Get(keyring.ServiceAnthropic(env.AnthropicBaseURL)); err == nil {
 			return apiKey, keyring.SourceKeychain
@@ -193,7 +204,7 @@ func resolveGitHubToken(env EnvVars, cfg UserConfig) (string, string) {
 	case env.GitHubToken != "":
 		return env.GitHubToken, "Environment variable (" + EnvGitHubToken + ")"
 	case cfg.GitHubToken != "":
-		return cfg.GitHubToken, SourceConfigFile
+		return cfg.GitHubToken, configFileSource()
 	default:
 		if token, err := keyring.Get(keyring.ServiceGitHub(env.GitHubAPIURL)); err == nil {
 			return token, keyring.SourceKeychain

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -357,7 +357,8 @@ func TestResolve_CircleCITokenFromConfigFile(t *testing.T) {
 	rc, err := Resolve("", "", false)
 	assert.NilError(t, err)
 	assert.Assert(t, rc.CircleCIToken == "cci-from-file", "expected CircleCI token from test config file")
-	assert.Equal(t, rc.CircleCITokenSource, SourceConfigFile)
+	assert.Assert(t, strings.HasPrefix(rc.CircleCITokenSource, "Config file ("), "expected source to include config file path, got: %s", rc.CircleCITokenSource)
+	assert.Assert(t, strings.Contains(rc.CircleCITokenSource, p), "expected source to contain config path %s, got: %s", p, rc.CircleCITokenSource)
 }
 
 func TestResolveCircleCI_ConfigFile(t *testing.T) {
@@ -370,7 +371,8 @@ func TestResolveCircleCI_ConfigFile(t *testing.T) {
 	rc, err := ResolveCircleCI(false)
 	assert.NilError(t, err)
 	assert.Assert(t, rc.CircleCIToken == "cci-from-file", "expected CircleCI token from test config file")
-	assert.Equal(t, rc.CircleCITokenSource, SourceConfigFile)
+	assert.Assert(t, strings.HasPrefix(rc.CircleCITokenSource, "Config file ("), "expected source to include config file path, got: %s", rc.CircleCITokenSource)
+	assert.Assert(t, strings.Contains(rc.CircleCITokenSource, p), "expected source to contain config path %s, got: %s", p, rc.CircleCITokenSource)
 	assert.Equal(t, rc.AnthropicAPIKey, "")
 	assert.Equal(t, rc.GitHubToken, "")
 }


### PR DESCRIPTION
## Summary

- Auth errors now tell you which token was used. Previously, "Not authorized" gave you no hint whether the problem was a bad env var, a stale config file token, or a keychain token with insufficient scope.

<img width="533" height="153" alt="Screenshot 2026-08-27 at 3 02 41 PM" src="https://github.com/user-attachments/assets/9acca945-d223-46ca-a042-087037ab85b6" />
<img width="596" height="281" alt="Screenshot 2026-08-27 at 3 16 19 PM" src="https://github.com/user-attachments/assets/814dae68-28e7-4ace-8b3f-37defebebe2d" />


## Implementation

- notAuthorized() now takes a tokenSource and surfaces it as a detail line
- The hand-written auth error in sidecar list got the same treatment via a new tokenSourceDetail() helper

## Test plan

- [ ] `CIRCLE_TOKEN=bad dist/chunk sidecar list` → shows `Token from: Environment variable (CIRCLE_TOKEN).`
- [ ] `CIRCLECI_TOKEN=bad dist/chunk sidecar list` → shows `Token from: Environment variable (CIRCLECI_TOKEN).`
- [ ] Config file token: inject `"circleCIToken": "bad"` into `~/.config/chunk/config.json` → shows `Token from: Config file (user config).`
- [ ] `task test` passes (1447 tests)

Fixes FACT-446
