### PR TITLE
Update TUI to account for session aware sidecars

### DIFF
--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -39,7 +39,8 @@ func newWatchCmd() *cobra.Command {
 				return fmt.Errorf("watch requires a TTY")
 			}
 
-			if err := watchd.EnsureRunning([]string{watchCmdName, "_daemon"}); err != nil {
+			daemonArgs := []string{watchCmdName, "_daemon"}
+			if err := watchd.EnsureRunning(daemonArgs); err != nil {
 				iostream.FromCmd(cmd).ErrPrintf("chunk watch: daemon unavailable, running without background updates: %v\n", err)
 			}
 
@@ -92,7 +93,7 @@ func newWatchCmd() *cobra.Command {
 				})
 			}
 
-			m := watch.New(entries, !focus)
+			m := watch.New(entries, !focus).WithDaemonArgs(daemonArgs)
 			p := tea.NewProgram(m, tea.WithContext(cmd.Context()))
 			_, err = p.Run()
 			return err

--- a/internal/tui/watch/client.go
+++ b/internal/tui/watch/client.go
@@ -2,14 +2,42 @@ package watch
 
 import (
 	tea "charm.land/bubbletea/v2"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/watchd"
 )
 
-// loadFromDaemon is the default Model.loadFn. It fetches a snapshot from the
-// watch daemon and converts it to a dataMsg. On failure it returns an errMsg
-// so prior state is preserved; the daemon is restarted at startup only (see
-// watch.go), and the next tick will reconnect once it is up.
+// loadFromDaemon is the default Model.loadFn.
 func loadFromDaemon(m Model) tea.Msg {
-	msg, err := fetchFromDaemon(m)
+	return loadWithRelaunch(m, fetchFromDaemon, watchd.EnsureLaunched)
+}
+
+// loadWithRelaunch fetches a snapshot, relaunching the daemon and retrying once
+// if it has gone away.
+//
+// EnsureRunning at startup is not enough on its own: the daemon can exit while
+// the dashboard is open — it crashes, someone kills it, or a chunk from another
+// build replaces it (see watchd.BuildID) — and nothing here would ever start
+// another. The dashboard would then hold whatever it last saw for as long as it
+// stayed open, which reads as a quiet dashboard rather than a broken one.
+//
+// relaunch is watchd.EnsureLaunched rather than EnsureRunning on purpose: a
+// failed poll should start a daemon if none is answering, not replace one that
+// is. fetch and relaunch are parameters so this can be tested without a daemon.
+func loadWithRelaunch(m Model, fetch func(Model) (dataMsg, error), relaunch func([]string) error) tea.Msg {
+	msg, err := fetch(m)
+	if err == nil {
+		return msg
+	}
+	// Without the daemon's argv there is nothing to relaunch; report the failure.
+	if len(m.daemonArgs) == 0 {
+		return errMsg{err}
+	}
+	if relaunchErr := relaunch(m.daemonArgs); relaunchErr != nil {
+		// Report the fetch failure rather than the relaunch failure: the first is
+		// what the reader is looking at, and the second is usually a restatement.
+		return errMsg{err}
+	}
+	msg, err = fetch(m)
 	if err != nil {
 		return errMsg{err}
 	}

--- a/internal/tui/watch/client_test.go
+++ b/internal/tui/watch/client_test.go
@@ -1,0 +1,87 @@
+package watch
+
+import (
+	"errors"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// fetchSeq returns a fetch func that yields the given results in order, and a
+// pointer to the call count.
+func fetchSeq(results ...error) (func(Model) (dataMsg, error), *int) {
+	calls := 0
+	return func(Model) (dataMsg, error) {
+		i := calls
+		calls++
+		if i < len(results) && results[i] != nil {
+			return dataMsg{}, results[i]
+		}
+		return dataMsg{branches: []string{"main"}}, nil
+	}, &calls
+}
+
+func TestLoadWithRelaunch_successNeverTouchesTheDaemon(t *testing.T) {
+	fetch, calls := fetchSeq(nil)
+	relaunched := 0
+	m := New(nil, false).WithDaemonArgs([]string{"watch", "_daemon"})
+
+	msg := loadWithRelaunch(m, fetch, func([]string) error { relaunched++; return nil })
+
+	_, ok := msg.(dataMsg)
+	assert.Assert(t, ok, "want dataMsg, got %T", msg)
+	assert.Equal(t, *calls, 1)
+	assert.Equal(t, relaunched, 0)
+}
+
+func TestLoadWithRelaunch_relaunchesAndRetriesOnce(t *testing.T) {
+	// First fetch fails (daemon gone), second succeeds (daemon back).
+	fetch, calls := fetchSeq(errors.New("connect to watch daemon: no such file"))
+	relaunched := 0
+	m := New(nil, false).WithDaemonArgs([]string{"watch", "_daemon"})
+
+	msg := loadWithRelaunch(m, fetch, func([]string) error { relaunched++; return nil })
+
+	_, ok := msg.(dataMsg)
+	assert.Assert(t, ok, "want dataMsg after relaunch, got %T", msg)
+	assert.Equal(t, relaunched, 1)
+	assert.Equal(t, *calls, 2)
+}
+
+func TestLoadWithRelaunch_withoutArgsItDoesNotTryToRelaunch(t *testing.T) {
+	fetch, calls := fetchSeq(errors.New("boom"))
+	relaunched := 0
+	m := New(nil, false) // no daemon argv
+
+	msg := loadWithRelaunch(m, fetch, func([]string) error { relaunched++; return nil })
+
+	err, ok := msg.(errMsg)
+	assert.Assert(t, ok, "want errMsg, got %T", msg)
+	assert.Error(t, err.err, "boom")
+	assert.Equal(t, relaunched, 0)
+	assert.Equal(t, *calls, 1)
+}
+
+func TestLoadWithRelaunch_reportsTheFetchErrorWhenRelaunchFails(t *testing.T) {
+	fetch, _ := fetchSeq(errors.New("connect to watch daemon: no such file"))
+	m := New(nil, false).WithDaemonArgs([]string{"watch", "_daemon"})
+
+	msg := loadWithRelaunch(m, fetch, func([]string) error { return errors.New("could not spawn") })
+
+	err, ok := msg.(errMsg)
+	assert.Assert(t, ok, "want errMsg, got %T", msg)
+	// The fetch failure is what the reader is looking at, not the relaunch one.
+	assert.Error(t, err.err, "connect to watch daemon: no such file")
+}
+
+func TestLoadWithRelaunch_reportsTheRetryErrorWhenBothFetchesFail(t *testing.T) {
+	fetch, calls := fetchSeq(errors.New("first"), errors.New("second"))
+	m := New(nil, false).WithDaemonArgs([]string{"watch", "_daemon"})
+
+	msg := loadWithRelaunch(m, fetch, func([]string) error { return nil })
+
+	err, ok := msg.(errMsg)
+	assert.Assert(t, ok, "want errMsg, got %T", msg)
+	assert.Error(t, err.err, "second")
+	assert.Equal(t, *calls, 2)
+}

--- a/internal/tui/watch/fetch.go
+++ b/internal/tui/watch/fetch.go
@@ -58,6 +58,7 @@ func convertSnapshot(snap watchd.Snapshot, m Model) dataMsg {
 				id:            sc.ID,
 				sidecarIDs:    []string{sc.ID},
 				name:          sc.Name,
+				sessionID:     sc.SessionID,
 				projectName:   sc.ProjectName,
 				repoName:      sc.RepoName,
 				branch:        p.Branch,
@@ -78,7 +79,7 @@ func convertSnapshot(snap watchd.Snapshot, m Model) dataMsg {
 		local := sidecarInfo{
 			id:          "",
 			sidecarIDs:  []string{""},
-			name:        "local",
+			name:        localRunnerName,
 			projectName: filepath.Base(p.Root),
 			repoName:    p.RepoName,
 			branch:      p.Branch,

--- a/internal/tui/watch/fetch.go
+++ b/internal/tui/watch/fetch.go
@@ -61,6 +61,7 @@ func convertSnapshot(snap watchd.Snapshot, m Model) dataMsg {
 				sessionID:     sc.SessionID,
 				projectName:   sc.ProjectName,
 				repoName:      sc.RepoName,
+				projectPath:   p.Root,
 				branch:        p.Branch,
 				projectIdx:    i,
 				snapshotName:  sc.SnapshotName,
@@ -82,6 +83,7 @@ func convertSnapshot(snap watchd.Snapshot, m Model) dataMsg {
 			name:        localRunnerName,
 			projectName: filepath.Base(p.Root),
 			repoName:    p.RepoName,
+			projectPath: p.Root,
 			branch:      p.Branch,
 			projectIdx:  i,
 		}

--- a/internal/tui/watch/fetch.go
+++ b/internal/tui/watch/fetch.go
@@ -101,7 +101,7 @@ func convertSnapshot(snap watchd.Snapshot, m Model) dataMsg {
 		allSidecars = append(allSidecars, local)
 	}
 
-	sortByActivity(allSidecars)
+	sortByActivity(allSidecars, m.ownSession)
 	allSidecars = mergeBranches(allSidecars)
 	allSidecars = filterSidecars(allSidecars, m.sidecarCapacity())
 

--- a/internal/tui/watch/model.go
+++ b/internal/tui/watch/model.go
@@ -11,6 +11,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
+	"github.com/CircleCI-Public/chunk-cli/internal/session"
 	"github.com/CircleCI-Public/chunk-cli/internal/upgrade"
 )
 
@@ -24,6 +25,10 @@ const (
 
 	levelDone  = "done"
 	levelError = "error"
+
+	// localRunnerName labels the synthesised row for validate runs that happened
+	// locally rather than on a sidecar.
+	localRunnerName = "local"
 )
 
 var spinFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
@@ -86,9 +91,14 @@ type ProjectEntry struct {
 // sidecarIDs lists every sidecar UUID (and "" for local runs) whose events
 // should appear in this entry's activity pane; populated by mergeBranches.
 type sidecarInfo struct {
-	id            string
-	sidecarIDs    []string // all IDs to match when filtering events
-	name          string
+	id         string
+	sidecarIDs []string // all IDs to match when filtering events
+	name       string
+	// sessionID is the agent session owning this sidecar, empty for the local
+	// runner and for state written before sidecars were session-scoped. Several
+	// sessions can hold sidecars for one worktree, so this is what distinguishes
+	// two otherwise identical rows.
+	sessionID     string
 	projectName   string
 	repoName      string    // basename of the main worktree (groups linked worktrees together)
 	branch        string    // current git branch for this worktree
@@ -155,6 +165,12 @@ type Model struct {
 
 	updateAvailable string // non-empty tag (e.g. "v1.2.3") when an update is available
 	upgradeCmd      string // "chunk upgrade" or "brew upgrade chunk"
+
+	// ownSession is the session running this dashboard, empty when a human ran
+	// `chunk watch` from a plain shell. When it matches a row's session that row
+	// is labelled as the viewer's own, which is the fastest way to answer "which
+	// of these is mine" without reading UUIDs.
+	ownSession string
 }
 
 // noSelection is the initial selectedID sentinel. It can never match a real
@@ -177,6 +193,7 @@ func New(projects []ProjectEntry, watchAll bool) Model {
 		toggledInvocs: make(map[time.Time]bool),
 		selectedID:    noSelection,
 		watchAll:      watchAll,
+		ownSession:    session.IDFromEnv(),
 	}
 }
 
@@ -380,6 +397,8 @@ func (m Model) renderSidecarPane(maxLines int) []string {
 	}
 
 	var lastRepo string
+	shared := sharedWorktrees(m.sidecars)
+	lastGroup, haveGroup := groupKey{}, false
 
 	for i, sc := range m.sidecars {
 		if len(lines) >= maxLines-2 {
@@ -394,22 +413,39 @@ func (m Model) renderSidecarPane(maxLines int) []string {
 			label := truncate(sc.repoName, leftPaneWidth-4)
 			add(vdim("── ") + bold(label))
 			lastRepo = sc.repoName
+			haveGroup = false
 		}
+
+		// A worktree driven by more than one session gets the branch printed
+		// once as a group header, and each row below it named by its session.
+		// Alone, a row keeps the branch as its own label: there is nothing to
+		// disambiguate, so it costs the reader nothing to know about sessions.
+		group := groupOf(sc)
+		multi := shared[group] > 1
+		if multi && (!haveGroup || group != lastGroup) {
+			// A detached HEAD has no branch to name the worktree with; the
+			// directory is the next best thing the reader can act on.
+			label := sc.branch
+			if label == "" {
+				label = sc.projectName
+			}
+			// The branch gets the full width: it is the thing the reader is
+			// looking for, and squeezing the count onto the same line would
+			// truncate a normal-length branch name to nothing.
+			add("  " + bold(truncate(label, leftPaneWidth-2)))
+			add("  " + vdim(fmt.Sprintf("%d sessions", shared[group])))
+		}
+		lastGroup, haveGroup = group, true
 
 		selected := i == m.selectedIdx
-		branchLabel := sc.branch
-		if branchLabel == "" {
-			branchLabel = sidecarDisplayName(sc.name, sc.id)
-		}
-		nameLine := truncate(branchLabel, leftPaneWidth-3)
+		nameLine := truncate(m.rowLabel(sc, multi), leftPaneWidth-3)
 
-		if selected {
-			if m.focusedPane == paneLeft {
-				add(green("▶ ") + bold(nameLine))
-			} else {
-				add(vdim("▶ ") + muted(nameLine))
-			}
-		} else {
+		switch {
+		case selected && m.focusedPane == paneLeft:
+			add(green("▶ ") + bold(nameLine))
+		case selected:
+			add(vdim("▶ ") + muted(nameLine))
+		default:
 			add("  " + nameLine)
 		}
 
@@ -474,6 +510,16 @@ func (m Model) renderActivityPane(maxLines int) []string {
 			title += "  " + muted(sc.repoName+"/"+branchLabel)
 		} else {
 			title += "  " + muted(branchLabel)
+		}
+		// Name the session as well as the sidecar. The left pane can be scrolled
+		// away from the selection, and with several sessions in one worktree the
+		// repo/branch above is no longer enough to say whose activity this is.
+		if sc.sessionID != "" {
+			if sc.sessionID == m.ownSession {
+				title += "  " + teal("● this session")
+			} else {
+				title += "  " + vdim("○ "+shortSession(sc.sessionID))
+			}
 		}
 		if sc.id != "" {
 			title += "  " + vdim(sidecarDisplayName(sc.name, sc.id))
@@ -909,20 +955,97 @@ func (m Model) loadData() tea.Msg {
 // sortByActivity puts the most recently active project first, and within a
 // project the most recently active sidecar first. Projects stay grouped so the
 // sidecar pane still renders one header per project.
+//
+// Worktree groups are the same story one level down: every row for a given
+// (repo, branch, project) sits together, ordered by the group's own most recent
+// activity. Without that tier the rows of a branch with two sessions could be
+// split apart by a busier branch in the same repo, and the pane could not label
+// the group once.
 func sortByActivity(sidecars []sidecarInfo) {
-	latest := map[string]time.Time{}
+	latestRepo := map[string]time.Time{}
+	latestGroup := map[groupKey]time.Time{}
 	for _, sc := range sidecars {
-		if eff := effectiveActivity(sc); eff.After(latest[sc.repoName]) {
-			latest[sc.repoName] = eff
+		eff := effectiveActivity(sc)
+		if eff.After(latestRepo[sc.repoName]) {
+			latestRepo[sc.repoName] = eff
+		}
+		if k := groupOf(sc); eff.After(latestGroup[k]) {
+			latestGroup[k] = eff
 		}
 	}
 	sort.SliceStable(sidecars, func(i, j int) bool {
 		a, b := sidecars[i], sidecars[j]
 		if a.repoName != b.repoName {
-			return latest[a.repoName].After(latest[b.repoName])
+			return latestRepo[a.repoName].After(latestRepo[b.repoName])
+		}
+		ka, kb := groupOf(a), groupOf(b)
+		if ka != kb {
+			return latestGroup[ka].After(latestGroup[kb])
 		}
 		return effectiveActivity(a).After(effectiveActivity(b))
 	})
+}
+
+// groupKey identifies one worktree: every row sharing it is a different session
+// (or the local runner) working in the same directory on the same branch.
+type groupKey struct {
+	repoName   string
+	branch     string
+	projectIdx int
+}
+
+func groupOf(sc sidecarInfo) groupKey {
+	return groupKey{sc.repoName, sc.branch, sc.projectIdx}
+}
+
+// sharedWorktrees counts the rows in each worktree group, so the pane can tell
+// a branch owned by one session from one several sessions are working in.
+//
+// mergeBranches has already folded the local runner into a real sidecar row
+// wherever both exist, so a group holding more than one row means two sidecars
+// claim the same worktree — which, now that sidecars are session-scoped, means
+// two sessions.
+func sharedWorktrees(sidecars []sidecarInfo) map[groupKey]int {
+	counts := make(map[groupKey]int, len(sidecars))
+	for _, sc := range sidecars {
+		counts[groupOf(sc)]++
+	}
+	return counts
+}
+
+// rowLabel names a row in the left pane. Alone in its worktree a row is its
+// branch, as it has always been. Sharing one, the branch has moved to the group
+// header and the row names its session instead — the viewer's own session by
+// name, since "which of these is mine" is the first thing they need to know.
+func (m Model) rowLabel(sc sidecarInfo, multi bool) string {
+	if !multi {
+		if sc.branch != "" {
+			return sc.branch
+		}
+		return sidecarDisplayName(sc.name, sc.id)
+	}
+	// The empty case is listed first deliberately: when the dashboard runs
+	// outside a session ownSession is empty too, and an unattributed row must
+	// not be mistaken for the viewer's own.
+	switch sc.sessionID {
+	case "":
+		// The local runner, or sidecar state written outside a session or before
+		// sessions existed: its name is the only identity it has.
+		return "○ " + sidecarDisplayName(sc.name, sc.id)
+	case m.ownSession:
+		return "● this session"
+	default:
+		return "○ " + shortSession(sc.sessionID)
+	}
+}
+
+// shortSession abbreviates a session ID for display. Session IDs are UUIDs, and
+// the first block is already enough to tell two of them apart on screen.
+func shortSession(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
 }
 
 // mergeBranches collapses entries with the same (repoName, branch, projectIdx) into
@@ -932,15 +1055,10 @@ func sortByActivity(sidecars []sidecarInfo) {
 // later, the sidecar's identity and sync state are promoted onto the primary so
 // the left pane shows sync status rather than pass/fail.
 func mergeBranches(sidecars []sidecarInfo) []sidecarInfo {
-	type key struct {
-		repoName   string
-		branch     string
-		projectIdx int
-	}
-	seen := map[key]int{}
+	seen := map[groupKey]int{}
 	result := make([]sidecarInfo, 0, len(sidecars))
 	for _, sc := range sidecars {
-		k := key{sc.repoName, sc.branch, sc.projectIdx}
+		k := groupOf(sc)
 		if idx, ok := seen[k]; !ok {
 			result = append(result, sc)
 			seen[k] = len(result) - 1

--- a/internal/tui/watch/model.go
+++ b/internal/tui/watch/model.go
@@ -398,20 +398,25 @@ func (m Model) renderSidecarPane(maxLines int) []string {
 
 	var lastRepo string
 	shared := sharedWorktrees(m.sidecars)
+	sessions := sessionsPerWorktree(m.sidecars)
 	lastGroup, haveGroup := groupKey{}, false
 
+	dropped := 0
 	for i, sc := range m.sidecars {
-		if len(lines) >= maxLines-2 {
-			break
-		}
+		// Cost the row before committing to it. A row is three to six lines and
+		// renderBody clips whatever runs past maxLines, so a row begun without the
+		// room to finish loses its tail — the sync state and age it exists to
+		// report. Building it aside first lets the pane drop it whole instead.
+		var row []string
+		addRow := func(s string) { row = append(row, s) }
 
 		// Repo separator — groups all worktrees of the same repo under one header.
 		if sc.repoName != lastRepo {
 			if lastRepo != "" {
-				add("")
+				addRow("")
 			}
 			label := truncate(sc.repoName, leftPaneWidth-4)
-			add(vdim("── ") + bold(label))
+			addRow(vdim("── ") + bold(label))
 			lastRepo = sc.repoName
 			haveGroup = false
 		}
@@ -432,8 +437,8 @@ func (m Model) renderSidecarPane(maxLines int) []string {
 			// The branch gets the full width: it is the thing the reader is
 			// looking for, and squeezing the count onto the same line would
 			// truncate a normal-length branch name to nothing.
-			add("  " + bold(truncate(label, leftPaneWidth-2)))
-			add("  " + vdim(fmt.Sprintf("%d sessions", shared[group])))
+			addRow("  " + bold(truncate(label, leftPaneWidth-2)))
+			addRow("  " + vdim(fmt.Sprintf("%d sessions", sessions[group])))
 		}
 		lastGroup, haveGroup = group, true
 
@@ -442,51 +447,67 @@ func (m Model) renderSidecarPane(maxLines int) []string {
 
 		switch {
 		case selected && m.focusedPane == paneLeft:
-			add(green("▶ ") + bold(nameLine))
+			addRow(green("▶ ") + bold(nameLine))
 		case selected:
-			add(vdim("▶ ") + muted(nameLine))
+			addRow(vdim("▶ ") + muted(nameLine))
 		default:
-			add("  " + nameLine)
+			addRow("  " + nameLine)
 		}
 
 		if sc.snapshotName != "" {
-			add("   " + vdim("◈ "+truncate(sc.snapshotName, leftPaneWidth-6)))
+			addRow("   " + vdim("◈ "+truncate(sc.snapshotName, leftPaneWidth-6)))
 		}
 		if sc.id != "" && sc.name != "" {
-			add("   " + vdim(truncate(sidecarDisplayName(sc.name, sc.id), leftPaneWidth-6)))
+			addRow("   " + vdim(truncate(sidecarDisplayName(sc.name, sc.id), leftPaneWidth-6)))
 		}
 
 		switch {
 		case sc.running:
 			frame := spinFrames[m.spinIdx%len(spinFrames)]
-			add("  " + blue(frame+" "+string(sc.lastOp)+"..."))
+			addRow("  " + blue(frame+" "+string(sc.lastOp)+"..."))
 		case sc.id == "": // local runner — no sync state
 			switch sc.lastLevel {
 			case levelDone:
-				add("  " + green("✓ passed"))
+				addRow("  " + green("✓ passed"))
 			case levelError:
-				add("  " + red("✗ failed"))
+				addRow("  " + red("✗ failed"))
 			default:
-				add("  " + muted("no runs yet"))
+				addRow("  " + muted("no runs yet"))
 			}
 		case sc.inSync:
-			add("  " + green("✓ in sync"))
+			addRow("  " + green("✓ in sync"))
 		case sc.lastSyncedRef == "":
-			add("  " + muted("not synced"))
+			addRow("  " + muted("not synced"))
 		default:
-			add("  " + yellow("↑ needs sync"))
+			addRow("  " + yellow("↑ needs sync"))
 		}
 
 		if !sc.lastActivity.IsZero() {
-			add("  " + vdim(ago(sc.lastActivity)))
+			addRow("  " + vdim(ago(sc.lastActivity)))
 		} else {
-			add("")
+			addRow("")
 		}
 
 		// Divider between sidecars in the same repo group.
 		if i < len(m.sidecars)-1 && m.sidecars[i+1].repoName == sc.repoName {
-			add(muted(strings.Repeat("─", leftPaneWidth)))
+			addRow(muted(strings.Repeat("─", leftPaneWidth)))
 		}
+
+		// Hold back a line for the hint whenever rows remain after this one.
+		budget := maxLines
+		if i < len(m.sidecars)-1 {
+			budget--
+		}
+		if len(lines)+len(row) > budget {
+			dropped = len(m.sidecars) - i
+			break
+		}
+		lines = append(lines, row...)
+	}
+	if dropped > 0 {
+		// Without this the rows simply stopped: a group's session count was the
+		// only clue that any were missing, and a dropped repo had none at all.
+		lines = append(lines, "  "+vdim(fmt.Sprintf("↓ %d more", dropped)))
 	}
 	return lines
 }
@@ -961,7 +982,7 @@ func (m Model) loadData() tea.Msg {
 // activity. Without that tier the rows of a branch with two sessions could be
 // split apart by a busier branch in the same repo, and the pane could not label
 // the group once.
-func sortByActivity(sidecars []sidecarInfo) {
+func sortByActivity(sidecars []sidecarInfo, ownSession string) {
 	latestRepo := map[string]time.Time{}
 	latestGroup := map[groupKey]time.Time{}
 	for _, sc := range sidecars {
@@ -981,6 +1002,16 @@ func sortByActivity(sidecars []sidecarInfo) {
 		ka, kb := groupOf(a), groupOf(b)
 		if ka != kb {
 			return latestGroup[ka].After(latestGroup[kb])
+		}
+		// Inside a group the viewer's own row leads. "Which of these is mine" is
+		// the first question a shared worktree raises, and a row that reshuffles
+		// by recency every poll makes the reader hunt for the answer the label
+		// was added to give. Ordering between the other rows is untouched.
+		if ownSession != "" {
+			aMine, bMine := a.sessionID == ownSession, b.sessionID == ownSession
+			if aMine != bMine {
+				return aMine
+			}
 		}
 		return effectiveActivity(a).After(effectiveActivity(b))
 	})
@@ -1009,6 +1040,19 @@ func sharedWorktrees(sidecars []sidecarInfo) map[groupKey]int {
 	counts := make(map[groupKey]int, len(sidecars))
 	for _, sc := range sidecars {
 		counts[groupOf(sc)]++
+	}
+	return counts
+}
+
+// sessionsPerWorktree counts the sessions in each group — one per sidecar. The
+// local runner occupies a row but is not a session, so a worktree with two
+// sessions and a local run reads "2 sessions" over three rows rather than three.
+func sessionsPerWorktree(sidecars []sidecarInfo) map[groupKey]int {
+	counts := make(map[groupKey]int, len(sidecars))
+	for _, sc := range sidecars {
+		if sc.id != "" {
+			counts[groupOf(sc)]++
+		}
 	}
 	return counts
 }
@@ -1061,6 +1105,18 @@ func shortUUID(id string) string {
 // later, the sidecar's identity and sync state are promoted onto the primary so
 // the left pane shows sync status rather than pass/fail.
 func mergeBranches(sidecars []sidecarInfo) []sidecarInfo {
+	// A local validate run belongs to the worktree, not to any session in it. With
+	// one session holding the worktree that distinction is invisible and folding
+	// the local row in buys a cleaner pane. With several, the fold would credit
+	// one session with runs another developer — or no agent at all — made, so
+	// those groups keep the local row separate.
+	realPerGroup := map[groupKey]int{}
+	for _, sc := range sidecars {
+		if sc.id != "" {
+			realPerGroup[groupOf(sc)]++
+		}
+	}
+
 	seen := map[groupKey]int{}
 	result := make([]sidecarInfo, 0, len(sidecars))
 	for _, sc := range sidecars {
@@ -1078,6 +1134,13 @@ func mergeBranches(sidecars []sidecarInfo) []sidecarInfo {
 			// has no session — from ever merging into the sidecar row it belongs
 			// to, leaving a duplicate "local" row under every branch.
 			if result[idx].id != "" && sc.id != "" {
+				result = append(result, sc)
+				seen[k] = len(result) - 1
+				continue
+			}
+			// One of the pair is the local runner. Fold it in only where a single
+			// session holds the worktree; see realPerGroup above.
+			if realPerGroup[k] > 1 {
 				result = append(result, sc)
 				seen[k] = len(result) - 1
 				continue
@@ -1146,8 +1209,12 @@ const (
 	// active within activeWindow.
 	fallbackWindow = 24 * time.Hour
 	// linesPerSidecar is the worst-case row cost of one sidecar in the sidecar
-	// pane: project header, name, status, age, and the gap between projects.
-	linesPerSidecar = 5
+	// pane: name, snapshot, sidecar id, status, age, and the divider to the next
+	// row. A shared worktree adds two more for its group header, so this is a
+	// floor rather than an exact figure; renderSidecarPane drops whatever does
+	// not fit and says so, so an optimistic count costs a "more" hint, not a
+	// half-drawn row.
+	linesPerSidecar = 6
 	// defaultCapacity is used until the first WindowSizeMsg gives a real height.
 	defaultCapacity = 5
 )

--- a/internal/tui/watch/model.go
+++ b/internal/tui/watch/model.go
@@ -168,6 +168,11 @@ type Model struct {
 	updateAvailable string // non-empty tag (e.g. "v1.2.3") when an update is available
 	upgradeCmd      string // "chunk upgrade" or "brew upgrade chunk"
 
+	// daemonArgs is the argv that starts the watch daemon, empty when the caller
+	// did not supply one. Held so a poll that finds the daemon gone can start
+	// another instead of freezing on the last snapshot.
+	daemonArgs []string
+
 	// ownSession is the session running this dashboard, empty when a human ran
 	// `chunk watch` from a plain shell. When it matches a row's session that row
 	// is labelled as the viewer's own, which is the fastest way to answer "which
@@ -197,6 +202,14 @@ func New(projects []ProjectEntry, watchAll bool) Model {
 		watchAll:      watchAll,
 		ownSession:    session.IDFromEnv(),
 	}
+}
+
+// WithDaemonArgs returns a copy of m that can relaunch the watch daemon when a
+// poll finds it gone. subArgs is the argv the daemon is started with, the same
+// one passed to watchd.EnsureRunning.
+func (m Model) WithDaemonArgs(subArgs []string) Model {
+	m.daemonArgs = subArgs
+	return m
 }
 
 func (m Model) Init() tea.Cmd {
@@ -350,6 +363,13 @@ func (m Model) renderSeparator() string {
 
 func (m Model) renderBody() string {
 	contentHeight := m.height - 4 // header + separator + footer + padding
+	// The footer grows by a line when the daemon is unreachable. Without handing
+	// that line back the message lands past the last row and is clipped at every
+	// terminal size, which is how a daemon that had died came to look like a
+	// dashboard that had merely gone quiet.
+	if m.daemonErr != nil {
+		contentHeight--
+	}
 	if contentHeight < 1 {
 		contentHeight = 1
 	}
@@ -525,6 +545,12 @@ func (m Model) renderSidecarPane(maxLines int) []string {
 	return lines
 }
 
+// renderActivityPane renders the right-hand pane for the selected sidecar.
+//
+// The selection is bounded on both sides before it indexes m.sidecars. Update
+// keeps it in range, so a negative value should not arise — but a panic here
+// takes the terminal down with it, still in the alternate screen, and the cost
+// of the second comparison is nothing next to that.
 func (m Model) renderActivityPane(maxLines int) []string {
 	lines := make([]string, 0, maxLines)
 
@@ -534,7 +560,7 @@ func (m Model) renderActivityPane(maxLines int) []string {
 	} else {
 		title = vdim("activity")
 	}
-	if m.selectedIdx < len(m.sidecars) {
+	if m.selectedIdx >= 0 && m.selectedIdx < len(m.sidecars) {
 		sc := m.sidecars[m.selectedIdx]
 		branchLabel := sc.branch
 		if branchLabel == "" {
@@ -562,7 +588,7 @@ func (m Model) renderActivityPane(maxLines int) []string {
 	lines = append(lines, title, "")
 
 	var filtered []eventlog.Event
-	if m.selectedIdx < len(m.sidecars) {
+	if m.selectedIdx >= 0 && m.selectedIdx < len(m.sidecars) {
 		sc := m.sidecars[m.selectedIdx]
 		if sc.projectIdx < len(m.events) {
 			for _, e := range m.events[sc.projectIdx] {
@@ -663,7 +689,7 @@ func invocEndTime(g invocationGroup) time.Time {
 
 // currentInvocGroups returns the invocation groups for the currently selected sidecar.
 func (m Model) currentInvocGroups() []invocationGroup {
-	if m.selectedIdx >= len(m.sidecars) {
+	if m.selectedIdx < 0 || m.selectedIdx >= len(m.sidecars) {
 		return nil
 	}
 	sc := m.sidecars[m.selectedIdx]

--- a/internal/tui/watch/model.go
+++ b/internal/tui/watch/model.go
@@ -3,6 +3,7 @@ package watch
 
 import (
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -101,6 +102,7 @@ type sidecarInfo struct {
 	sessionID     string
 	projectName   string
 	repoName      string    // basename of the main worktree (groups linked worktrees together)
+	projectPath   string    // absolute root of this worktree, "" when unknown
 	branch        string    // current git branch for this worktree
 	projectIdx    int       // index into Model.projects
 	snapshotName  string    // name of the active snapshot for this project, if any
@@ -399,6 +401,8 @@ func (m Model) renderSidecarPane(maxLines int) []string {
 	var lastRepo string
 	shared := sharedWorktrees(m.sidecars)
 	sessions := sessionsPerWorktree(m.sidecars)
+	ambiguous := ambiguousBranches(m.sidecars)
+	dirLabels := worktreeLabels(m.sidecars, ambiguous)
 	lastGroup, haveGroup := groupKey{}, false
 
 	dropped := 0
@@ -427,10 +431,19 @@ func (m Model) renderSidecarPane(maxLines int) []string {
 		// disambiguate, so it costs the reader nothing to know about sessions.
 		group := groupOf(sc)
 		multi := shared[group] > 1
+		// "" unless this branch lives in more than one directory.
+		dirLabel := ""
+		if ambiguous[worktreeKey{sc.repoName, sc.branch}] {
+			dirLabel = dirLabels[sc.projectIdx]
+		}
 		if multi && (!haveGroup || group != lastGroup) {
-			// A detached HEAD has no branch to name the worktree with; the
-			// directory is the next best thing the reader can act on.
+			// A detached HEAD has no branch to name the worktree with, and a
+			// branch checked out twice names two of them; either way the
+			// directory is what the reader can act on.
 			label := sc.branch
+			if dirLabel != "" {
+				label = dirLabel
+			}
 			if label == "" {
 				label = sc.projectName
 			}
@@ -443,7 +456,7 @@ func (m Model) renderSidecarPane(maxLines int) []string {
 		lastGroup, haveGroup = group, true
 
 		selected := i == m.selectedIdx
-		nameLine := truncate(m.rowLabel(sc, multi), leftPaneWidth-3)
+		nameLine := truncate(m.rowLabel(sc, multi, dirLabel), leftPaneWidth-3)
 
 		switch {
 		case selected && m.focusedPane == paneLeft:
@@ -1057,12 +1070,129 @@ func sessionsPerWorktree(sidecars []sidecarInfo) map[groupKey]int {
 	return counts
 }
 
+// worktreeKey identifies a branch within a repo, with no directory attached. Two
+// rows sharing one in different directories are two checkouts of the same
+// branch — a second clone, or a worktree that happens to be on the same branch —
+// and the branch name alone cannot tell them apart.
+type worktreeKey struct {
+	repoName string
+	branch   string
+}
+
+// ambiguousBranches reports which (repo, branch) pairs are checked out in more
+// than one directory. Those rows cannot be named by their branch: repoName is the
+// basename of the main worktree, so two clones collapse under one repo header and
+// would render as two identical branch rows, separable only by a truncated
+// sidecar UUID — the very confusion per-session labels were added to remove.
+//
+// A detached HEAD has no branch to be ambiguous about, and those rows are already
+// named by their directory, so they are left alone.
+func ambiguousBranches(sidecars []sidecarInfo) map[worktreeKey]bool {
+	dirs := map[worktreeKey]map[int]bool{}
+	for _, sc := range sidecars {
+		if sc.branch == "" {
+			continue
+		}
+		k := worktreeKey{sc.repoName, sc.branch}
+		if dirs[k] == nil {
+			dirs[k] = map[int]bool{}
+		}
+		dirs[k][sc.projectIdx] = true
+	}
+	out := make(map[worktreeKey]bool, len(dirs))
+	for k, seen := range dirs {
+		if len(seen) > 1 {
+			out[k] = true
+		}
+	}
+	return out
+}
+
+// worktreeLabels names each directory involved in an ambiguous branch. A row's
+// projectIdx fixes its repo and branch — a directory is only ever on one branch
+// at a time — so one label per index is unambiguous.
+func worktreeLabels(sidecars []sidecarInfo, ambiguous map[worktreeKey]bool) map[int]string {
+	paths := map[worktreeKey]map[int]string{}
+	for _, sc := range sidecars {
+		k := worktreeKey{sc.repoName, sc.branch}
+		if !ambiguous[k] {
+			continue
+		}
+		path := sc.projectPath
+		if path == "" {
+			path = sc.projectName
+		}
+		if paths[k] == nil {
+			paths[k] = map[int]string{}
+		}
+		paths[k][sc.projectIdx] = path
+	}
+
+	labels := map[int]string{}
+	for _, byIdx := range paths {
+		for idx, label := range shortestUniqueSuffixes(byIdx) {
+			labels[idx] = label
+		}
+	}
+	return labels
+}
+
+// shortestUniqueSuffixes labels each path with the fewest trailing segments that
+// tell them all apart, so the pane spends its 28 columns on the part that
+// differs. One segment is usually not enough: two clones of a repo share a
+// basename, which is what made the branch ambiguous in the first place.
+func shortestUniqueSuffixes(paths map[int]string) map[int]string {
+	segs := make(map[int][]string, len(paths))
+	longest := 1
+	for idx, path := range paths {
+		parts := strings.Split(strings.Trim(filepath.ToSlash(path), "/"), "/")
+		segs[idx] = parts
+		if len(parts) > longest {
+			longest = len(parts)
+		}
+	}
+
+	out := make(map[int]string, len(paths))
+	for n := 1; n <= longest; n++ {
+		counts := map[string]int{}
+		for idx, parts := range segs {
+			out[idx] = pathSuffix(parts, n)
+			counts[out[idx]]++
+		}
+		collision := false
+		for _, c := range counts {
+			if c > 1 {
+				collision = true
+				break
+			}
+		}
+		if !collision {
+			return out
+		}
+	}
+	// Identical paths cannot be told apart; the full path is the best available.
+	return out
+}
+
+func pathSuffix(parts []string, n int) string {
+	if n >= len(parts) {
+		return strings.Join(parts, "/")
+	}
+	return strings.Join(parts[len(parts)-n:], "/")
+}
+
 // rowLabel names a row in the left pane. Alone in its worktree a row is its
 // branch, as it has always been. Sharing one, the branch has moved to the group
 // header and the row names its session instead — the viewer's own session by
 // name, since "which of these is mine" is the first thing they need to know.
-func (m Model) rowLabel(sc sidecarInfo, multi bool) string {
+func (m Model) rowLabel(sc sidecarInfo, multi bool, dirLabel string) string {
 	if !multi {
+		// dirLabel is set only where the branch is checked out in more than one
+		// directory, and there the directory is the only thing that distinguishes
+		// this row from its twin.
+		if dirLabel != "" {
+			return dirLabel
+		}
 		if sc.branch != "" {
 			return sc.branch
 		}

--- a/internal/tui/watch/model.go
+++ b/internal/tui/watch/model.go
@@ -1066,6 +1066,11 @@ func mergeBranches(sidecars []sidecarInfo) []sidecarInfo {
 			// Only merge when one entry is a local runner (id == ""). Two real
 			// sidecars on the same branch belong to different sessions and must
 			// stay separate so they are distinguishable in the left pane.
+			//
+			// This guard, not the key, is what keeps sessions apart. Adding
+			// sessionID to the key instead would stop the local runner — which
+			// has no session — from ever merging into the sidecar row it belongs
+			// to, leaving a duplicate "local" row under every branch.
 			if result[idx].id != "" && sc.id != "" {
 				result = append(result, sc)
 				seen[k] = len(result) - 1
@@ -1073,10 +1078,14 @@ func mergeBranches(sidecars []sidecarInfo) []sidecarInfo {
 			}
 			result[idx].sidecarIDs = append(result[idx].sidecarIDs, sc.sidecarIDs...)
 			// Promote a real sidecar over a local-only primary so the left pane
-			// shows sync state rather than a pass/fail badge.
+			// shows sync state rather than a pass/fail badge. The session comes
+			// with it: the row now stands for that sidecar, and leaving the
+			// session behind would strip the "this session" label off the
+			// viewer's own row whenever local activity happened to sort first.
 			if result[idx].id == "" && sc.id != "" {
 				result[idx].id = sc.id
 				result[idx].name = sc.name
+				result[idx].sessionID = sc.sessionID
 				result[idx].inSync = sc.inSync
 				result[idx].lastSyncedRef = sc.lastSyncedRef
 				result[idx].snapshotName = sc.snapshotName

--- a/internal/tui/watch/model_test.go
+++ b/internal/tui/watch/model_test.go
@@ -234,7 +234,7 @@ func TestSortByActivity_freshestProjectFirst(t *testing.T) {
 		{id: "newest", repoName: "busy-project", lastActivity: now.Add(-1 * time.Minute)},
 	}
 
-	sortByActivity(sidecars)
+	sortByActivity(sidecars, "")
 
 	want := []string{"newest", "older", "stale"}
 	for i, id := range want {
@@ -252,7 +252,7 @@ func TestSortByActivity_keepsProjectsGrouped(t *testing.T) {
 		{id: "a2", repoName: "a", lastActivity: now.Add(-3 * time.Minute)},
 	}
 
-	sortByActivity(sidecars)
+	sortByActivity(sidecars, "")
 
 	// Project b is freshest so it leads, then both of a's sidecars together.
 	want := []string{"b1", "a1", "a2"}
@@ -272,7 +272,7 @@ func TestFilterSidecars_noPerProjectCap(t *testing.T) {
 		{id: "s4", projectName: "p", lastActivity: now.Add(-4 * time.Minute)},
 	}
 
-	sortByActivity(sidecars)
+	sortByActivity(sidecars, "")
 	got := filterSidecars(sidecars, 2)
 
 	if len(got) != 4 {
@@ -368,8 +368,8 @@ func TestSidecarCapacity(t *testing.T) {
 	}{
 		{"unset height", 0, defaultCapacity},
 		{"tiny terminal", 8, 1},
-		{"40 rows", 40, 6},
-		{"80 rows", 80, 14},
+		{"40 rows", 40, 5},
+		{"80 rows", 80, 12},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -561,6 +561,89 @@ func TestRenderSidecarPane_detachedHeadNamesTheDirectory(t *testing.T) {
 	assert.Assert(t, strings.Contains(lines[countAt-1], "wt-detached"), lines[countAt-1])
 }
 
+func TestRenderSidecarPane_dropsWholeRowsRatherThanCuttingOne(t *testing.T) {
+	now := time.Now()
+	m := sessionModel("", []sidecarInfo{
+		{id: "id1", sessionID: "sessA", repoName: "repo-a", branch: "main",
+			lastActivity: now, inSync: true},
+		{id: "id2", sessionID: "sessB", repoName: "repo-b", branch: "main",
+			lastActivity: now.Add(-time.Minute), inSync: true},
+	})
+
+	// Room for the title, the blank under it, and the first row only. The second
+	// row would previously have been started and then clipped by renderBody,
+	// losing its sync badge and age.
+	pane := strings.Join(m.renderSidecarPane(9), "\n")
+
+	// A complete row ends in an age line, so one age line per sync badge means
+	// no row was cut part-way through.
+	assert.Equal(t, strings.Count(pane, "in sync"), strings.Count(pane, "ago"), pane)
+	assert.Assert(t, strings.Contains(pane, "1 more"), pane)
+}
+
+func TestRenderSidecarPane_noOverflowHintWhenEverythingFits(t *testing.T) {
+	now := time.Now()
+	m := sessionModel("", []sidecarInfo{
+		{id: "id1", sessionID: "sessA", repoName: "repo-a", branch: "main",
+			lastActivity: now, inSync: true},
+		{id: "id2", sessionID: "sessB", repoName: "repo-b", branch: "main",
+			lastActivity: now.Add(-time.Minute), inSync: true},
+	})
+
+	pane := strings.Join(m.renderSidecarPane(40), "\n")
+
+	assert.Assert(t, !strings.Contains(pane, "more"), pane)
+}
+
+func TestSortByActivity_pinsTheViewersOwnRowFirstInItsGroup(t *testing.T) {
+	now := time.Now()
+	// The viewer's own session is the stalest of the three, so recency alone
+	// would bury it in the middle of the group.
+	sidecars := []sidecarInfo{
+		{id: "theirs-new", sessionID: "sessB", repoName: "r", branch: "main", lastActivity: now},
+		{id: "mine", sessionID: "sessMine", repoName: "r", branch: "main", lastActivity: now.Add(-30 * time.Minute)},
+		{id: "theirs-mid", sessionID: "sessC", repoName: "r", branch: "main", lastActivity: now.Add(-5 * time.Minute)},
+	}
+
+	sortByActivity(sidecars, "sessMine")
+
+	// Own row first, and the rest still in recency order behind it.
+	want := []string{"mine", "theirs-new", "theirs-mid"}
+	for i, id := range want {
+		assert.Equal(t, sidecars[i].id, id, "position %d", i)
+	}
+}
+
+func TestSortByActivity_pinningDoesNotJumpGroups(t *testing.T) {
+	now := time.Now()
+	// A busier branch must still lead the repo: pinning orders rows inside a
+	// group, it does not promote the viewer's group over a fresher one.
+	sidecars := []sidecarInfo{
+		{id: "busy", sessionID: "sessB", repoName: "r", branch: "feature", lastActivity: now},
+		{id: "mine", sessionID: "sessMine", repoName: "r", branch: "main", lastActivity: now.Add(-30 * time.Minute)},
+	}
+
+	sortByActivity(sidecars, "sessMine")
+
+	assert.Equal(t, sidecars[0].id, "busy")
+}
+
+func TestRenderSidecarPane_localRunnerIsNotCountedAsASession(t *testing.T) {
+	now := time.Now()
+	m := sessionModel("", []sidecarInfo{
+		{id: "id1", sessionID: "sessA", repoName: "r", branch: "main", lastActivity: now},
+		{id: "id2", sessionID: "sessB", repoName: "r", branch: "main", lastActivity: now.Add(-1 * time.Minute)},
+		{id: "", name: localRunnerName, repoName: "r", branch: "main", lastActivity: now.Add(-2 * time.Minute)},
+	})
+
+	pane := strings.Join(m.renderSidecarPane(40), "\n")
+
+	// Three rows, but only two of them are sessions.
+	assert.Assert(t, strings.Contains(pane, "2 sessions"), pane)
+	assert.Assert(t, !strings.Contains(pane, "3 sessions"), pane)
+	assert.Assert(t, strings.Contains(pane, "○ "+localRunnerName), pane)
+}
+
 func TestRowLabel(t *testing.T) {
 	m := New(nil, false)
 	m.ownSession = "mine1234-abcd"
@@ -596,7 +679,7 @@ func TestSortByActivity_keepsWorktreeGroupsTogether(t *testing.T) {
 		{id: "main-new", repoName: "r", branch: "main", lastActivity: now.Add(-1 * time.Minute)},
 	}
 
-	sortByActivity(sidecars)
+	sortByActivity(sidecars, "")
 
 	want := []string{"main-new", "main-old", "feature"}
 	for i, id := range want {
@@ -642,6 +725,25 @@ func TestConvertSnapshot_carriesSessionID(t *testing.T) {
 	assert.Equal(t, got["id2"], "sessB")
 }
 
+// A local validate run belongs to the worktree, not to any one agent. Folding
+// its events into a session's row makes the pane claim another session ran them.
+func TestConvertSnapshot_localRunIsNotAttributedToASession(t *testing.T) {
+	now := time.Now()
+	snap := twoSessionSnapshot(now.Add(-5*time.Minute), now.Add(-2*time.Minute), now.Add(-1*time.Minute))
+	m := New(nil, false)
+	m.height = 60
+
+	msg := convertSnapshot(snap, m)
+
+	for _, sc := range msg.sidecars {
+		if sc.sessionID == "" {
+			continue // the local row itself, or unattributed state
+		}
+		assert.Assert(t, !hasSidecarID(sc.sidecarIDs, ""),
+			"session %q absorbed the local run: ids=%v", sc.sessionID, sc.sidecarIDs)
+	}
+}
+
 // twoSessionSnapshot builds a daemon snapshot for one worktree driven by two
 // sessions. localAt, when non-zero, adds a local (non-sidecar) validate run.
 func twoSessionSnapshot(aAt, bAt, localAt time.Time) watchd.Snapshot {
@@ -683,16 +785,53 @@ func TestConvertSnapshot_twoSessionsSurviveTheMerge(t *testing.T) {
 	assert.Assert(t, strings.Contains(pane, "sessB"), pane)
 }
 
-// A local run fresher than either sidecar makes the local row lead its group,
-// so mergeBranches promotes a sidecar onto it. The promotion has to carry the
-// session, or the viewer's own row silently loses its label.
+// oneSessionSnapshot builds a snapshot for a worktree held by a single session,
+// with the local run fresher than the sidecar so the local row leads its group.
+func oneSessionSnapshot(sidecarAt, localAt time.Time) watchd.Snapshot {
+	ev := func(ts time.Time, sidecarID string) eventlog.Event {
+		return eventlog.Event{Ts: ts, SidecarID: sidecarID, Op: eventlog.OpValidate,
+			Level: levelDone, Msg: "1/1 passed"}
+	}
+	return watchd.Snapshot{Projects: []watchd.ProjectSnapshot{{
+		Root:     "/repo",
+		Branch:   "main",
+		RepoName: "repo",
+		Sidecars: []watchd.SidecarState{
+			{ID: "idA", Name: "repo-sessA", SessionID: "sessA", RepoName: "repo", LastActivity: sidecarAt},
+		},
+		Events: []eventlog.Event{ev(sidecarAt, "idA"), ev(localAt, "")},
+	}}}
+}
+
+// A local run fresher than the sidecar makes the local row lead its group, so
+// mergeBranches promotes the sidecar onto it. The promotion has to carry the
+// session, or the activity pane stops naming it. Only a worktree held by one
+// session folds the local row in at all — see the test below for the other case.
 func TestConvertSnapshot_promotionKeepsTheSession(t *testing.T) {
+	now := time.Now()
+	msg := convertSnapshot(oneSessionSnapshot(now.Add(-10*time.Minute), now), New(nil, true))
+
+	assert.Equal(t, len(msg.sidecars), 1)
+	assert.Equal(t, msg.sidecars[0].id, "idA")
+	assert.Equal(t, msg.sidecars[0].sessionID, "sessA")
+
+	m := sessionModel("sessA", msg.sidecars)
+	m.selectedIdx = 0
+	m.width = 120
+	pane := strings.Join(m.renderActivityPane(20), "\n")
+	assert.Assert(t, strings.Contains(pane, "this session"), pane)
+}
+
+// Two sessions plus a local run: the local row belongs to neither session, so it
+// stays a row of its own. The worktree then shows three rows described as two
+// sessions, and no session is credited with the local run.
+func TestConvertSnapshot_localRowStaysSeparateWhenSessionsShareAWorktree(t *testing.T) {
 	now := time.Now()
 	msg := convertSnapshot(
 		twoSessionSnapshot(now.Add(-10*time.Minute), now.Add(-11*time.Minute), now),
 		New(nil, true))
 
-	assert.Equal(t, len(msg.sidecars), 2)
+	assert.Equal(t, len(msg.sidecars), 3)
 	sessions := map[string]string{}
 	for _, sc := range msg.sidecars {
 		sessions[sc.id] = sc.sessionID
@@ -702,5 +841,6 @@ func TestConvertSnapshot_promotionKeepsTheSession(t *testing.T) {
 
 	m := sessionModel("sessA", msg.sidecars)
 	pane := strings.Join(m.renderSidecarPane(40), "\n")
+	assert.Assert(t, strings.Contains(pane, "2 sessions"), pane)
 	assert.Assert(t, strings.Contains(pane, "this session"), pane)
 }

--- a/internal/tui/watch/model_test.go
+++ b/internal/tui/watch/model_test.go
@@ -8,8 +8,10 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"gotest.tools/v3/assert"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
+	"github.com/CircleCI-Public/chunk-cli/internal/watchd"
 )
 
 // groupEvents tests
@@ -500,4 +502,165 @@ func TestRenderFooter_updateNoticeShownWhenItFits(t *testing.T) {
 	if !strings.Contains(footer, "v1.2.3") || !strings.Contains(footer, "chunk upgrade") {
 		t.Errorf("expected update notice in footer, got %q", footer)
 	}
+}
+
+// session-aware rendering tests
+
+// sessionModel builds a model whose own session is fixed, so tests do not
+// depend on whether the suite itself runs inside an agent session.
+func sessionModel(own string, sidecars []sidecarInfo) Model {
+	m := New(nil, false)
+	m.ownSession = own
+	m.sidecars = sidecars
+	m.selectedIdx = -1 // no selection, so the ▶ marker cannot mask a label
+	return m
+}
+
+func TestRenderSidecarPane_singleSessionKeepsBranchLabel(t *testing.T) {
+	m := sessionModel("sessA", []sidecarInfo{
+		{id: "id1", name: "chunk-cli-sessA", sessionID: "sessA",
+			repoName: "chunk-cli", branch: "main", lastActivity: time.Now()},
+	})
+
+	pane := strings.Join(m.renderSidecarPane(40), "\n")
+
+	// One session in the worktree: nothing to disambiguate, so the row reads
+	// exactly as it did before sessions existed.
+	assert.Assert(t, strings.Contains(pane, "main"), pane)
+	assert.Assert(t, !strings.Contains(pane, "sessions"), pane)
+	assert.Assert(t, !strings.Contains(pane, "this session"), pane)
+}
+
+func TestRenderSidecarPane_twoSessionsAreNamed(t *testing.T) {
+	now := time.Now()
+	m := sessionModel("aaaaaaaa-1111-2222-3333-444444444444", []sidecarInfo{
+		{id: "id1", name: "chunk-cli-aaaaaaaa", sessionID: "aaaaaaaa-1111-2222-3333-444444444444",
+			repoName: "chunk-cli", branch: "main", lastActivity: now},
+		{id: "id2", name: "chunk-cli-bbbbbbbb", sessionID: "bbbbbbbb-1111-2222-3333-444444444444",
+			repoName: "chunk-cli", branch: "main", lastActivity: now.Add(-5 * time.Minute)},
+	})
+
+	pane := strings.Join(m.renderSidecarPane(40), "\n")
+
+	// The branch is named once for the group, and each row by its session.
+	assert.Assert(t, strings.Contains(pane, "2 sessions"), pane)
+	assert.Assert(t, strings.Contains(pane, "this session"), pane)
+	assert.Assert(t, strings.Contains(pane, "bbbbbbbb"), pane)
+	// The full UUID is never printed — it is unreadable at this pane width.
+	assert.Assert(t, !strings.Contains(pane, "bbbbbbbb-1111"), pane)
+}
+
+func TestRenderSidecarPane_groupHeaderPrintedOncePerWorktree(t *testing.T) {
+	now := time.Now()
+	m := sessionModel("", []sidecarInfo{
+		{id: "id1", sessionID: "sessA", repoName: "chunk-cli", branch: "main", lastActivity: now},
+		{id: "id2", sessionID: "sessB", repoName: "chunk-cli", branch: "main", lastActivity: now},
+	})
+
+	pane := strings.Join(m.renderSidecarPane(40), "\n")
+
+	assert.Equal(t, strings.Count(pane, "2 sessions"), 1, pane)
+}
+
+func TestRenderSidecarPane_detachedHeadNamesTheDirectory(t *testing.T) {
+	now := time.Now()
+	// A distinct projectName, so finding it proves the group header used the
+	// directory rather than merely matching the repo header above it.
+	m := sessionModel("", []sidecarInfo{
+		{id: "id1", sessionID: "sessA", repoName: "monorepo", projectName: "wt-detached", lastActivity: now},
+		{id: "id2", sessionID: "sessB", repoName: "monorepo", projectName: "wt-detached", lastActivity: now},
+	})
+
+	// With no branch to name the group, the header must still say something the
+	// reader can act on rather than rendering blank.
+	lines := m.renderSidecarPane(40)
+	countAt := -1
+	for i, l := range lines {
+		if strings.Contains(l, "2 sessions") {
+			countAt = i
+		}
+	}
+	assert.Assert(t, countAt > 0, strings.Join(lines, "\n"))
+	assert.Assert(t, strings.Contains(lines[countAt-1], "wt-detached"), lines[countAt-1])
+}
+
+func TestRowLabel(t *testing.T) {
+	m := New(nil, false)
+	m.ownSession = "mine1234-abcd"
+
+	tests := []struct {
+		name  string
+		sc    sidecarInfo
+		multi bool
+		want  string
+	}{
+		{"alone uses the branch", sidecarInfo{id: "x", branch: "main", sessionID: "other"}, false, "main"},
+		{"alone with no branch falls back to the name", sidecarInfo{id: "x", name: "sc-1"}, false, "sc-1"},
+		{"own session is called out", sidecarInfo{id: "x", branch: "main", sessionID: "mine1234-abcd"}, true, "● this session"},
+		{"other session is shortened", sidecarInfo{id: "x", branch: "main", sessionID: "theirs99-abcd"}, true, "○ theirs99"},
+		{"local runner keeps its name", sidecarInfo{id: "", name: localRunnerName, branch: "main"}, true, "○ " + localRunnerName},
+		{"pre-session state keeps its name", sidecarInfo{id: "x", name: "sc-legacy", branch: "main"}, true, "○ sc-legacy"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, m.rowLabel(tc.sc, tc.multi), tc.want)
+		})
+	}
+}
+
+func TestSortByActivity_keepsWorktreeGroupsTogether(t *testing.T) {
+	now := time.Now()
+	// Two sessions on main, with a busier branch in the same repo between them.
+	// Without a worktree tier the busy branch splits main's rows apart and the
+	// pane cannot print one header for them.
+	sidecars := []sidecarInfo{
+		{id: "main-old", repoName: "r", branch: "main", lastActivity: now.Add(-10 * time.Minute)},
+		{id: "feature", repoName: "r", branch: "feature", lastActivity: now.Add(-2 * time.Minute)},
+		{id: "main-new", repoName: "r", branch: "main", lastActivity: now.Add(-1 * time.Minute)},
+	}
+
+	sortByActivity(sidecars)
+
+	want := []string{"main-new", "main-old", "feature"}
+	for i, id := range want {
+		assert.Equal(t, sidecars[i].id, id, "position %d", i)
+	}
+}
+
+func TestRenderActivityPane_namesTheSelectedSession(t *testing.T) {
+	now := time.Now()
+	m := sessionModel("mine1234-abcd", []sidecarInfo{
+		{id: "id1", name: "sc-1", sessionID: "theirs99-abcd", repoName: "chunk-cli",
+			branch: "main", lastActivity: now},
+	})
+	m.selectedIdx = 0
+	m.width = 120
+
+	pane := strings.Join(m.renderActivityPane(20), "\n")
+
+	// The left pane can be scrolled away from the selection, so the activity
+	// header has to say whose events these are on its own.
+	assert.Assert(t, strings.Contains(pane, "theirs99"), pane)
+}
+
+func TestConvertSnapshot_carriesSessionID(t *testing.T) {
+	now := time.Now()
+	snap := watchd.Snapshot{Projects: []watchd.ProjectSnapshot{{
+		Root:     "/tmp/repo",
+		Branch:   "main",
+		RepoName: "repo",
+		Sidecars: []watchd.SidecarState{
+			{ID: "id1", Name: "sc-1", SessionID: "sessA", LastActivity: now},
+			{ID: "id2", Name: "sc-2", SessionID: "sessB", LastActivity: now},
+		},
+	}}}
+
+	msg := convertSnapshot(snap, New(nil, true))
+
+	got := map[string]string{}
+	for _, sc := range msg.sidecars {
+		got[sc.id] = sc.sessionID
+	}
+	assert.Equal(t, got["id1"], "sessA")
+	assert.Equal(t, got["id2"], "sessB")
 }

--- a/internal/tui/watch/model_test.go
+++ b/internal/tui/watch/model_test.go
@@ -664,3 +664,66 @@ func TestConvertSnapshot_carriesSessionID(t *testing.T) {
 	assert.Equal(t, got["id1"], "sessA")
 	assert.Equal(t, got["id2"], "sessB")
 }
+
+// twoSessionSnapshot builds a daemon snapshot for one worktree driven by two
+// sessions. localAt, when non-zero, adds a local (non-sidecar) validate run.
+func twoSessionSnapshot(aAt, bAt, localAt time.Time) watchd.Snapshot {
+	ev := func(ts time.Time, sidecarID string) eventlog.Event {
+		return eventlog.Event{Ts: ts, SidecarID: sidecarID, Op: eventlog.OpValidate,
+			Level: levelDone, Msg: "1/1 passed"}
+	}
+	events := []eventlog.Event{ev(aAt, "idA"), ev(bAt, "idB")}
+	if !localAt.IsZero() {
+		events = append(events, ev(localAt, ""))
+	}
+	return watchd.Snapshot{Projects: []watchd.ProjectSnapshot{{
+		Root:     "/repo",
+		Branch:   "main",
+		RepoName: "repo",
+		Sidecars: []watchd.SidecarState{
+			{ID: "idA", Name: "repo-sessA", SessionID: "sessA", RepoName: "repo", LastActivity: aAt},
+			{ID: "idB", Name: "repo-sessB", SessionID: "sessB", RepoName: "repo", LastActivity: bAt},
+		},
+		Events: events,
+	}}}
+}
+
+// The unit tests above set m.sidecars directly, so they cannot catch a merge
+// that collapses two sessions into one row. This drives the real path —
+// convertSnapshot → sortByActivity → mergeBranches → filterSidecars — and
+// asserts both sessions survive it with their identities intact.
+func TestConvertSnapshot_twoSessionsSurviveTheMerge(t *testing.T) {
+	now := time.Now()
+	msg := convertSnapshot(twoSessionSnapshot(now, now.Add(-5*time.Minute), time.Time{}), New(nil, true))
+
+	assert.Equal(t, len(msg.sidecars), 2)
+	assert.Equal(t, sharedWorktrees(msg.sidecars)[groupOf(msg.sidecars[0])], 2)
+
+	m := sessionModel("sessA", msg.sidecars)
+	pane := strings.Join(m.renderSidecarPane(40), "\n")
+	assert.Assert(t, strings.Contains(pane, "2 sessions"), pane)
+	assert.Assert(t, strings.Contains(pane, "this session"), pane)
+	assert.Assert(t, strings.Contains(pane, "sessB"), pane)
+}
+
+// A local run fresher than either sidecar makes the local row lead its group,
+// so mergeBranches promotes a sidecar onto it. The promotion has to carry the
+// session, or the viewer's own row silently loses its label.
+func TestConvertSnapshot_promotionKeepsTheSession(t *testing.T) {
+	now := time.Now()
+	msg := convertSnapshot(
+		twoSessionSnapshot(now.Add(-10*time.Minute), now.Add(-11*time.Minute), now),
+		New(nil, true))
+
+	assert.Equal(t, len(msg.sidecars), 2)
+	sessions := map[string]string{}
+	for _, sc := range msg.sidecars {
+		sessions[sc.id] = sc.sessionID
+	}
+	assert.Equal(t, sessions["idA"], "sessA")
+	assert.Equal(t, sessions["idB"], "sessB")
+
+	m := sessionModel("sessA", msg.sidecars)
+	pane := strings.Join(m.renderSidecarPane(40), "\n")
+	assert.Assert(t, strings.Contains(pane, "this session"), pane)
+}

--- a/internal/tui/watch/model_test.go
+++ b/internal/tui/watch/model_test.go
@@ -1,6 +1,7 @@
 package watch
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -440,6 +441,60 @@ func TestUpdate_unknownSelectionFallsBackToFreshest(t *testing.T) {
 
 // The update notice is right-aligned with padding, so a notice that does not
 // fit would wrap the footer and push the fixed-height layout off screen.
+// The daemon-unavailable line used to be appended past the last row of the
+// terminal, so it was clipped at every height and a dead daemon looked like a
+// dashboard that had simply gone quiet.
+func TestRender_daemonErrorIsVisibleAndStillFitsTheTerminal(t *testing.T) {
+	now := time.Now()
+	for _, height := range []int{12, 24, 40, 60} {
+		m := sessionModel("", []sidecarInfo{
+			{id: "id1", sessionID: "sessA", repoName: "repo", branch: "main",
+				lastActivity: now, inSync: true},
+		})
+		m.width = 100
+		m.height = height
+		m.selectedIdx = 0
+		m.daemonErr = errors.New("connect to watch daemon: no such file")
+
+		out := m.render()
+
+		assert.Assert(t, strings.Contains(out, "daemon unavailable: connect to watch daemon"),
+			"height %d: message missing:\n%s", height, out)
+		assert.Assert(t, strings.Count(out, "\n") <= height,
+			"height %d: rendered %d lines, which would clip the message", height, strings.Count(out, "\n"))
+	}
+}
+
+func TestRender_withoutADaemonErrorTheLayoutIsUnchanged(t *testing.T) {
+	now := time.Now()
+	m := sessionModel("", []sidecarInfo{
+		{id: "id1", sessionID: "sessA", repoName: "repo", branch: "main",
+			lastActivity: now, inSync: true},
+	})
+	m.width = 100
+	m.height = 24
+	m.selectedIdx = 0
+
+	assert.Equal(t, strings.Count(m.render(), "\n"), 24)
+}
+
+// sessionModel leaves the selection at -1 so labels are not masked by the ▶
+// marker. Rendering must survive that rather than indexing m.sidecars[-1].
+func TestRender_survivesAnOutOfRangeSelection(t *testing.T) {
+	now := time.Now()
+	for _, idx := range []int{-1, 0, 5} {
+		m := sessionModel("", []sidecarInfo{
+			{id: "id1", sessionID: "sessA", repoName: "repo", branch: "main",
+				lastActivity: now, inSync: true},
+		})
+		m.width = 100
+		m.height = 24
+		m.selectedIdx = idx
+
+		assert.Assert(t, m.render() != "", "selection %d rendered nothing", idx)
+	}
+}
+
 func TestRenderFooter_updateNoticeNeverWidensFooter(t *testing.T) {
 	for _, width := range []int{40, 80, 100, 120, 200} {
 		for _, focus := range []pane{paneLeft, paneRight} {

--- a/internal/tui/watch/model_test.go
+++ b/internal/tui/watch/model_test.go
@@ -595,6 +595,98 @@ func TestRenderSidecarPane_noOverflowHintWhenEverythingFits(t *testing.T) {
 	assert.Assert(t, !strings.Contains(pane, "more"), pane)
 }
 
+func TestRenderSidecarPane_sameBranchInTwoCheckoutsNamesTheDirectory(t *testing.T) {
+	now := time.Now()
+	// Two clones of one repo, both on main. repoName is the basename of the main
+	// worktree, so both collapse under one repo header — and the basenames match
+	// too, which is exactly why the branch alone cannot name these rows.
+	m := sessionModel("", []sidecarInfo{
+		{id: "id1", sessionID: "sessA", repoName: "chunk-cli", projectName: "chunk-cli",
+			projectPath: "/Users/j/work/chunk-cli", branch: "main", projectIdx: 0, lastActivity: now},
+		{id: "id2", sessionID: "sessB", repoName: "chunk-cli", projectName: "chunk-cli",
+			projectPath: "/Users/j/tmp/chunk-cli", branch: "main", projectIdx: 1,
+			lastActivity: now.Add(-1 * time.Minute)},
+	})
+
+	pane := strings.Join(m.renderSidecarPane(40), "\n")
+
+	assert.Assert(t, strings.Contains(pane, "work/chunk-cli"), pane)
+	assert.Assert(t, strings.Contains(pane, "tmp/chunk-cli"), pane)
+}
+
+func TestRenderSidecarPane_distinctBranchesKeepTheirBranchLabels(t *testing.T) {
+	now := time.Now()
+	// Two directories of one repo on different branches: the branch already tells
+	// them apart, so nothing should change.
+	m := sessionModel("", []sidecarInfo{
+		{id: "id1", sessionID: "sessA", repoName: "chunk-cli", projectName: "chunk-cli",
+			projectPath: "/Users/j/work/chunk-cli", branch: "main", projectIdx: 0, lastActivity: now},
+		{id: "id2", sessionID: "sessB", repoName: "chunk-cli", projectName: "chunk-cli-wt",
+			projectPath: "/Users/j/work/chunk-cli-wt", branch: "feature", projectIdx: 1,
+			lastActivity: now.Add(-1 * time.Minute)},
+	})
+
+	pane := strings.Join(m.renderSidecarPane(40), "\n")
+
+	assert.Assert(t, strings.Contains(pane, "main"), pane)
+	assert.Assert(t, strings.Contains(pane, "feature"), pane)
+	assert.Assert(t, !strings.Contains(pane, "work/chunk-cli"), pane)
+}
+
+func TestRenderSidecarPane_ambiguousBranchNamesTheDirectoryInTheGroupHeader(t *testing.T) {
+	now := time.Now()
+	// One of the two checkouts is itself shared by two sessions: its group header
+	// has to name the directory, since "main" would match the other checkout.
+	m := sessionModel("sessA", []sidecarInfo{
+		{id: "id1", sessionID: "sessA", repoName: "chunk-cli", projectName: "chunk-cli",
+			projectPath: "/Users/j/work/chunk-cli", branch: "main", projectIdx: 0, lastActivity: now},
+		{id: "id2", sessionID: "sessB", repoName: "chunk-cli", projectName: "chunk-cli",
+			projectPath: "/Users/j/work/chunk-cli", branch: "main", projectIdx: 0,
+			lastActivity: now.Add(-1 * time.Minute)},
+		{id: "id3", sessionID: "sessC", repoName: "chunk-cli", projectName: "chunk-cli",
+			projectPath: "/Users/j/tmp/chunk-cli", branch: "main", projectIdx: 1,
+			lastActivity: now.Add(-2 * time.Minute)},
+	})
+
+	pane := strings.Join(m.renderSidecarPane(40), "\n")
+
+	assert.Assert(t, strings.Contains(pane, "work/chunk-cli"), pane)
+	assert.Assert(t, strings.Contains(pane, "2 sessions"), pane)
+	assert.Assert(t, strings.Contains(pane, "tmp/chunk-cli"), pane)
+}
+
+func TestShortestUniqueSuffixes(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths map[int]string
+		want  map[int]string
+	}{
+		{
+			"colliding basenames take the parent",
+			map[int]string{0: "/Users/j/work/chunk-cli", 1: "/Users/j/tmp/chunk-cli"},
+			map[int]string{0: "work/chunk-cli", 1: "tmp/chunk-cli"},
+		},
+		{
+			"distinct basenames stay short",
+			map[int]string{0: "/Users/j/work/chunk-cli", 1: "/Users/j/work/chunk-cli-wt"},
+			map[int]string{0: "chunk-cli", 1: "chunk-cli-wt"},
+		},
+		{
+			"digs as deep as it must",
+			map[int]string{0: "/a/one/x/repo", 1: "/a/two/x/repo"},
+			map[int]string{0: "one/x/repo", 1: "two/x/repo"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shortestUniqueSuffixes(tc.paths)
+			for idx, want := range tc.want {
+				assert.Equal(t, got[idx], want, "index %d", idx)
+			}
+		})
+	}
+}
+
 func TestSortByActivity_pinsTheViewersOwnRowFirstInItsGroup(t *testing.T) {
 	now := time.Now()
 	// The viewer's own session is the stalest of the three, so recency alone
@@ -649,21 +741,23 @@ func TestRowLabel(t *testing.T) {
 	m.ownSession = "mine1234-abcd"
 
 	tests := []struct {
-		name  string
-		sc    sidecarInfo
-		multi bool
-		want  string
+		name     string
+		sc       sidecarInfo
+		multi    bool
+		dirLabel string
+		want     string
 	}{
-		{"alone uses the branch", sidecarInfo{id: "x", branch: "main", sessionID: "other"}, false, "main"},
-		{"alone with no branch falls back to the identifier", sidecarInfo{id: "11111111-aaaa-bbbb-cccc-000000000001", name: "sc-1"}, false, "11111111-aaaa-bbbb-cccc-000000000001"},
-		{"own session is called out", sidecarInfo{id: "x", branch: "main", sessionID: "mine1234-abcd"}, true, "● this session"},
-		{"other session is shortened", sidecarInfo{id: "x", branch: "main", sessionID: "theirs99-abcd"}, true, "○ theirs99"},
-		{"local runner keeps its name", sidecarInfo{id: "", name: localRunnerName, branch: "main"}, true, "○ " + localRunnerName},
-		{"pre-session state is abbreviated too", sidecarInfo{id: "11111111-aaaa-bbbb-cccc-000000000001", name: "sc-legacy", branch: "main"}, true, "○ 11111111"},
+		{"alone uses the branch", sidecarInfo{id: "x", branch: "main", sessionID: "other"}, false, "", "main"},
+		{"a branch checked out twice is named by directory", sidecarInfo{id: "x", branch: "main"}, false, "work/repo", "work/repo"},
+		{"alone with no branch falls back to the identifier", sidecarInfo{id: "11111111-aaaa-bbbb-cccc-000000000001", name: "sc-1"}, false, "", "11111111-aaaa-bbbb-cccc-000000000001"},
+		{"own session is called out", sidecarInfo{id: "x", branch: "main", sessionID: "mine1234-abcd"}, true, "", "● this session"},
+		{"other session is shortened", sidecarInfo{id: "x", branch: "main", sessionID: "theirs99-abcd"}, true, "", "○ theirs99"},
+		{"local runner keeps its name", sidecarInfo{id: "", name: localRunnerName, branch: "main"}, true, "", "○ " + localRunnerName},
+		{"pre-session state is abbreviated too", sidecarInfo{id: "11111111-aaaa-bbbb-cccc-000000000001", name: "sc-legacy", branch: "main"}, true, "", "○ 11111111"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, m.rowLabel(tc.sc, tc.multi), tc.want)
+			assert.Equal(t, m.rowLabel(tc.sc, tc.multi, tc.dirLabel), tc.want)
 		})
 	}
 }

--- a/internal/watchd/build.go
+++ b/internal/watchd/build.go
@@ -1,0 +1,43 @@
+package watchd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/version"
+)
+
+// BuildID identifies the binary a process was started from.
+//
+// The daemon serves snapshots shaped by the code it was started from: a field
+// added to SidecarState since then is absent rather than wrong, so a newer
+// client renders a well-formed view of stale data with nothing to say why. A
+// sidecar owned by a session, for instance, arrives from a pre-session daemon
+// looking like a sidecar nobody owns. Comparing this on every ping is what makes
+// that visible instead of silent.
+//
+// The version alone will not do: every local build reports the same development
+// version, so the executable's path, size and modification time come along to
+// tell two of them apart. Path is included so a dev build and an installed one
+// are never mistaken for each other.
+func BuildID() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return buildID(version.Value, "", 0, time.Time{})
+	}
+	fi, err := os.Stat(exe)
+	if err != nil {
+		return buildID(version.Value, exe, 0, time.Time{})
+	}
+	return buildID(version.Value, exe, fi.Size(), fi.ModTime())
+}
+
+// buildID formats the identity. Split out from BuildID so it can be tested
+// without standing up binaries on disk.
+func buildID(ver, exe string, size int64, mod time.Time) string {
+	if exe == "" {
+		return ver
+	}
+	return fmt.Sprintf("%s|%s|%d|%d", ver, exe, size, mod.UnixNano())
+}

--- a/internal/watchd/client.go
+++ b/internal/watchd/client.go
@@ -107,6 +107,35 @@ func EnsureRunning(subArgs []string) error {
 	return launchDaemon(subArgs)
 }
 
+// EnsureLaunched starts the daemon when nothing is answering and otherwise
+// leaves whatever is there alone.
+//
+// Unlike EnsureRunning it never replaces a daemon from another build. It is
+// called when a poll fails mid-session, and a dashboard that has been open for a
+// while has no business restarting a daemon another one is using: the build
+// check is a startup decision, made once, where the cost of being wrong is one
+// restart rather than a restart per poll for as long as two dashboards are open.
+func EnsureLaunched(subArgs []string) error {
+	pidPath, err := PIDPath()
+	if err != nil {
+		return err
+	}
+	sockPath, err := SocketPath()
+	if err != nil {
+		return err
+	}
+	running, _, err := IsRunning(pidPath)
+	if err != nil {
+		return fmt.Errorf("check running: %w", err)
+	}
+	if running {
+		if reachable, _ := ping(sockPath); reachable {
+			return nil
+		}
+	}
+	return launchDaemon(subArgs)
+}
+
 func launchDaemon(subArgs []string) error {
 	if _, err := EnsureDir(); err != nil {
 		return fmt.Errorf("ensure watchd dir: %w", err)

--- a/internal/watchd/client.go
+++ b/internal/watchd/client.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -37,14 +39,40 @@ func FetchSnapshot(roots []string) (Snapshot, error) {
 	return snap, nil
 }
 
-// ping returns true if the daemon at sockPath is reachable.
-func ping(sockPath string) bool {
+// ping reports whether the daemon at sockPath is reachable, along with the build
+// identity it names. A daemon older than that identity reports "".
+func ping(sockPath string) (bool, string) {
 	resp, err := unixClient(sockPath).Get("http://watchd/ping")
 	if err != nil {
-		return false
+		return false, ""
 	}
-	_ = resp.Body.Close()
-	return resp.StatusCode == 200
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return false, ""
+	}
+	// Bounded: the identity is short, and a body this side cannot recognise is
+	// no reason to read an unbounded amount of it.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 512))
+	if err != nil {
+		return true, ""
+	}
+	return true, strings.TrimSpace(string(body))
+}
+
+// stopDaemon asks the daemon to exit and waits until it stops answering, so the
+// replacement does not race it for the socket.
+func stopDaemon(pid int, sockPath string) error {
+	if err := terminate(pid); err != nil {
+		return fmt.Errorf("signal pid %d: %w", pid, err)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if reachable, _ := ping(sockPath); !reachable {
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("watch daemon pid %d did not exit within 3s", pid)
 }
 
 // EnsureRunning checks whether the watch daemon is running and serving, and
@@ -59,12 +87,22 @@ func EnsureRunning(subArgs []string) error {
 	if err != nil {
 		return err
 	}
-	running, _, err := IsRunning(pidPath)
+	running, pid, err := IsRunning(pidPath)
 	if err != nil {
 		return fmt.Errorf("check running: %w", err)
 	}
-	if running && ping(sockPath) {
-		return nil
+	if running {
+		reachable, build := ping(sockPath)
+		if reachable {
+			if build == BuildID() {
+				return nil
+			}
+			// A daemon from another build is replaced rather than reused: see
+			// BuildID for why reusing it degrades silently.
+			if stopErr := stopDaemon(pid, sockPath); stopErr != nil {
+				return fmt.Errorf("replace stale watch daemon: %w", stopErr)
+			}
+		}
 	}
 	return launchDaemon(subArgs)
 }
@@ -108,7 +146,7 @@ func launchDaemon(subArgs []string) error {
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		ok, _, _ := IsRunning(pidPath)
-		if ok && ping(sockPath) {
+		if reachable, _ := ping(sockPath); ok && reachable {
 			return nil
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/internal/watchd/daemon_test.go
+++ b/internal/watchd/daemon_test.go
@@ -25,12 +25,15 @@ func TestDaemonRoundTrip(t *testing.T) {
 
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		if ping(sockPath) {
+		if reachable, _ := ping(sockPath); reachable {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	assert.Assert(t, ping(sockPath), "daemon did not become reachable within 5s")
+	reachable, build := ping(sockPath)
+	assert.Assert(t, reachable, "daemon did not become reachable within 5s")
+	// The daemon runs in this process, so it reports this build.
+	assert.Equal(t, build, BuildID())
 
 	_, err = FetchSnapshot(nil)
 	assert.NilError(t, err)
@@ -43,4 +46,33 @@ func TestDaemonRoundTrip(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("daemon did not shut down within 5s after context cancel")
 	}
+}
+
+func TestBuildID_distinguishesBuildsTheVersionCannot(t *testing.T) {
+	mod := time.Unix(1_700_000_000, 0)
+
+	// Every local build reports the same development version, so the version
+	// alone would call two different binaries the same daemon.
+	same := buildID("dev", "/usr/local/bin/chunk", 100, mod)
+	assert.Equal(t, same, buildID("dev", "/usr/local/bin/chunk", 100, mod))
+
+	// A rebuild in place: same path, new size and timestamp.
+	assert.Assert(t, buildID("dev", "/usr/local/bin/chunk", 101, mod) != same)
+	assert.Assert(t, buildID("dev", "/usr/local/bin/chunk", 100, mod.Add(time.Second)) != same)
+
+	// A dev build alongside an installed one.
+	assert.Assert(t, buildID("dev", "/repo/dist/chunk", 100, mod) != same)
+
+	// A tagged release differs from a dev build of the same binary.
+	assert.Assert(t, buildID("v1.2.3", "/usr/local/bin/chunk", 100, mod) != same)
+}
+
+func TestBuildID_fallsBackToTheVersionWithoutAnExecutable(t *testing.T) {
+	assert.Equal(t, buildID("v1.2.3", "", 0, time.Time{}), "v1.2.3")
+}
+
+// A daemon that predates the identity answers /ping with an empty body, so the
+// client must read that as a mismatch and replace it rather than trust it.
+func TestPing_emptyBuildIsAMismatch(t *testing.T) {
+	assert.Assert(t, BuildID() != "", "BuildID must never be empty, or a stale daemon would look current")
 }

--- a/internal/watchd/daemon_test.go
+++ b/internal/watchd/daemon_test.go
@@ -2,6 +2,7 @@ package watchd
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -75,4 +76,56 @@ func TestBuildID_fallsBackToTheVersionWithoutAnExecutable(t *testing.T) {
 // client must read that as a mismatch and replace it rather than trust it.
 func TestPing_emptyBuildIsAMismatch(t *testing.T) {
 	assert.Assert(t, BuildID() != "", "BuildID must never be empty, or a stale daemon would look current")
+}
+
+// EnsureLaunched must leave a reachable daemon alone whatever build it reports,
+// so a failed poll in one dashboard cannot restart the daemon another is using.
+func TestEnsureLaunched_leavesAReachableDaemonAlone(t *testing.T) {
+	// Not t.TempDir(): it embeds the test name, and a unix socket path is capped
+	// at 104 bytes on darwin, so a descriptive name here silently breaks listen.
+	dir, err := os.MkdirTemp("", "wd")
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	t.Setenv("CHUNK_WATCHD_DIR", dir)
+	// The daemon polls every known project before it serves, and every project
+	// costs a git call. Pointed at the developer's real data directory that first
+	// poll can outlast the wait below, so keep it hermetic.
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- RunDaemon(ctx) }()
+
+	sockPath, err := SocketPath()
+	assert.NilError(t, err)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if reachable, _ := ping(sockPath); reachable {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	reachable, _ := ping(sockPath)
+	assert.Assert(t, reachable, "daemon did not become reachable within 5s")
+
+	pidPath, err := PIDPath()
+	assert.NilError(t, err)
+	_, before, err := IsRunning(pidPath)
+	assert.NilError(t, err)
+
+	// Args that could not possibly start anything: if EnsureLaunched tried to
+	// relaunch, it would fail rather than silently succeed.
+	assert.NilError(t, EnsureLaunched([]string{"definitely", "not", "a", "command"}))
+
+	_, after, err := IsRunning(pidPath)
+	assert.NilError(t, err)
+	assert.Equal(t, before, after, "the running daemon was replaced")
+
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("daemon did not shut down")
+	}
 }

--- a/internal/watchd/ipc.go
+++ b/internal/watchd/ipc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -13,7 +14,12 @@ import (
 func newServer(d *daemon) *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		// The body carries this daemon's build identity. A daemon predating the
+		// identity answers with an empty body, which reads as a mismatch — which
+		// is right, since that is exactly the daemon a client needs to replace.
+		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, BuildID())
 	})
 	mux.HandleFunc("/snapshot", func(w http.ResponseWriter, r *http.Request) {
 		var roots []string

--- a/internal/watchd/load.go
+++ b/internal/watchd/load.go
@@ -56,6 +56,7 @@ func loadSidecars(dataDir, root, snapshotName, head string) []SidecarState {
 		ss := SidecarState{
 			ID:            as.SidecarID,
 			Name:          as.Name,
+			SessionID:     as.SessionID,
 			ProjectName:   projectName,
 			RepoName:      repoName,
 			SnapshotName:  snapshotName,

--- a/internal/watchd/load_test.go
+++ b/internal/watchd/load_test.go
@@ -29,6 +29,30 @@ func TestLoadSidecars_deduplicatesIDs(t *testing.T) {
 	assert.Equal(t, len(result), 2, "want 2 unique sidecars")
 }
 
+func TestLoadSidecars_carriesSessionID(t *testing.T) {
+	dir := t.TempDir()
+	root := t.TempDir()
+
+	// Two sessions holding a sidecar each for the same project: the session ID
+	// is the only thing that tells their state files apart, so dropping it
+	// leaves the dashboard unable to label them.
+	writeSidecarJSON(t, dir, "sidecar.sessA.json", `{"sidecar_id":"id1","name":"sc1","session_id":"sessA"}`)
+	writeSidecarJSON(t, dir, "sidecar.sessB.json", `{"sidecar_id":"id2","name":"sc2","session_id":"sessB"}`)
+	writeSidecarJSON(t, dir, "sidecar.json", `{"sidecar_id":"id3","name":"sc3"}`)
+
+	result := loadSidecars(dir, root, "", "")
+	assert.Equal(t, len(result), 3)
+
+	got := map[string]string{}
+	for _, ss := range result {
+		got[ss.ID] = ss.SessionID
+	}
+	assert.Equal(t, got["id1"], "sessA")
+	assert.Equal(t, got["id2"], "sessB")
+	// State written outside a session stays unattributed rather than guessing.
+	assert.Equal(t, got["id3"], "")
+}
+
 func TestLoadSidecars_inSyncWhenHeadMatches(t *testing.T) {
 	dir := t.TempDir()
 	root := t.TempDir()

--- a/internal/watchd/pid_notwindows.go
+++ b/internal/watchd/pid_notwindows.go
@@ -26,3 +26,13 @@ func IsRunning(path string) (bool, int, error) {
 	}
 	return true, p, nil
 }
+
+// terminate asks the process to exit. The daemon handles SIGTERM and shuts down
+// cleanly, removing its socket and PID file on the way out.
+func terminate(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return proc.Signal(syscall.SIGTERM)
+}

--- a/internal/watchd/pid_windows.go
+++ b/internal/watchd/pid_windows.go
@@ -32,3 +32,13 @@ func IsRunning(path string) (bool, int, error) {
 	}
 	return code == windows.STILL_ACTIVE, p, nil
 }
+
+// terminate stops the process. Windows has no SIGTERM, so the process is killed
+// outright; the next daemon to start removes the socket file it leaves behind.
+func terminate(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return proc.Kill()
+}

--- a/internal/watchd/types.go
+++ b/internal/watchd/types.go
@@ -9,8 +9,13 @@ import (
 
 // SidecarState describes one active sidecar as maintained by the daemon.
 type SidecarState struct {
-	ID            string      `json:"id"`
-	Name          string      `json:"name"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// SessionID is the agent session that owns this sidecar, empty for state
+	// written outside a session or before sessions existed. Sidecars are
+	// isolated per session, so two entries for one project and branch are two
+	// sessions working in the same tree — this is what tells them apart.
+	SessionID     string      `json:"session_id,omitempty"`
 	ProjectName   string      `json:"project_name"`
 	RepoName      string      `json:"repo_name"`
 	SnapshotName  string      `json:"snapshot_name"`


### PR DESCRIPTION
## Summary

Sidecars are isolated per session, so several sessions can hold one for the same worktree - but the dashboard rendered a row per sidecar, all labeled with the same branch name. The session ID never reached the TUI: `ActiveSidecar` persists it, `watchd.SidecarState` didn't carry it, so `loadSidecars` dropped it.

## Before / After

Two sessions in one worktree. Left pane, fixture state.

**Before** - two rows, same label, nothing saying who owns what:

── chunk-cli
▶ jesse/update-tui-session…
   22222222-aaaa-4bbb-8c…
  ⠋ validate...
────────────────────────────
  jesse/update-tui-session…
   11111111-aaaa-4bbb-8c…
  ✓ in sync

**After** - branch once for the group, rows named by session, yours pinned first:

── chunk-cli
  jesse/update-tui-session-…
  2 sessions
▶ ● this session
   11111111-aaaa-4bbb-8c…
  ✓ in sync
────────────────────────────
  ○ bbbbbbbb
   22222222-aaaa-4bbb-8c…
  ⠋ validate...

The same problem arrives a second way: one branch checked out in two directories collapsed under one repo header, both rows reading `main`. They now read `work/chunk-cli` and `tmp/chunk-cli` - the shortest path suffix that tells them apart, since two clones share a basename.

A worktree with **one** session is untouched: verified byte-identical against a binary built from `main`.

## Fixed

Found while testing the above. The daemon ones are here because they blocked verifying it at all.

- Rows started without room to finish were clipped mid-render, losing the sync state and age they exist to report - now costed, dropped whole, and followed by a `↓ N more` hint
- A local `chunk validate` run was credited to whichever sidecar `mergeBranches` inserted last - shared worktrees keep the local row separate, and the header counts sessions not rows
- The daemon serves snapshots shaped by the build that started it with no mismatch detection, so `chunk watch` showed pre-session data after an upgrade until the daemon was killed by hand - `/ping` now reports a build identity
- A dashboard whose daemon died froze on stale data forever, and the "daemon unavailable" line was appended past the last row so it was clipped at every height - polls now relaunch, and the message has room
- `renderActivityPane` bounded the selection above but not below, so a negative index could have panicked on `m.sidecars[-1]`

## Test Plan

- [x] `task test` (1490 tests, `-race`), `task acceptance-test` (289), `task lint`
- [x] Single session frame-diffed against `main` - byte-identical
- [x] Two sessions, two checkouts, and a local run all render as described above
- [x] Overflow at 130x24 drops a row whole with `↓ 1 more`; every row complete at 130x26
- [x] Stale daemon replaced at startup, matching build reused; a daemon killed mid-session is relaunched on the next poll