### PR TITLE
fix(sidecar): stop forcing IdentitiesOnly=yes for rsync over SSH

### DIFF
--- a/internal/sidecar/rsync.go
+++ b/internal/sidecar/rsync.go
@@ -97,21 +97,7 @@ func rsyncTo(ctx context.Context, client *circleci.Client,
 		return fmt.Errorf("rsync: parse proxy addr: %w", err)
 	}
 
-	sshArgs := []string{"ssh", "-p", port,
-		"-o", "StrictHostKeyChecking=no",
-		"-o", "UserKnownHostsFile=/dev/null",
-		"-o", "IdentitiesOnly=yes", // prevent agent key flood before explicit key is tried
-		"-q",
-	}
-	if sess.IdentityFile != "" {
-		// Pass path directly — rsync tokenizes -e by whitespace and calls execve,
-		// so shell quoting (ShellEscape) would embed literal quote characters in
-		// the filename and cause ssh to fall through to agent keys.
-		sshArgs = append(sshArgs, "-i", sess.IdentityFile)
-	} else if sess.UseAgent && sess.AuthSock != "" {
-		sshArgs = append(sshArgs, "-o", "IdentitiesOnly=no")
-	}
-	sshCmd := strings.Join(sshArgs, " ")
+	sshCmd := sshCommand(sess, port)
 
 	src := strings.TrimRight(cwd, "/") + "/"
 	dst := fmt.Sprintf("%s@127.0.0.1:%s", defaultSSHUser, repoPath)
@@ -135,6 +121,32 @@ func rsyncTo(ctx context.Context, client *circleci.Client,
 
 	status(iostream.LevelDone, "Synced")
 	return nil
+}
+
+// sshCommand builds the command rsync passes to -e in order to reach the
+// sidecar through the local proxy listening on port.
+//
+// IdentitiesOnly=yes is set only alongside an explicit -i. OpenSSH honours the
+// first occurrence of an option, so setting it unconditionally cannot be undone
+// later: an IdentitiesOnly=no appended for agent sessions is silently ignored,
+// leaving ssh unable to offer the agent key OpenSession registered. With no -i
+// to restrict, IdentitiesOnly=yes also does not mean "no keys" — ssh falls back
+// to the default ~/.ssh/id_* filenames, so it offers unrelated keys instead.
+//
+// -q is deliberately absent so ssh diagnostics reach the rsync error instead of
+// being swallowed.
+func sshCommand(sess *Session, port string) string {
+	args := []string{"ssh", "-p", port,
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+	}
+	if sess.IdentityFile != "" {
+		// Pass path directly — rsync tokenizes -e by whitespace and calls execve,
+		// so shell quoting (ShellEscape) would embed literal quote characters in
+		// the filename and cause ssh to fall through to agent keys.
+		args = append(args, "-o", "IdentitiesOnly=yes", "-i", sess.IdentityFile)
+	}
+	return strings.Join(args, " ")
 }
 
 // startSSHProxy starts a local TCP listener on a random port and bridges each

--- a/internal/sidecar/rsync.go
+++ b/internal/sidecar/rsync.go
@@ -133,10 +133,11 @@ func rsyncTo(ctx context.Context, client *circleci.Client,
 // to restrict, IdentitiesOnly=yes also does not mean "no keys" — ssh falls back
 // to the default ~/.ssh/id_* filenames, so it offers unrelated keys instead.
 //
-// -q is deliberately absent so ssh diagnostics reach the rsync error instead of
-// being swallowed.
+// -F /dev/null keeps a user ssh_config from redirecting the 127.0.0.1 hop, and
+// -q is deliberately absent so ssh diagnostics reach the rsync error.
 func sshCommand(sess *Session, port string) string {
 	args := []string{"ssh", "-p", port,
+		"-F", "/dev/null",
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",
 	}

--- a/internal/sidecar/rsync.go
+++ b/internal/sidecar/rsync.go
@@ -112,7 +112,7 @@ func rsyncTo(ctx context.Context, client *circleci.Client,
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		detail := strings.TrimSpace(stderr.String())
+		detail := rsyncErrDetail(stderr.String())
 		if detail != "" {
 			return fmt.Errorf("rsync: %w\n%s", err, detail)
 		}
@@ -121,6 +121,23 @@ func rsyncTo(ctx context.Context, client *circleci.Client,
 
 	status(iostream.LevelDone, "Synced")
 	return nil
+}
+
+// rsyncErrDetail trims ssh's stderr down to what is worth showing the user.
+//
+// UserKnownHostsFile=/dev/null means ssh never remembers the proxy host, so it
+// announces "Warning: Permanently added ..." on every connection. Dropping it
+// stops an expected notice from fronting the real cause of an rsync failure.
+func rsyncErrDetail(stderr string) string {
+	lines := strings.Split(stderr, "\n")
+	kept := lines[:0]
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "Warning: Permanently added ") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
 }
 
 // sshCommand builds the command rsync passes to -e in order to reach the
@@ -133,19 +150,38 @@ func rsyncTo(ctx context.Context, client *circleci.Client,
 // to restrict, IdentitiesOnly=yes also does not mean "no keys" — ssh falls back
 // to the default ~/.ssh/id_* filenames, so it offers unrelated keys instead.
 //
-// -F /dev/null keeps a user ssh_config from redirecting the 127.0.0.1 hop, and
+// A user ssh_config cannot override what we pass here: command-line options are
+// parsed first, so -p and every -o below win. Only options we do not set can leak
+// in, and just three can redirect this hop — ProxyCommand, ProxyJump and the
+// ControlMaster socket — so they are pinned individually rather than discarding
+// the whole config with -F /dev/null. That keeps /etc/ssh/ssh_config and settings
+// like UseKeychain intact, which a passphrase-protected -i key needs in order to
+// authenticate instead of blocking on a prompt inside the rsync child.
+//
 // -q is deliberately absent so ssh diagnostics reach the rsync error.
 func sshCommand(sess *Session, port string) string {
 	args := []string{"ssh", "-p", port,
-		"-F", "/dev/null",
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "ProxyCommand=none",
+		"-o", "ProxyJump=none",
+		"-o", "ControlPath=none",
+		// rsync drives ssh over pipes; a config "RequestTTY yes" only adds a
+		// "Pseudo-terminal will not be allocated" notice to the error detail.
+		"-o", "RequestTTY=no",
 	}
 	if sess.IdentityFile != "" {
 		// Pass path directly — rsync tokenizes -e by whitespace and calls execve,
 		// so shell quoting (ShellEscape) would embed literal quote characters in
 		// the filename and cause ssh to fall through to agent keys.
 		args = append(args, "-o", "IdentitiesOnly=yes", "-i", sess.IdentityFile)
+	} else if sess.UseAgent && sess.AuthSock != "" {
+		// Set IdentitiesOnly=no explicitly: a user ssh_config with
+		// "IdentitiesOnly yes" would otherwise stop ssh offering the agent key
+		// OpenSession registered, reproducing the failure this helper fixes.
+		// Pinning IdentityAgent keeps the agent in step with ExecOverSSH, which
+		// dials sess.AuthSock rather than the ambient SSH_AUTH_SOCK.
+		args = append(args, "-o", "IdentitiesOnly=no", "-o", "IdentityAgent="+sess.AuthSock)
 	}
 	return strings.Join(args, " ")
 }

--- a/internal/sidecar/rsync_test.go
+++ b/internal/sidecar/rsync_test.go
@@ -7,6 +7,19 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+// hardeningOpts are pinned on every session type. A user ssh_config cannot
+// override them (command-line options are parsed first), and the options it
+// could otherwise interfere through are neutralised one by one so the rest of
+// the user's config — /etc/ssh/ssh_config, UseKeychain — keeps working.
+var hardeningOpts = []string{
+	"-o StrictHostKeyChecking=no",
+	"-o UserKnownHostsFile=/dev/null",
+	"-o ProxyCommand=none",
+	"-o ProxyJump=none",
+	"-o ControlPath=none",
+	"-o RequestTTY=no",
+}
+
 func TestSSHCommand(t *testing.T) {
 	cases := []struct {
 		name string
@@ -16,53 +29,70 @@ func TestSSHCommand(t *testing.T) {
 		notWant []string
 	}{
 		{
-			name: "agent session omits IdentitiesOnly so the agent key can be offered",
+			name: "agent session pins IdentitiesOnly=no so the agent key can be offered",
 			sess: &Session{UseAgent: true, AuthSock: "/tmp/agent.sock"},
 			want: []string{
 				"ssh -p 2222",
-				"-F /dev/null",
-				"-o StrictHostKeyChecking=no",
-				"-o UserKnownHostsFile=/dev/null",
+				"-o IdentitiesOnly=no",
+				"-o IdentityAgent=/tmp/agent.sock",
 			},
-			// -q would hide ssh's diagnostics from the rsync error.
-			notWant: []string{"IdentitiesOnly", "-i ", " -q"},
+			// -q would hide ssh's diagnostics from the rsync error. Discarding the
+			// user's config wholesale breaks passphrase-protected keys.
+			notWant: []string{"-o IdentitiesOnly=yes", "-F /dev/null", " -q"},
 		},
 		{
 			name: "identity file session restricts ssh to that key",
 			sess: &Session{IdentityFile: "/home/dev/.ssh/chunk_ai"},
 			want: []string{
 				"ssh -p 2222",
-				"-F /dev/null",
 				"-o IdentitiesOnly=yes",
 				"-i /home/dev/.ssh/chunk_ai",
 			},
 			// The path is passed raw: rsync splits -e on whitespace and execve's
 			// the result, so quoting would embed literal quotes in the filename.
-			notWant: []string{"'", " -q"},
+			// IdentityAgent is for the agent path only.
+			notWant: []string{"'", " -q", "-F /dev/null", "-o IdentityAgent="},
 		},
 		{
 			name: "identity file takes precedence when an agent is also available",
 			sess: &Session{IdentityFile: "/home/dev/.ssh/chunk_ai", UseAgent: true, AuthSock: "/tmp/agent.sock"},
 			want: []string{"-o IdentitiesOnly=yes", "-i /home/dev/.ssh/chunk_ai"},
+			// Pinning the agent alongside an explicit key would undo IdentitiesOnly.
+			notWant: []string{"-o IdentityAgent=", "-o IdentitiesOnly=no"},
 		},
 		{
-			name:    "empty session behaves like the agent path",
-			sess:    &Session{},
-			want:    []string{"-F /dev/null"},
-			notWant: []string{"IdentitiesOnly"},
+			name: "agent session without a socket cannot pin the agent",
+			sess: &Session{UseAgent: true},
+			// Emitting a bare "-o IdentityAgent=" would point ssh at no agent
+			// at all, so neither option is set and ssh falls back to defaults.
+			notWant: []string{"-o IdentityAgent=", "-i "},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := sshCommand(tc.sess, "2222")
-			for _, w := range tc.want {
+			for _, w := range append(tc.want, hardeningOpts...) {
 				assert.Assert(t, strings.Contains(got, w), "want %q in %q", w, got)
 			}
 			for _, w := range tc.notWant {
 				assert.Assert(t, !strings.Contains(got, w), "want %q absent from %q", w, got)
 			}
 		})
+	}
+}
+
+// TestSSHCommandOmitsIdentityFileFlag checks that no -i reaches ssh on the
+// agent path. Matching the substring "-i " alone would miss an -i emitted as
+// the final token, so the built command is tokenised instead.
+func TestSSHCommandOmitsIdentityFileFlag(t *testing.T) {
+	for _, sess := range []*Session{
+		{UseAgent: true, AuthSock: "/tmp/agent.sock"},
+		{UseAgent: true},
+	} {
+		for _, tok := range strings.Fields(sshCommand(sess, "2222")) {
+			assert.Assert(t, tok != "-i", "agent path must not pass -i: %q", sshCommand(sess, "2222"))
+		}
 	}
 }
 
@@ -75,10 +105,52 @@ func TestSSHCommandSetsIdentitiesOnlyAtMostOnce(t *testing.T) {
 		{UseAgent: true, AuthSock: "/tmp/agent.sock"},
 		{IdentityFile: "/home/dev/.ssh/chunk_ai"},
 		{IdentityFile: "/home/dev/.ssh/chunk_ai", UseAgent: true, AuthSock: "/tmp/agent.sock"},
-		{},
+		{UseAgent: true},
 	} {
 		cmd := sshCommand(sess, "2222")
 		assert.Assert(t, strings.Count(cmd, "-o IdentitiesOnly=") <= 1,
 			"IdentitiesOnly set more than once, later values are ignored: %q", cmd)
+	}
+}
+
+func TestRsyncErrDetail(t *testing.T) {
+	const hostKeyNotice = "Warning: Permanently added '[127.0.0.1]:52134' (ED25519) to the list of known hosts."
+
+	cases := []struct {
+		name   string
+		stderr string
+		want   string
+	}{
+		{
+			name:   "drops the expected host key notice so the real cause leads",
+			stderr: hostKeyNotice + "\nrsync: mkpath: Read-only file system\nrsync: error: unexpected end of file",
+			want:   "rsync: mkpath: Read-only file system\nrsync: error: unexpected end of file",
+		},
+		{
+			name:   "notice alone leaves nothing to report",
+			stderr: hostKeyNotice + "\n",
+			want:   "",
+		},
+		{
+			name:   "genuine ssh diagnostics survive",
+			stderr: hostKeyNotice + "\ndev@127.0.0.1: Permission denied (publickey).",
+			want:   "dev@127.0.0.1: Permission denied (publickey).",
+		},
+		{
+			name:   "unrelated warnings are kept",
+			stderr: "Warning: something else entirely",
+			want:   "Warning: something else entirely",
+		},
+		{
+			name:   "empty stderr stays empty",
+			stderr: "",
+			want:   "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, rsyncErrDetail(tc.stderr), tc.want)
+		})
 	}
 }

--- a/internal/sidecar/rsync_test.go
+++ b/internal/sidecar/rsync_test.go
@@ -20,6 +20,7 @@ func TestSSHCommand(t *testing.T) {
 			sess: &Session{UseAgent: true, AuthSock: "/tmp/agent.sock"},
 			want: []string{
 				"ssh -p 2222",
+				"-F /dev/null",
 				"-o StrictHostKeyChecking=no",
 				"-o UserKnownHostsFile=/dev/null",
 			},
@@ -31,6 +32,7 @@ func TestSSHCommand(t *testing.T) {
 			sess: &Session{IdentityFile: "/home/dev/.ssh/chunk_ai"},
 			want: []string{
 				"ssh -p 2222",
+				"-F /dev/null",
 				"-o IdentitiesOnly=yes",
 				"-i /home/dev/.ssh/chunk_ai",
 			},
@@ -46,7 +48,7 @@ func TestSSHCommand(t *testing.T) {
 		{
 			name:    "empty session behaves like the agent path",
 			sess:    &Session{},
-			want:    []string{"ssh -p 2222"},
+			want:    []string{"-F /dev/null"},
 			notWant: []string{"IdentitiesOnly"},
 		},
 	}

--- a/internal/sidecar/rsync_test.go
+++ b/internal/sidecar/rsync_test.go
@@ -1,0 +1,82 @@
+package sidecar
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSSHCommand(t *testing.T) {
+	cases := []struct {
+		name string
+		sess *Session
+		// want / notWant are matched as substrings of the built command.
+		want    []string
+		notWant []string
+	}{
+		{
+			name: "agent session omits IdentitiesOnly so the agent key can be offered",
+			sess: &Session{UseAgent: true, AuthSock: "/tmp/agent.sock"},
+			want: []string{
+				"ssh -p 2222",
+				"-o StrictHostKeyChecking=no",
+				"-o UserKnownHostsFile=/dev/null",
+			},
+			// -q would hide ssh's diagnostics from the rsync error.
+			notWant: []string{"IdentitiesOnly", "-i ", " -q"},
+		},
+		{
+			name: "identity file session restricts ssh to that key",
+			sess: &Session{IdentityFile: "/home/dev/.ssh/chunk_ai"},
+			want: []string{
+				"ssh -p 2222",
+				"-o IdentitiesOnly=yes",
+				"-i /home/dev/.ssh/chunk_ai",
+			},
+			// The path is passed raw: rsync splits -e on whitespace and execve's
+			// the result, so quoting would embed literal quotes in the filename.
+			notWant: []string{"'", " -q"},
+		},
+		{
+			name: "identity file takes precedence when an agent is also available",
+			sess: &Session{IdentityFile: "/home/dev/.ssh/chunk_ai", UseAgent: true, AuthSock: "/tmp/agent.sock"},
+			want: []string{"-o IdentitiesOnly=yes", "-i /home/dev/.ssh/chunk_ai"},
+		},
+		{
+			name:    "empty session behaves like the agent path",
+			sess:    &Session{},
+			want:    []string{"ssh -p 2222"},
+			notWant: []string{"IdentitiesOnly"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sshCommand(tc.sess, "2222")
+			for _, w := range tc.want {
+				assert.Assert(t, strings.Contains(got, w), "want %q in %q", w, got)
+			}
+			for _, w := range tc.notWant {
+				assert.Assert(t, !strings.Contains(got, w), "want %q absent from %q", w, got)
+			}
+		})
+	}
+}
+
+// TestSSHCommandSetsIdentitiesOnlyAtMostOnce guards the exact bug this file's
+// helper was extracted for. OpenSSH honours the first occurrence of an option
+// and silently ignores the rest, so the original unconditional
+// IdentitiesOnly=yes plus a later IdentitiesOnly=no was not a fix.
+func TestSSHCommandSetsIdentitiesOnlyAtMostOnce(t *testing.T) {
+	for _, sess := range []*Session{
+		{UseAgent: true, AuthSock: "/tmp/agent.sock"},
+		{IdentityFile: "/home/dev/.ssh/chunk_ai"},
+		{IdentityFile: "/home/dev/.ssh/chunk_ai", UseAgent: true, AuthSock: "/tmp/agent.sock"},
+		{},
+	} {
+		cmd := sshCommand(sess, "2222")
+		assert.Assert(t, strings.Count(cmd, "-o IdentitiesOnly=") <= 1,
+			"IdentitiesOnly set more than once, later values are ignored: %q", cmd)
+	}
+}


### PR DESCRIPTION
## Summary

- Set `-o IdentitiesOnly=yes` only when passing an explicit `-i` identity file
- Set `-o IdentitiesOnly=no` explicitly for ssh-agent sessions, and pin the agent with `-o IdentityAgent=<sess.AuthSock>`
- Pin `ProxyCommand`, `ProxyJump`, `ControlPath` and `RequestTTY` so a user `~/.ssh/config` cannot hijack the `127.0.0.1` hop, rather than discarding the whole config with `-F /dev/null`
- Drop `-q` so ssh diagnostics reach the rsync error, and filter ssh's expected `Warning: Permanently added ...` line out of that error detail

## Why

`chunk sidecar sync` failed with `connection unexpectedly closed (0 bytes received)` when the sidecar session authenticated through ssh-agent, while `exec` on the same sidecar worked.

The `rsync -e ssh` command always passed `-o IdentitiesOnly=yes`, then appended `-o IdentitiesOnly=no` for agent sessions. OpenSSH honours the first occurrence of an option, so the second had no effect:

```
$ ssh -o IdentitiesOnly=yes -o IdentitiesOnly=no -G example.com | grep identitiesonly
identitiesonly yes
```

`OpenSession` registers the agent key with the sidecar, then ssh could not offer that key, exited 255, and `-q` hid the reason. rsync only saw an empty stream.

## Why not `-F /dev/null`

An earlier revision of this PR isolated the hop by discarding the user's config entirely. That also discards `/etc/ssh/ssh_config` and macOS `UseKeychain`, so a passphrase-protected `--identity-file` key has no way to obtain its passphrase and **blocks indefinitely on a prompt inside the rsync child** — a hang with no output. (`-F <unopenable path>` is also fatal in ssh, unlike `UserKnownHostsFile`, which matters for the Windows build target.)

It is also mostly unnecessary. Command-line options are parsed first, so a user config can never override `-p` or any `-o` set here; only options left unset can leak in:

```
Host * in user config          resolved
-----------------------------  ---------------------------
Port 9999                      port 2299            (our -p wins)
StrictHostKeyChecking yes      stricthostkeychecking false
UserKnownHostsFile ~/...       userknownhostsfile /dev/null
ProxyCommand /bin/false        proxycommand /bin/false   <- leaks
IdentityAgent /tmp/evil.sock   identityagent /tmp/evil.sock  <- leaks
IdentitiesOnly yes             identitiesonly yes            <- leaks
```

Pinning those three is enough, and keeps the rest of the user's config working. Note the third one is why the agent path now sets `IdentitiesOnly=no` explicitly rather than leaving it unset: a user config with `IdentitiesOnly yes` would otherwise suppress the agent key and reproduce this very bug.

Pinning `IdentityAgent` to `sess.AuthSock` is also what keeps the rsync child on the same agent `ExecOverSSH` dials (`ssh.go:279`); previously the child resolved `SSH_AUTH_SOCK` from the ambient environment, which diverges whenever a caller sets `variants.Options.AuthSock` to a non-ambient socket.

## Test plan

- [x] `go test -race ./...` (35 packages) and `task lint` (0 issues)
- [x] Unit: every pinned option asserted per session type; `IdentitiesOnly` set at most once; `-i` absent on the agent path (tokenised, so a trailing `-i` is caught); `rsyncErrDetail` filtering
- [x] Integration against a local `sshd` with only the agent key authorized, driving the strings the code actually generates, with a hostile `ssh_config` setting `IdentitiesOnly yes`, `ProxyCommand /bin/false`, a bogus `IdentityAgent`, `ControlMaster auto` and `RequestTTY yes`:
  - agent path → `exit=0`, file synced
  - identity-file path → `exit=0`, file synced
  - previous arguments under the same config → `Permission denied (publickey)`
- [x] Confirmed OpenSSH prefers agent keys, so omitting `-i` on the agent path does not flood the server with default `~/.ssh/id_*` offers: with five file identities configured, ssh made exactly one offer (the agent key)
- [ ] Manual: `chunk sidecar sync` on macOS with `SSH_AUTH_SOCK` set and no `--identity-file`
- [ ] Manual: `chunk sidecar sync --identity-file ~/.ssh/chunk_ai` with a passphrase-protected key in the macOS Keychain

Fixes #559
