### PR TITLE
Split Exec into SubmitExec and StreamOutput

### DIFF
--- a/internal/circleci/client.go
+++ b/internal/circleci/client.go
@@ -227,14 +227,16 @@ type execSubmitAttrs struct {
 	Phase string `json:"phase"`
 }
 
-// Exec submits a command and collects its output.
+// SubmitExec submits a command for execution and returns its command ID without
+// consuming any output.
 //
-// When onOutput is non-nil it receives each run of output bytes as it arrives
-// and Stdout/Stderr are left empty — accumulating is then the caller's choice,
-// which matters because output can be arbitrarily large.
-func (c *Client) Exec(
-	ctx context.Context, sidecarID, command string, args []string, env map[string]string, onOutput OutputFn,
-) (*ExecResponse, error) {
+// Splitting submission from streaming is what makes a command observable while
+// it runs: the ID is the handle to its output stream, and a caller that wants to
+// hand that handle to something else — a log tailer, the watch daemon — needs it
+// before the command finishes, not after.
+func (c *Client) SubmitExec(
+	ctx context.Context, sidecarID, command string, args []string, env map[string]string,
+) (string, error) {
 	var attrs execSubmitAttrs
 	envelope := v3Envelope{Data: v3DataEntity{Attributes: &attrs}}
 	_, err := c.cl.Call(ctx, hc.NewRequest(http.MethodPost, "/api/v3/sidecar/instances/%s/exec",
@@ -243,9 +245,40 @@ func (c *Client) Exec(
 		hc.JSONDecoder(&envelope),
 	))
 	if err != nil {
-		return nil, mapErr("exec", err)
+		return "", mapErr("exec", err)
 	}
-	return c.streamCommandOutput(ctx, envelope.Data.ID, onOutput)
+	return envelope.Data.ID, nil
+}
+
+// StreamOutput consumes a command's output stream from cursor to termination,
+// reconnecting as needed. An empty cursor starts from the beginning of whatever
+// output the server still retains, which is what makes this usable both to tail
+// a running command and to replay one that has already exited.
+//
+// When onOutput is non-nil it receives each run of output bytes as it arrives and
+// the returned Stdout/Stderr are left empty — accumulating is then the caller's
+// choice, which matters because output can be arbitrarily large.
+func (c *Client) StreamOutput(
+	ctx context.Context, commandID, cursor string, onOutput OutputFn,
+) (*ExecResponse, error) {
+	return c.streamCommandOutput(ctx, commandID, cursor, onOutput)
+}
+
+// Exec submits a command and collects its output. It is the composition of
+// SubmitExec and StreamOutput, retained because most callers want exactly that
+// and have no use for the command ID until the command is done.
+//
+// When onOutput is non-nil it receives each run of output bytes as it arrives
+// and Stdout/Stderr are left empty — accumulating is then the caller's choice,
+// which matters because output can be arbitrarily large.
+func (c *Client) Exec(
+	ctx context.Context, sidecarID, command string, args []string, env map[string]string, onOutput OutputFn,
+) (*ExecResponse, error) {
+	commandID, err := c.SubmitExec(ctx, sidecarID, command, args, env)
+	if err != nil {
+		return nil, err
+	}
+	return c.streamCommandOutput(ctx, commandID, "", onOutput)
 }
 
 // exitEvent is the payload of a terminal `exit` frame.
@@ -264,15 +297,17 @@ type errorEvent struct {
 
 // streamCommandOutput reads a command's output stream to its end, reconnecting
 // from the last cursor whenever the connection drops before a terminal event.
+// cursor is where to start; empty means the beginning of retained output.
 //
 // The API ends a stream with exactly one exit or error event, or with nothing at
 // all; nothing at all means the connection was interrupted, which is precisely
 // what makes resuming safe rather than a guess.
-func (c *Client) streamCommandOutput(ctx context.Context, commandID string, onOutput OutputFn) (*ExecResponse, error) {
+func (c *Client) streamCommandOutput(
+	ctx context.Context, commandID, cursor string, onOutput OutputFn,
+) (*ExecResponse, error) {
 	result := &ExecResponse{CommandID: commandID}
 
 	var (
-		cursor   string
 		attempts int
 		stalls   int
 	)

--- a/internal/circleci/submit_stream_test.go
+++ b/internal/circleci/submit_stream_test.go
@@ -1,0 +1,147 @@
+package circleci
+
+import (
+	"bytes"
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+)
+
+// newSubmitStreamFake wires the shared SSE fake and returns a client plus the
+// fake, so a test can submit and stream as separate steps.
+func newSubmitStreamFake(t *testing.T, resp *fakes.ExecResponse) (*Client, *fakes.FakeCircleCI) {
+	t.Helper()
+	previous := streamRetryBase
+	streamRetryBase = time.Millisecond
+	t.Cleanup(func() { streamRetryBase = previous })
+
+	fake := fakes.NewFakeCircleCI()
+	fake.ExecResponse = resp
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+	return newTestClient(t, srv.URL), fake
+}
+
+// The whole point of the split: the command ID must be available before any
+// output is consumed, so it can be handed to something else while the command is
+// still running.
+func TestSubmitExecReturnsIDBeforeStreaming(t *testing.T) {
+	client, _ := newSubmitStreamFake(t, &fakes.ExecResponse{
+		CommandID: "cmd-abc",
+		Stdout:    "hello\n",
+		ExitCode:  0,
+	})
+
+	commandID, err := client.SubmitExec(context.Background(), "sb-1", "sh", []string{"-c", "echo hello"}, nil)
+	assert.NilError(t, err)
+	assert.Check(t, commandID != "", "SubmitExec must return a usable command ID")
+}
+
+func TestStreamOutputConsumesSubmittedCommand(t *testing.T) {
+	client, _ := newSubmitStreamFake(t, &fakes.ExecResponse{
+		CommandID: "cmd-abc",
+		Stdout:    "out\n",
+		Stderr:    "err\n",
+		ExitCode:  3,
+	})
+
+	commandID, err := client.SubmitExec(context.Background(), "sb-1", "sh", nil, nil)
+	assert.NilError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	onOutput := func(stream string, data []byte) {
+		if stream == StreamStderr {
+			stderr.Write(data)
+		} else {
+			stdout.Write(data)
+		}
+	}
+	resp, err := client.StreamOutput(context.Background(), commandID, "", onOutput)
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(resp.ExitCode, 3))
+	assert.Check(t, cmp.Equal(stdout.String(), "out\n"))
+	assert.Check(t, cmp.Equal(stderr.String(), "err\n"))
+	assert.Check(t, cmp.Equal(resp.CommandID, commandID))
+}
+
+// Attaching after the command has already finished is the replay case, and it is
+// what makes reading back an old run work at all. It must behave the same as
+// attaching while it runs.
+func TestStreamOutputReplaysAnAlreadyExitedCommand(t *testing.T) {
+	client, _ := newSubmitStreamFake(t, &fakes.ExecResponse{
+		CommandID: "cmd-abc",
+		Stdout:    "finished output\n",
+		ExitCode:  0,
+	})
+
+	commandID, err := client.SubmitExec(context.Background(), "sb-1", "sh", nil, nil)
+	assert.NilError(t, err)
+
+	// Drain it once, as the submitting process would.
+	first, err := client.StreamOutput(context.Background(), commandID, "", nil)
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(first.Stdout, "finished output\n"))
+
+	// Then attach again from the beginning, as a dashboard opened later would.
+	var replayed bytes.Buffer
+	second, err := client.StreamOutput(context.Background(), commandID, "", func(_ string, data []byte) {
+		replayed.Write(data)
+	})
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(second.ExitCode, 0))
+	assert.Check(t, cmp.Equal(replayed.String(), "finished output\n"))
+}
+
+// StreamOutput accumulates into the response only when no callback is given —
+// the callback form leaves them empty because output can be arbitrarily large.
+func TestStreamOutputAccumulatesWithoutCallback(t *testing.T) {
+	client, _ := newSubmitStreamFake(t, &fakes.ExecResponse{
+		CommandID: "cmd-abc",
+		Stdout:    "buffered\n",
+		ExitCode:  0,
+	})
+
+	commandID, err := client.SubmitExec(context.Background(), "sb-1", "sh", nil, nil)
+	assert.NilError(t, err)
+
+	resp, err := client.StreamOutput(context.Background(), commandID, "", nil)
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(resp.Stdout, "buffered\n"))
+}
+
+// Exec must remain exactly the composition of the two, since every existing
+// caller still uses it.
+func TestExecStillComposesSubmitAndStream(t *testing.T) {
+	client, _ := newSubmitStreamFake(t, &fakes.ExecResponse{
+		CommandID: "cmd-abc",
+		Stdout:    "composed\n",
+		ExitCode:  7,
+	})
+
+	var got bytes.Buffer
+	resp, err := client.Exec(context.Background(), "sb-1", "sh", nil, nil, func(_ string, data []byte) {
+		got.Write(data)
+	})
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(resp.ExitCode, 7))
+	assert.Check(t, cmp.Equal(got.String(), "composed\n"))
+	assert.Check(t, resp.CommandID != "")
+}
+
+func TestStreamOutputHonoursCancellation(t *testing.T) {
+	client, _ := newSubmitStreamFake(t, &fakes.ExecResponse{CommandID: "cmd-abc", Stdout: "x\n", ExitCode: 0})
+
+	commandID, err := client.SubmitExec(context.Background(), "sb-1", "sh", nil, nil)
+	assert.NilError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = client.StreamOutput(ctx, commandID, "", nil)
+	assert.Check(t, err != nil, "a cancelled context must abort the stream")
+}


### PR DESCRIPTION
**1 of 4** — splitting #548. Base: `main`.

## Summary

`Exec` submitted a command and consumed its output in one call, so the command ID only existed once the command had finished. Anything observing a command while it runs needs it up front.

`SubmitExec` returns the ID; `StreamOutput` consumes the stream from a cursor. `Exec` is retained as the composition of the two — no caller changes, no behaviour changes.

## Test plan
- [x] `task test`, `task lint`, `task build`
