### PR TITLE
Sample live CPU, memory and disk per sidecar

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -277,6 +277,103 @@ refused as a key, since a config-only key would stay stable across code changes;
 it, because a repo that never caches is otherwise silent about why. See
 **[docs/HOOKS.md](HOOKS.md#result-caching)** for the user-facing behaviour.
 
+## Watch Daemon (`internal/watchd/`)
+
+The daemon backs `chunk watch`. It polls every registered project every 5 s,
+tailing each project's `events.jsonl` by byte offset, and serves snapshots as
+JSON over a Unix socket at `~/.chunk/watchd/watchd.sock`
+(`CHUNK_WATCHD_DIR` overrides the directory).
+
+Beyond that it owns two things that outlive the processes they came from.
+
+### Command output buffering
+
+`chunk validate` and `chunk sidecar exec` submit a remote command and register
+it with the daemon before consuming any output. Both go through one helper
+(`submitAndStream`), so a new command path cannot quietly skip registration and
+leave its output unreachable:
+
+```
+POST /command   {command_id, sidecar_id, project_root, op, name, submitted_at}
+GET  /output?command_id=<id>&offset=<n>
+    → {data, next_offset, running, exit_code, truncated, found}
+GET  /snapshot  → ... plus per-project `commands` and a top-level `auth_error`
+```
+
+The daemon then streams that command's output itself and buffers it. This is
+what makes hook-driven runs observable: the hook process exits the moment its
+command finishes, so anything holding the only copy of the output loses it.
+
+Design constraints worth preserving:
+
+- **Registration is best-effort and never starts the daemon.** `RegisterCommand`
+  reports no error and uses a 2 s timeout. It sits on the hook path in front of a
+  command the developer is waiting on, so a missing daemon must cost nothing.
+  Launching one as a side effect of a hook firing would be intrusive, and a hook
+  that hangs on a daemon launch is far worse than a missing logs pane.
+- **Offsets are the daemon's own byte positions**, not the API's opaque SSE
+  cursor. The server cursor stays private to the daemon, so no reader has to
+  reason about reconnects. Positions are logical — they count evicted bytes — so
+  an offset that lands before the retained window is exactly the signal that the
+  reader missed some, which is what sets `truncated`.
+- **Buffers are capped in bytes, not lines** (`MaxCommandBytes`), keeping the
+  tail. Output is neither small nor uniform, so a line count says nothing about
+  memory.
+- **Streamers never run on the poll path.** Each is its own goroutine with its own
+  context, so a hung stream cannot stall the dashboard for every other project.
+- **Credentials resolve lazily and never prompt.** `authprompt.ResolveCircleCIClient`
+  returns `ErrNeedsAuth` rather than asking; the daemon reports that in
+  `Snapshot.AuthError` and carries on serving. It has no terminal, so a process
+  blocked on a hidden prompt would be indistinguishable from one that has hung.
+  Resolution is deferred to first use because it can read the OS keychain, and the
+  daemon starts on every `chunk watch` whether or not anything needs a token.
+
+### Resource sampling
+
+There is no metrics endpoint, so usage is sampled inside the sidecar. The naive
+implementation is a trap: `sidecar.ExecOverSSH` opens a fresh WebSocket *and* SSH
+handshake per call, so a 2 s interval would mean a handshake every 2 s per
+sidecar. Instead the daemon submits **one** long-lived shell loop through the exec
+API (`SubmitExec` with `sh -c`, then `StreamOutput`) and parses frames off its
+output stream.
+
+Going through the exec API rather than SSH is deliberate. The SSH exec channel
+fork/execs the command string instead of interpreting it, which is why every
+`ExecOverSSH` call in this repo is a bare `binary arg` invocation — a shell loop
+cannot run over it at all. The exec API takes argv as structured data, so it runs
+scripts correctly, and its output stream is already long-lived and resumable.
+That removes the handshake-per-sample problem outright with no persistent
+connection for the daemon to supervise.
+
+- **Sampling is gated on an attached dashboard.** A snapshot request is the
+  signal; after `idleShutdown` with none, samplers stop. Cost stays proportional
+  to benefit.
+- **Memory must be read cgroup-aware** — v2, then v1, then `/proc/meminfo`. The
+  sidecar is containerised, so `/proc/meminfo` reports the *host's* memory and
+  would make every sidecar look like it had hundreds of gigabytes free.
+- **CPU is a delta.** `/proc/stat` is cumulative since boot, so a percentage
+  exists only between two frames. One frame yields no CPU reading rather than a
+  number that looks plausible and means nothing.
+- **`reconcile` runs once per poll across all projects**, not per project. It
+  stops any sampler absent from what it is given, so feeding it one project's
+  sidecars at a time would make each project tear down every other project's
+  samplers.
+- **The remote loop is bounded, not infinite** (`samplerIterations`). Cancelling
+  the stream stops the daemon reading, but nothing guarantees the remote process
+  dies with it; a loop that ends on its own caps how long an orphan can linger.
+  `run` simply submits another while a dashboard is still attached.
+- **Repeated failure pauses a sidecar, it does not disqualify it.** After
+  `maxSamplerFailures` consecutive failures the daemon stops sampling that sidecar
+  for `sampleCooloff` and then retries. Without the ceiling an unsampleable
+  sidecar is retried forever, each attempt costing an API call; without the retry
+  one bad minute costs that sidecar its numbers for the rest of the session. The
+  sampler slot survives either way, so the last reading stays on screen to be
+  dimmed as stale rather than vanishing.
+
+Parsing is separated from transport (`parseSampleFrame`, `cpuPercent`,
+`splitFrames`, `consumeSamples`) so it is testable against captured fixtures with
+no SSH involved.
+
 ## HTTP Client (`internal/httpcl/`)
 
 Shared HTTP infrastructure used by `anthropic/`, `circleci/`, and `github/`:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -102,6 +102,8 @@ chunk
 │   │   --sidecar-id <id>           # Sidecar ID (defaults to active sidecar)
 │   │   --command <cmd>             # Command to run (required)
 │   │   --args <args>               # Command arguments
+│   ├── logs <command-id>           # Print output of a command that ran on a sidecar
+│   │   -f / --follow               # Keep printing until the command exits
 │   ├── add-ssh-key                 # Add SSH key to sidecar
 │   │   --sidecar-id <id>           # Sidecar ID (defaults to active sidecar)
 │   │   --public-key <key>          # SSH public key string
@@ -207,6 +209,43 @@ chunk
   Non-interactive sessions (agents, CI) should set `orgID` in project config or
   pass `--org-id` / `CIRCLECI_ORG_ID`.
 - `watch` requires a TTY — it exits with an error if stdout is not a terminal. It polls sidecar state every 5 seconds and keeps an in-memory window of the 300 most recent event log entries. Use `j`/`k` or `↑`/`↓` to select a sidecar, `q` or `Esc` to quit. By default it watches every project it knows about; pass `--focus` to watch only the current directory. Running `watch` in a project also registers that project so future runs find it. `--all` is deprecated — it is now the default.
+- **`watch` can show a command's output.** In the activity pane, an invocation
+  marked `▤` has output the daemon still holds; `Enter` opens a scrollback view
+  of it. A command that is still running tails live — the pane polls every 200 ms
+  while it is open, and drops back to the 5 s snapshot tick when closed, so a tail
+  never speeds up everything else. `↑`/`↓` and `PgUp`/`PgDn` scroll, `g` jumps to
+  the top, `G` re-follows the end, and `Esc` closes the pane rather than quitting
+  the dashboard. Scrolling up detaches from the bottom so arriving output does not
+  yank the view away from what you are reading; scrolling back to the end
+  re-follows automatically.
+  - Output is capped at 256 KiB per command, keeping the **tail** — the end of a
+    failed run is the part worth reading. When earlier output has been dropped the
+    pane says `(earlier output dropped)` rather than presenting a partial run as if
+    it were whole.
+  - The daemon holds at most 20 commands per project, evicting the oldest
+    *finished* one first. A running command is never evicted.
+  - Buffers are in memory only, so restarting the daemon loses them. `Enter` on an
+    invocation the daemon no longer knows about says so.
+  - Output streaming needs a CircleCI token. Without one the dashboard still works
+    and shows a one-line hint in the footer; the daemon never prompts.
+- **`chunk sidecar logs <command-id>`** is the non-TUI door onto the same output,
+  for scripts and for agents with no terminal. Command IDs appear in the `watch`
+  dashboard. It reads the watch daemon's buffer when the daemon has the command
+  and falls back to streaming from the API when it does not, so it works either
+  way. `-f`/`--follow` keeps printing until the command exits.
+  - Output goes to stdout and nothing else does, so it can be piped. A non-zero
+    remote status is reported on **stderr** as `exit status N`.
+  - `logs` itself exits non-zero only when *reading* failed. A failing command is
+    not a failing read — conflating the two would make the exit status useless to
+    a caller.
+- **`watch` shows live resource usage** for the selected sidecar — CPU, memory and
+  disk, sampled every 2 seconds. Sampling only runs while a dashboard is attached,
+  since each sampled sidecar is running a shell loop for it; close `watch` and it
+  stops. A
+  sample older than three intervals renders dimmed and marked `(stale)` rather
+  than disappearing, so a stalled sampler looks stalled instead of looking like an
+  idle sidecar. Memory is read from the sidecar's cgroup, not `/proc/meminfo`,
+  because the latter reports the host's memory.
 - **`watch` rows are per branch, except when they cannot be.** A branch's local runs
   are folded into its sidecar's row, so one row shows both kinds of run along with
   sync state. A branch with more than one sidecar — two agent sessions in one

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -275,7 +275,7 @@ chunk watch  1 sidecar  main@a3f9e12                      15:04:32
                        │
 ── chunk-cli           │ 14:58:01  sync      ✓  done
 ▶ my-sidecar           │ 14:55:12  validate  ✓  done
-  ✓ in sync            │ 14:52:44  sync      ✓  done
+  synced via rsync     │ 14:52:44  sync      ✓  done
   6m ago               │
 ──────────────────────────────────────────────────────────────────
   ↑/↓ j/k  select  ·  q  quit
@@ -290,6 +290,61 @@ chunk watch /path/to/other    # add another project
 ```
 
 `watch` requires a TTY — it will not run in a non-interactive shell (CI, pipes).
+
+#### Reading a command's output
+
+An invocation marked `▤` in the activity pane has output the watch daemon still
+holds. Press `Enter` on it to open a scrollback view: a command that is still
+running tails live, and one that has already finished is replayed from the
+buffer. This is the answer to "the hook ran validate, it failed, and the output
+is gone" — the daemon keeps a copy even though the process that ran the command
+has exited.
+
+```
+output  go test ./...  ✗ exit 1
+──────────────────────────────────────────────────────────────────
+ --- FAIL: TestSyncSkipsIgnoredFiles (0.03s)
+     sync_test.go:112: expected 3 files, got 4
+ FAIL
+──────────────────────────────────────────────────────────────────
+ esc back  ↑/↓ scroll  g/G top/follow  ctrl-c quit
+```
+
+Scrolling up detaches from the bottom so arriving output does not yank the view
+away from what you are reading; scroll back to the end (or press `G`) to follow
+again. `Esc` closes the pane and returns to the dashboard.
+
+Output is capped at 256 KiB per command and 20 commands per project, keeping the
+most recent of each — the pane says `(earlier output dropped)` rather than
+presenting a partial run as if it were whole. Buffers live in memory, so
+restarting the daemon clears them.
+
+For scripts and for agents with no terminal, the same output is available without
+the TUI:
+
+```bash
+chunk sidecar logs <command-id>        # command IDs appear in the dashboard
+chunk sidecar logs <command-id> -f     # keep printing until the command exits
+```
+
+Output goes to stdout so it can be piped; a non-zero remote status is reported on
+stderr as `exit status N`. `logs` itself fails only when *reading* failed.
+
+#### Live resource usage
+
+While the dashboard is open, each sidecar row also shows CPU, memory and disk,
+sampled every 2 seconds:
+
+```
+▶ my-sidecar           │ 14:55:12  validate  ⣟  running
+  ⣟ validate...        │
+  cpu  87%  mem  41%  disk  12%
+```
+
+Sampling runs only while `watch` is attached — close the dashboard and it stops.
+A reading older than a few intervals is dimmed and marked `(stale)` rather than
+disappearing, so a sampler that has stalled looks stalled instead of looking like
+an idle sidecar.
 
 ### Snapshots
 

--- a/internal/ui/watch/fetch.go
+++ b/internal/ui/watch/fetch.go
@@ -72,6 +72,7 @@ func convertSnapshot(snap watchd.Snapshot, m Model) dataMsg {
 				lastOp:       sc.LastOp,
 				lastLevel:    sc.LastLevel,
 				running:      sc.Running,
+				resources:    sc.Resources,
 			})
 		}
 

--- a/internal/ui/watch/model.go
+++ b/internal/ui/watch/model.go
@@ -127,6 +127,8 @@ type sidecarInfo struct {
 	lastActivity time.Time
 	lastOp       eventlog.Op
 	lastLevel    string // level of the most recent event ("done", "error", etc.)
+	// resources is the latest resource sample, nil when the daemon has none.
+	resources *watchd.Resources
 }
 
 // pane identifies which side of the split layout has keyboard focus.
@@ -611,6 +613,10 @@ func (m Model) renderSidecarPane(st watchStyles, maxLines int) []string {
 		}
 
 		addRow("  " + m.rowStatus(st, sc))
+
+		if line := renderResources(st, sc.resources); line != "" {
+			addRow("  " + line)
+		}
 
 		if !sc.lastActivity.IsZero() {
 			addRow("  " + st.vdim(ago(sc.lastActivity)))

--- a/internal/ui/watch/output_test.go
+++ b/internal/ui/watch/output_test.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/watchd"
 )
 
 func TestResolveCR(t *testing.T) {
@@ -244,4 +247,96 @@ func TestOutputPaneVisibleLinesHandlesDegenerateSizes(t *testing.T) {
 	lines, atEnd = empty.visibleLines(5)
 	assert.Check(t, cmp.Len(lines, 0))
 	assert.Check(t, atEnd)
+}
+
+func TestRenderResources(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name      string
+		in        *watchd.Resources
+		wantEmpty bool
+		contains  []string
+	}{
+		{
+			name:      "nil sample renders nothing",
+			in:        nil,
+			wantEmpty: true,
+		},
+		{
+			name:      "zero timestamp renders nothing",
+			in:        &watchd.Resources{CPUPercent: 50},
+			wantEmpty: true,
+		},
+		{
+			name: "percentages when limits are known",
+			in: &watchd.Resources{
+				CPUPercent: 42, MemUsedBytes: 512, MemLimitBytes: 1024,
+				DiskUsedBytes: 30, DiskTotalBytes: 100, SampledAt: now,
+			},
+			contains: []string{"cpu", "42%", "mem", "50%", "disk", "30%"},
+		},
+		{
+			name: "absolute memory when no limit is known",
+			in: &watchd.Resources{
+				CPUPercent: 10, MemUsedBytes: 5 * 1024 * 1024, SampledAt: now,
+			},
+			contains: []string{"mem", "5.0M"},
+		},
+		{
+			name: "stale sample is marked rather than hidden",
+			in: &watchd.Resources{
+				CPUPercent: 42, MemUsedBytes: 512, MemLimitBytes: 1024,
+				SampledAt: now.Add(-10 * watchd.StaleSamples * watchd.SampleInterval),
+			},
+			contains: []string{"stale"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderResources(newWatchStyles(false), tt.in)
+			if tt.wantEmpty {
+				assert.Check(t, cmp.Equal(got, ""))
+				return
+			}
+			for _, want := range tt.contains {
+				assert.Check(t, cmp.Contains(got, want))
+			}
+		})
+	}
+}
+
+// TestStaleBudgetOutlivesAPollCycle guards the relationship that makes the
+// (stale) marker mean anything. A sample is already a sampler round-trip old when
+// the daemon serves it, and the dashboard then holds that one snapshot for a
+// whole pollInterval while re-evaluating its age on every frame. The budget has
+// to cover both, or a healthy sampler renders as stale for the tail of every
+// cycle — which trains the reader to ignore the marker entirely.
+func TestStaleBudgetOutlivesAPollCycle(t *testing.T) {
+	// Worst arrival age seen against real sidecars, measured when the daemon
+	// served the sample rather than when the sampler produced it.
+	const arrivalAge = 6 * time.Second
+
+	budget := watchd.StaleSamples * watchd.SampleInterval
+	assert.Assert(t, budget > pollInterval+arrivalAge,
+		"stale budget %s must outlast one poll cycle (%s) plus sampler latency (%s)",
+		budget, pollInterval, arrivalAge)
+}
+
+func TestHumanBytes(t *testing.T) {
+	tests := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0B"},
+		{512, "512B"},
+		{1024, "1.0K"},
+		{1536, "1.5K"},
+		{20 * 1024, "20K"},
+		{5 * 1024 * 1024, "5.0M"},
+		{3 * 1024 * 1024 * 1024, "3.0G"},
+	}
+	for _, tt := range tests {
+		got := humanBytes(tt.in)
+		assert.Check(t, cmp.Equal(got, tt.want), "humanBytes(%d)", tt.in)
+	}
 }

--- a/internal/ui/watch/resources.go
+++ b/internal/ui/watch/resources.go
@@ -1,0 +1,65 @@
+package watch
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/watchd"
+)
+
+// renderResources formats one resource sample for the sidecar pane, or "" when
+// there is nothing to show.
+//
+// A stale sample is dimmed rather than dropped. A sampler whose connection died
+// would otherwise leave the row looking like an idle sidecar, which is the wrong
+// conclusion from the same evidence — the numbers are real, they are just old.
+func renderResources(st watchStyles, r *watchd.Resources) string {
+	if r == nil || r.SampledAt.IsZero() {
+		return ""
+	}
+	cpu := fmt.Sprintf("cpu %3.0f%%", r.CPUPercent)
+	mem := "mem —"
+	if r.MemLimitBytes > 0 {
+		pct := float64(r.MemUsedBytes) / float64(r.MemLimitBytes) * 100
+		mem = fmt.Sprintf("mem %3.0f%%", pct)
+	} else if r.MemUsedBytes > 0 {
+		mem = "mem " + humanBytes(r.MemUsedBytes)
+	}
+
+	line := cpu + "  " + mem
+	if r.DiskTotalBytes > 0 {
+		pct := float64(r.DiskUsedBytes) / float64(r.DiskTotalBytes) * 100
+		line += fmt.Sprintf("  disk %3.0f%%", pct)
+	}
+
+	if stale(r.SampledAt) {
+		return st.vdim(line + " (stale)")
+	}
+	return st.teal(line)
+}
+
+// stale reports whether a sample is old enough that it should not be presented as
+// current.
+func stale(at time.Time) bool {
+	return time.Since(at) > watchd.StaleSamples*watchd.SampleInterval
+}
+
+// humanBytes formats a byte count in the largest unit that keeps it under 1024.
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%dB", n)
+	}
+	units := []string{"K", "M", "G", "T"}
+	value := float64(n)
+	for _, u := range units {
+		value /= unit
+		if value < unit {
+			if value < 10 {
+				return fmt.Sprintf("%.1f%s", value, u)
+			}
+			return fmt.Sprintf("%.0f%s", value, u)
+		}
+	}
+	return fmt.Sprintf("%.0fP", value/unit)
+}

--- a/internal/watchd/daemon.go
+++ b/internal/watchd/daemon.go
@@ -45,6 +45,8 @@ type daemon struct {
 	// never execute on the poll path, so a hung stream cannot stall the
 	// dashboard for every other project.
 	out *outputStore
+	// res samples resource usage, only while a dashboard is attached.
+	res *resourceSampler
 }
 
 // RunDaemon is the watch daemon entry point, called by the hidden _daemon subcommand.
@@ -92,11 +94,13 @@ func RunDaemon(ctx context.Context, client *circleci.Client, authMessage string,
 		client:    client,
 		authError: authMessage,
 		out:       newOutputStore(ctx),
+		res:       newResourceSampler(client),
 	}
 	// Still cancelled explicitly: this returns before the process exits in tests
 	// and any embedded caller, and it is what stops streamers promptly rather
 	// than whenever the parent context happens to be torn down.
 	defer d.out.stopAll()
+	defer d.res.stopAll()
 
 	// Poll once before accepting connections so the first request has data.
 	d.poll()
@@ -170,6 +174,23 @@ func (d *daemon) poll() {
 	for _, ps := range work {
 		d.updateProject(ps)
 	}
+
+	// Reconcile samplers once per poll, across every project. Doing it inside
+	// updateProject would hand reconcile one project's sidecars at a time, and it
+	// stops any sampler absent from what it is given — so each project's turn
+	// would tear down every other project's samplers.
+	d.res.reconcile(d.allSidecars())
+}
+
+// allSidecars returns every known sidecar across all projects.
+func (d *daemon) allSidecars() []SidecarState {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	var all []SidecarState
+	for _, ps := range d.projects {
+		all = append(all, ps.snap.Sidecars...)
+	}
+	return all
 }
 
 // initProject opens the event log for root and returns a new projectState.
@@ -205,6 +226,7 @@ func (d *daemon) updateProject(ps *projectState) {
 
 	sidecars := loadSidecars(ps.dataDir, ps.root, snapName)
 	annotateActivity(sidecars, ps.events)
+	d.res.annotate(sidecars)
 
 	snap := ProjectSnapshot{
 		Root:     ps.root,
@@ -223,6 +245,11 @@ func (d *daemon) updateProject(ps *projectState) {
 // snapshot returns a Snapshot filtered to the requested roots.
 // If roots is empty all known projects are returned.
 func (d *daemon) snapshot(roots []string) Snapshot {
+	// A snapshot request is the daemon's signal that a dashboard is attached, and
+	// resource sampling is gated on that: a persistent SSH connection per sidecar
+	// is only worth holding while someone is looking at it.
+	d.res.touch()
+
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 

--- a/internal/watchd/load.go
+++ b/internal/watchd/load.go
@@ -62,6 +62,7 @@ func loadSidecars(dataDir, root, snapshotName string) []SidecarState {
 			RepoName:     repoName,
 			SnapshotName: snapshotName,
 			FileMtime:    mtime,
+			Workspace:    as.Workspace,
 		}
 		if dup {
 			result[at] = ss

--- a/internal/watchd/resources.go
+++ b/internal/watchd/resources.go
@@ -1,0 +1,558 @@
+package watchd
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+)
+
+const (
+	// SampleInterval is how often the remote sampler emits a reading.
+	SampleInterval = 2 * time.Second
+
+	// StaleSamples is how many intervals a sample may age before the dashboard
+	// should treat it as stale. A sampler that dies must look stalled rather than
+	// look like an idle sidecar, so the last value is kept and marked, not
+	// discarded.
+	//
+	// The budget has to cover more than SampleInterval: the reading crosses an SSH
+	// connection before the daemon sees it, and the dashboard then renders that
+	// same snapshot until its next 5s poll while re-evaluating the age every
+	// frame. Measured against real sidecars, a healthy sampler reaches ~10s of
+	// apparent age just before a poll lands, so a tighter bound flags working
+	// samplers as stale for part of every cycle. Twelve seconds clears that and
+	// still catches a dead sampler within two polls.
+	StaleSamples = 6
+
+	// idleShutdown is how long after the last snapshot request sampling stops.
+	// Snapshot requests arrive every 5s from an attached dashboard, so this
+	// tolerates a couple of missed polls before tearing connections down.
+	idleShutdown = 20 * time.Second
+
+	// sampleFrameSep terminates one sample in the remote sampler's output.
+	sampleFrameSep = "---CHUNK-SAMPLE---"
+)
+
+// remoteSamplerScript is the shell loop run inside the sidecar: one long-lived
+// process whose stdout the daemon reads, rather than one exec per reading.
+//
+// Memory is read from cgroup files where available because the sidecar is
+// containerised — /proc/meminfo reports the *host's* memory, which would make
+// every sidecar look like it had hundreds of gigabytes free. cgroup v2 is tried
+// first, then v1, then /proc/meminfo as a last resort.
+func remoteSamplerScript() string {
+	secs := strconv.Itoa(int(SampleInterval.Seconds()))
+	if secs == "0" {
+		secs = "2"
+	}
+	// Bounded rather than infinite: cancelling the stream stops the daemon
+	// reading, but nothing guarantees the remote process dies with it. A loop that
+	// ends on its own caps how long an orphan can linger on the sidecar; run
+	// simply submits another while a dashboard is still attached.
+	return `n=0
+while [ $n -lt ` + strconv.Itoa(samplerIterations) + ` ]; do
+  n=$((n+1))
+  grep '^cpu ' /proc/stat
+  if [ -r /sys/fs/cgroup/memory.current ]; then
+    echo "mem_current $(cat /sys/fs/cgroup/memory.current)"
+    echo "mem_max $(cat /sys/fs/cgroup/memory.max 2>/dev/null || echo max)"
+  elif [ -r /sys/fs/cgroup/memory/memory.usage_in_bytes ]; then
+    echo "mem_current $(cat /sys/fs/cgroup/memory/memory.usage_in_bytes)"
+    echo "mem_max $(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)"
+  else
+    grep -E '^(MemTotal|MemAvailable):' /proc/meminfo
+  fi
+  df -PB1 "${CHUNK_SAMPLE_DIR:-.}" 2>/dev/null | tail -1
+  echo ` + sampleFrameSep + `
+  sleep ` + secs + `
+done`
+}
+
+// samplerIterations is how many readings one remote sampler process emits before
+// exiting, bounding how long an orphaned loop can survive on the sidecar.
+const samplerIterations = 120
+
+// cpuTimes is the cumulative jiffy counters from /proc/stat's cpu line.
+type cpuTimes struct {
+	total int64
+	idle  int64
+}
+
+// sample is one parsed reading, before CPU is differenced.
+type sample struct {
+	cpu       cpuTimes
+	haveCPU   bool
+	memUsed   int64
+	memLimit  int64
+	diskUsed  int64
+	diskTotal int64
+}
+
+// parseSampleFrame parses one frame of the remote sampler's output.
+//
+// Note what this deliberately does not do: derive a CPU percentage. /proc/stat
+// reports cumulative jiffies since boot, so a percentage only exists between two
+// frames. A single frame yields no CPU number at all, which is correct — the
+// alternative is reporting a number that looks plausible and means nothing.
+func parseSampleFrame(frame string) sample {
+	var s sample
+	sc := bufio.NewScanner(strings.NewReader(frame))
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		switch {
+		case fields[0] == "cpu":
+			var total, idle int64
+			for i, f := range fields[1:] {
+				v, err := strconv.ParseInt(f, 10, 64)
+				if err != nil {
+					continue
+				}
+				total += v
+				// Fields are user, nice, system, idle, iowait, ... — idle and
+				// iowait are both time the CPU was not doing work.
+				if i == 3 || i == 4 {
+					idle += v
+				}
+			}
+			s.cpu = cpuTimes{total: total, idle: idle}
+			s.haveCPU = total > 0
+
+		case fields[0] == "mem_current":
+			s.memUsed, _ = strconv.ParseInt(fields[1], 10, 64)
+
+		case fields[0] == "mem_max":
+			// cgroup v2 writes the literal "max" for no limit; v1 writes a
+			// sentinel so large it is indistinguishable from none. Either way,
+			// leaving the limit at zero is how "unknown" is represented.
+			if v, err := strconv.ParseInt(fields[1], 10, 64); err == nil && v < 1<<62 {
+				s.memLimit = v
+			}
+
+		case fields[0] == "MemTotal:":
+			if v, err := strconv.ParseInt(fields[1], 10, 64); err == nil {
+				s.memLimit = v * 1024 // /proc/meminfo is in kB
+			}
+
+		case fields[0] == "MemAvailable:":
+			if v, err := strconv.ParseInt(fields[1], 10, 64); err == nil {
+				// Used is derived after the loop, once MemTotal is known.
+				s.memUsed = -v * 1024
+			}
+
+		case strings.HasPrefix(fields[0], "/") && len(fields) >= 4:
+			// df -PB1 output: Filesystem 1B-blocks Used Available ...
+			s.diskTotal, _ = strconv.ParseInt(fields[1], 10, 64)
+			s.diskUsed, _ = strconv.ParseInt(fields[2], 10, 64)
+		}
+	}
+	// MemAvailable path: used = total - available, stashed as a negative above so
+	// field order in the frame does not matter.
+	if s.memUsed < 0 && s.memLimit > 0 {
+		s.memUsed = s.memLimit + s.memUsed
+	}
+	if s.memUsed < 0 {
+		s.memUsed = 0
+	}
+	return s
+}
+
+// cpuPercent derives a utilisation percentage from two consecutive readings.
+// Returns 0 and false when the readings cannot yield one.
+func cpuPercent(prev, cur cpuTimes) (float64, bool) {
+	dTotal := cur.total - prev.total
+	dIdle := cur.idle - prev.idle
+	if dTotal <= 0 || dIdle < 0 {
+		return 0, false
+	}
+	busy := float64(dTotal-dIdle) / float64(dTotal) * 100
+	if busy < 0 {
+		busy = 0
+	}
+	if busy > 100 {
+		busy = 100
+	}
+	return busy, true
+}
+
+// sidecarSampler is one sidecar's sampling goroutine and its latest reading.
+//
+// The sampler outlives its goroutine. When sampling gives up the slot stays, so
+// the last reading survives and the dashboard can dim it as stale — a sampler
+// that died should look stalled, not look like a sidecar with nothing to report.
+type sidecarSampler struct {
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	latest *Resources
+	// retryAt is when a sampler that gave up may be started again; zero while it
+	// is running.
+	retryAt time.Time
+}
+
+// setCancel adopts the cancel function of a freshly started goroutine.
+func (s *sidecarSampler) setCancel(cancel context.CancelFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cancel = cancel
+}
+
+// stop cancels this sampler's goroutine, if it has one running.
+func (s *sidecarSampler) stop() {
+	s.mu.Lock()
+	cancel := s.cancel
+	s.cancel = nil
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// giveUp records that sampling has stopped for now, and when it may resume.
+func (s *sidecarSampler) giveUp(after time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cancel = nil
+	s.retryAt = time.Now().Add(after)
+}
+
+// claimRetry reports whether a sampler that gave up is due another attempt,
+// clearing the marker so two polls cannot both act on it.
+func (s *sidecarSampler) claimRetry() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.retryAt.IsZero() || time.Now().Before(s.retryAt) {
+		return false
+	}
+	s.retryAt = time.Time{}
+	return true
+}
+
+func (s *sidecarSampler) set(r Resources) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.latest = &r
+}
+
+func (s *sidecarSampler) get() *Resources {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.latest == nil {
+		return nil
+	}
+	cp := *s.latest
+	return &cp
+}
+
+// errNoClient stops a sampling session that can never succeed. The daemon
+// resolves its client once at startup, so a nil one will still be nil next
+// time: retrying would spin without ever producing a figure.
+var errNoClient = errors.New("no CircleCI client, so resources cannot be sampled")
+
+// resourceSampler owns one sampling goroutine per sidecar, started only while a
+// dashboard is attached and stopped when the sidecar goes away or the dashboard
+// does.
+type resourceSampler struct {
+	// client is nil when the daemon started without credentials, in which case
+	// sampling never starts and the dashboard simply shows no resource figures.
+	client *circleci.Client
+	// sample runs one sampling session and returns when it ends. It is a field so
+	// tests can drive the lifecycle — reconnects, give-up, cancellation — without
+	// reaching the API.
+	sample func(ctx context.Context, sc SidecarState, s *sidecarSampler) error
+
+	mu       sync.Mutex
+	samplers map[string]*sidecarSampler // keyed by sidecar ID
+	lastSeen time.Time                  // last snapshot request
+}
+
+func newResourceSampler(client *circleci.Client) *resourceSampler {
+	r := &resourceSampler{
+		client:   client,
+		samplers: make(map[string]*sidecarSampler),
+	}
+	r.sample = r.sampleOnce
+	return r
+}
+
+// touch records that a dashboard asked for a snapshot.
+func (r *resourceSampler) touch() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.lastSeen = time.Now()
+}
+
+// attached reports whether a dashboard has asked for a snapshot recently enough
+// that sampling is worth its cost.
+func (r *resourceSampler) attached() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return !r.lastSeen.IsZero() && time.Since(r.lastSeen) < idleShutdown
+}
+
+// reconcile starts samplers for sidecars that should have one and stops those
+// that should not. Called from the poll path, so it must not block: starting a
+// sampler only spawns a goroutine, and stopping one only cancels a context.
+func (r *resourceSampler) reconcile(sidecars []SidecarState) {
+	if !r.attached() {
+		r.stopAll()
+		return
+	}
+
+	want := make(map[string]SidecarState, len(sidecars))
+	for _, sc := range sidecars {
+		if sc.ID != "" {
+			want[sc.ID] = sc
+		}
+	}
+
+	r.mu.Lock()
+	var toStart []startRequest
+	for id, sc := range want {
+		s, ok := r.samplers[id]
+		if !ok {
+			s = &sidecarSampler{}
+			r.samplers[id] = s
+			toStart = append(toStart, startRequest{sidecar: sc, sampler: s})
+			continue
+		}
+		// A sampler that gave up keeps its slot, so restarting it is a retry
+		// rather than a fresh start. The cooloff is what lets a transient failure
+		// recover instead of costing this sidecar its numbers for the rest of the
+		// session.
+		if s.claimRetry() {
+			toStart = append(toStart, startRequest{sidecar: sc, sampler: s})
+		}
+	}
+	var toStop []*sidecarSampler
+	for id, s := range r.samplers {
+		if _, ok := want[id]; !ok {
+			toStop = append(toStop, s)
+			delete(r.samplers, id)
+		}
+	}
+	// Started under the lock: a goroutine whose sampler was stopped between being
+	// recorded and adopting its cancel function could never be cancelled at all.
+	for _, req := range toStart {
+		ctx, cancel := context.WithCancel(context.Background())
+		req.sampler.setCancel(cancel)
+		go r.run(ctx, req.sidecar, req.sampler)
+	}
+	r.mu.Unlock()
+
+	for _, s := range toStop {
+		s.stop()
+	}
+}
+
+// startRequest pairs a sidecar with the sampler slot that tracks it.
+type startRequest struct {
+	sidecar SidecarState
+	sampler *sidecarSampler
+}
+
+// annotate attaches the latest sample to each sidecar.
+func (r *resourceSampler) annotate(sidecars []SidecarState) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i := range sidecars {
+		if s, ok := r.samplers[sidecars[i].ID]; ok {
+			sidecars[i].Resources = s.get()
+		}
+	}
+}
+
+func (r *resourceSampler) stopAll() {
+	r.mu.Lock()
+	samplers := make([]*sidecarSampler, 0, len(r.samplers))
+	for id, s := range r.samplers {
+		samplers = append(samplers, s)
+		delete(r.samplers, id)
+	}
+	r.mu.Unlock()
+	for _, s := range samplers {
+		s.stop()
+	}
+}
+
+// maxSamplerFailures is how many consecutive failures a sidecar gets before the
+// daemon stops sampling it for sampleCooloff.
+//
+// Without a ceiling a sidecar that can never be sampled — deleted, or an
+// unreachable image — is retried forever. Each attempt costs an API call, so a
+// handful of dead sidecars turns into constant background traffic that degrades
+// everything else the daemon and the CLI are doing.
+const maxSamplerFailures = 3
+
+// sampleCooloff is how long a sidecar goes unsampled after the daemon gives up on
+// it. Giving up for good would let one bad minute cost a sidecar its numbers for
+// the rest of the session, which reads as a broken dashboard rather than as the
+// transient it was; retrying any sooner would defeat the ceiling above.
+const sampleCooloff = 2 * time.Minute
+
+// run drives one sidecar's sampler, retrying with backoff until it is cancelled
+// or has failed too many times in a row, in which case reconcile starts it again
+// once sampleCooloff has passed.
+func (r *resourceSampler) run(ctx context.Context, sc SidecarState, s *sidecarSampler) {
+	backoff := time.Second
+	failures := 0
+	for ctx.Err() == nil {
+		err := r.sample(ctx, sc, s)
+		if ctx.Err() != nil {
+			return
+		}
+		if err == nil {
+			// The remote loop ended on its own; start another immediately.
+			failures = 0
+			backoff = time.Second
+			continue
+		}
+
+		failures++
+		if failures >= maxSamplerFailures {
+			log.Printf("watchd: pausing sampling of %s for %s after %d failures: %v",
+				sc.ID, sampleCooloff, failures, err)
+			s.giveUp(sampleCooloff)
+			return
+		}
+		log.Printf("watchd: resource sampler for %s: %v", sc.ID, err)
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < 30*time.Second {
+			backoff *= 2
+		}
+	}
+}
+
+// sampleOnce runs the sampler on the sidecar and publishes each frame it
+// produces, returning when the remote loop ends, the stream breaks, or ctx is
+// cancelled. run decides whether to try again.
+//
+// It goes through the async exec API rather than SSH deliberately. The sidecar's
+// SSH exec channel fork/execs the command string instead of interpreting it, so a
+// shell script — pipes, a while loop, redirections — cannot run over it at all;
+// that is why every other ExecOverSSH call in this repo is a bare `binary arg`
+// invocation. The exec API takes argv as structured data ("sh", "-c", script), so
+// it runs scripts correctly, and its output stream is already long-lived and
+// resumable. That also removes the handshake-per-sample problem outright, with no
+// persistent connection for the daemon to supervise.
+func (r *resourceSampler) sampleOnce(ctx context.Context, sc SidecarState, s *sidecarSampler) error {
+	client := r.client
+	if client == nil {
+		return errNoClient
+	}
+
+	dir := "."
+	if sc.Workspace != "" {
+		dir = sc.Workspace
+	}
+
+	commandID, err := client.SubmitExec(ctx, sc.ID, "sh",
+		[]string{"-c", remoteSamplerScript()},
+		map[string]string{"CHUNK_SAMPLE_DIR": dir},
+	)
+	if err != nil {
+		return fmt.Errorf("submit sampler: %w", err)
+	}
+
+	frames := make(chan string)
+	parsed := make(chan struct{})
+	frameErr := make(chan error, 1)
+	pr, pw := io.Pipe()
+	go func() {
+		consumeSamples(frames, s)
+		close(parsed)
+	}()
+	go func() {
+		frameErr <- readFrames(pr, frames)
+		close(frames)
+	}()
+
+	_, streamErr := client.StreamOutput(ctx, commandID, "", func(_ string, data []byte) {
+		_, _ = pw.Write(data)
+	})
+	_ = pw.Close()
+	<-parsed
+	if streamErr != nil {
+		return streamErr
+	}
+	// A frame reader that stopped early otherwise looks like a healthy session:
+	// the stream ends clean, and run restarts it at once — submitting a fresh
+	// exec on every pass. Reporting it is what puts the backoff in play.
+	if err := <-frameErr; err != nil {
+		return fmt.Errorf("read sampler output: %w", err)
+	}
+	return nil
+}
+
+// consumeSamples parses frames off a reader, differencing CPU between them, and
+// publishes each complete reading. It is separated from transport so it can be
+// tested against captured sampler output with no SSH involved.
+func consumeSamples(frames <-chan string, s *sidecarSampler) {
+	var prev cpuTimes
+	havePrev := false
+	for frame := range frames {
+		cur := parseSampleFrame(frame)
+		res := Resources{
+			MemUsedBytes:   cur.memUsed,
+			MemLimitBytes:  cur.memLimit,
+			DiskUsedBytes:  cur.diskUsed,
+			DiskTotalBytes: cur.diskTotal,
+			SampledAt:      time.Now(),
+		}
+		if cur.haveCPU {
+			if havePrev {
+				if pct, ok := cpuPercent(prev, cur.cpu); ok {
+					res.CPUPercent = pct
+				}
+			}
+			prev = cur.cpu
+			havePrev = true
+		}
+		s.set(res)
+	}
+}
+
+// splitFrames reads sampler output and emits one string per complete frame,
+// returning the scanner's error if it stopped for any reason but end of input.
+func splitFrames(r *bufio.Scanner, out chan<- string) error {
+	var b strings.Builder
+	for r.Scan() {
+		line := r.Text()
+		if strings.TrimSpace(line) == sampleFrameSep {
+			out <- b.String()
+			b.Reset()
+			continue
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return r.Err()
+}
+
+// readFrames splits sampler output into frames and guarantees the writing side
+// cannot block once it stops.
+//
+// bufio.Scanner gives up on a line past its 64KB token limit, and after that
+// nothing reads the pipe again — so StreamOutput's callback, which writes into
+// it, would block on io.Pipe forever, taking the sampler goroutine with it past
+// even cancellation. Closing the read half turns that hang into a write error.
+func readFrames(pr *io.PipeReader, out chan<- string) error {
+	err := splitFrames(bufio.NewScanner(pr), out)
+	_ = pr.CloseWithError(io.ErrClosedPipe)
+	return err
+}

--- a/internal/watchd/resources.go
+++ b/internal/watchd/resources.go
@@ -270,6 +270,15 @@ type resourceSampler struct {
 	// tests can drive the lifecycle — reconnects, give-up, cancellation — without
 	// reaching the API.
 	sample func(ctx context.Context, sc SidecarState, s *sidecarSampler) error
+	// logf reports a sampling failure, and is a field for much the same reason.
+	//
+	// These cannot be returned: run is a detached goroutine with no caller. Nor
+	// should they be dropped — a sidecar quietly losing its figures for two
+	// minutes is precisely what someone looking at a blank column needs told.
+	// So they are reported, but to an injected logger rather than the package
+	// global, which keeps the choice of where daemon output goes with the daemon
+	// and lets a test read what was said.
+	logf func(format string, args ...any)
 
 	mu       sync.Mutex
 	samplers map[string]*sidecarSampler // keyed by sidecar ID
@@ -279,6 +288,7 @@ type resourceSampler struct {
 func newResourceSampler(client *circleci.Client) *resourceSampler {
 	r := &resourceSampler{
 		client:   client,
+		logf:     log.Printf,
 		samplers: make(map[string]*sidecarSampler),
 	}
 	r.sample = r.sampleOnce
@@ -430,12 +440,12 @@ func (r *resourceSampler) run(ctx context.Context, sc SidecarState, s *sidecarSa
 
 		failures++
 		if failures >= maxSamplerFailures {
-			log.Printf("watchd: pausing sampling of %s for %s after %d failures: %v",
+			r.logf("watchd: pausing sampling of %s for %s after %d failures: %v",
 				sc.ID, sampleCooloff, failures, err)
 			s.giveUp(sampleCooloff)
 			return
 		}
-		log.Printf("watchd: resource sampler for %s: %v", sc.ID, err)
+		r.logf("watchd: resource sampler for %s: %v", sc.ID, err)
 
 		select {
 		case <-ctx.Done():

--- a/internal/watchd/resources.go
+++ b/internal/watchd/resources.go
@@ -341,14 +341,24 @@ func (r *resourceSampler) reconcile(sidecars []SidecarState) {
 			delete(r.samplers, id)
 		}
 	}
-	// Started under the lock: a goroutine whose sampler was stopped between being
-	// recorded and adopting its cancel function could never be cancelled at all.
+	// setCancel stays under the lock: a sampler stopped between being recorded
+	// and adopting its cancel function could never be cancelled at all. The
+	// goroutines themselves do not — spawning under r.mu would put every call
+	// r.run makes inside this lock's ordering, so a future sampling path that
+	// touched r.mu would deadlock against a hold it never mentions. A sampler
+	// stopped in the gap below simply starts on an already-cancelled context,
+	// and run returns without sampling.
+	starts := make([]func(), 0, len(toStart))
 	for _, req := range toStart {
 		ctx, cancel := context.WithCancel(context.Background())
 		req.sampler.setCancel(cancel)
-		go r.run(ctx, req.sidecar, req.sampler)
+		starts = append(starts, func() { r.run(ctx, req.sidecar, req.sampler) })
 	}
 	r.mu.Unlock()
+
+	for _, start := range starts {
+		go start()
+	}
 
 	for _, s := range toStop {
 		s.stop()
@@ -482,6 +492,16 @@ func (r *resourceSampler) sampleOnce(ctx context.Context, sc SidecarState, s *si
 		close(frames)
 	}()
 
+	// The write is synchronous — io.Pipe hands each write straight to the reader
+	// — so a slow parser applies backpressure to the stream rather than letting
+	// output pile up unbounded in memory. StreamOutput calls this inline while
+	// scanning, so the stall reaches the HTTP read, which is the intent.
+	//
+	// It cannot stall for good: readFrames closes the read side on every exit
+	// path, so a parser that stops early turns the next write into an immediate
+	// ErrClosedPipe instead of a block with nobody left to read. The error is
+	// dropped because the frame reader's own error is the one worth reporting,
+	// and it is collected from frameErr below.
 	_, streamErr := client.StreamOutput(ctx, commandID, "", func(_ string, data []byte) {
 		_, _ = pw.Write(data)
 	})

--- a/internal/watchd/resources_test.go
+++ b/internal/watchd/resources_test.go
@@ -1,0 +1,367 @@
+package watchd
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+// Captured shapes of the files the remote sampler reads.
+const (
+	frameCgroupV2 = `cpu  100 0 50 800 50 0 0 0 0 0
+mem_current 536870912
+mem_max 2147483648
+/dev/vda1 10737418240 3221225472 7516192768 30% /
+`
+	frameCgroupV2NoLimit = `cpu  200 0 100 1600 100 0 0 0 0 0
+mem_current 536870912
+mem_max max
+/dev/vda1 10737418240 3221225472 7516192768 30% /
+`
+	frameCgroupV1 = `cpu  100 0 50 800 50 0 0 0 0 0
+mem_current 268435456
+mem_max 1073741824
+/dev/vda1 10737418240 1073741824 9663676416 10% /
+`
+	// The host-memory fallback. MemTotal here is deliberately huge, which is
+	// exactly the trap: reporting it as the sidecar's limit makes every sidecar
+	// look like it has hundreds of gigabytes free.
+	frameProcMeminfo = `cpu  100 0 50 800 50 0 0 0 0 0
+MemTotal:       263876624 kB
+MemAvailable:   131938312 kB
+/dev/vda1 10737418240 3221225472 7516192768 30% /
+`
+)
+
+func TestParseSampleFrameCgroupV2(t *testing.T) {
+	s := parseSampleFrame(frameCgroupV2)
+	assert.Check(t, s.haveCPU)
+	assert.Check(t, cmp.Equal(s.memUsed, int64(536870912)))
+	assert.Check(t, cmp.Equal(s.memLimit, int64(2147483648)))
+	assert.Check(t, cmp.Equal(s.diskTotal, int64(10737418240)))
+	assert.Check(t, cmp.Equal(s.diskUsed, int64(3221225472)))
+}
+
+func TestParseSampleFrameCgroupV1(t *testing.T) {
+	s := parseSampleFrame(frameCgroupV1)
+	assert.Check(t, cmp.Equal(s.memUsed, int64(268435456)))
+	assert.Check(t, cmp.Equal(s.memLimit, int64(1073741824)))
+}
+
+func TestParseSampleFrameUnlimitedCgroupMemoryHasNoLimit(t *testing.T) {
+	s := parseSampleFrame(frameCgroupV2NoLimit)
+	// "max" means no limit, which must read as unknown rather than as zero bytes
+	// available or some sentinel treated as a real number.
+	assert.Check(t, cmp.Equal(s.memLimit, int64(0)))
+	assert.Check(t, cmp.Equal(s.memUsed, int64(536870912)))
+}
+
+func TestParseSampleFrameProcMeminfoFallbackDerivesUsed(t *testing.T) {
+	s := parseSampleFrame(frameProcMeminfo)
+	// used = total - available, both converted from kB.
+	wantLimit := int64(263876624) * 1024
+	wantUsed := wantLimit - int64(131938312)*1024
+	assert.Check(t, cmp.Equal(s.memLimit, wantLimit))
+	assert.Check(t, cmp.Equal(s.memUsed, wantUsed))
+	assert.Check(t, s.memUsed > 0, "derived usage must not go negative")
+}
+
+func TestParseSampleFrameGarbageIsHarmless(t *testing.T) {
+	s := parseSampleFrame("total nonsense\n\n   \nnot-a-number x\n")
+	assert.Check(t, !s.haveCPU)
+	assert.Check(t, cmp.Equal(s.memUsed, int64(0)))
+	assert.Check(t, cmp.Equal(s.memLimit, int64(0)))
+}
+
+func TestCPUPercentRequiresElapsedTime(t *testing.T) {
+	first := parseSampleFrame(frameCgroupV2)
+	_, sameOK := cpuPercent(first.cpu, first.cpu)
+	assert.Check(t, !sameOK, "two identical readings have no elapsed time between them")
+}
+
+func TestCPUPercentDerivesFromDelta(t *testing.T) {
+	prev := cpuTimes{total: 1000, idle: 900}
+	cur := cpuTimes{total: 1200, idle: 1000}
+	// 200 jiffies elapsed, 100 of them idle → 50% busy.
+	pct, ok := cpuPercent(prev, cur)
+	assert.Assert(t, ok)
+	assert.Check(t, cmp.Equal(pct, 50.0))
+}
+
+func TestCPUPercentClampsAndRejectsCounterReset(t *testing.T) {
+	// A sidecar restart resets counters; a negative delta must not produce a
+	// wild percentage.
+	_, ok := cpuPercent(cpuTimes{total: 5000, idle: 4000}, cpuTimes{total: 100, idle: 50})
+	assert.Check(t, !ok, "a counter reset must yield no reading rather than a bogus one")
+
+	// Idle moving backwards alone is also incoherent.
+	_, idleOK := cpuPercent(cpuTimes{total: 1000, idle: 500}, cpuTimes{total: 1200, idle: 400})
+	assert.Check(t, !idleOK)
+}
+
+func TestSplitFramesEmitsCompleteFramesOnly(t *testing.T) {
+	input := "a\nb\n" + sampleFrameSep + "\nc\n" + sampleFrameSep + "\npartial\n"
+	frames := make(chan string, 4)
+	splitFrames(bufio.NewScanner(strings.NewReader(input)), frames)
+	close(frames)
+
+	var got []string
+	for f := range frames {
+		got = append(got, f)
+	}
+	// The trailing partial frame is withheld: emitting it would publish a
+	// reading with half its fields missing.
+	assert.Assert(t, cmp.Len(got, 2))
+	assert.Check(t, cmp.Equal(got[0], "a\nb\n"))
+	assert.Check(t, cmp.Equal(got[1], "c\n"))
+}
+
+func TestConsumeSamplesWithholdsCPUUntilSecondFrame(t *testing.T) {
+	s := &sidecarSampler{}
+	frames := make(chan string, 2)
+	frames <- frameCgroupV2
+	close(frames)
+	consumeSamples(frames, s)
+
+	got := s.get()
+	assert.Assert(t, got != nil)
+	assert.Check(t, cmp.Equal(got.CPUPercent, 0.0), "one frame cannot yield a CPU percentage")
+	assert.Check(t, cmp.Equal(got.MemUsedBytes, int64(536870912)))
+	assert.Check(t, cmp.Equal(got.MemLimitBytes, int64(2147483648)))
+}
+
+func TestConsumeSamplesDerivesCPUAcrossFrames(t *testing.T) {
+	s := &sidecarSampler{}
+	frames := make(chan string, 2)
+	frames <- frameCgroupV2        // cpu total 1000, idle 850
+	frames <- frameCgroupV2NoLimit // cpu total 2000, idle 1700
+	close(frames)
+	consumeSamples(frames, s)
+
+	got := s.get()
+	assert.Assert(t, got != nil)
+	assert.Check(t, got.CPUPercent > 0, "a second frame must produce a CPU reading, got %v", got.CPUPercent)
+	assert.Check(t, got.CPUPercent <= 100)
+}
+
+func TestResourceSamplerDoesNothingWhenNoDashboardAttached(t *testing.T) {
+	r := newResourceSampler(nil)
+	// Never touched, so no dashboard has ever asked for a snapshot.
+	assert.Check(t, !r.attached())
+
+	r.reconcile([]SidecarState{{ID: "sc-1"}})
+
+	r.mu.Lock()
+	n := len(r.samplers)
+	r.mu.Unlock()
+	assert.Check(t, cmp.Equal(n, 0), "sampling must not start without an attached dashboard")
+}
+
+func TestResourceSamplerStopsSamplersWhenSidecarLeaves(t *testing.T) {
+	r := newResourceSampler(nil)
+	r.sample = blockingSampler(make(chan string, 4))
+	r.touch()
+	t.Cleanup(r.stopAll)
+
+	r.reconcile([]SidecarState{{ID: "sc-1"}, {ID: "sc-2"}})
+	r.mu.Lock()
+	started := len(r.samplers)
+	r.mu.Unlock()
+	assert.Assert(t, cmp.Equal(started, 2))
+
+	// sc-2 disappears from the poll; its sampler must be cancelled and dropped.
+	r.reconcile([]SidecarState{{ID: "sc-1"}})
+	r.mu.Lock()
+	_, keptOne := r.samplers["sc-1"]
+	_, keptTwo := r.samplers["sc-2"]
+	r.mu.Unlock()
+	assert.Check(t, keptOne, "sc-1 should still be sampled")
+	assert.Check(t, !keptTwo, "a sidecar that left the poll must stop being sampled")
+}
+
+func TestResourceSamplerIgnoresLocalRunner(t *testing.T) {
+	r := newResourceSampler(nil)
+	r.touch()
+	// The local runner has an empty ID and no sidecar to connect to.
+	r.reconcile([]SidecarState{{ID: ""}})
+	r.mu.Lock()
+	n := len(r.samplers)
+	r.mu.Unlock()
+	assert.Check(t, cmp.Equal(n, 0))
+}
+
+func TestResourceSamplerAnnotateAttachesLatest(t *testing.T) {
+	r := newResourceSampler(nil)
+	r.sample = blockingSampler(make(chan string, 4))
+	r.touch()
+	t.Cleanup(r.stopAll)
+	r.reconcile([]SidecarState{{ID: "sc-1"}})
+
+	r.mu.Lock()
+	s := r.samplers["sc-1"]
+	r.mu.Unlock()
+	assert.Assert(t, s != nil)
+	s.set(Resources{CPUPercent: 42})
+
+	sidecars := []SidecarState{{ID: "sc-1"}, {ID: "sc-other"}}
+	r.annotate(sidecars)
+	assert.Assert(t, sidecars[0].Resources != nil)
+	assert.Check(t, cmp.Equal(sidecars[0].Resources.CPUPercent, 42.0))
+	assert.Check(t, cmp.Nil(sidecars[1].Resources))
+}
+
+func TestRemoteSamplerScriptPrefersCgroupOverProcMeminfo(t *testing.T) {
+	script := remoteSamplerScript()
+	// The ordering matters more than the exact text: reading /proc/meminfo first
+	// would report host memory on every containerised sidecar.
+	v2 := strings.Index(script, "/sys/fs/cgroup/memory.current")
+	v1 := strings.Index(script, "/sys/fs/cgroup/memory/memory.usage_in_bytes")
+	host := strings.Index(script, "/proc/meminfo")
+	assert.Assert(t, v2 >= 0 && v1 >= 0 && host >= 0)
+	assert.Check(t, v2 < v1, "cgroup v2 must be tried before v1")
+	assert.Check(t, v1 < host, "cgroup must be tried before /proc/meminfo")
+	assert.Check(t, cmp.Contains(script, sampleFrameSep))
+}
+
+// blockingSampler is a sample function that records which sidecars it was asked
+// to sample and then waits for cancellation, standing in for a session that runs
+// until the daemon stops it. It keeps lifecycle tests off the network entirely.
+func blockingSampler(started chan<- string) func(context.Context, SidecarState, *sidecarSampler) error {
+	return func(ctx context.Context, sc SidecarState, _ *sidecarSampler) error {
+		select {
+		case started <- sc.ID:
+		default:
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	}
+}
+
+func TestSidecarSamplerGiveUpKeepsTheLastReading(t *testing.T) {
+	s := &sidecarSampler{}
+	s.set(Resources{CPUPercent: 12})
+	s.giveUp(time.Minute)
+
+	// The reading has to survive: the dashboard dims a stale sample, and dropping
+	// it instead would make a sidecar the daemon stopped watching look like one
+	// with nothing to report.
+	got := s.get()
+	assert.Assert(t, got != nil)
+	assert.Check(t, cmp.Equal(got.CPUPercent, 12.0))
+}
+
+func TestSidecarSamplerRetryIsClaimedOnce(t *testing.T) {
+	s := &sidecarSampler{}
+	assert.Check(t, !s.claimRetry(), "a sampler that never gave up is not due a retry")
+
+	s.giveUp(time.Hour)
+	assert.Check(t, !s.claimRetry(), "the cooloff has not elapsed")
+
+	s.giveUp(0)
+	assert.Check(t, s.claimRetry(), "an elapsed cooloff is due a retry")
+	assert.Check(t, !s.claimRetry(), "the retry must be claimable only once")
+}
+
+func TestResourceSamplerRetriesAfterCooloff(t *testing.T) {
+	started := make(chan string, 4)
+	r := newResourceSampler(nil)
+	r.sample = blockingSampler(started)
+	r.touch()
+	t.Cleanup(r.stopAll)
+
+	sidecars := []SidecarState{{ID: "sc-1"}}
+	r.reconcile(sidecars)
+	assert.Check(t, cmp.Equal(<-started, "sc-1"))
+
+	r.mu.Lock()
+	s := r.samplers["sc-1"]
+	r.mu.Unlock()
+	assert.Assert(t, s != nil)
+	s.set(Resources{CPUPercent: 7})
+
+	// Sampling gave up with the cooloff still running: no restart yet.
+	s.giveUp(time.Hour)
+	r.reconcile(sidecars)
+	select {
+	case id := <-started:
+		t.Fatalf("restarted %s before the cooloff elapsed", id)
+	default:
+	}
+
+	// Cooloff elapsed: the same slot is restarted, so the last reading is still
+	// there for the dashboard to dim rather than being replaced by nothing.
+	s.giveUp(0)
+	r.reconcile(sidecars)
+	assert.Check(t, cmp.Equal(<-started, "sc-1"))
+
+	r.mu.Lock()
+	same := r.samplers["sc-1"] == s
+	r.mu.Unlock()
+	assert.Check(t, same, "a retry must reuse the sampler slot, not replace it")
+	assert.Assert(t, s.get() != nil)
+	assert.Check(t, cmp.Equal(s.get().CPUPercent, 7.0))
+}
+
+func TestResourceSamplerStopCancelsTheRunningSession(t *testing.T) {
+	started := make(chan string, 1)
+	r := newResourceSampler(nil)
+	stopped := make(chan struct{})
+	r.sample = func(ctx context.Context, sc SidecarState, _ *sidecarSampler) error {
+		started <- sc.ID
+		<-ctx.Done()
+		close(stopped)
+		return ctx.Err()
+	}
+	r.touch()
+
+	r.reconcile([]SidecarState{{ID: "sc-1"}})
+	assert.Check(t, cmp.Equal(<-started, "sc-1"))
+
+	r.stopAll()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stopAll must cancel the running sampling session")
+	}
+}
+
+// TestReadFramesUnblocksWriterWhenScannerGivesUp covers the shape that would
+// otherwise hang a sampler for good: the frame reader stops, nothing drains the
+// pipe, and the stream callback writing into it blocks past cancellation.
+func TestReadFramesUnblocksWriterWhenScannerGivesUp(t *testing.T) {
+	pr, pw := io.Pipe()
+	frames := make(chan string, 4)
+	done := make(chan error, 1)
+	go func() { done <- readFrames(pr, frames) }()
+
+	// One line past bufio's token limit is all it takes.
+	go func() {
+		_, _ = pw.Write([]byte(strings.Repeat("x", bufio.MaxScanTokenSize+2) + "\n"))
+	}()
+
+	select {
+	case err := <-done:
+		assert.Assert(t, err != nil, "an abandoned scan must be reported, not swallowed")
+	case <-time.After(5 * time.Second):
+		t.Fatal("readFrames never returned")
+	}
+
+	// The write side must now fail rather than wait for a reader that is gone.
+	wrote := make(chan error, 1)
+	go func() {
+		_, err := pw.Write([]byte("still sampling\n"))
+		wrote <- err
+	}()
+	select {
+	case err := <-wrote:
+		assert.Assert(t, err != nil, "write should fail once the reader has closed the pipe")
+	case <-time.After(5 * time.Second):
+		t.Fatal("write blocked: the sampler goroutine would hang here forever")
+	}
+}

--- a/internal/watchd/resources_test.go
+++ b/internal/watchd/resources_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"io"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -363,5 +364,46 @@ func TestReadFramesUnblocksWriterWhenScannerGivesUp(t *testing.T) {
 		assert.Assert(t, err != nil, "write should fail once the reader has closed the pipe")
 	case <-time.After(5 * time.Second):
 		t.Fatal("write blocked: the sampler goroutine would hang here forever")
+	}
+}
+
+// Sampling must be able to touch the sampler's own state without waiting on
+// reconcile. This passed before the spawn moved out from under r.mu — reconcile
+// released it immediately after the loop, so the goroutine only ever blocked
+// briefly — but it pins the property that made that safe, which was incidental
+// then and is deliberate now.
+func TestSamplerGoroutineDoesNotWaitOnReconcile(t *testing.T) {
+	r := newResourceSampler(nil)
+	reached := make(chan struct{})
+	r.sample = func(ctx context.Context, sc SidecarState, _ *sidecarSampler) error {
+		// annotate takes r.mu, standing in for any sampling path that ever does.
+		r.annotate([]SidecarState{{ID: sc.ID}})
+		close(reached)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	r.touch()
+	r.reconcile([]SidecarState{{ID: "sc-1"}})
+
+	select {
+	case <-reached:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the sampler goroutine could not take r.mu while reconcile ran")
+	}
+	r.stopAll()
+}
+
+// The lock ordering review asked about is r.mu -> s.mu, via setCancel. It is
+// only a hazard if some path takes them the other way round, and none can:
+// sidecarSampler holds no reference to resourceSampler, so nothing reachable
+// while s.mu is held can reach r.mu. This fails to compile if that ever changes.
+func TestSidecarSamplerHoldsNoBackReference(t *testing.T) {
+	var s sidecarSampler
+	typ := reflect.TypeOf(s)
+	for i := range typ.NumField() {
+		f := typ.Field(i)
+		assert.Check(t, !strings.Contains(f.Type.String(), "resourceSampler"),
+			"sidecarSampler.%s reaches back to resourceSampler, which would make the "+
+				"r.mu -> s.mu ordering in reconcile a real deadlock risk", f.Name)
 	}
 }

--- a/internal/watchd/resources_test.go
+++ b/internal/watchd/resources_test.go
@@ -3,9 +3,12 @@ package watchd
 import (
 	"bufio"
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -398,12 +401,64 @@ func TestSamplerGoroutineDoesNotWaitOnReconcile(t *testing.T) {
 // sidecarSampler holds no reference to resourceSampler, so nothing reachable
 // while s.mu is held can reach r.mu. This fails to compile if that ever changes.
 func TestSidecarSamplerHoldsNoBackReference(t *testing.T) {
-	var s sidecarSampler
-	typ := reflect.TypeOf(s)
+	// TypeFor, not TypeOf on a value: sidecarSampler holds a mutex, and copying
+	// one to inspect it is exactly what vet objects to.
+	typ := reflect.TypeFor[sidecarSampler]()
 	for i := range typ.NumField() {
 		f := typ.Field(i)
 		assert.Check(t, !strings.Contains(f.Type.String(), "resourceSampler"),
 			"sidecarSampler.%s reaches back to resourceSampler, which would make the "+
 				"r.mu -> s.mu ordering in reconcile a real deadlock risk", f.Name)
 	}
+}
+
+// Sampling failures have nowhere to be returned to — run is detached — so the
+// report is the only signal that a sidecar has stopped producing figures.
+// Pinning it here also pins that it goes somewhere injectable rather than
+// straight to the process log.
+func TestSamplerReportsWhyItGaveUp(t *testing.T) {
+	var mu sync.Mutex
+	var lines []string
+
+	r := newResourceSampler(nil)
+	r.logf = func(format string, args ...any) {
+		mu.Lock()
+		defer mu.Unlock()
+		lines = append(lines, fmt.Sprintf(format, args...))
+	}
+	gaveUp := make(chan struct{})
+	var attempts int
+	r.sample = func(_ context.Context, _ SidecarState, s *sidecarSampler) error {
+		attempts++
+		if attempts == maxSamplerFailures {
+			defer close(gaveUp)
+		}
+		return errors.New("ssh: connection refused")
+	}
+	r.touch()
+	r.reconcile([]SidecarState{{ID: "sc-1"}})
+
+	select {
+	case <-gaveUp:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the sampler never reached its failure ceiling")
+	}
+	r.stopAll()
+
+	mu.Lock()
+	defer mu.Unlock()
+	joined := strings.Join(lines, "\n")
+	assert.Check(t, strings.Contains(joined, "sc-1"),
+		"the report must name the sidecar that stopped: %q", joined)
+	assert.Check(t, strings.Contains(joined, "pausing sampling"),
+		"giving up is the part worth saying out loud: %q", joined)
+	assert.Check(t, strings.Contains(joined, "connection refused"),
+		"the cause has to survive into the report: %q", joined)
+}
+
+// Nothing in the package may reach for the process logger directly: the daemon
+// decides where its output goes, and a test cannot read stderr.
+func TestResourceSamplerLogsThroughTheInjectedLogger(t *testing.T) {
+	r := newResourceSampler(nil)
+	assert.Assert(t, r.logf != nil, "a nil logger would panic on the first failure")
 }

--- a/internal/watchd/types.go
+++ b/internal/watchd/types.go
@@ -7,6 +7,20 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
 )
 
+// Resources is one sample of a sidecar's resource usage.
+//
+// Memory is reported as used-of-limit rather than a percentage so the display
+// can show both, and because a limit of zero (unknown) has to be distinguishable
+// from a usage of zero.
+type Resources struct {
+	CPUPercent     float64   `json:"cpu_percent"`
+	MemUsedBytes   int64     `json:"mem_used_bytes"`
+	MemLimitBytes  int64     `json:"mem_limit_bytes"`
+	DiskUsedBytes  int64     `json:"disk_used_bytes"`
+	DiskTotalBytes int64     `json:"disk_total_bytes"`
+	SampledAt      time.Time `json:"sampled_at"`
+}
+
 // SidecarState describes one active sidecar as maintained by the daemon.
 type SidecarState struct {
 	ID   string `json:"id"`
@@ -15,15 +29,21 @@ type SidecarState struct {
 	// written outside a session or before sessions existed. Sidecars are
 	// isolated per session, so two entries for one project and branch are two
 	// sessions working in the same tree — this is what tells them apart.
-	SessionID    string      `json:"session_id,omitempty"`
-	ProjectName  string      `json:"project_name"`
-	RepoName     string      `json:"repo_name"`
-	SnapshotName string      `json:"snapshot_name"`
-	FileMtime    time.Time   `json:"file_mtime"`
+	SessionID    string    `json:"session_id,omitempty"`
+	ProjectName  string    `json:"project_name"`
+	RepoName     string    `json:"repo_name"`
+	SnapshotName string    `json:"snapshot_name"`
+	FileMtime    time.Time `json:"file_mtime"`
+	// Workspace is the sidecar-side repo path, used to sample disk usage where
+	// the work actually happens rather than wherever a shell starts.
+	Workspace    string      `json:"workspace,omitempty"`
 	LastActivity time.Time   `json:"last_activity"`
 	LastOp       eventlog.Op `json:"last_op"`
 	LastLevel    string      `json:"last_level"`
 	Running      bool        `json:"running"`
+	// Resources is the most recent resource sample, or nil when none has
+	// arrived — sampling only runs while a dashboard is attached.
+	Resources *Resources `json:"resources,omitempty"`
 }
 
 // CommandState describes one remote command the daemon is buffering output for.


### PR DESCRIPTION
**4 of 4** — splitting #548. Base: `jesse/logs-3-scrollback`.

## Summary

Live CPU, memory and disk per sidecar in `chunk watch`.

- One long-lived sampler per sidecar, started only while a dashboard is attached.
- Runs over the async exec API rather than SSH, so there is no persistent connection for the daemon to supervise.
- Memory comes from cgroup files; `/proc/meminfo` reports the host's, which would make every sidecar look like it had hundreds of gigabytes free.
- Backoff and a cooloff after repeated failures, so a dead sidecar is not retried forever.

Most droppable piece of the stack — if it needs to go, don't merge it.

## Test plan
- [x] `task test`, `task lint`, `task build`
- [x] Resource samples verified live on 10 sidecars (cgroup memory, not host)
- [x] `chunk watch` by hand: resource line renders per row
