### PR TITLE
Add a scrollback pane and sidecar logs

### DIFF
--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -43,6 +43,7 @@ func newSidecarCmd() *cobra.Command {
 	cmd.AddCommand(newSidecarCreateCmd())
 	cmd.AddCommand(newSidecarDeleteCmd())
 	cmd.AddCommand(newSidecarExecCmd())
+	cmd.AddCommand(newSidecarLogsCmd())
 	cmd.AddCommand(newSidecarAddSSHKeyCmd())
 	cmd.AddCommand(newSidecarSSHCmd())
 	cmd.AddCommand(newSidecarSyncCmd())

--- a/internal/cmd/sidecarlogs.go
+++ b/internal/cmd/sidecarlogs.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+	"github.com/CircleCI-Public/chunk-cli/internal/watchd"
+)
+
+// newSidecarLogsCmd prints a remote command's output.
+//
+// This is the non-TUI door onto the same data `chunk watch` shows, which matters
+// because the most common reader here has no terminal at all: an agent that just
+// ran validate and wants to know why it failed can pipe this, where it cannot
+// drive a dashboard.
+//
+// It prefers the watch daemon's buffer and falls back to the API, so it works
+// whether or not a daemon is running.
+func newSidecarLogsCmd() *cobra.Command {
+	var follow bool
+
+	cmd := &cobra.Command{
+		Use:   "logs <command-id>",
+		Short: "Print the output of a command that ran on a sidecar",
+		Long: "Print the output of a command that ran on a sidecar.\n\n" +
+			"Command IDs appear in the chunk watch dashboard. Output is read from the\n" +
+			"watch daemon's buffer when it has it, and from the CircleCI API otherwise.\n\n" +
+			"Exits non-zero only when reading failed. A command that itself exited\n" +
+			"non-zero is reported on stderr as \"exit status N\" and does not change this\n" +
+			"command's own status, so a failing remote command is not a failing read.",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			commandID := args[0]
+			io := iostream.FromCmd(cmd)
+
+			// The daemon first: it needs no network round trip and it holds output
+			// for commands whose submitting process has long since exited.
+			if chunk, err := watchd.FetchOutput(commandID, 0); err == nil && chunk.Found {
+				if chunk.Truncated {
+					io.ErrPrintln("warning: earlier output was dropped from the buffer")
+				}
+				_, _ = io.Out.Write(chunk.Data)
+				if chunk.Error != "" {
+					// Output may be short because streaming broke, not because the
+					// command was quiet. Say which.
+					io.ErrPrintf("warning: output stream ended early: %s\n", chunk.Error)
+				}
+				if !chunk.Running || !follow {
+					return reportExitCode(chunk.ExitCode, io)
+				}
+				return followFromDaemon(cmd, commandID, chunk.NextOffset, io)
+			}
+
+			// No daemon, or it has forgotten this command: stream from the API.
+			insecureStorage := insecureStorageFlag(cmd)
+			rc, err := config.Resolve("", "", insecureStorage)
+			if err != nil {
+				return fmt.Errorf("resolve config: %w", err)
+			}
+			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, ui.PromptHidden)
+			if err != nil {
+				return err
+			}
+			result, err := client.StreamOutput(cmd.Context(), commandID, "", func(_ string, data []byte) {
+				_, _ = io.Out.Write(data)
+			})
+			if err != nil {
+				if authErr := notAuthorized("read command output", rc.CircleCITokenSource, err); authErr != nil {
+					return authErr
+				}
+				return &userError{
+					msg:        fmt.Sprintf("Could not read output for command %s.", commandID),
+					suggestion: "Check the command ID in the chunk watch dashboard.",
+					err:        err,
+				}
+			}
+			return reportExitCode(&result.ExitCode, io)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Keep printing output until the command exits")
+	return cmd
+}
+
+// followFromDaemon keeps reading a running command's output from the daemon until
+// it exits or the context is cancelled.
+func followFromDaemon(cmd *cobra.Command, commandID string, offset int64, io iostream.Streams) error {
+	ctx := cmd.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(followInterval):
+		}
+		chunk, err := watchd.FetchOutput(commandID, offset)
+		if err != nil {
+			return &userError{msg: "Lost contact with the watch daemon while following output.", err: err}
+		}
+		if !chunk.Found {
+			// The daemon evicted the command mid-follow. Report what happened
+			// rather than exiting 0 as though the command had passed.
+			return &userError{
+				msg:    fmt.Sprintf("The watch daemon dropped output for command %s while following it.", commandID),
+				errMsg: "command output evicted",
+			}
+		}
+		_, _ = io.Out.Write(chunk.Data)
+		offset = chunk.NextOffset
+		if !chunk.Running {
+			// Same reasoning as the non-follow path: a stream that broke leaves no
+			// exit code, so reporting only the code would end a truncated follow
+			// silently at exit 0, as though the command had simply finished.
+			if chunk.Error != "" {
+				io.ErrPrintf("warning: output stream ended early: %s\n", chunk.Error)
+			}
+			return reportExitCode(chunk.ExitCode, io)
+		}
+	}
+}
+
+// followInterval is how often --follow asks the daemon for more output. It polls
+// a local socket, so this can be brisk without costing anything remote.
+const followInterval = 200 * time.Millisecond
+
+// reportExitCode notes the remote command's status on stderr.
+//
+// It deliberately does not make `logs` exit non-zero: this command succeeded if
+// it printed what it was asked for, and conflating "the command I am reading
+// about failed" with "reading failed" leaves the exit status meaning nothing to a
+// caller. stdout therefore stays pure output for piping, and the status goes to
+// stderr where a human still sees it. A nil code means the command never
+// terminated as far as the reader could tell, which is not a failure either.
+func reportExitCode(code *int, io iostream.Streams) error {
+	if code == nil || *code == 0 {
+		return nil
+	}
+	io.ErrPrintf("exit status %d\n", *code)
+	return nil
+}

--- a/internal/cmd/sidecarlogs.go
+++ b/internal/cmd/sidecarlogs.go
@@ -67,6 +67,12 @@ func newSidecarLogsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// --follow is not consulted here because it cannot change anything:
+			// StreamOutput reconnects until a terminal exit event arrives, so it
+			// already runs to completion. For a finished command that is a bounded
+			// replay; for a running one it follows whether asked to or not. The
+			// flag is therefore redundant on this path rather than ignored — the
+			// API exposes no way to read only what has arrived so far.
 			result, err := client.StreamOutput(cmd.Context(), commandID, "", func(_ string, data []byte) {
 				_, _ = io.Out.Write(data)
 			})

--- a/internal/cmd/sidecarlogs_test.go
+++ b/internal/cmd/sidecarlogs_test.go
@@ -1,0 +1,164 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/watchd"
+)
+
+func TestRemoteCommandLabel(t *testing.T) {
+	tests := []struct {
+		name   string
+		script string
+		want   string
+	}{
+		{
+			// The shape newExecFn actually builds.
+			name:   "strips the workspace cd",
+			script: "cd '/home/user/repo' && go test ./...",
+			want:   "go test ./...",
+		},
+		{
+			name:   "keeps later && intact",
+			script: "cd '/home/user/repo' && go build ./... && go test ./...",
+			want:   "go build ./... && go test ./...",
+		},
+		{
+			// WorkspaceExists probes with a bare test, no cd.
+			name:   "script without a cd is used whole",
+			script: "test -d '/home/user/repo'",
+			want:   "test -d '/home/user/repo'",
+		},
+		{
+			name:   "multi-line script is titled by its first line",
+			script: "cd '/repo' && set -e\ngo vet ./...\ngo test ./...",
+			want:   "set -e",
+		},
+		{
+			name:   "empty script stays empty",
+			script: "",
+			want:   "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := remoteCommandLabel(tt.script)
+			assert.Check(t, cmp.Equal(got, tt.want))
+		})
+	}
+}
+
+func TestRemoteCommandLabelIsBounded(t *testing.T) {
+	// A label is a pane header, so an enormous generated script must not become
+	// one. The output is shown in full regardless.
+	long := strings.Repeat("x", 500)
+	got := remoteCommandLabel("cd '/repo' && " + long)
+	assert.Check(t, len(got) <= 120, "label should be capped, got %d chars", len(got))
+}
+
+func TestReportExitCode(t *testing.T) {
+	// Reading succeeded in every one of these cases, so none of them is an error:
+	// making `logs` fail because the command it reports on failed would leave the
+	// exit status meaning nothing.
+	var errOut strings.Builder
+	io := iostream.Streams{Out: &errOut, Err: &errOut}
+
+	err := reportExitCode(nil, io)
+	assert.Check(t, cmp.Nil(err), "an unterminated command is not a failure")
+
+	zero := 0
+	err = reportExitCode(&zero, io)
+	assert.Check(t, cmp.Nil(err))
+	assert.Check(t, cmp.Equal(errOut.String(), ""), "a passing command says nothing")
+
+	two := 2
+	err = reportExitCode(&two, io)
+	assert.Check(t, cmp.Nil(err), "logs must not fail because the logged command did")
+	// The status still has to be visible, just on stderr so stdout stays pipeable.
+	assert.Check(t, cmp.Contains(errOut.String(), "exit status 2"))
+}
+
+func TestSidecarLogsRequiresExactlyOneArg(t *testing.T) {
+	cmd := newSidecarLogsCmd()
+	err := cmd.Args(cmd, nil)
+	assert.Check(t, err != nil, "no command ID should be rejected")
+
+	err = cmd.Args(cmd, []string{"a", "b"})
+	assert.Check(t, err != nil, "two command IDs should be rejected")
+
+	err = cmd.Args(cmd, []string{"cmd-1"})
+	assert.NilError(t, err)
+}
+
+func TestSidecarLogsIsRegistered(t *testing.T) {
+	var found bool
+	for _, sub := range newSidecarCmd().Commands() {
+		if sub.Name() == "logs" {
+			found = true
+			break
+		}
+	}
+	assert.Check(t, found, "sidecar logs should be registered as a subcommand")
+}
+
+// fakeWatchd serves /output over a unix socket at the daemon's expected path,
+// returning the supplied chunks in order.
+func fakeWatchd(t *testing.T, chunks []watchd.OutputChunk) {
+	t.Helper()
+	// Not t.TempDir(): a unix socket path is capped near 104 bytes and macOS
+	// temp dirs are long enough to blow that on their own.
+	dir, err := os.MkdirTemp("/tmp", "watchd")
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	t.Setenv("CHUNK_WATCHD_DIR", dir)
+
+	ln, err := net.Listen("unix", filepath.Join(dir, "watchd.sock"))
+	assert.NilError(t, err)
+
+	var mu sync.Mutex
+	var i int
+	srv := &http.Server{ReadHeaderTimeout: time.Second, Handler: http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+			chunk := chunks[len(chunks)-1]
+			if i < len(chunks) {
+				chunk = chunks[i]
+				i++
+			}
+			_ = json.NewEncoder(w).Encode(chunk)
+		})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+}
+
+// A stream that dies mid-follow leaves no exit code, so reporting only the code
+// would end the follow silently at exit 0 as though the command had finished.
+func TestFollowReportsAStreamThatEndedEarly(t *testing.T) {
+	fakeWatchd(t, []watchd.OutputChunk{
+		{Found: true, Running: true, Data: []byte("first\n"), NextOffset: 6},
+		{Found: true, Running: false, NextOffset: 6, Error: "connection reset"},
+	})
+
+	var out, errOut strings.Builder
+	cmd := newSidecarLogsCmd()
+	cmd.SetContext(context.Background())
+
+	err := followFromDaemon(cmd, "cmd-1", 0, iostream.Streams{Out: &out, Err: &errOut})
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Contains(out.String(), "first"))
+	assert.Check(t, cmp.Contains(errOut.String(), "output stream ended early: connection reset"))
+}

--- a/internal/cmd/sidecarlogs_test.go
+++ b/internal/cmd/sidecarlogs_test.go
@@ -73,8 +73,11 @@ func TestReportExitCode(t *testing.T) {
 	// Reading succeeded in every one of these cases, so none of them is an error:
 	// making `logs` fail because the command it reports on failed would leave the
 	// exit status meaning nothing.
-	var errOut strings.Builder
-	io := iostream.Streams{Out: &errOut, Err: &errOut}
+	// Separate buffers, per review: pointed at one, this could not tell stderr
+	// from stdout, and the whole point of the status going to stderr is that
+	// stdout stays clean enough to pipe.
+	var out, errOut strings.Builder
+	io := iostream.Streams{Out: &out, Err: &errOut}
 
 	err := reportExitCode(nil, io)
 	assert.Check(t, cmp.Nil(err), "an unterminated command is not a failure")
@@ -87,8 +90,9 @@ func TestReportExitCode(t *testing.T) {
 	two := 2
 	err = reportExitCode(&two, io)
 	assert.Check(t, cmp.Nil(err), "logs must not fail because the logged command did")
-	// The status still has to be visible, just on stderr so stdout stays pipeable.
 	assert.Check(t, cmp.Contains(errOut.String(), "exit status 2"))
+	assert.Check(t, cmp.Equal(out.String(), ""),
+		"the status belongs on stderr: stdout carries the command's own output")
 }
 
 func TestSidecarLogsRequiresExactlyOneArg(t *testing.T) {

--- a/internal/ui/watch/fetch.go
+++ b/internal/ui/watch/fetch.go
@@ -36,6 +36,7 @@ func convertSnapshot(snap watchd.Snapshot, m Model) dataMsg {
 	headRefs := make([]string, 0, n)
 	offsets := make([]int64, n) // daemon owns offsets; TUI keeps zeros
 	allEventsByProject := make([][]eventlog.Event, 0, n)
+	allCommandsByProject := make([][]watchd.CommandState, 0, n)
 	var allSidecars []sidecarInfo
 
 	for i, p := range snap.Projects {
@@ -52,6 +53,7 @@ func convertSnapshot(snap watchd.Snapshot, m Model) dataMsg {
 		branches = append(branches, p.Branch)
 		headRefs = append(headRefs, p.HeadRef)
 		allEventsByProject = append(allEventsByProject, p.Events)
+		allCommandsByProject = append(allCommandsByProject, p.Commands)
 
 		for _, sc := range p.Sidecars {
 			allSidecars = append(allSidecars, sidecarInfo{
@@ -112,5 +114,7 @@ func convertSnapshot(snap watchd.Snapshot, m Model) dataMsg {
 		offsets:  offsets,
 		branches: branches,
 		headRefs: headRefs,
+		commands: allCommandsByProject,
+		authErr:  snap.AuthError,
 	}
 }

--- a/internal/ui/watch/model.go
+++ b/internal/ui/watch/model.go
@@ -16,6 +16,7 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 	"github.com/CircleCI-Public/chunk-cli/internal/upgrade"
+	"github.com/CircleCI-Public/chunk-cli/internal/watchd"
 )
 
 const (
@@ -148,6 +149,8 @@ type dataMsg struct {
 	offsets  []int64
 	branches []string
 	headRefs []string
+	commands [][]watchd.CommandState
+	authErr  string
 }
 
 // Model is the BubbleTea model for the watch dashboard.
@@ -193,6 +196,20 @@ type Model struct {
 	// is labelled as the viewer's own, which is the fastest way to answer "which
 	// of these is mine" without reading UUIDs.
 	ownSession string
+
+	// commands is every command the daemon is buffering output for, per project;
+	// index matches projects. Used to resolve an invocation to a command ID.
+	commands [][]watchd.CommandState
+
+	// output is the open scrollback pane, nil when none is open.
+	output *outputPane
+	// outputSeq increments on every pane opening, so a tick chain from a closed
+	// pane can be told apart from the current one and dropped.
+	outputSeq int
+
+	// authErr explains why command output is unavailable, when it is. An empty
+	// logs pane with no explanation sends people hunting the wrong fault.
+	authErr string
 }
 
 // noSelection is the initial selectedID sentinel. It can never match a real
@@ -232,6 +249,57 @@ func (m Model) Init() tea.Cmd {
 	return tea.Batch(m.loadData, doSpin(), checkUpdateCmd())
 }
 
+// updateDashboardKey handles keys for the two-pane dashboard, when no output
+// pane is open. Split out of Update so neither grows past the complexity limit.
+func (m Model) updateDashboardKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.Code {
+	case 'q', tea.KeyEscape:
+		return m, tea.Quit
+	case tea.KeyRight, 'l':
+		m.focusedPane = paneRight
+	case tea.KeyLeft, 'h':
+		m.focusedPane = paneLeft
+	case 's', tea.KeyDown:
+		if m.focusedPane == paneLeft {
+			if m.selectedIdx < len(m.sidecars)-1 {
+				m.selectedIdx++
+			}
+			m.selectedID = selectedSidecarID(m.sidecars, m.selectedIdx)
+			m.rightSelectedIdx = 0
+		} else {
+			m.rightSelectedIdx++
+		}
+	case 'w', tea.KeyUp:
+		if m.focusedPane == paneLeft {
+			if m.selectedIdx > 0 {
+				m.selectedIdx--
+			}
+			m.selectedID = selectedSidecarID(m.sidecars, m.selectedIdx)
+			m.rightSelectedIdx = 0
+		} else if m.rightSelectedIdx > 0 {
+			m.rightSelectedIdx--
+		}
+	case tea.KeyEnter:
+		if m.focusedPane == paneRight {
+			// Enter opens output when the invocation has any; otherwise it falls
+			// back to expand/collapse, so the key never feels dead.
+			if opened, cmd := m.openSelectedOutput(); opened != nil {
+				return *opened, cmd
+			}
+			m = m.toggleSelectedInvoc()
+		}
+	case tea.KeySpace:
+		if m.focusedPane == paneRight {
+			m = m.toggleSelectedInvoc()
+		}
+	case 'c':
+		if msg.Mod == tea.ModCtrl {
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.BackgroundColorMsg:
@@ -244,45 +312,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyPressMsg:
-		switch msg.Code {
-		case 'q', tea.KeyEscape:
-			return m, tea.Quit
-		case tea.KeyRight, 'l':
-			m.focusedPane = paneRight
-		case tea.KeyLeft, 'h':
-			m.focusedPane = paneLeft
-		case 's', tea.KeyDown:
-			if m.focusedPane == paneLeft {
-				if m.selectedIdx < len(m.sidecars)-1 {
-					m.selectedIdx++
-				}
-				m.selectedID = selectedSidecarID(m.sidecars, m.selectedIdx)
-				m.rightSelectedIdx = 0
-			} else {
-				m.rightSelectedIdx++
-			}
-		case 'w', tea.KeyUp:
-			if m.focusedPane == paneLeft {
-				if m.selectedIdx > 0 {
-					m.selectedIdx--
-				}
-				m.selectedID = selectedSidecarID(m.sidecars, m.selectedIdx)
-				m.rightSelectedIdx = 0
-			} else if m.rightSelectedIdx > 0 {
-				m.rightSelectedIdx--
-			}
-		case tea.KeyEnter, tea.KeySpace:
-			if m.focusedPane == paneRight {
-				m = m.toggleSelectedInvoc()
-			}
-		case 'c':
-			if msg.Mod == tea.ModCtrl {
-				return m, tea.Quit
-			}
+		// An open output pane owns the keyboard: it is a full-height reading view,
+		// and leaving the underlying list navigable would scroll two things at
+		// once. Esc closes it rather than quitting the dashboard.
+		if m.output != nil {
+			return m.updateOutputKey(msg)
 		}
-		return m, nil
+		return m.updateDashboardKey(msg)
 
 	case tea.MouseClickMsg:
+		// The output pane covers the dashboard, so a click here would move a
+		// selection and toggle invocations the reader cannot even see.
+		if m.output != nil {
+			return m, nil
+		}
 		if msg.Button == tea.MouseLeft {
 			m = m.withMouseClick(msg.X, msg.Y)
 		}
@@ -292,6 +335,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.daemonErr = msg.err
 		return m, tea.Tick(pollInterval, func(time.Time) tea.Msg { return tickMsg{} })
 
+	case outputMsg:
+		return m.withOutputChunk(msg)
+
+	case outputTickMsg:
+		// Only the current pane's tick chain may continue. Without the sequence
+		// check, closing and reopening the pane leaves the old chain alive to
+		// find a non-nil pane and schedule alongside the new one, so every
+		// reopen would add another poller.
+		if m.output == nil || msg.seq != m.outputSeq {
+			return m, nil
+		}
+		return m, tea.Batch(fetchOutput(m.output.commandID, m.output.offset), outputTick(msg.seq))
+
 	case dataMsg:
 		m.daemonErr = nil
 		m.projects = msg.projects
@@ -300,6 +356,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.offsets = msg.offsets
 		m.branches = msg.branches
 		m.headRefs = msg.headRefs
+		m.commands = msg.commands
+		m.authErr = msg.authErr
 		// Sidecars are re-sorted by recency each poll, so track the selection
 		// by id. An unknown id (first poll, or the sidecar aged out) falls back
 		// to index 0, the most recently active sidecar.
@@ -343,6 +401,9 @@ func (m Model) render() string {
 		return "loading...\n"
 	}
 	st := m.styles()
+	if m.output != nil {
+		return m.renderHeader(st) + m.renderSeparator(st) + m.renderOutputPane(st)
+	}
 	return m.renderHeader(st) +
 		m.renderSeparator(st) +
 		m.renderBody(st) +
@@ -417,9 +478,34 @@ func (m Model) renderBody(st watchStyles) string {
 		if m.focusedPane == paneRight {
 			div = st.muted("│")
 		}
-		b.WriteString(" " + lPad + " " + div + " " + r + "\n")
+		// Clip rather than let a long line wrap: the two panes are drawn as one
+		// fixed-height block, so a line that wraps shifts everything below it and
+		// the layout no longer matches the height it was built for.
+		b.WriteString(" " + lPad + " " + div + " " + clip(r, m.width-leftPaneWidth-4) + "\n")
 	}
 	return b.String()
+}
+
+// rowStatus is the one-line state a sidecar row reports: what it is doing now,
+// or how its tree compares to the sidecar's. Split out of renderSidecarPane so
+// neither grows past the complexity limit.
+func (m Model) rowStatus(st watchStyles, sc sidecarInfo) string {
+	switch {
+	case sc.running:
+		frame := spinFrames[m.spinIdx%len(spinFrames)]
+		return st.running(frame + " " + string(sc.lastOp) + "...")
+	case sc.id == "": // local runner — no sync state
+		switch sc.lastLevel {
+		case levelDone:
+			return st.success(ui.IconOK + " passed")
+		case levelError:
+			return st.err(ui.IconFail + " failed")
+		default:
+			return st.muted("no runs yet")
+		}
+	default:
+		return st.muted("synced via rsync")
+	}
 }
 
 func (m Model) renderSidecarPane(st watchStyles, maxLines int) []string {
@@ -515,22 +601,7 @@ func (m Model) renderSidecarPane(st watchStyles, maxLines int) []string {
 			addRow("   " + st.vdim("◈ "+truncate(sc.snapshotName, leftPaneWidth-6)))
 		}
 
-		switch {
-		case sc.running:
-			frame := spinFrames[m.spinIdx%len(spinFrames)]
-			addRow("  " + st.running(frame+" "+string(sc.lastOp)+"..."))
-		case sc.id == "": // local runner — no sync state
-			switch sc.lastLevel {
-			case levelDone:
-				addRow("  " + st.success(ui.IconOK+" passed"))
-			case levelError:
-				addRow("  " + st.err(ui.IconFail+" failed"))
-			default:
-				addRow("  " + st.muted("no runs yet"))
-			}
-		default:
-			addRow("  " + st.muted("synced via rsync"))
-		}
+		addRow("  " + m.rowStatus(st, sc))
 
 		if !sc.lastActivity.IsZero() {
 			addRow("  " + st.vdim(ago(sc.lastActivity)))
@@ -666,7 +737,7 @@ func (m Model) buildCollapsibleLines(st watchStyles, groups []invocationGroup, r
 		if ri > 0 {
 			add("")
 		}
-		add(renderInvocationHeader(st, groups[gi], expanded, selected))
+		add(renderInvocationHeader(st, groups[gi], expanded, selected, m.commandForInvocation(groups[gi]) != nil))
 		if expanded {
 			g := groups[gi]
 			for ei := len(g.events) - 1; ei >= 0 && len(rendered) < maxLines; ei-- {
@@ -825,7 +896,7 @@ func outcomeOf(g invocationGroup) (icon, label, level string) {
 }
 
 // renderInvocationHeader renders a one-line summary for an invocation group.
-func renderInvocationHeader(st watchStyles, g invocationGroup, expanded, selected bool) string {
+func renderInvocationHeader(st watchStyles, g invocationGroup, expanded, selected, hasOutput bool) string {
 	var arrow string
 	if expanded {
 		arrow = "▼ "
@@ -865,9 +936,19 @@ func renderInvocationHeader(st watchStyles, g invocationGroup, expanded, selecte
 		}
 	}
 
-	label2 := "validate" + "  " + outcomeStr + "  " + tsStr + durStr
+	// Marks an invocation whose output the daemon still holds, so "which of these
+	// can I actually read" is answerable without pressing Enter on each one.
+	outMark := ""
+	if hasOutput {
+		outMark = "  " + st.teal("▤")
+		if selected {
+			outMark = "  " + st.teal("▤ enter")
+		}
+	}
+
+	label2 := "validate" + "  " + outcomeStr + "  " + tsStr + durStr + outMark
 	if selected {
-		label2 = st.emphasis("validate") + "  " + outcomeStr + "  " + tsStr + durStr
+		label2 = st.emphasis("validate") + "  " + outcomeStr + "  " + tsStr + durStr + outMark
 	}
 	return arrow + label2
 }
@@ -979,7 +1060,8 @@ func (m Model) renderFooter(st watchStyles) string {
 	} else {
 		keys = []struct{ key, action string }{
 			{"↑/↓ w/s", "navigate"},
-			{"Enter/Space", "toggle"},
+			{"Enter", "output"},
+			{"Space", "toggle"},
 			{"←", "sidecars"},
 			{"q", "quit"},
 		}
@@ -988,13 +1070,29 @@ func (m Model) renderFooter(st watchStyles) string {
 	for _, k := range keys {
 		parts = append(parts, st.vdim(k.key)+" "+st.dim(k.action))
 	}
-	bar := strings.Join(parts, "  "+st.vdim("·")+"  ")
+	sep := "  " + st.vdim("·") + "  "
+	bar := strings.Join(parts, sep)
+	// Drop hints from the end until the bar fits. The same fixed-height reasoning
+	// as the notice below: a wrapped footer costs a line the layout did not budget
+	// for, which is worse than a hint the reader can find by pressing the key.
+	for len(parts) > 1 && lipgloss.Width(bar) > m.width-2 {
+		parts = parts[:len(parts)-1]
+		bar = strings.Join(parts, sep)
+	}
+	bar = clip(bar, m.width-2)
 
-	// Right-align the update notice, but drop it entirely when it does not
-	// fit: padding it onto an over-long bar would wrap the footer and break
-	// the fixed-height layout.
-	if m.updateAvailable != "" {
-		notice := "↑ " + m.updateAvailable + "  " + st.dim(m.upgradeCmd)
+	// Right-align one notice, dropping it entirely when it does not fit: padding
+	// it onto an over-long bar would wrap the footer and break the fixed-height
+	// layout. An auth failure wins the slot over the update hint — a logs pane
+	// that will never fill is more immediate than a version.
+	notice := ""
+	switch {
+	case m.authErr != "":
+		notice = st.warning(ui.IconWarn + " " + m.authErr)
+	case m.updateAvailable != "":
+		notice = "↑ " + m.updateAvailable + "  " + st.dim(m.upgradeCmd)
+	}
+	if notice != "" {
 		if gap := m.width - 2 - lipgloss.Width(bar) - lipgloss.Width(notice); gap >= 2 {
 			bar += strings.Repeat(" ", gap) + notice
 		}

--- a/internal/ui/watch/model.go
+++ b/internal/ui/watch/model.go
@@ -736,17 +736,22 @@ func (m Model) buildCollapsibleLines(st watchStyles, groups []invocationGroup, r
 	rendered := make([]string, 0, maxLines)
 	add := func(s string) { rendered = append(rendered, s) }
 
+	// Hoisted: the groups all belong to this one row, and resolving it per
+	// header would repeat the lookup for every line drawn.
+	selected := m.selectedSidecar()
+
 	lastGI := -1
 	for gi := len(groups) - 1; gi >= 0 && len(rendered) < maxLines; gi-- {
 		ri := len(groups) - 1 - gi // right-pane index: 0 = most recent
 		isMostRecent := gi == len(groups)-1
 		expanded := m.invocExpanded(groups[gi], isMostRecent)
-		selected := m.focusedPane == paneRight && ri == rightSel
+		isSel := m.focusedPane == paneRight && ri == rightSel
 
 		if ri > 0 {
 			add("")
 		}
-		add(renderInvocationHeader(st, groups[gi], expanded, selected, m.commandForInvocation(groups[gi]) != nil))
+		hasOutput := selected != nil && m.commandForInvocation(*selected, groups[gi]) != nil
+		add(renderInvocationHeader(st, groups[gi], expanded, isSel, hasOutput))
 		if expanded {
 			g := groups[gi]
 			for ei := len(g.events) - 1; ei >= 0 && len(rendered) < maxLines; ei-- {
@@ -785,6 +790,16 @@ func invocEndTime(g invocationGroup) time.Time {
 }
 
 // currentInvocGroups returns the invocation groups for the currently selected sidecar.
+// selectedSidecar is the row the dashboard is showing, or nil when the selection
+// is out of range. Callers that also need the row's invocations take it from
+// here so the two cannot come from different sidecars.
+func (m Model) selectedSidecar() *sidecarInfo {
+	if m.selectedIdx < 0 || m.selectedIdx >= len(m.sidecars) {
+		return nil
+	}
+	return &m.sidecars[m.selectedIdx]
+}
+
 func (m Model) currentInvocGroups() []invocationGroup {
 	if m.selectedIdx < 0 || m.selectedIdx >= len(m.sidecars) {
 		return nil

--- a/internal/ui/watch/model.go
+++ b/internal/ui/watch/model.go
@@ -346,6 +346,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.output == nil || msg.seq != m.outputSeq {
 			return m, nil
 		}
+		// A finished command's buffer is final: the daemon appends everything the
+		// stream produced before marking it done, and serves data and Running
+		// under one lock, so a chunk that reported Running:false was already
+		// complete. Polling past it is a socket round trip every 200ms for output
+		// that cannot change — and the pane can sit open on a finished command
+		// indefinitely.
+		if !m.output.running {
+			return m, nil
+		}
 		return m, tea.Batch(fetchOutput(m.output.commandID, m.output.offset), outputTick(msg.seq))
 
 	case dataMsg:

--- a/internal/ui/watch/output.go
+++ b/internal/ui/watch/output.go
@@ -1,0 +1,197 @@
+package watch
+
+import (
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/watchd"
+)
+
+// tailInterval is how often an open output pane asks the daemon for more bytes.
+// Only the output request runs this fast; the snapshot request stays on
+// pollInterval, so a tail does not multiply the cost of everything else.
+const tailInterval = 200 * time.Millisecond
+
+// maxPaneLines caps the scrollback one pane retains.
+//
+// The daemon's MaxCommandBytes caps what it *holds*, which is not the same bound:
+// a tail is served incrementally from an advancing offset, so over a long run the
+// pane receives every byte the command ever wrote, including bytes the daemon has
+// since evicted. Without a cap here, watching a verbose test suite grows this
+// slice for as long as the suite runs. The limit sits comfortably above the
+// daemon's retained window, so opening a finished command still shows all of it.
+const maxPaneLines = 5000
+
+// outputMsg carries a chunk of command output back to the model.
+type outputMsg struct {
+	commandID string
+	chunk     watchd.OutputChunk
+	err       error
+}
+
+// outputTickMsg drives the fast poll while a pane is open. seq identifies which
+// pane opening the tick belongs to, so a chain from a closed pane cannot keep
+// polling alongside the current one.
+type outputTickMsg struct{ seq int }
+
+// outputPane is the scrollback view over one command's output.
+type outputPane struct {
+	commandID string
+	// name labels the pane; taken from the invocation that opened it.
+	name string
+	// lines is the rendered scrollback, already carriage-return resolved.
+	lines []string
+	// pending holds a trailing partial line, waiting for its newline.
+	pending string
+	// offset is the next byte offset to request.
+	offset int64
+	// scroll is the first visible line; 0 means pinned to the bottom.
+	scroll int
+	// pinned tracks whether new output should keep the view at the bottom. Any
+	// manual scroll unpins, so output arriving does not yank the view away from
+	// what the developer is reading.
+	pinned    bool
+	running   bool
+	exitCode  *int
+	truncated bool
+	err       error
+}
+
+// feed appends raw output bytes, resolving carriage returns into line rewrites.
+//
+// Raw bytes are what the remote command wrote, deliberately: the exec path passes
+// them through so CR redraws and ANSI colour render as intended in a terminal.
+// Inside a split-pane view they would corrupt the layout instead, so \r is
+// interpreted here — a progress bar becomes the last frame it drew, not a
+// hundred stacked copies.
+func (p *outputPane) feed(data []byte) {
+	if len(data) == 0 {
+		return
+	}
+	text := p.pending + string(data)
+	p.pending = ""
+
+	parts := strings.Split(text, "\n")
+	// The final part has no newline yet; hold it until one arrives.
+	p.pending = parts[len(parts)-1]
+	for _, raw := range parts[:len(parts)-1] {
+		p.lines = append(p.lines, resolveCR(raw))
+	}
+	p.trim()
+}
+
+// trim drops the oldest scrollback past maxPaneLines, keeping the tail — the end
+// of a run is what anyone opened the pane to read.
+//
+// An unpinned view is shifted by the same amount so it keeps showing the lines it
+// was already showing, rather than appearing to jump forward because the content
+// moved underneath it. Dropping lines is the same loss the daemon reports with
+// Truncated, so it is flagged the same way.
+func (p *outputPane) trim() {
+	excess := len(p.lines) - maxPaneLines
+	if excess <= 0 {
+		return
+	}
+	// Copy the tail down rather than reslicing, so the backing array is reused
+	// instead of growing without bound behind a moving window.
+	p.lines = append(p.lines[:0], p.lines[excess:]...)
+	p.truncated = true
+	p.scroll = max(0, p.scroll-excess)
+}
+
+// resolveCR collapses carriage-return rewrites within a single line, keeping only
+// what would still be visible after the last one.
+//
+// A bare \r moves the cursor to column zero, so text after it overwrites text
+// before it — but only as far as it reaches. "abcdef\rXY" leaves "XYcdef" on a
+// real terminal, not "XY", and truncating to "XY" would silently drop output.
+func resolveCR(line string) string {
+	line = strings.TrimSuffix(line, "\r")
+	if !strings.Contains(line, "\r") {
+		return line
+	}
+	var canvas []rune
+	col := 0
+	for _, r := range line {
+		if r == '\r' {
+			col = 0
+			continue
+		}
+		if col < len(canvas) {
+			canvas[col] = r
+		} else {
+			canvas = append(canvas, r)
+		}
+		col++
+	}
+	return string(canvas)
+}
+
+// visibleLines returns the slice of scrollback to draw, plus whether the view is
+// showing the end of the output.
+func (p *outputPane) visibleLines(height int) ([]string, bool) {
+	all := p.lines
+	if p.pending != "" {
+		all = append(append([]string(nil), all...), resolveCR(p.pending))
+	}
+	if height <= 0 || len(all) == 0 {
+		return nil, true
+	}
+	if len(all) <= height {
+		return all, true
+	}
+	if p.pinned {
+		return all[len(all)-height:], true
+	}
+	start := p.scroll
+	if start > len(all)-height {
+		start = len(all) - height
+	}
+	if start < 0 {
+		start = 0
+	}
+	return all[start : start+height], start+height >= len(all)
+}
+
+// scrollBy moves the view, unpinning it from the bottom. Scrolling back to the
+// end re-pins, so a developer who scrolls up to read and then returns to the
+// bottom starts following again without a separate key.
+func (p *outputPane) scrollBy(delta, height int) {
+	total := len(p.lines)
+	if p.pending != "" {
+		total++
+	}
+	if total <= height {
+		p.pinned = true
+		return
+	}
+	if p.pinned {
+		p.scroll = total - height
+	}
+	p.scroll += delta
+	if p.scroll < 0 {
+		p.scroll = 0
+	}
+	maxStart := total - height
+	if p.scroll >= maxStart {
+		p.scroll = maxStart
+		p.pinned = true
+		return
+	}
+	p.pinned = false
+}
+
+// fetchOutput asks the daemon for more of a command's output.
+func fetchOutput(commandID string, offset int64) tea.Cmd {
+	return func() tea.Msg {
+		chunk, err := watchd.FetchOutput(commandID, offset)
+		return outputMsg{commandID: commandID, chunk: chunk, err: err}
+	}
+}
+
+// outputTick schedules the next fast poll for the pane opening identified by seq.
+func outputTick(seq int) tea.Cmd {
+	return tea.Tick(tailInterval, func(time.Time) tea.Msg { return outputTickMsg{seq: seq} })
+}

--- a/internal/ui/watch/output.go
+++ b/internal/ui/watch/output.go
@@ -132,27 +132,50 @@ func resolveCR(line string) string {
 // visibleLines returns the slice of scrollback to draw, plus whether the view is
 // showing the end of the output.
 func (p *outputPane) visibleLines(height int) ([]string, bool) {
-	all := p.lines
+	// n counts the pending line without building the slice that would hold it.
+	// The window is at most `height` rows, so there is no reason for the cost
+	// here to scale with the scrollback: this runs on every 200ms tick and every
+	// keypress, and materialising all of p.lines meant copying up to
+	// maxPaneLines strings each time.
+	n := len(p.lines)
 	if p.pending != "" {
-		all = append(append([]string(nil), all...), resolveCR(p.pending))
+		n++
 	}
-	if height <= 0 || len(all) == 0 {
+	if height <= 0 || n == 0 {
 		return nil, true
 	}
-	if len(all) <= height {
-		return all, true
+
+	start, end, atEnd := 0, n, true
+	switch {
+	case n <= height:
+	case p.pinned:
+		start = n - height
+	default:
+		start = p.scroll
+		if start > n-height {
+			start = n - height
+		}
+		if start < 0 {
+			start = 0
+		}
+		end = start + height
+		atEnd = end >= n
 	}
-	if p.pinned {
-		return all[len(all)-height:], true
+
+	// Reaching past the committed lines is the only case that needs a slice of
+	// its own, and then it holds the window rather than the scrollback.
+	//
+	// Appending to p.lines directly would be cheaper still and wrong: feed and
+	// trim both leave it with spare capacity, so the pending line would land in
+	// the backing array and the next feed would overwrite it underneath a slice
+	// the renderer is still holding.
+	if end <= len(p.lines) {
+		return p.lines[start:end], atEnd
 	}
-	start := p.scroll
-	if start > len(all)-height {
-		start = len(all) - height
-	}
-	if start < 0 {
-		start = 0
-	}
-	return all[start : start+height], start+height >= len(all)
+	out := make([]string, 0, end-start)
+	out = append(out, p.lines[start:]...)
+	out = append(out, resolveCR(p.pending))
+	return out, atEnd
 }
 
 // scrollBy moves the view, unpinning it from the bottom. Scrolling back to the

--- a/internal/ui/watch/output_test.go
+++ b/internal/ui/watch/output_test.go
@@ -1,0 +1,247 @@
+package watch
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestResolveCR(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no carriage return is untouched",
+			in:   "plain line",
+			want: "plain line",
+		},
+		{
+			name: "trailing CR is stripped",
+			in:   "crlf line\r",
+			want: "crlf line",
+		},
+		{
+			// The realistic worst case: a test runner's progress bar. Each frame
+			// overwrites the last, so only what remains visible should survive.
+			name: "progress bar keeps the last frame",
+			in:   "  0%\r 50%\r100%",
+			want: "100%",
+		},
+		{
+			// A short rewrite does not erase what it does not reach. Truncating
+			// to just the rewrite would silently drop output.
+			name: "short rewrite overwrites only as far as it reaches",
+			in:   "abcdef\rXY",
+			want: "XYcdef",
+		},
+		{
+			name: "leading CR is harmless",
+			in:   "\rvalue",
+			want: "value",
+		},
+		{
+			name: "empty stays empty",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveCR(tt.in)
+			assert.Check(t, cmp.Equal(got, tt.want))
+		})
+	}
+}
+
+// Captured verbatim from a real sidecar run of
+//
+//	printf "\033[31mRED TEXT\033[0m\n"; for i in 1 2 3 4 5; do printf "\r%d%% complete" $((i*20)); done
+//
+// Real output is the only fixture that catches the combination this feature has
+// to survive: colour, a carriage-return progress bar, and a plain line together.
+const realSidecarOutput = "\x1b[31mRED TEXT\x1b[0m\n\r20% complete\r40% complete\r60% complete\r80% complete\r100% complete\nnow failing\n"
+
+func TestOutputPaneHandlesRealSidecarOutput(t *testing.T) {
+	var p outputPane
+	p.feed([]byte(realSidecarOutput))
+
+	assert.Assert(t, cmp.Len(p.lines, 3))
+	// Colour is passed through untouched.
+	assert.Check(t, cmp.Equal(p.lines[0], "\x1b[31mRED TEXT\x1b[0m"))
+	// Five progress frames collapse to the last one, rather than stacking five
+	// lines or corrupting the split-pane layout.
+	assert.Check(t, cmp.Equal(p.lines[1], "100% complete"))
+	assert.Check(t, cmp.Equal(p.lines[2], "now failing"))
+	assert.Check(t, cmp.Equal(p.pending, ""))
+}
+
+func TestOutputPaneFeedSplitsLinesAndHoldsPartial(t *testing.T) {
+	var p outputPane
+	p.feed([]byte("first\nsecond\npart"))
+
+	assert.Assert(t, cmp.Len(p.lines, 2))
+	assert.Check(t, cmp.Equal(p.lines[0], "first"))
+	assert.Check(t, cmp.Equal(p.lines[1], "second"))
+	// The trailing fragment is held back until its newline arrives, so a line is
+	// never rendered half-written.
+	assert.Check(t, cmp.Equal(p.pending, "part"))
+
+	p.feed([]byte("ial\n"))
+	assert.Assert(t, cmp.Len(p.lines, 3))
+	assert.Check(t, cmp.Equal(p.lines[2], "partial"))
+	assert.Check(t, cmp.Equal(p.pending, ""))
+}
+
+func TestOutputPaneFeedAcrossChunkBoundary(t *testing.T) {
+	var p outputPane
+	// A CR sequence split across two reads must still resolve correctly — the
+	// daemon chunks on byte counts, not line boundaries.
+	p.feed([]byte("  0%\r 50"))
+	p.feed([]byte("%\r100%\n"))
+	assert.Assert(t, cmp.Len(p.lines, 1))
+	assert.Check(t, cmp.Equal(p.lines[0], "100%"))
+}
+
+func TestOutputPaneFeedEmptyIsNoop(t *testing.T) {
+	var p outputPane
+	p.feed(nil)
+	p.feed([]byte{})
+	assert.Check(t, cmp.Len(p.lines, 0))
+	assert.Check(t, cmp.Equal(p.pending, ""))
+}
+
+func TestOutputPanePreservesANSI(t *testing.T) {
+	var p outputPane
+	// Colour must survive into the pane: the exec path passes raw bytes through
+	// deliberately so remote output renders as intended.
+	p.feed([]byte("\x1b[31mFAIL\x1b[0m\n"))
+	assert.Assert(t, cmp.Len(p.lines, 1))
+	assert.Check(t, cmp.Contains(p.lines[0], "\x1b[31m"))
+}
+
+func TestClipMeasuresDisplayWidthNotBytes(t *testing.T) {
+	// An escape sequence occupies no columns, so a coloured word that fits must
+	// not be clipped on its byte length.
+	colored := "\x1b[31mFAIL\x1b[0m"
+	assert.Check(t, cmp.Equal(clip(colored, 10), colored))
+
+	// Over-wide input is cut rather than left to wrap and break the layout.
+	long := strings.Repeat("x", 40)
+	assert.Check(t, cmp.Equal(len(clip(long, 10)), 10))
+
+	assert.Check(t, cmp.Equal(clip("anything", 0), ""))
+}
+
+func TestOutputPaneVisibleLinesFollowsTailWhenPinned(t *testing.T) {
+	p := outputPane{pinned: true}
+	for i := 0; i < 10; i++ {
+		p.lines = append(p.lines, string(rune('a'+i)))
+	}
+
+	lines, atEnd := p.visibleLines(3)
+	assert.Assert(t, cmp.Len(lines, 3))
+	assert.Check(t, cmp.Equal(lines[2], "j"), "a pinned pane shows the end of the output")
+	assert.Check(t, atEnd)
+}
+
+func TestOutputPaneVisibleLinesIncludesPending(t *testing.T) {
+	p := outputPane{pinned: true, lines: []string{"done"}, pending: "in progress"}
+	lines, _ := p.visibleLines(5)
+	assert.Assert(t, cmp.Len(lines, 2))
+	// A partial line is still worth showing while tailing — it is the newest
+	// thing the command has written.
+	assert.Check(t, cmp.Equal(lines[1], "in progress"))
+}
+
+func TestOutputPaneScrollUnpinsAndRepins(t *testing.T) {
+	p := outputPane{pinned: true}
+	for i := 0; i < 10; i++ {
+		p.lines = append(p.lines, string(rune('a'+i)))
+	}
+
+	// Scrolling up detaches from the bottom, so arriving output does not yank
+	// the view away from what is being read.
+	p.scrollBy(-2, 3)
+	assert.Check(t, !p.pinned)
+	lines, atEnd := p.visibleLines(3)
+	assert.Check(t, cmp.Equal(lines[0], "f"))
+	assert.Check(t, !atEnd)
+
+	// Returning to the bottom re-pins without a separate key.
+	p.scrollBy(2, 3)
+	assert.Check(t, p.pinned)
+	_, atEnd = p.visibleLines(3)
+	assert.Check(t, atEnd)
+}
+
+func TestOutputPaneScrollStaysPinnedWhenContentFits(t *testing.T) {
+	p := outputPane{pinned: true, lines: []string{"one", "two"}}
+	p.scrollBy(-5, 10)
+	assert.Check(t, p.pinned, "there is nothing to scroll when everything fits")
+}
+
+func TestOutputPaneScrollClampsAtTop(t *testing.T) {
+	p := outputPane{pinned: true}
+	for i := 0; i < 10; i++ {
+		p.lines = append(p.lines, string(rune('a'+i)))
+	}
+	p.scrollBy(-100, 3)
+	assert.Check(t, cmp.Equal(p.scroll, 0))
+	lines, _ := p.visibleLines(3)
+	assert.Check(t, cmp.Equal(lines[0], "a"))
+}
+
+// TestOutputPaneCapsScrollback covers the case the daemon's own byte cap does not:
+// a tail is served from an advancing offset, so a long verbose command feeds the
+// pane far more than the daemon ever holds at once.
+func TestOutputPaneCapsScrollback(t *testing.T) {
+	p := outputPane{pinned: true}
+	for i := range maxPaneLines + 500 {
+		p.feed(fmt.Appendf(nil, "line-%d\n", i))
+	}
+
+	assert.Check(t, cmp.Len(p.lines, maxPaneLines))
+	assert.Check(t, p.truncated, "dropping scrollback must be reported, not silent")
+	// The tail is what survives; the oldest lines are the ones that went.
+	assert.Check(t, cmp.Equal(p.lines[len(p.lines)-1], fmt.Sprintf("line-%d", maxPaneLines+499)))
+	assert.Check(t, cmp.Equal(p.lines[0], "line-500"))
+}
+
+// TestOutputPaneTrimKeepsUnpinnedViewOnItsContent checks that trimming shifts a
+// scrolled-back reader by the number of lines dropped, so the pane keeps showing
+// the same text instead of appearing to jump forward on its own.
+func TestOutputPaneTrimKeepsUnpinnedViewOnItsContent(t *testing.T) {
+	p := outputPane{}
+	for i := range maxPaneLines {
+		p.lines = append(p.lines, fmt.Sprintf("line-%d", i))
+	}
+	p.scroll = 1000
+	p.pinned = false
+	// Copied, not aliased: visibleLines returns a window into p.lines, and the
+	// trim below rewrites that array in place.
+	window, _ := p.visibleLines(3)
+	before := append([]string(nil), window...)
+
+	p.feed([]byte("line-a\nline-b\n"))
+
+	assert.Check(t, cmp.Equal(p.scroll, 998))
+	after, _ := p.visibleLines(3)
+	assert.DeepEqual(t, before, after)
+}
+
+func TestOutputPaneVisibleLinesHandlesDegenerateSizes(t *testing.T) {
+	p := outputPane{lines: []string{"a", "b"}}
+	lines, atEnd := p.visibleLines(0)
+	assert.Check(t, cmp.Len(lines, 0))
+	assert.Check(t, atEnd)
+
+	empty := outputPane{}
+	lines, atEnd = empty.visibleLines(5)
+	assert.Check(t, cmp.Len(lines, 0))
+	assert.Check(t, atEnd)
+}

--- a/internal/ui/watch/outputmodel.go
+++ b/internal/ui/watch/outputmodel.go
@@ -1,0 +1,237 @@
+package watch
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/ui"
+	"github.com/CircleCI-Public/chunk-cli/internal/watchd"
+)
+
+// clip cuts a line to at most width display columns, measuring with lipgloss so
+// ANSI sequences the remote command emitted are not counted as visible width and
+// are not cut mid-escape.
+func clip(s string, width int) string {
+	if width < 1 {
+		return ""
+	}
+	if lipgloss.Width(s) <= width {
+		return s
+	}
+	return lipgloss.NewStyle().MaxWidth(width).Render(s)
+}
+
+// commandForInvocation resolves which buffered command produced an invocation.
+//
+// The join is a heuristic: match the sidecar, then take the command whose submit
+// time falls inside the invocation's span. It holds because a sidecar runs its
+// validate commands sequentially, so overlapping candidates are rare. When
+// nothing matches, no output affordance is shown — which is the honest outcome,
+// since the daemon genuinely has nothing for that invocation.
+//
+// Recording the command ID on the events themselves would make this exact rather
+// than probable; that is what the event log's command_id field is for once it
+// lands.
+func (m Model) commandForInvocation(g invocationGroup) *watchd.CommandState {
+	if len(g.events) == 0 || m.selectedIdx >= len(m.sidecars) {
+		return nil
+	}
+	sc := m.sidecars[m.selectedIdx]
+	if sc.projectIdx >= len(m.commands) {
+		return nil
+	}
+	start := g.events[0].Ts
+	end := invocEndTime(g)
+
+	var best *watchd.CommandState
+	for i := range m.commands[sc.projectIdx] {
+		cs := &m.commands[sc.projectIdx][i]
+		if !hasSidecarID(sc.sidecarIDs, cs.SidecarID) {
+			continue
+		}
+		// Submitted within the invocation's span, allowing a small margin at the
+		// front: the "$ <cmd>" status event is written just before submission.
+		if cs.SubmittedAt.Before(start.Add(-2*time.Second)) || cs.SubmittedAt.After(end.Add(2*time.Second)) {
+			continue
+		}
+		// Latest match wins, so a re-run inside one group resolves to the newer.
+		if best == nil || cs.SubmittedAt.After(best.SubmittedAt) {
+			best = cs
+		}
+	}
+	return best
+}
+
+// openSelectedOutput opens the scrollback pane for the right-pane selection.
+// Returns nil when the selected invocation has no buffered output.
+func (m Model) openSelectedOutput() (*Model, tea.Cmd) {
+	groups := m.currentInvocGroups()
+	gi := len(groups) - 1 - m.rightSelectedIdx
+	if gi < 0 || gi >= len(groups) {
+		return nil, nil
+	}
+	cs := m.commandForInvocation(groups[gi])
+	if cs == nil {
+		return nil, nil
+	}
+	name := cs.Name
+	if name == "" {
+		name = invocLabel(groups[gi])
+	}
+	m.output = &outputPane{
+		commandID: cs.CommandID,
+		name:      name,
+		pinned:    true,
+		running:   cs.Running,
+		exitCode:  cs.ExitCode,
+	}
+	m.outputSeq++
+	return &m, tea.Batch(fetchOutput(cs.CommandID, 0), outputTick(m.outputSeq))
+}
+
+// invocLabel names an invocation for the pane header, falling back to its op.
+func invocLabel(g invocationGroup) string {
+	for _, e := range g.events {
+		if strings.HasPrefix(e.Msg, "$ ") {
+			return strings.TrimPrefix(e.Msg, "$ ")
+		}
+	}
+	if len(g.events) > 0 {
+		return string(g.events[0].Op)
+	}
+	return "command"
+}
+
+// updateOutputKey handles keys while the output pane is open.
+func (m Model) updateOutputKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	height := m.outputHeight()
+	switch msg.Code {
+	case tea.KeyEscape, 'q':
+		// Closing returns to the dashboard rather than quitting it. Quitting from
+		// here would make Esc mean two different things depending on state.
+		//
+		// No tick is scheduled: the dashboard's own poll chain kept running the
+		// whole time the pane was open, and starting another here would leave two
+		// chains polling, doubling the rate on every open/close.
+		m.output = nil
+		return m, nil
+	case tea.KeyDown, 'j', 's':
+		m.output.scrollBy(1, height)
+	case tea.KeyUp, 'k', 'w':
+		m.output.scrollBy(-1, height)
+	case tea.KeyPgDown:
+		m.output.scrollBy(height, height)
+	case tea.KeyPgUp:
+		m.output.scrollBy(-height, height)
+	case 'g':
+		m.output.scroll = 0
+		m.output.pinned = false
+	case 'G':
+		m.output.pinned = true
+	case 'c':
+		if msg.Mod == tea.ModCtrl {
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+// withOutputChunk folds a fetched chunk into the open pane.
+func (m Model) withOutputChunk(msg outputMsg) (tea.Model, tea.Cmd) {
+	if m.output == nil || m.output.commandID != msg.commandID {
+		return m, nil // pane closed or switched while the request was in flight
+	}
+	if msg.err != nil {
+		m.output.err = msg.err
+		return m, nil
+	}
+	if !msg.chunk.Found {
+		m.output.err = fmt.Errorf("the watch daemon has no output for this command")
+		return m, nil
+	}
+	m.output.feed(msg.chunk.Data)
+	m.output.offset = msg.chunk.NextOffset
+	m.output.running = msg.chunk.Running
+	m.output.exitCode = msg.chunk.ExitCode
+	if msg.chunk.Truncated {
+		m.output.truncated = true
+	}
+	// A stream that failed leaves real output behind but no exit code. Reporting
+	// why keeps an empty pane from reading as "this command printed nothing".
+	if msg.chunk.Error != "" {
+		m.output.err = errors.New(msg.chunk.Error)
+	} else {
+		m.output.err = nil
+	}
+	return m, nil
+}
+
+// outputHeight is the number of scrollback lines the pane can draw.
+func (m Model) outputHeight() int {
+	// header + separator + pane title + pane separator + footer
+	h := m.height - 5
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
+// renderOutputPane draws the full-width scrollback view.
+func (m Model) renderOutputPane(st watchStyles) string {
+	p := m.output
+	height := m.outputHeight()
+	// An error line comes out of the scrollback budget rather than on top of it.
+	// Added on top it makes the pane one line taller than the dashboard it
+	// replaces, which scrolls the terminal by a line on every render — the
+	// fixed-height layout the rest of this view is careful to hold.
+	if p.err != nil && height > 1 {
+		height--
+	}
+	lines, atEnd := p.visibleLines(height)
+
+	var status string
+	switch {
+	case p.err != nil:
+		status = st.err("error")
+	case p.running:
+		status = st.running(spinFrames[m.spinIdx%len(spinFrames)] + " running")
+	case p.exitCode != nil && *p.exitCode == 0:
+		status = st.success(ui.IconOK + " exit 0")
+	case p.exitCode != nil:
+		status = st.err(fmt.Sprintf("%s exit %d", ui.IconFail, *p.exitCode))
+	default:
+		status = st.muted("ended")
+	}
+
+	title := st.emphasis("output") + "  " + st.muted(truncate(p.name, max(10, m.width/2))) + "  " + status
+	if p.truncated {
+		title += "  " + st.warning("(earlier output dropped)")
+	}
+	if !atEnd {
+		title += "  " + st.vdim("↑ scrolled")
+	}
+
+	var b strings.Builder
+	b.WriteString(title + "\n")
+	b.WriteString(st.vdim(strings.Repeat("─", m.width)) + "\n")
+	if p.err != nil {
+		b.WriteString(" " + st.err(p.err.Error()) + "\n")
+	}
+	for i := 0; i < height; i++ {
+		if i < len(lines) {
+			b.WriteString(" " + clip(lines[i], m.width-1) + "\n")
+			continue
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString(st.vdim("esc") + st.muted(" back  ") +
+		st.vdim("↑/↓") + st.muted(" scroll  ") +
+		st.vdim("g/G") + st.muted(" top/follow  ") +
+		st.vdim("ctrl-c") + st.muted(" quit") + "\n")
+	return b.String()
+}

--- a/internal/ui/watch/outputmodel.go
+++ b/internal/ui/watch/outputmodel.go
@@ -37,12 +37,14 @@ func clip(s string, width int) string {
 // Recording the command ID on the events themselves would make this exact rather
 // than probable; that is what the event log's command_id field is for once it
 // lands.
-func (m Model) commandForInvocation(g invocationGroup) *watchd.CommandState {
-	if len(g.events) == 0 || m.selectedIdx >= len(m.sidecars) {
-		return nil
-	}
-	sc := m.sidecars[m.selectedIdx]
-	if sc.projectIdx >= len(m.commands) {
+//
+// The sidecar is a parameter rather than read from m.selectedIdx: resolving it
+// here while taking g from the caller let the two disagree, so a call for any
+// invocation other than the selected one would have matched against the wrong
+// sidecar and returned a confidently wrong command. Both callers pass the row
+// the group came from, and now they cannot do otherwise.
+func (m Model) commandForInvocation(sc sidecarInfo, g invocationGroup) *watchd.CommandState {
+	if len(g.events) == 0 || sc.projectIdx >= len(m.commands) {
 		return nil
 	}
 	start := g.events[0].Ts
@@ -75,7 +77,11 @@ func (m Model) openSelectedOutput() (*Model, tea.Cmd) {
 	if gi < 0 || gi >= len(groups) {
 		return nil, nil
 	}
-	cs := m.commandForInvocation(groups[gi])
+	sc := m.selectedSidecar()
+	if sc == nil {
+		return nil, nil
+	}
+	cs := m.commandForInvocation(*sc, groups[gi])
 	if cs == nil {
 		return nil, nil
 	}

--- a/internal/ui/watch/outputmodel.go
+++ b/internal/ui/watch/outputmodel.go
@@ -152,6 +152,10 @@ func (m Model) withOutputChunk(msg outputMsg) (tea.Model, tea.Cmd) {
 	}
 	if !msg.chunk.Found {
 		m.output.err = fmt.Errorf("the watch daemon has no output for this command")
+		// Evicted buffers do not come back, so the tail has nothing left to wait
+		// for. Leaving running set would keep the chain polling for a command the
+		// daemon has already forgotten.
+		m.output.running = false
 		return m, nil
 	}
 	m.output.feed(msg.chunk.Data)

--- a/internal/ui/watch/outputmodel_test.go
+++ b/internal/ui/watch/outputmodel_test.go
@@ -1,0 +1,341 @@
+package watch
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
+	"github.com/CircleCI-Public/chunk-cli/internal/watchd"
+)
+
+// modelWithInvocation builds a model holding one sidecar, one invocation, and
+// optionally a buffered command matching it.
+func modelWithInvocation(t *testing.T, cmds []watchd.CommandState) Model {
+	t.Helper()
+	start := time.Now().Add(-time.Minute)
+	events := []eventlog.Event{
+		{Ts: start, SidecarID: "sc-1", Op: eventlog.OpValidate, Level: "info", Msg: "$ go test ./..."},
+		{Ts: start.Add(5 * time.Second), SidecarID: "sc-1", Op: eventlog.OpValidate, Level: "error", Msg: "1/2 passed  5.0s"},
+	}
+	return Model{
+		width:  120,
+		height: 40,
+		sidecars: []sidecarInfo{{
+			id:         "sc-1",
+			sidecarIDs: []string{"sc-1"},
+			projectIdx: 0,
+		}},
+		events:      [][]eventlog.Event{events},
+		commands:    [][]watchd.CommandState{cmds},
+		focusedPane: paneRight,
+	}
+}
+
+func TestCommandForInvocationMatchesOnSidecarAndTime(t *testing.T) {
+	submitted := time.Now().Add(-time.Minute).Add(time.Second)
+	m := modelWithInvocation(t, []watchd.CommandState{{
+		CommandID:   "cmd-1",
+		SidecarID:   "sc-1",
+		SubmittedAt: submitted,
+	}})
+
+	groups := m.currentInvocGroups()
+	assert.Assert(t, cmp.Len(groups, 1))
+	got := m.commandForInvocation(groups[0])
+	assert.Assert(t, got != nil)
+	assert.Check(t, cmp.Equal(got.CommandID, "cmd-1"))
+}
+
+func TestCommandForInvocationIgnoresOtherSidecar(t *testing.T) {
+	submitted := time.Now().Add(-time.Minute).Add(time.Second)
+	m := modelWithInvocation(t, []watchd.CommandState{{
+		CommandID:   "cmd-other",
+		SidecarID:   "sc-2",
+		SubmittedAt: submitted,
+	}})
+
+	groups := m.currentInvocGroups()
+	got := m.commandForInvocation(groups[0])
+	assert.Check(t, cmp.Nil(got), "a command from another sidecar must not be offered")
+}
+
+func TestCommandForInvocationIgnoresCommandOutsideSpan(t *testing.T) {
+	m := modelWithInvocation(t, []watchd.CommandState{{
+		CommandID:   "cmd-old",
+		SidecarID:   "sc-1",
+		SubmittedAt: time.Now().Add(-2 * time.Hour),
+	}})
+
+	groups := m.currentInvocGroups()
+	got := m.commandForInvocation(groups[0])
+	assert.Check(t, cmp.Nil(got), "a command from a different run must not be joined to this one")
+}
+
+func TestCommandForInvocationPrefersLatestMatch(t *testing.T) {
+	base := time.Now().Add(-time.Minute)
+	m := modelWithInvocation(t, []watchd.CommandState{
+		{CommandID: "cmd-first", SidecarID: "sc-1", SubmittedAt: base.Add(time.Second)},
+		{CommandID: "cmd-second", SidecarID: "sc-1", SubmittedAt: base.Add(3 * time.Second)},
+	})
+
+	groups := m.currentInvocGroups()
+	got := m.commandForInvocation(groups[0])
+	assert.Assert(t, got != nil)
+	assert.Check(t, cmp.Equal(got.CommandID, "cmd-second"), "a re-run inside one group resolves to the newer command")
+}
+
+func TestOpenSelectedOutputRequiresACommand(t *testing.T) {
+	m := modelWithInvocation(t, nil)
+	opened, cmd := m.openSelectedOutput()
+	assert.Check(t, cmp.Nil(opened), "with no buffered command there is nothing to open")
+	assert.Check(t, cmp.Nil(cmd))
+}
+
+func TestOpenSelectedOutputSetsUpPane(t *testing.T) {
+	submitted := time.Now().Add(-time.Minute).Add(time.Second)
+	exit := 1
+	m := modelWithInvocation(t, []watchd.CommandState{{
+		CommandID:   "cmd-1",
+		SidecarID:   "sc-1",
+		Name:        "go test ./...",
+		SubmittedAt: submitted,
+		ExitCode:    &exit,
+	}})
+
+	opened, cmd := m.openSelectedOutput()
+	assert.Assert(t, opened != nil)
+	assert.Assert(t, opened.output != nil)
+	assert.Check(t, cmp.Equal(opened.output.commandID, "cmd-1"))
+	assert.Check(t, cmp.Equal(opened.output.name, "go test ./..."))
+	assert.Check(t, opened.output.pinned, "a freshly opened pane follows the end")
+	assert.Check(t, cmd != nil)
+	assert.Check(t, opened.outputSeq > m.outputSeq, "opening must advance the tick generation")
+}
+
+func TestOpenSelectedOutputFallsBackToInvocationLabel(t *testing.T) {
+	submitted := time.Now().Add(-time.Minute).Add(time.Second)
+	m := modelWithInvocation(t, []watchd.CommandState{{
+		CommandID:   "cmd-1",
+		SidecarID:   "sc-1",
+		SubmittedAt: submitted,
+	}})
+
+	opened, _ := m.openSelectedOutput()
+	assert.Assert(t, opened != nil)
+	// Taken from the "$ ..." status event when the registration carried no name.
+	assert.Check(t, cmp.Equal(opened.output.name, "go test ./..."))
+}
+
+// Closing must not schedule a dashboard tick: the dashboard's own poll chain ran
+// throughout, so starting another leaves two chains polling and doubles the rate
+// on every open/close cycle.
+func TestClosingOutputPaneDoesNotStartASecondPollChain(t *testing.T) {
+	m := modelWithInvocation(t, nil)
+	m.output = &outputPane{commandID: "cmd-1"}
+
+	next, cmd := m.updateOutputKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	nm, ok := next.(Model)
+	assert.Assert(t, ok)
+	assert.Check(t, cmp.Nil(nm.output), "escape closes the pane")
+	assert.Check(t, cmp.Nil(cmd), "closing must not schedule another poll")
+}
+
+// A tick belonging to a previous pane opening must die rather than poll
+// alongside the current one.
+func TestStaleOutputTickIsDropped(t *testing.T) {
+	m := modelWithInvocation(t, nil)
+	m.output = &outputPane{commandID: "cmd-2"}
+	m.outputSeq = 2
+
+	_, cmd := m.Update(outputTickMsg{seq: 1})
+	assert.Check(t, cmp.Nil(cmd), "a tick from a closed pane must not continue")
+
+	_, live := m.Update(outputTickMsg{seq: 2})
+	assert.Check(t, live != nil, "the current pane's tick must continue")
+}
+
+func TestOutputTickStopsWhenPaneClosed(t *testing.T) {
+	m := modelWithInvocation(t, nil)
+	_, cmd := m.Update(outputTickMsg{seq: 0})
+	assert.Check(t, cmp.Nil(cmd))
+}
+
+// With the pane covering the dashboard, a click would move a selection the
+// reader cannot see.
+func TestMouseClickIgnoredWhileOutputPaneOpen(t *testing.T) {
+	m := modelWithInvocation(t, nil)
+	m.rightSelectedIdx = 3
+	m.output = &outputPane{commandID: "cmd-1"}
+
+	next, _ := m.Update(tea.MouseClickMsg{Button: tea.MouseLeft, X: 90, Y: 6})
+	nm, ok := next.(Model)
+	assert.Assert(t, ok)
+	assert.Check(t, cmp.Equal(nm.rightSelectedIdx, 3), "selection must not move behind the pane")
+}
+
+func TestWithOutputChunkIgnoresChunkForAnotherCommand(t *testing.T) {
+	m := modelWithInvocation(t, nil)
+	m.output = &outputPane{commandID: "cmd-current"}
+
+	next, _ := m.Update(outputMsg{
+		commandID: "cmd-stale",
+		chunk:     watchd.OutputChunk{Found: true, Data: []byte("wrong output"), NextOffset: 12},
+	})
+	nm, ok := next.(Model)
+	assert.Assert(t, ok)
+	assert.Check(t, cmp.Len(nm.output.lines, 0), "output for a different command must be discarded")
+	assert.Check(t, cmp.Equal(nm.output.offset, int64(0)))
+}
+
+func TestWithOutputChunkReportsMissingCommand(t *testing.T) {
+	m := modelWithInvocation(t, nil)
+	m.output = &outputPane{commandID: "cmd-1"}
+
+	next, _ := m.Update(outputMsg{commandID: "cmd-1", chunk: watchd.OutputChunk{Found: false}})
+	nm, ok := next.(Model)
+	assert.Assert(t, ok)
+	assert.Check(t, nm.output.err != nil, "a forgotten command must be reported, not shown as empty")
+}
+
+func TestWithOutputChunkAdvancesOffsetAndState(t *testing.T) {
+	m := modelWithInvocation(t, nil)
+	m.output = &outputPane{commandID: "cmd-1", pinned: true}
+	exit := 2
+
+	next, _ := m.Update(outputMsg{commandID: "cmd-1", chunk: watchd.OutputChunk{
+		Found: true, Data: []byte("line\n"), NextOffset: 5, Running: false, ExitCode: &exit, Truncated: true,
+	}})
+	nm, ok := next.(Model)
+	assert.Assert(t, ok)
+	assert.Check(t, cmp.Equal(nm.output.offset, int64(5)))
+	assert.Check(t, cmp.Len(nm.output.lines, 1))
+	assert.Check(t, nm.output.truncated)
+	assert.Assert(t, nm.output.exitCode != nil)
+	assert.Check(t, cmp.Equal(*nm.output.exitCode, 2))
+}
+
+// truncated must latch: a later chunk that happens not to be truncated does not
+// mean the earlier gap healed.
+func TestWithOutputChunkKeepsTruncatedLatched(t *testing.T) {
+	m := modelWithInvocation(t, nil)
+	m.output = &outputPane{commandID: "cmd-1", truncated: true}
+
+	next, _ := m.Update(outputMsg{commandID: "cmd-1", chunk: watchd.OutputChunk{
+		Found: true, Data: []byte("more\n"), NextOffset: 5, Running: true,
+	}})
+	nm, ok := next.(Model)
+	assert.Assert(t, ok)
+	assert.Check(t, nm.output.truncated)
+}
+
+// The daemon explaining why a stream broke is worth nothing if the pane drops it.
+func TestWithOutputChunkSurfacesStreamError(t *testing.T) {
+	m := modelWithInvocation(t, nil)
+	m.output = &outputPane{commandID: "cmd-1"}
+
+	next, _ := m.Update(outputMsg{commandID: "cmd-1", chunk: watchd.OutputChunk{
+		Found: true, Data: []byte("partial\n"), NextOffset: 8,
+		Error: "400 Bad Request — Invalid command ID",
+	}})
+	nm, ok := next.(Model)
+	assert.Assert(t, ok)
+	assert.Assert(t, nm.output.err != nil)
+	assert.Check(t, cmp.Contains(nm.output.err.Error(), "Invalid command ID"))
+	// The output that did arrive is still kept.
+	assert.Check(t, cmp.Len(nm.output.lines, 1))
+
+	out := nm.renderOutputPane(newWatchStyles(false))
+	assert.Check(t, cmp.Contains(out, "Invalid command ID"))
+}
+
+func TestWithOutputChunkClearsStreamErrorWhenItResolves(t *testing.T) {
+	m := modelWithInvocation(t, nil)
+	m.output = &outputPane{commandID: "cmd-1"}
+
+	next, _ := m.Update(outputMsg{commandID: "cmd-1", chunk: watchd.OutputChunk{
+		Found: true, Running: true, Error: "transient",
+	}})
+	nm := next.(Model)
+	assert.Assert(t, nm.output.err != nil)
+
+	next, _ = nm.Update(outputMsg{commandID: "cmd-1", chunk: watchd.OutputChunk{
+		Found: true, Running: true,
+	}})
+	nm2 := next.(Model)
+	assert.Check(t, cmp.Nil(nm2.output.err), "a recovered stream must stop reporting an error")
+}
+
+func TestRenderOutputPaneShowsStatusAndHints(t *testing.T) {
+	m := modelWithInvocation(t, nil)
+	exit := 1
+	m.output = &outputPane{
+		commandID: "cmd-1",
+		name:      "go test ./...",
+		lines:     []string{"FAIL\tpkg/foo"},
+		pinned:    true,
+		exitCode:  &exit,
+		truncated: true,
+	}
+
+	out := m.renderOutputPane(newWatchStyles(false))
+	assert.Check(t, cmp.Contains(out, "go test ./..."))
+	assert.Check(t, cmp.Contains(out, "exit 1"))
+	assert.Check(t, cmp.Contains(out, "FAIL"))
+	assert.Check(t, cmp.Contains(out, "earlier output dropped"))
+	assert.Check(t, cmp.Contains(out, "esc"))
+}
+
+func TestRenderUsesOutputPaneWhenOpen(t *testing.T) {
+	m := modelWithInvocation(t, nil)
+	m.output = &outputPane{commandID: "cmd-1", name: "lint", lines: []string{"only-in-output-pane"}}
+
+	out := m.render()
+	assert.Check(t, cmp.Contains(out, "only-in-output-pane"))
+	// The two-pane dashboard must not also be drawn.
+	assert.Check(t, !strings.Contains(out, "sidecars"), "the dashboard should be replaced, not appended")
+}
+
+// TestOutputPaneHoldsTheDashboardHeight pins the layout budget. The pane replaces
+// the dashboard in the same fixed-height frame, so drawing one line more scrolls
+// the terminal on every render — and an error line added on top of a full
+// scrollback is exactly how that happens.
+func TestOutputPaneHoldsTheDashboardHeight(t *testing.T) {
+	dashboard := modelWithInvocation(t, nil)
+	want := strings.Count(dashboard.render(), "\n")
+
+	// Enough output to fill the pane, so nothing is absorbed by blank padding.
+	filled := func() *outputPane {
+		p := &outputPane{commandID: "cmd-1", name: "go test ./...", pinned: true}
+		p.feed([]byte(strings.Repeat("a line of output\n", 200)))
+		return p
+	}
+
+	quiet := modelWithInvocation(t, nil)
+	quiet.output = filled()
+	assert.Check(t, cmp.Equal(strings.Count(quiet.render(), "\n"), want))
+
+	failed := modelWithInvocation(t, nil)
+	failed.output = filled()
+	failed.output.err = errors.New("stream ended early")
+	assert.Check(t, cmp.Equal(strings.Count(failed.render(), "\n"), want),
+		"an error line must come out of the scrollback budget, not add to it")
+}
+
+func TestOutputPaneRendersAtDegenerateHeights(t *testing.T) {
+	for _, height := range []int{0, 1, 2, 5, 6} {
+		m := modelWithInvocation(t, nil)
+		m.height = height
+		m.output = &outputPane{commandID: "cmd-1", name: "go test", pinned: true}
+		m.output.feed([]byte("one\ntwo\n"))
+		m.output.err = errors.New("boom")
+		// Nothing to assert beyond "does not panic and draws something": a pane one
+		// line tall is a terminal being resized, not a state worth a layout.
+		assert.Check(t, m.render() != "", "height %d", height)
+	}
+}

--- a/internal/ui/watch/outputmodel_test.go
+++ b/internal/ui/watch/outputmodel_test.go
@@ -2,6 +2,7 @@ package watch
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -387,4 +388,56 @@ func TestOutputTickStopsWhenTheBufferWasEvicted(t *testing.T) {
 
 	_, done := nm.Update(outputTickMsg{seq: 1})
 	assert.Check(t, cmp.Nil(done), "an evicted buffer must not keep being polled")
+}
+
+// The render path must not scale with the scrollback. It runs on every 200ms
+// tick and every keypress, and the pane holds up to maxPaneLines, so building
+// the whole thing to show forty rows was the difference between a fixed cost
+// and a per-frame copy of the entire buffer.
+func TestVisibleLinesDoesNotCopyTheWholeScrollback(t *testing.T) {
+	p := &outputPane{pending: "still typing", pinned: true}
+	for i := range maxPaneLines {
+		p.lines = append(p.lines, fmt.Sprintf("line %d", i))
+	}
+
+	const height = 40
+
+	// Bytes, not allocation count: the old implementation was also a couple of
+	// allocations, they were just the size of the whole scrollback. Counting
+	// events would have called this fixed when it was not.
+	res := testing.Benchmark(func(b *testing.B) {
+		for range b.N {
+			p.visibleLines(height)
+		}
+	})
+	perRender := res.AllocedBytesPerOp()
+
+	// A window of `height` string headers, with room to spare. The whole
+	// scrollback would be maxPaneLines headers, two orders of magnitude more.
+	assert.Check(t, perRender < 4096,
+		"visibleLines allocated %d bytes per render for a %d-row window of %d lines",
+		perRender, height, len(p.lines))
+
+	got, atEnd := p.visibleLines(height)
+	assert.Check(t, cmp.Len(got, height))
+	assert.Check(t, atEnd)
+	assert.Check(t, cmp.Equal(got[height-1], "still typing"), "the pending line stays last")
+}
+
+// The pending line must not be written into the scrollback's spare capacity:
+// feed and trim both leave room behind len(p.lines), so an in-place append
+// would be overwritten by the next feed under a slice the renderer still holds.
+func TestVisibleLinesDoesNotWriteIntoTheScrollback(t *testing.T) {
+	p := &outputPane{pinned: true}
+	p.lines = make([]string, 2, 8) // spare capacity, as feed leaves behind
+	p.lines[0], p.lines[1] = "one", "two"
+	p.pending = "three"
+
+	got, _ := p.visibleLines(10)
+	assert.Check(t, cmp.Equal(strings.Join(got, "|"), "one|two|three"))
+
+	// Reading the window must not have extended the scrollback itself.
+	assert.Check(t, cmp.Len(p.lines, 2))
+	assert.Check(t, cmp.Equal(p.lines[:cap(p.lines)][2], ""),
+		"the pending line leaked into the backing array")
 }

--- a/internal/ui/watch/outputmodel_test.go
+++ b/internal/ui/watch/outputmodel_test.go
@@ -48,7 +48,7 @@ func TestCommandForInvocationMatchesOnSidecarAndTime(t *testing.T) {
 
 	groups := m.currentInvocGroups()
 	assert.Assert(t, cmp.Len(groups, 1))
-	got := m.commandForInvocation(groups[0])
+	got := m.commandForInvocation(*m.selectedSidecar(), groups[0])
 	assert.Assert(t, got != nil)
 	assert.Check(t, cmp.Equal(got.CommandID, "cmd-1"))
 }
@@ -62,7 +62,7 @@ func TestCommandForInvocationIgnoresOtherSidecar(t *testing.T) {
 	}})
 
 	groups := m.currentInvocGroups()
-	got := m.commandForInvocation(groups[0])
+	got := m.commandForInvocation(*m.selectedSidecar(), groups[0])
 	assert.Check(t, cmp.Nil(got), "a command from another sidecar must not be offered")
 }
 
@@ -74,7 +74,7 @@ func TestCommandForInvocationIgnoresCommandOutsideSpan(t *testing.T) {
 	}})
 
 	groups := m.currentInvocGroups()
-	got := m.commandForInvocation(groups[0])
+	got := m.commandForInvocation(*m.selectedSidecar(), groups[0])
 	assert.Check(t, cmp.Nil(got), "a command from a different run must not be joined to this one")
 }
 
@@ -86,7 +86,7 @@ func TestCommandForInvocationPrefersLatestMatch(t *testing.T) {
 	})
 
 	groups := m.currentInvocGroups()
-	got := m.commandForInvocation(groups[0])
+	got := m.commandForInvocation(*m.selectedSidecar(), groups[0])
 	assert.Assert(t, got != nil)
 	assert.Check(t, cmp.Equal(got.CommandID, "cmd-second"), "a re-run inside one group resolves to the newer command")
 }
@@ -440,4 +440,32 @@ func TestVisibleLinesDoesNotWriteIntoTheScrollback(t *testing.T) {
 	assert.Check(t, cmp.Len(p.lines, 2))
 	assert.Check(t, cmp.Equal(p.lines[:cap(p.lines)][2], ""),
 		"the pending line leaked into the backing array")
+}
+
+// The join must follow the sidecar it is handed, not whichever row happens to
+// be selected. Before the sidecar became a parameter these two came from
+// different places, so a call for a non-selected invocation matched against the
+// wrong row and returned a command that never produced that output.
+func TestCommandForInvocationUsesTheSidecarItIsGiven(t *testing.T) {
+	submitted := time.Now().Add(-time.Minute).Add(time.Second)
+	m := modelWithInvocation(t, []watchd.CommandState{{
+		CommandID:   "cmd-1",
+		SidecarID:   "sc-1",
+		SubmittedAt: submitted,
+	}})
+	groups := m.currentInvocGroups()
+	assert.Assert(t, cmp.Len(groups, 1))
+
+	// The selected row still matches, as before.
+	sel := m.selectedSidecar()
+	assert.Assert(t, sel != nil)
+	got := m.commandForInvocation(*sel, groups[0])
+	assert.Assert(t, got != nil)
+	assert.Check(t, cmp.Equal(got.CommandID, "cmd-1"))
+
+	// A row holding a different sidecar matches nothing, whatever is selected.
+	other := *sel
+	other.sidecarIDs = []string{"sc-elsewhere"}
+	assert.Check(t, cmp.Nil(m.commandForInvocation(other, groups[0])),
+		"the answer must follow the row passed in, not m.selectedIdx")
 }

--- a/internal/ui/watch/outputmodel_test.go
+++ b/internal/ui/watch/outputmodel_test.go
@@ -150,7 +150,9 @@ func TestClosingOutputPaneDoesNotStartASecondPollChain(t *testing.T) {
 // alongside the current one.
 func TestStaleOutputTickIsDropped(t *testing.T) {
 	m := modelWithInvocation(t, nil)
-	m.output = &outputPane{commandID: "cmd-2"}
+	// Running, so that the reschedule turns on the sequence check alone — a
+	// finished pane stops for its own reason and would not test this.
+	m.output = &outputPane{commandID: "cmd-2", running: true}
 	m.outputSeq = 2
 
 	_, cmd := m.Update(outputTickMsg{seq: 1})
@@ -338,4 +340,51 @@ func TestOutputPaneRendersAtDegenerateHeights(t *testing.T) {
 		// line tall is a terminal being resized, not a state worth a layout.
 		assert.Check(t, m.render() != "", "height %d", height)
 	}
+}
+
+// A finished command's buffer never changes again, so the fast tail must stop
+// rather than keep asking. The pane can sit open on a finished command for as
+// long as someone is reading it, and at 200ms that is a socket round trip five
+// times a second for output that cannot move.
+func TestOutputTickStopsOnceTheCommandFinishes(t *testing.T) {
+	m := modelWithInvocation(t, nil)
+	m.output = &outputPane{commandID: "cmd-1", running: true}
+	m.outputSeq = 1
+
+	_, live := m.Update(outputTickMsg{seq: 1})
+	assert.Assert(t, live != nil, "a running command must keep tailing")
+
+	// The chunk that reports the exit is complete by construction: the daemon
+	// appends everything before marking the command done.
+	code := 0
+	next, _ := m.Update(outputMsg{
+		commandID: "cmd-1",
+		chunk:     watchd.OutputChunk{Found: true, Running: false, ExitCode: &code},
+	})
+	nm, ok := next.(Model)
+	assert.Assert(t, ok)
+	assert.Check(t, !nm.output.running)
+
+	_, done := nm.Update(outputTickMsg{seq: 1})
+	assert.Check(t, cmp.Nil(done), "a finished command must not reschedule the tail")
+}
+
+// An evicted buffer is not coming back, so the tail has nothing to wait for.
+// Without this the chain polls forever for a command the daemon has forgotten.
+func TestOutputTickStopsWhenTheBufferWasEvicted(t *testing.T) {
+	m := modelWithInvocation(t, nil)
+	m.output = &outputPane{commandID: "cmd-1", running: true}
+	m.outputSeq = 1
+
+	next, _ := m.Update(outputMsg{
+		commandID: "cmd-1",
+		chunk:     watchd.OutputChunk{Found: false},
+	})
+	nm, ok := next.(Model)
+	assert.Assert(t, ok)
+	assert.Check(t, nm.output.err != nil, "the pane must say why it is empty")
+	assert.Check(t, !nm.output.running)
+
+	_, done := nm.Update(outputTickMsg{seq: 1})
+	assert.Check(t, cmp.Nil(done), "an evicted buffer must not keep being polled")
 }

--- a/internal/ui/watch/width_test.go
+++ b/internal/ui/watch/width_test.go
@@ -1,0 +1,43 @@
+package watch
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/watchd"
+)
+
+// TestDashboardNeverExceedsItsWidth pins the other half of the fixed-size layout.
+// A line wider than the terminal wraps, which costs a row the height budget never
+// allowed for — so an over-wide line breaks the layout exactly as an extra line
+// does. The output affordance and its footer hint are the widest things the right
+// pane grew, so narrow terminals are where they show up first.
+func TestDashboardNeverExceedsItsWidth(t *testing.T) {
+	cmds := []watchd.CommandState{{
+		CommandID:   "cmd-1",
+		SidecarID:   "sc-1",
+		SubmittedAt: time.Now().Add(-time.Minute).Add(time.Second),
+	}}
+	for _, hasOutput := range []bool{false, true} {
+		for _, width := range []int{40, 50, 60, 70, 80, 120} {
+			for _, focus := range []pane{paneLeft, paneRight} {
+				m := modelWithInvocation(t, nil)
+				if hasOutput {
+					m = modelWithInvocation(t, cmds)
+				}
+				m.width = width
+				m.focusedPane = focus
+				m.authErr = "not authenticated to CircleCI — command output unavailable"
+				for i, line := range strings.Split(m.render(), "\n") {
+					if got := lipgloss.Width(line); got > width {
+						t.Errorf("hasOutput=%v width=%d focus=%d: line %d is %d columns",
+							hasOutput, width, focus, i, got)
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
**3 of 4** — splitting #548. Base: `jesse/logs-2-daemon-buffer`.

## Summary

Consumes the buffer the previous PR fills.

- `chunk watch` gains a scrollback pane over one command's output: `Enter` opens, `g`/`G` jump to top / re-follow, `Esc` closes the pane rather than quitting. Scrolling up detaches so arriving output does not yank the view away.
- Carriage returns are resolved, so a progress bar renders as its last frame rather than a hundred stacked copies.
- `chunk sidecar logs <command-id>` is the same data for readers with no terminal. It exits non-zero only when *reading* failed.

## Test plan
- [x] `task test`, `task lint`, `task build`
- [x] `chunk watch` by hand: pane renders, `Enter` opens output for validate and exec rows
- [x] `chunk sidecar logs` replayed a command after the submitting process exited
