### PR TITLE
Fix Windows build failure caused by undefined windows.STILL_ACTIVE

### DIFF
--- a/internal/watchd/pid_windows.go
+++ b/internal/watchd/pid_windows.go
@@ -8,6 +8,10 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// stillActive is the exit code returned by GetExitCodeProcess when the process is still running.
+// Equivalent to STILL_ACTIVE / STATUS_PENDING (0x103) from the Windows SDK.
+const stillActive = 259
+
 // IsRunning reports whether the process whose PID is stored in path is alive.
 // Returns (false, 0, nil) when the file doesn't exist.
 //
@@ -30,5 +34,5 @@ func IsRunning(path string) (bool, int, error) {
 	if err := windows.GetExitCodeProcess(h, &code); err != nil {
 		return false, 0, nil
 	}
-	return code == windows.STILL_ACTIVE, p, nil
+	return code == stillActive, p, nil
 }


### PR DESCRIPTION
## Summary

- `golang.org/x/sys/windows` does not export `STILL_ACTIVE`, causing the goreleaser Windows cross-compile to fail in the nightly release
- Defines `stillActive = 259` locally in `pid_windows.go` — this is the well-known Windows `STATUS_PENDING` / `STILL_ACTIVE` value (`0x103`) returned by `GetExitCodeProcess` for a live process

## Test plan

- [x] `GOOS=windows GOARCH=amd64 go build ./internal/watchd/` compiles cleanly
- [x] `go test -race ./internal/watchd/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)