### PR TITLE
Enable Renovate uv manager for harness Python dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,4 +10,12 @@
   "vulnerabilityAlerts": {
     "enabled": true
   },
+  "enabledManagers": ["gomod", "uv"],
+  "packageRules": [
+    {
+      "matchManagers": ["uv"],
+      "matchFileNames": ["harness/**"],
+      "groupName": "harness python deps"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Enables the `uv` Renovate manager so Python dependencies in `harness/` are picked up (the `pyproject.toml` + `uv.lock` pair was previously ignored)
- Keeps `gomod` in `enabledManagers` so Go dependency updates are unaffected
- Groups all `harness/` Python dep updates into a single PR via `groupName: "harness python deps"`

## Test plan

- [ ] Verify Renovate's Dependency Dashboard issue shows `harness/pyproject.toml` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)