### PR TITLE
Fix Renovate config: replace uv manager with pep621

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,10 +10,10 @@
   "vulnerabilityAlerts": {
     "enabled": true
   },
-  "enabledManagers": ["gomod", "uv"],
+  "enabledManagers": ["gomod", "pep621"],
   "packageRules": [
     {
-      "matchManagers": ["uv"],
+      "matchManagers": ["pep621"],
       "matchFileNames": ["harness/**"],
       "groupName": "harness python deps"
     }


### PR DESCRIPTION
## Summary

- The `"uv"` manager name in `enabledManagers` is not supported by the version of Renovate running on the Mend-hosted GitHub App, causing a config validation error that blocks all Renovate PRs
- Replaces `"uv"` with `"pep621"` in both `enabledManagers` and `matchManagers` — this is the supported manager name for `pyproject.toml` on the current Mend-hosted Renovate version
- Fixes issue #556 (Action Required: Fix Renovate Configuration)

## Test plan

- [ ] Merge and confirm issue #556 is closed by Renovate
- [ ] Confirm Renovate resumes opening PRs (including the grouped harness python deps PR)
- [ ] When Mend updates their hosted app to a version that supports `"uv"`, swap back to get `uv.lock` regeneration support

🤖 Generated with [Claude Code](https://claude.com/claude-code)