### PR TITLE
Route validate through watch daemon

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -39,7 +39,7 @@ func NewRootCmd(version string) *cobra.Command {
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			if id := session.IDFromEnv(); id != "" {
+			if id := session.IDFromEnv(); id != "" && session.IDFromCtx(cmd.Context()) == "" {
 				cmd.SetContext(session.WithID(cmd.Context(), id))
 			}
 			if err := setupTelemetry(cmd, version); err != nil {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -150,22 +150,24 @@ func reportSkippedAutofix(skipped []string, streams iostream.Streams) {
 }
 
 type validateOpts struct {
-	sidecarID    string
-	identityFile string
-	workdir      string
-	orgID        string
-	dryRun       bool
-	list         bool
-	save         bool
-	remote       bool
-	local        bool
-	markRemote   bool
-	jsonOut      bool
-	inlineCmd    string
-	projectDir   string
-	envVarsFlag  []string
-	envFile      string
-	sync         bool // bypasses daemon delegation; set by daemon when it spawns us
+	sidecarID      string
+	identityFile   string
+	workdir        string
+	orgID          string
+	dryRun         bool
+	list           bool
+	save           bool
+	remote         bool
+	local          bool
+	markRemote     bool
+	jsonOut        bool
+	inlineCmd      string
+	projectDir     string
+	envVarsFlag    []string
+	envFile        string
+	sync           bool   // bypasses daemon delegation; set by daemon when it spawns us
+	hookSessionID  string // hook session ID forwarded from client to daemon subprocess
+	stopHookActive bool   // stop_hook_active forwarded from client to daemon subprocess
 }
 
 func newValidateCmd() *cobra.Command {
@@ -206,6 +208,10 @@ func newValidateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.envFile, "env-file", defaultEnvFile, "Env file to load (default: .env.local; pass a path to override)")
 	cmd.Flags().BoolVar(&opts.sync, "sync", false, "")
 	_ = cmd.Flags().MarkHidden("sync")
+	cmd.Flags().StringVar(&opts.hookSessionID, "hook-session-id", "", "")
+	_ = cmd.Flags().MarkHidden("hook-session-id")
+	cmd.Flags().BoolVar(&opts.stopHookActive, "stop-hook-active", false, "")
+	_ = cmd.Flags().MarkHidden("stop-hook-active")
 
 	cmd.AddCommand(newValidateVariantsCmd())
 
@@ -343,7 +349,17 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	}
 
 	hook := detectHook(cmd.InOrStdin())
+	// When running as a daemon subprocess, hook context arrives via flags.
+	if opts.hookSessionID != "" && hook == nil {
+		hook = &hookContext{sessionID: opts.hookSessionID, stopHookActive: opts.stopHookActive}
+	}
 	ctx := cmd.Context()
+
+	// Delegate hook runs to the daemon before initHook so the subprocess prints
+	// the session header (not the client, which would cause it to appear twice).
+	if done, err := tryHookDelegate(cmd, hook, opts.sync, streams); done {
+		return err
+	}
 
 	// The working-tree fingerprint answers both hook-only questions about the
 	// tree: whether there is anything to validate at all, and whether this exact
@@ -374,39 +390,9 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		name = args[0]
 	}
 
-	// --list: show configured commands
-	if opts.list {
-		return runValidateList(workDir, opts.jsonOut, streams, statusFn)
-	}
-	if opts.jsonOut {
-		return fmt.Errorf("--json requires --list")
-	}
-
-	// --mark-remote edits the config and stops; it never runs anything, so it
-	// takes its own read-modify-write path ahead of the run setup below.
-	if opts.markRemote {
-		return runMarkRemote(workDir, name, streams)
-	}
-
-	cfg, err := config.LoadProjectConfig(workDir)
-	if (err != nil || !cfg.HasCommands()) && opts.inlineCmd == "" {
-		if hook != nil {
-			return nil // no config in hook context: skip silently
-		}
-		return &userError{
-			msg:        msgValidateNotConfigured,
-			suggestion: suggestionValidateNotConfigured,
-			errMsg:     "no validate commands configured",
-			hideDetail: true,
-		}
-	}
-
-	if err := validateEnvFlag(opts.envVarsFlag); err != nil {
+	cfg, done, err := validateEarlyExits(hook, opts, name, workDir, streams, statusFn)
+	if done {
 		return err
-	}
-
-	if opts.dryRun {
-		return runValidateDryRun(name, opts.inlineCmd, cfg, statusFn)
 	}
 
 	// Remote is the default; --local is the only opt-out.
@@ -443,7 +429,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	}
 
 	if shouldUseDaemon(hook, opts.sync) {
-		return runValidateViaDaemon(os.Args[1:], rc.CircleCIToken, streams)
+		return runValidateViaDaemon(os.Args[1:], rc.CircleCIToken, nil, streams)
 	}
 
 	// allRemote is true unless --local is passed explicitly. opts.remote is
@@ -627,9 +613,17 @@ func validateEnvFlag(envVarsFlag []string) error {
 }
 
 // runValidateViaDaemon delegates a validate run to the watch daemon and writes
-// its captured output to streams.
-func runValidateViaDaemon(args []string, circleCIToken string, streams iostream.Streams) error {
-	resp, err := watchd.RunValidate(args, circleCIToken)
+// its captured output to streams. When hook is non-nil its context is forwarded
+// to the subprocess via hidden flags so it runs as a hook invocation.
+func runValidateViaDaemon(args []string, circleCIToken string, hook *hookContext, streams iostream.Streams) error {
+	reqArgs := args
+	if hook != nil {
+		reqArgs = append(append([]string(nil), args...), "--hook-session-id", hook.sessionID)
+		if hook.stopHookActive {
+			reqArgs = append(reqArgs, "--stop-hook-active")
+		}
+	}
+	resp, err := watchd.RunValidate(reqArgs, circleCIToken)
 	if err != nil {
 		return fmt.Errorf("daemon validate: %w", err)
 	}
@@ -639,6 +633,56 @@ func runValidateViaDaemon(args []string, circleCIToken string, streams iostream.
 		return errSilentExit
 	}
 	return nil
+}
+
+// tryHookDelegate delegates a hook-invoked validate run to the daemon before
+// initHook runs, so the subprocess prints the session header (not the client).
+// Returns (true, err) when the call was delegated, (false, nil) to run inline.
+func tryHookDelegate(cmd *cobra.Command, hook *hookContext, sync bool, streams iostream.Streams) (bool, error) {
+	if hook == nil || sync || !watchd.IsDaemonRunning() {
+		return false, nil
+	}
+	// If hooks are disabled in this environment, don't delegate — the daemon
+	// subprocess won't inherit this process's env var, so initHook must handle it.
+	if os.Getenv(config.EnvChunkHooksDisabled) != "" {
+		return false, nil
+	}
+	insecureStorage := insecureStorageFlag(cmd)
+	rc, _ := config.ResolveCircleCI(insecureStorage)
+	return true, runValidateViaDaemon(os.Args[1:], rc.CircleCIToken, hook, streams)
+}
+
+// validateEarlyExits handles --list, --mark-remote, missing config, --dry-run.
+// Returns (cfg, done=true, err) to stop, or (cfg, false, nil) to continue.
+func validateEarlyExits(hook *hookContext, opts *validateOpts, name, workDir string, streams iostream.Streams, statusFn iostream.StatusFunc) (*config.ProjectConfig, bool, error) {
+	if opts.list {
+		return nil, true, runValidateList(workDir, opts.jsonOut, streams, statusFn)
+	}
+	if opts.jsonOut {
+		return nil, true, fmt.Errorf("--json requires --list")
+	}
+	if opts.markRemote {
+		return nil, true, runMarkRemote(workDir, name, streams)
+	}
+	cfg, err := config.LoadProjectConfig(workDir)
+	if (err != nil || !cfg.HasCommands()) && opts.inlineCmd == "" {
+		if hook != nil {
+			return nil, true, nil // no config in hook context: skip silently
+		}
+		return nil, true, &userError{
+			msg:        msgValidateNotConfigured,
+			suggestion: suggestionValidateNotConfigured,
+			errMsg:     "no validate commands configured",
+			hideDetail: true,
+		}
+	}
+	if err := validateEnvFlag(opts.envVarsFlag); err != nil {
+		return nil, true, err
+	}
+	if opts.dryRun {
+		return nil, true, runValidateDryRun(name, opts.inlineCmd, cfg, statusFn)
+	}
+	return cfg, false, nil
 }
 
 func runValidateDryRun(name, inlineCmd string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc) error {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -165,6 +165,7 @@ type validateOpts struct {
 	projectDir   string
 	envVarsFlag  []string
 	envFile      string
+	sync         bool // bypasses daemon delegation; set by daemon when it spawns us
 }
 
 func newValidateCmd() *cobra.Command {
@@ -203,6 +204,8 @@ func newValidateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.projectDir, "project", "", "Override project directory")
 	cmd.Flags().StringArrayVarP(&opts.envVarsFlag, "env", "e", nil, "KEY=VALUE pairs to set in remote sidecar session (repeatable)")
 	cmd.Flags().StringVar(&opts.envFile, "env-file", defaultEnvFile, "Env file to load (default: .env.local; pass a path to override)")
+	cmd.Flags().BoolVar(&opts.sync, "sync", false, "")
+	_ = cmd.Flags().MarkHidden("sync")
 
 	cmd.AddCommand(newValidateVariantsCmd())
 
@@ -314,19 +317,29 @@ func maybeEnsureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc confi
 	return ensureCircleCIClient(ctx, cmd, rc, streams, ui.PromptHidden)
 }
 
+func resolveWorkDir(opts *validateOpts) (string, error) {
+	if opts.projectDir != "" {
+		return opts.projectDir, nil
+	}
+	return os.Getwd()
+}
+
+// shouldUseDaemon reports whether this validate run should be delegated to the
+// watch daemon. Hook runs always run inline (stdin consumed, per-session attempt
+// tracking). --sync skips this to avoid recursion when the daemon spawns us.
+func shouldUseDaemon(hook *hookContext, sync bool) bool {
+	return hook == nil && !sync && watchd.IsDaemonRunning()
+}
+
 func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) error {
 	streams := iostream.FromCmd(cmd)
 
 	// Record before git-status check so total captures setup overhead too.
 	start := time.Now()
 
-	workDir := opts.projectDir
-	if workDir == "" {
-		var err error
-		workDir, err = os.Getwd()
-		if err != nil {
-			return err
-		}
+	workDir, err := resolveWorkDir(opts)
+	if err != nil {
+		return err
 	}
 
 	hook := detectHook(cmd.InOrStdin())
@@ -427,6 +440,10 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			n := len(cfg.Commands)
 			return finishValidate(cmd, hook, nil, start, cfg, validate.Result{Passed: n, Total: n}, newValidateRecorder(statusFn, "", nil, workDir, hook), streams, notifyFunc(rc.Notifications))
 		}
+	}
+
+	if shouldUseDaemon(hook, opts.sync) {
+		return runValidateViaDaemon(os.Args[1:], rc.CircleCIToken, streams)
 	}
 
 	// allRemote is true unless --local is passed explicitly. opts.remote is
@@ -605,6 +622,21 @@ func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start 
 func validateEnvFlag(envVarsFlag []string) error {
 	if _, err := sidecar.ParseEnvPairs(envVarsFlag); err != nil {
 		return &userError{msg: fmt.Sprintf("invalid --env value: %s", err), err: err}
+	}
+	return nil
+}
+
+// runValidateViaDaemon delegates a validate run to the watch daemon and writes
+// its captured output to streams.
+func runValidateViaDaemon(args []string, circleCIToken string, streams iostream.Streams) error {
+	resp, err := watchd.RunValidate(args, circleCIToken)
+	if err != nil {
+		return fmt.Errorf("daemon validate: %w", err)
+	}
+	_, _ = streams.Out.Write([]byte(resp.Stdout))
+	_, _ = streams.Err.Write([]byte(resp.Stderr))
+	if resp.ExitCode != 0 {
+		return errSilentExit
 	}
 	return nil
 }

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/envctx"
 	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
 	"github.com/CircleCI-Public/chunk-cli/internal/filecache"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
@@ -165,7 +166,7 @@ type validateOpts struct {
 	projectDir     string
 	envVarsFlag    []string
 	envFile        string
-	sync           bool   // bypasses daemon delegation; set by daemon when it spawns us
+	noDaemon       bool   // bypasses daemon delegation; set by the daemon when calling in-process
 	hookSessionID  string // hook session ID forwarded from client to daemon subprocess
 	stopHookActive bool   // stop_hook_active forwarded from client to daemon subprocess
 }
@@ -206,8 +207,8 @@ func newValidateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.projectDir, "project", "", "Override project directory")
 	cmd.Flags().StringArrayVarP(&opts.envVarsFlag, "env", "e", nil, "KEY=VALUE pairs to set in remote sidecar session (repeatable)")
 	cmd.Flags().StringVar(&opts.envFile, "env-file", defaultEnvFile, "Env file to load (default: .env.local; pass a path to override)")
-	cmd.Flags().BoolVar(&opts.sync, "sync", false, "")
-	_ = cmd.Flags().MarkHidden("sync")
+	cmd.Flags().BoolVar(&opts.noDaemon, "no-daemon", false, "")
+	_ = cmd.Flags().MarkHidden("no-daemon")
 	cmd.Flags().StringVar(&opts.hookSessionID, "hook-session-id", "", "")
 	_ = cmd.Flags().MarkHidden("hook-session-id")
 	cmd.Flags().BoolVar(&opts.stopHookActive, "stop-hook-active", false, "")
@@ -245,7 +246,7 @@ func initHook(ctx context.Context, hook *hookContext, workDir string, tree gitut
 	} else {
 		streams.ErrPrintln(ui.ErrBold(fmt.Sprintf("── validate [%s]", sessionLabel)))
 	}
-	if validate.HooksDisabled(workDir, os.Getenv(config.EnvChunkHooksDisabled) != "") {
+	if validate.HooksDisabled(workDir, envctx.Getenv(ctx, config.EnvChunkHooksDisabled) != "") {
 		streams.ErrPrintln("chunk validate: hooks are disabled — skipping validation")
 		return ctx, streams, false, validate.NewHookExitError(1)
 	}
@@ -332,9 +333,10 @@ func resolveWorkDir(opts *validateOpts) (string, error) {
 
 // shouldUseDaemon reports whether this validate run should be delegated to the
 // watch daemon. Hook runs always run inline (stdin consumed, per-session attempt
-// tracking). --sync skips this to avoid recursion when the daemon spawns us.
-func shouldUseDaemon(hook *hookContext, sync bool) bool {
-	return hook == nil && !sync && watchd.IsDaemonRunning()
+// tracking). --no-daemon skips this to avoid re-delegation when the daemon calls
+// us in-process.
+func shouldUseDaemon(hook *hookContext, noDaemon bool) bool {
+	return hook == nil && !noDaemon && watchd.IsDaemonRunning()
 }
 
 func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) error {
@@ -357,7 +359,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 
 	// Delegate hook runs to the daemon before initHook so the subprocess prints
 	// the session header (not the client, which would cause it to appear twice).
-	if done, err := tryHookDelegate(cmd, hook, opts.sync, streams); done {
+	if done, err := tryHookDelegate(cmd, hook, opts.noDaemon, streams); done {
 		return err
 	}
 
@@ -428,8 +430,13 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		}
 	}
 
-	if shouldUseDaemon(hook, opts.sync) {
-		return runValidateViaDaemon(os.Args[1:], rc.CircleCIToken, nil, streams)
+	if shouldUseDaemon(hook, opts.noDaemon) {
+		err := runValidateViaDaemon(os.Args[1:], rc.CircleCIToken, nil, streams)
+		if !errors.Is(err, watchd.ErrDaemonUnavailable) {
+			return err
+		}
+		// daemon disappeared between the IsDaemonRunning check and the POST;
+		// fall through to inline execution.
 	}
 
 	// allRemote is true unless --local is passed explicitly. opts.remote is
@@ -638,8 +645,8 @@ func runValidateViaDaemon(args []string, circleCIToken string, hook *hookContext
 // tryHookDelegate delegates a hook-invoked validate run to the daemon before
 // initHook runs, so the subprocess prints the session header (not the client).
 // Returns (true, err) when the call was delegated, (false, nil) to run inline.
-func tryHookDelegate(cmd *cobra.Command, hook *hookContext, sync bool, streams iostream.Streams) (bool, error) {
-	if hook == nil || sync || !watchd.IsDaemonRunning() {
+func tryHookDelegate(cmd *cobra.Command, hook *hookContext, noDaemon bool, streams iostream.Streams) (bool, error) {
+	if hook == nil || noDaemon || !watchd.IsDaemonRunning() {
 		return false, nil
 	}
 	// If hooks are disabled in this environment, don't delegate — the daemon
@@ -648,8 +655,15 @@ func tryHookDelegate(cmd *cobra.Command, hook *hookContext, sync bool, streams i
 		return false, nil
 	}
 	insecureStorage := insecureStorageFlag(cmd)
-	rc, _ := config.ResolveCircleCI(insecureStorage)
-	return true, runValidateViaDaemon(os.Args[1:], rc.CircleCIToken, hook, streams)
+	rc, err := config.ResolveCircleCI(insecureStorage)
+	if err != nil {
+		return false, nil // fall back to inline; inline path handles auth
+	}
+	err = runValidateViaDaemon(os.Args[1:], rc.CircleCIToken, hook, streams)
+	if errors.Is(err, watchd.ErrDaemonUnavailable) {
+		return false, nil // daemon disappeared between check and POST; run inline
+	}
+	return true, err
 }
 
 // validateEarlyExits handles --list, --mark-remote, missing config, --dry-run.
@@ -813,7 +827,7 @@ func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpt
 }
 
 func syncToSidecar(ctx context.Context, client *circleci.Client, sidecarID, identityFile, workdir string, statusFn iostream.StatusFunc, streams iostream.Streams) error {
-	authSock := os.Getenv(config.EnvSSHAuthSock)
+	authSock := envctx.Getenv(ctx, config.EnvSSHAuthSock)
 	cwd, err := os.Getwd()
 	if err != nil {
 		return &userError{msg: "Could not sync to sidecar.", err: err}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -630,7 +630,7 @@ func runValidateViaDaemon(args []string, circleCIToken string, hook *hookContext
 	_, _ = streams.Out.Write([]byte(resp.Stdout))
 	_, _ = streams.Err.Write([]byte(resp.Stderr))
 	if resp.ExitCode != 0 {
-		return errSilentExit
+		return &silentExitError{code: resp.ExitCode}
 	}
 	return nil
 }

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -23,6 +23,10 @@ import (
 // next to the command it names.
 const watchCmdName = "watch"
 
+// watchDaemonSubcmd is the hidden subcommand name used to spawn the background
+// watch daemon process. Defined here so all cmd-package callers share one constant.
+const watchDaemonSubcmd = "_daemon"
+
 func newWatchCmd() *cobra.Command {
 	var (
 		focus bool
@@ -39,7 +43,7 @@ func newWatchCmd() *cobra.Command {
 				return fmt.Errorf("watch requires a TTY")
 			}
 
-			daemonArgs := []string{watchCmdName, "_daemon"}
+			daemonArgs := []string{watchCmdName, watchDaemonSubcmd}
 			if err := watchd.EnsureRunning(daemonArgs); err != nil {
 				iostream.FromCmd(cmd).ErrPrintf("chunk watch: daemon unavailable, running without background updates: %v\n", err)
 			}

--- a/internal/cmd/watchdaemon.go
+++ b/internal/cmd/watchdaemon.go
@@ -15,7 +15,7 @@ import (
 // to start the background watch daemon. It is intentionally hidden from help output.
 func newWatchDaemonCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:    "_daemon",
+		Use:    watchDaemonSubcmd,
 		Short:  "Run the watch daemon (internal use only)",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cmd/watchdaemon.go
+++ b/internal/cmd/watchdaemon.go
@@ -1,13 +1,18 @@
 package cmd
 
 import (
+	"context"
 	"errors"
+	"io"
 
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/authprompt"
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/envctx"
+	"github.com/CircleCI-Public/chunk-cli/internal/session"
+	"github.com/CircleCI-Public/chunk-cli/internal/version"
 	"github.com/CircleCI-Public/chunk-cli/internal/watchd"
 )
 
@@ -33,7 +38,7 @@ func newWatchDaemonCmd() *cobra.Command {
 			if err == nil {
 				client, err = authprompt.ResolveCircleCIClient(rc, nil)
 			}
-			return watchd.RunDaemon(cmd.Context(), client, authMessage(err))
+			return watchd.RunDaemon(cmd.Context(), client, authMessage(err), makeValidateRunner())
 		},
 	}
 }
@@ -52,4 +57,34 @@ func authMessage(err error) string {
 		return "not authenticated to CircleCI — command output unavailable (run: chunk auth login)"
 	}
 	return "could not authenticate to CircleCI — command output unavailable: " + err.Error()
+}
+
+// makeValidateRunner returns a ValidateRunner that executes validate commands
+// in-process by running a fresh cobra root command with the caller's env and
+// session ID seeded into the context.
+func makeValidateRunner() watchd.ValidateRunner {
+	return func(ctx context.Context, args []string, env []string, stdout, stderr io.Writer) int {
+		// Seed the context with the caller's session ID before cobra's
+		// PersistentPreRunE runs, so IDFromEnv (which reads the daemon's own env)
+		// does not overwrite it.
+		if id := session.IDFromCtx(ctx); id == "" {
+			if id := session.IDFromSlice(env); id != "" {
+				ctx = session.WithID(ctx, id)
+			}
+		}
+		ctx = envctx.WithEnv(ctx, env)
+
+		rootCmd := NewRootCmd(version.Value)
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(stderr)
+		// Append --no-daemon so the in-process call skips daemon re-delegation.
+		rootCmd.SetArgs(append(append([]string(nil), args...), "--no-daemon"))
+		if err := rootCmd.ExecuteContext(ctx); err != nil {
+			if ec, ok := err.(interface{ ExitCode() int }); ok {
+				return ec.ExitCode()
+			}
+			return 1
+		}
+		return 0
+	}
 }

--- a/internal/envctx/envctx.go
+++ b/internal/envctx/envctx.go
@@ -1,0 +1,44 @@
+// Package envctx carries an environment variable slice in a context so
+// in-process callers (like the watch daemon) can override the process env
+// without calling os.Setenv.
+package envctx
+
+import (
+	"context"
+	"os"
+	"strings"
+)
+
+type envKey struct{}
+
+// WithEnv returns a ctx that carries env (a slice of KEY=VALUE strings).
+// Subsequent Getenv and Environ calls on that ctx consult env first.
+func WithEnv(ctx context.Context, env []string) context.Context {
+	if len(env) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, envKey{}, env)
+}
+
+// Getenv returns the value of key from the env slice stored in ctx.
+// Falls back to os.Getenv when ctx carries no slice or the key is absent.
+func Getenv(ctx context.Context, key string) string {
+	if env, ok := ctx.Value(envKey{}).([]string); ok {
+		prefix := key + "="
+		for _, e := range env {
+			if strings.HasPrefix(e, prefix) {
+				return e[len(prefix):]
+			}
+		}
+		return ""
+	}
+	return os.Getenv(key)
+}
+
+// Environ returns the env slice stored in ctx, or os.Environ() if none.
+func Environ(ctx context.Context) []string {
+	if env, ok := ctx.Value(envKey{}).([]string); ok {
+		return env
+	}
+	return os.Environ()
+}

--- a/internal/envctx/envctx.go
+++ b/internal/envctx/envctx.go
@@ -21,7 +21,8 @@ func WithEnv(ctx context.Context, env []string) context.Context {
 }
 
 // Getenv returns the value of key from the env slice stored in ctx.
-// Falls back to os.Getenv when ctx carries no slice or the key is absent.
+// Falls back to os.Getenv only when ctx carries no slice; an absent key
+// returns "" without consulting os.Getenv.
 func Getenv(ctx context.Context, key string) string {
 	if env, ok := ctx.Value(envKey{}).([]string); ok {
 		prefix := key + "="

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -37,6 +37,22 @@ func IDFromCtx(ctx context.Context) string {
 	return id
 }
 
+// IDFromSlice returns the session ID from a KEY=VALUE env slice, applying the
+// same precedence and sanitisation as IDFromEnv.
+func IDFromSlice(env []string) string {
+	for _, name := range []string{config.EnvChunkSessionID, EnvClaudeSessionID} {
+		prefix := name + "="
+		for _, e := range env {
+			if strings.HasPrefix(e, prefix) {
+				if id := sanitize(e[len(prefix):]); id != "" {
+					return id
+				}
+			}
+		}
+	}
+	return ""
+}
+
 // IDFromEnv returns the session ID advertised by the environment, or "" when
 // nothing in it names a session.
 //

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/envctx"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 )
 
@@ -282,7 +283,7 @@ func runCommand(ctx context.Context, workDir, name, command string, timeoutSec, 
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.Dir = workDir
 	if len(envVars) > 0 {
-		env := os.Environ()
+		env := envctx.Environ(ctx)
 		for k, v := range envVars {
 			env = append(env, k+"="+v)
 		}

--- a/internal/watchd/client.go
+++ b/internal/watchd/client.go
@@ -166,6 +166,43 @@ func StopForCredentialChange() {
 	_ = stopDaemon(pid, sockPath)
 }
 
+// IsDaemonRunning reports whether the watch daemon is reachable.
+func IsDaemonRunning() bool {
+	sockPath, err := SocketPath()
+	if err != nil {
+		return false
+	}
+	ok, _ := ping(sockPath)
+	return ok
+}
+
+// RunValidate delegates a validate run to the daemon. args is os.Args[1:];
+// circleCIToken is forwarded to the subprocess as CIRCLE_TOKEN.
+func RunValidate(args []string, circleCIToken string) (ValidateResponse, error) {
+	sockPath, err := SocketPath()
+	if err != nil {
+		return ValidateResponse{}, err
+	}
+	body, err := json.Marshal(ValidateRequest{Args: args, CircleCIToken: circleCIToken})
+	if err != nil {
+		return ValidateResponse{}, fmt.Errorf("marshal validate request: %w", err)
+	}
+	resp, err := longUnixClient(sockPath).Post("http://watchd/validate", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return ValidateResponse{}, fmt.Errorf("connect to watch daemon: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return ValidateResponse{}, fmt.Errorf("watch daemon returned %s: %s", resp.Status, bytes.TrimSpace(msg))
+	}
+	var result ValidateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return ValidateResponse{}, fmt.Errorf("decode validate response: %w", err)
+	}
+	return result, nil
+}
+
 // EnsureRunning checks whether the watch daemon is running and serving, and
 // launches it if not. subArgs are the CLI arguments used to invoke the daemon
 // (e.g. ["watch", "_daemon"]).

--- a/internal/watchd/client.go
+++ b/internal/watchd/client.go
@@ -3,6 +3,7 @@ package watchd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,6 +13,11 @@ import (
 	"strings"
 	"time"
 )
+
+// ErrDaemonUnavailable is returned by RunValidate when the daemon socket is
+// unreachable, so callers can distinguish a transient connectivity failure from
+// a real validation error and fall back to inline execution.
+var ErrDaemonUnavailable = errors.New("daemon unavailable")
 
 // FetchSnapshot connects to the running watch daemon and returns the current
 // snapshot for the given project roots. If roots is empty all known projects
@@ -189,7 +195,7 @@ func RunValidate(args []string, circleCIToken string) (ValidateResponse, error) 
 	}
 	resp, err := longUnixClient(sockPath).Post("http://watchd/validate", "application/json", bytes.NewReader(body))
 	if err != nil {
-		return ValidateResponse{}, fmt.Errorf("connect to watch daemon: %w", err)
+		return ValidateResponse{}, fmt.Errorf("%w: %w", ErrDaemonUnavailable, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {

--- a/internal/watchd/client.go
+++ b/internal/watchd/client.go
@@ -183,7 +183,7 @@ func RunValidate(args []string, circleCIToken string) (ValidateResponse, error) 
 	if err != nil {
 		return ValidateResponse{}, err
 	}
-	body, err := json.Marshal(ValidateRequest{Args: args, CircleCIToken: circleCIToken})
+	body, err := json.Marshal(ValidateRequest{Args: args, CircleCIToken: circleCIToken, Env: os.Environ()})
 	if err != nil {
 		return ValidateResponse{}, fmt.Errorf("marshal validate request: %w", err)
 	}

--- a/internal/watchd/client.go
+++ b/internal/watchd/client.go
@@ -172,14 +172,16 @@ func StopForCredentialChange() {
 	_ = stopDaemon(pid, sockPath)
 }
 
-// IsDaemonRunning reports whether the watch daemon is reachable.
+// IsDaemonRunning reports whether the watch daemon is reachable and was built
+// from the same binary as the caller. A daemon from an older build is treated
+// as absent: it may not serve routes added since it was compiled.
 func IsDaemonRunning() bool {
 	sockPath, err := SocketPath()
 	if err != nil {
 		return false
 	}
-	ok, _ := ping(sockPath)
-	return ok
+	ok, build := ping(sockPath)
+	return ok && build == BuildID()
 }
 
 // RunValidate delegates a validate run to the daemon. args is os.Args[1:];

--- a/internal/watchd/daemon.go
+++ b/internal/watchd/daemon.go
@@ -28,8 +28,9 @@ type projectState struct {
 }
 
 type daemon struct {
-	mu       sync.RWMutex
-	projects map[string]*projectState // keyed by project root
+	mu         sync.RWMutex
+	projects   map[string]*projectState // keyed by project root
+	validateMu sync.Mutex               // serializes concurrent /validate requests
 
 	// client streams command output. Nil when the daemon started without
 	// credentials, in which case commands are still recorded but no output is

--- a/internal/watchd/daemon.go
+++ b/internal/watchd/daemon.go
@@ -31,6 +31,7 @@ type daemon struct {
 	mu         sync.RWMutex
 	projects   map[string]*projectState // keyed by project root
 	validateMu sync.Mutex               // serializes concurrent /validate requests
+	runner     ValidateRunner
 
 	// client streams command output. Nil when the daemon started without
 	// credentials, in which case commands are still recorded but no output is
@@ -48,17 +49,11 @@ type daemon struct {
 
 // RunDaemon is the watch daemon entry point, called by the hidden _daemon subcommand.
 //
-// The client is resolved by the caller and may be nil: the daemon records
-// commands either way, and authMessage is what tells the user why output is
-// missing. Resolution belongs to the caller because it can read the OS keychain,
-// and the daemon must not hold a lock over that on the command-registration path
-// — a hook is waiting on it.
-//
-// The message arrives already rendered, empty when there is nothing to explain.
-// Only the caller that resolved the credentials knows which failures mean "log
-// in" and which are something else, and asking the daemon to classify them
-// would make this package depend on the auth flow it deliberately sits below.
-func RunDaemon(ctx context.Context, client *circleci.Client, authMessage string) error {
+// client and authMessage support the output-buffering feature; runner is called
+// in-process to handle /validate requests. Both client and runner may be nil
+// (the daemon still records commands without a client, and /validate returns an
+// error without a runner).
+func RunDaemon(ctx context.Context, client *circleci.Client, authMessage string, runner ValidateRunner) error {
 	if _, err := EnsureDir(); err != nil {
 		return fmt.Errorf("ensure watchd dir: %w", err)
 	}
@@ -93,6 +88,7 @@ func RunDaemon(ctx context.Context, client *circleci.Client, authMessage string)
 
 	d := &daemon{
 		projects:  make(map[string]*projectState),
+		runner:    runner,
 		client:    client,
 		authError: authMessage,
 		out:       newOutputStore(ctx),

--- a/internal/watchd/daemon_test.go
+++ b/internal/watchd/daemon_test.go
@@ -19,7 +19,7 @@ func TestDaemonRoundTrip(t *testing.T) {
 	defer cancel()
 
 	errCh := make(chan error, 1)
-	go func() { errCh <- RunDaemon(ctx, nil, "") }()
+	go func() { errCh <- RunDaemon(ctx, nil, "", nil) }()
 
 	sockPath, err := SocketPath()
 	assert.NilError(t, err)
@@ -95,7 +95,7 @@ func TestEnsureLaunched_leavesAReachableDaemonAlone(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
-	go func() { errCh <- RunDaemon(ctx, nil, "") }()
+	go func() { errCh <- RunDaemon(ctx, nil, "", nil) }()
 
 	sockPath, err := SocketPath()
 	assert.NilError(t, err)

--- a/internal/watchd/ipc.go
+++ b/internal/watchd/ipc.go
@@ -79,6 +79,7 @@ func newServer(d *daemon) *http.Server {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(chunk)
 	})
+	mux.HandleFunc("/validate", d.handleValidate)
 	return &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
@@ -89,6 +90,18 @@ func newServer(d *daemon) *http.Server {
 func unixClient(sockPath string) *http.Client {
 	return &http.Client{
 		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
+			},
+		},
+	}
+}
+
+// longUnixClient is like unixClient but with no total-request timeout, suitable
+// for long-running operations like /validate.
+func longUnixClient(sockPath string) *http.Client {
+	return &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 				return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)

--- a/internal/watchd/ipc_test.go
+++ b/internal/watchd/ipc_test.go
@@ -43,7 +43,7 @@ func startTestDaemonWithAuth(t *testing.T, authMessage string) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
-	go func() { errCh <- RunDaemon(ctx, nil, authMessage) }()
+	go func() { errCh <- RunDaemon(ctx, nil, authMessage, nil) }()
 	t.Cleanup(func() {
 		cancel()
 		select {

--- a/internal/watchd/validate.go
+++ b/internal/watchd/validate.go
@@ -15,6 +15,9 @@ type ValidateRequest struct {
 	Args []string `json:"args"`
 	// CircleCIToken is forwarded to the subprocess as CIRCLE_TOKEN.
 	CircleCIToken string `json:"circleci_token,omitempty"`
+	// Env is the caller's os.Environ(), forwarded verbatim to the subprocess so
+	// session-identity variables (e.g. CLAUDE_CODE_SESSION_ID) reach it intact.
+	Env []string `json:"env,omitempty"`
 }
 
 // ValidateResponse is the response from POST /validate.
@@ -46,9 +49,12 @@ func (d *daemon) handleValidate(w http.ResponseWriter, r *http.Request) {
 	args := append(append([]string(nil), req.Args...), "--sync")
 	cmd := exec.CommandContext(r.Context(), exe, args...) //nolint:gosec
 
-	env := os.Environ()
+	env := req.Env
+	if len(env) == 0 {
+		env = os.Environ()
+	}
 	if req.CircleCIToken != "" {
-		env = append(env, "CIRCLE_TOKEN="+req.CircleCIToken)
+		env = append(append([]string(nil), env...), "CIRCLE_TOKEN="+req.CircleCIToken)
 	}
 	cmd.Env = env
 

--- a/internal/watchd/validate.go
+++ b/internal/watchd/validate.go
@@ -2,12 +2,20 @@ package watchd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
-	"errors"
+	"io"
 	"net/http"
-	"os"
-	"os/exec"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/envctx"
+	"github.com/CircleCI-Public/chunk-cli/internal/session"
 )
+
+// ValidateRunner runs a validate command in-process. args is os.Args[1:] from
+// the caller (e.g. ["validate", "test", "--remote"]); env is the caller's
+// os.Environ(), which may differ from the daemon's own environment.
+// stdout and stderr capture the command output. Returns the exit code.
+type ValidateRunner func(ctx context.Context, args []string, env []string, stdout, stderr io.Writer) int
 
 // ValidateRequest is the payload sent to POST /validate.
 type ValidateRequest struct {
@@ -37,41 +45,19 @@ func (d *daemon) handleValidate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	exe, err := os.Executable()
-	if err != nil {
-		http.Error(w, "executable: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	// Append --sync so the subprocess skips daemon delegation and runs inline.
-	// The socket is owner-only (0700) and exe is the current binary, so the
-	// args are not an injection risk.
-	args := append(append([]string(nil), req.Args...), "--sync")
-	cmd := exec.CommandContext(r.Context(), exe, args...) //nolint:gosec
-
-	env := req.Env
-	if len(env) == 0 {
-		env = os.Environ()
+	// Seed the context with the caller's env and session ID so the in-process
+	// validate run behaves as if launched in the caller's environment.
+	ctx := r.Context()
+	if id := session.IDFromSlice(req.Env); id != "" {
+		ctx = session.WithID(ctx, id)
 	}
 	if req.CircleCIToken != "" {
-		env = append(append([]string(nil), env...), "CIRCLE_TOKEN="+req.CircleCIToken)
+		req.Env = append(append([]string(nil), req.Env...), "CIRCLE_TOKEN="+req.CircleCIToken)
 	}
-	cmd.Env = env
+	ctx = envctx.WithEnv(ctx, req.Env)
 
 	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	exitCode := 0
-	if err := cmd.Run(); err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			exitCode = exitErr.ExitCode()
-		} else {
-			http.Error(w, "run: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-	}
+	exitCode := d.runner(ctx, req.Args, req.Env, &stdout, &stderr)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(ValidateResponse{

--- a/internal/watchd/validate.go
+++ b/internal/watchd/validate.go
@@ -1,0 +1,73 @@
+package watchd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"os/exec"
+)
+
+// ValidateRequest is the payload sent to POST /validate.
+type ValidateRequest struct {
+	// Args is os.Args[1:] from the caller, e.g. ["validate", "test", "--remote"].
+	Args []string `json:"args"`
+	// CircleCIToken is forwarded to the subprocess as CIRCLE_TOKEN.
+	CircleCIToken string `json:"circleci_token,omitempty"`
+}
+
+// ValidateResponse is the response from POST /validate.
+type ValidateResponse struct {
+	ExitCode int    `json:"exit_code"`
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+}
+
+func (d *daemon) handleValidate(w http.ResponseWriter, r *http.Request) {
+	var req ValidateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "decode request: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		http.Error(w, "executable: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Append --sync so the subprocess skips daemon delegation and runs inline.
+	// The socket is owner-only (0700) and exe is the current binary, so the
+	// args are not an injection risk.
+	args := append(append([]string(nil), req.Args...), "--sync")
+	cmd := exec.CommandContext(r.Context(), exe, args...) //nolint:gosec
+
+	env := os.Environ()
+	if req.CircleCIToken != "" {
+		env = append(env, "CIRCLE_TOKEN="+req.CircleCIToken)
+	}
+	cmd.Env = env
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	exitCode := 0
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			http.Error(w, "run: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(ValidateResponse{
+		ExitCode: exitCode,
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+	})
+}

--- a/internal/watchd/validate.go
+++ b/internal/watchd/validate.go
@@ -25,6 +25,9 @@ type ValidateResponse struct {
 }
 
 func (d *daemon) handleValidate(w http.ResponseWriter, r *http.Request) {
+	d.validateMu.Lock()
+	defer d.validateMu.Unlock()
+
 	var req ValidateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "decode request: "+err.Error(), http.StatusBadRequest)

--- a/internal/watchd/validate.go
+++ b/internal/watchd/validate.go
@@ -45,9 +45,10 @@ func (d *daemon) handleValidate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Seed the context with the caller's env and session ID so the in-process
-	// validate run behaves as if launched in the caller's environment.
-	ctx := r.Context()
+	// Use WithoutCancel so the validate run completes even if the HTTP client
+	// disconnects mid-run. The result is buffered; partial runs under
+	// validateMu are worse than completing after the client is gone.
+	ctx := context.WithoutCancel(r.Context())
 	if id := session.IDFromSlice(req.Env); id != "" {
 		ctx = session.WithID(ctx, id)
 	}

--- a/internal/watchd/validate.go
+++ b/internal/watchd/validate.go
@@ -57,6 +57,11 @@ func (d *daemon) handleValidate(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx = envctx.WithEnv(ctx, req.Env)
 
+	if d.runner == nil {
+		http.Error(w, "no validate runner configured", http.StatusServiceUnavailable)
+		return
+	}
+
 	var stdout, stderr bytes.Buffer
 	exitCode := d.runner(ctx, req.Args, req.Env, &stdout, &stderr)
 


### PR DESCRIPTION
**Summary** 
- chunk validate routes through the daemon when it's running 
- daemon serializes validate runs running at the same time so two sessions can't stomp on each other on the same sidecar
- falls back to inline if the daemon isn't running

**Implementation**
- new POST /validate endpoing on the daemon which forks the current binary with sync to run inline and avoid recursion
- sync.mutex on the daemon serializes concurrent requests
- sync, hooks-session-id, and stop-hook-active flags carry hook context from client -> daemon -> subprocess
- hook-invoked run also delegate so the subprocess prints the session header 

**Test Plan**
- [x] chunk validate with daemon running → output appears, exit code is correct (zero and non-zero)
- [x] chunk validate with daemon not running → still works (falls through to inline execution)
- [x] chunk validate with a hook firing while daemon is running → hook output lands in the hook feedback block, not stdout
- [ ] Two concurrent chunk validate calls with daemon up → second one waits, not crashes (serialized by validateMu)
- [ ] Existing validate_test.go suite passes with --sync flag behavior intact (daemon never re-delegates)
<img width="1095" height="502" alt="Screenshot 2026-09-02 at 12 03 47 PM" src="https://github.com/user-attachments/assets/46582ec8-2d93-4f56-ad1a-83b5be0ae2f5" />
