### PR TITLE
Record sidecar command ID in the event log

### DIFF
--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -472,7 +472,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return failBeforeRun(rec, start, err)
 	}
 
-	result, execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, opts.workdir, allRemote, envVars, cfg, rec.Status, streams)
+	result, execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, opts.workdir, allRemote, envVars, cfg, rec.Status, rec, streams)
 	if execErr == nil && resultCache != nil {
 		if err := resultCache.Put(cacheKey, validate.CachedResult{CachedAt: time.Now()}); err != nil {
 			streams.ErrPrintf("  %s\n", ui.ErrDim(fmt.Sprintf("chunk validate: cache write failed: %v", err)))
@@ -625,7 +625,7 @@ func runValidateDryRun(name, inlineCmd string, cfg *config.ProjectConfig, status
 // provided options. It is shared by both direct and hook invocations.
 // allRemote is true when --remote is passed explicitly (all commands run on the
 // sidecar); false means only commands with Remote:true are routed to the sidecar.
-func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) (validate.Result, error) {
+func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, rec *eventlog.Recorder, streams iostream.Streams) (validate.Result, error) {
 	// --cmd: inline command (always local in per-command mode)
 	if inlineCmd != "" {
 		cmdName := name
@@ -639,7 +639,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 			streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", cmdName)))
 		}
 		if sidecarID != "" && allRemote {
-			execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, streams)
+			execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, rec, streams)
 			if err != nil {
 				return validate.Result{}, err
 			}
@@ -650,7 +650,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 
 	// All-remote execution (--remote flag): send everything to the sidecar.
 	if sidecarID != "" && allRemote {
-		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, streams)
+		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, rec, streams)
 		if err != nil {
 			return validate.Result{}, err
 		}
@@ -662,8 +662,8 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 	if sidecarID != "" {
 		if name != "" {
 			if cmd := cfg.FindCommand(name); cmd != nil && cmd.Remote {
-				statusFn(iostream.LevelInfo, fmt.Sprintf("running %s on sidecar %s", name, sidecarID))
-				execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, streams)
+				rec.Status(iostream.LevelInfo, fmt.Sprintf("running %s on sidecar %s", name, sidecarID))
+				execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, rec, streams)
 				if err != nil {
 					return validate.Result{}, err
 				}
@@ -672,7 +672,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 			statusFn(iostream.LevelInfo, fmt.Sprintf("running %s locally (not marked remote)", name))
 			// Named command is not marked remote; fall through to local execution.
 		} else {
-			return runSplitCommands(ctx, client, sidecarID, workdir, workDir, envVars, rc, cfg, statusFn, streams)
+			return runSplitCommands(ctx, client, sidecarID, workdir, workDir, envVars, rc, cfg, statusFn, rec, streams)
 		}
 	}
 
@@ -821,7 +821,7 @@ func reapAbandonedSidecars(ctx context.Context, client *circleci.Client, workDir
 // it was not already streamed, so there is nothing left for them to do.
 func newExecFn(
 	ctx context.Context, client *circleci.Client, sidecarID, workdir string,
-	envVars map[string]string, rc config.ResolvedConfig, streams iostream.Streams,
+	envVars map[string]string, rc config.ResolvedConfig, rec *eventlog.Recorder, streams iostream.Streams,
 ) (func(context.Context, string) (string, string, int, error), string, error) {
 	cwd, _ := os.Getwd()
 	_, repo, _ := gitremote.DetectOrgAndRepo(cwd)
@@ -848,8 +848,12 @@ func newExecFn(
 	execFn := func(ctx context.Context, script string) (string, string, int, error) {
 		result, err := client.Exec(ctx, sidecarID, "sh", []string{"-c", script}, merged, onOutput)
 		if err != nil {
+			// result is nil on all error paths; clear any stale pending ID so it
+			// is not attributed to a different command's event later.
+			rec.SetCommandID("")
 			return "", "", 0, err
 		}
+		rec.SetCommandID(result.CommandID)
 		return "", "", result.ExitCode, nil
 	}
 	return execFn, dest, nil
@@ -877,7 +881,7 @@ func hostForwardEnv(token string) map[string]string {
 // question they were written to answer, so running them here reports a pass the
 // sidecar never gave — the same false green as a failed creation, arrived at one
 // step later.
-func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, streams iostream.Streams) (validate.Result, error) {
+func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, rec *eventlog.Recorder, streams iostream.Streams) (validate.Result, error) {
 	remoteCfg, localCfg := splitByRemote(cfg)
 	if len(remoteCfg.Commands) > 0 {
 		statusFn(iostream.LevelInfo, fmt.Sprintf("running on sidecar %s: %s", sidecarID, commandNames(remoteCfg.Commands)))
@@ -888,11 +892,13 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 	var combined validate.Result
 	var runErr error
 	if len(remoteCfg.Commands) > 0 {
-		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, streams)
+		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, rec, streams)
 		if err != nil {
 			return validate.Result{}, unreachableSidecar(sidecarID, commandNames(remoteCfg.Commands), err)
 		}
-		if wsErr := validate.WorkspaceExists(ctx, execFn, dest); wsErr != nil {
+		wsErr := validate.WorkspaceExists(ctx, execFn, dest)
+		rec.SetCommandID("") // workspace probe's ID should not stamp a real command's event
+		if wsErr != nil {
 			return validate.Result{}, missingWorkspace(sidecarID, dest, commandNames(remoteCfg.Commands), wsErr)
 		}
 		r, err := validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, statusFn, streams)

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -472,7 +472,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return failBeforeRun(rec, start, err)
 	}
 
-	result, execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, opts.workdir, allRemote, envVars, cfg, rec.Status, rec, streams)
+	result, execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, opts.workdir, allRemote, envVars, cfg, rec, streams)
 	if execErr == nil && resultCache != nil {
 		if err := resultCache.Put(cacheKey, validate.CachedResult{CachedAt: time.Now()}); err != nil {
 			streams.ErrPrintf("  %s\n", ui.ErrDim(fmt.Sprintf("chunk validate: cache write failed: %v", err)))
@@ -625,7 +625,7 @@ func runValidateDryRun(name, inlineCmd string, cfg *config.ProjectConfig, status
 // provided options. It is shared by both direct and hook invocations.
 // allRemote is true when --remote is passed explicitly (all commands run on the
 // sidecar); false means only commands with Remote:true are routed to the sidecar.
-func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, rec *eventlog.Recorder, streams iostream.Streams) (validate.Result, error) {
+func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, rec *eventlog.Recorder, streams iostream.Streams) (validate.Result, error) {
 	// --cmd: inline command (always local in per-command mode)
 	if inlineCmd != "" {
 		cmdName := name
@@ -643,9 +643,9 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 			if err != nil {
 				return validate.Result{}, err
 			}
-			return validate.RunRemoteInline(ctx, execFn, cmdName, inlineCmd, dest, statusFn, streams)
+			return validate.RunRemoteInline(ctx, execFn, cmdName, inlineCmd, dest, rec.Status, streams)
 		}
-		return validate.RunInline(ctx, workDir, cmdName, inlineCmd, envVars, statusFn, streams)
+		return validate.RunInline(ctx, workDir, cmdName, inlineCmd, envVars, rec.Status, streams)
 	}
 
 	// All-remote execution (--remote flag): send everything to the sidecar.
@@ -654,7 +654,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 		if err != nil {
 			return validate.Result{}, err
 		}
-		return validate.RunRemote(ctx, execFn, cfg, name, dest, workDir, statusFn, streams)
+		return validate.RunRemote(ctx, execFn, cfg, name, dest, workDir, rec.Status, streams)
 	}
 
 	// Per-command remote routing: commands with Remote:true go to the sidecar,
@@ -667,12 +667,12 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 				if err != nil {
 					return validate.Result{}, err
 				}
-				return validate.RunRemote(ctx, execFn, cfg, name, dest, workDir, statusFn, streams)
+				return validate.RunRemote(ctx, execFn, cfg, name, dest, workDir, rec.Status, streams)
 			}
-			statusFn(iostream.LevelInfo, fmt.Sprintf("running %s locally (not marked remote)", name))
+			rec.Status(iostream.LevelInfo, fmt.Sprintf("running %s locally (not marked remote)", name))
 			// Named command is not marked remote; fall through to local execution.
 		} else {
-			return runSplitCommands(ctx, client, sidecarID, workdir, workDir, envVars, rc, cfg, statusFn, rec, streams)
+			return runSplitCommands(ctx, client, sidecarID, workdir, workDir, envVars, rc, cfg, rec, streams)
 		}
 	}
 
@@ -708,11 +708,11 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 				return validate.Result{}, err
 			}
 		}
-		return mapValidateError(validate.RunNamed(ctx, workDir, name, cfg, envVars, statusFn, streams))
+		return mapValidateError(validate.RunNamed(ctx, workDir, name, cfg, envVars, rec.Status, streams))
 	}
 
 	// Run all
-	return mapValidateError(validate.RunAll(ctx, workDir, cfg, envVars, statusFn, streams))
+	return mapValidateError(validate.RunAll(ctx, workDir, cfg, envVars, rec.Status, streams))
 }
 
 // setupRemote resolves (or creates) the sidecar ID based on the validate flags
@@ -881,13 +881,13 @@ func hostForwardEnv(token string) map[string]string {
 // question they were written to answer, so running them here reports a pass the
 // sidecar never gave — the same false green as a failed creation, arrived at one
 // step later.
-func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, statusFn iostream.StatusFunc, rec *eventlog.Recorder, streams iostream.Streams) (validate.Result, error) {
+func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, rec *eventlog.Recorder, streams iostream.Streams) (validate.Result, error) {
 	remoteCfg, localCfg := splitByRemote(cfg)
 	if len(remoteCfg.Commands) > 0 {
-		statusFn(iostream.LevelInfo, fmt.Sprintf("running on sidecar %s: %s", sidecarID, commandNames(remoteCfg.Commands)))
+		rec.Status(iostream.LevelInfo, fmt.Sprintf("running on sidecar %s: %s", sidecarID, commandNames(remoteCfg.Commands)))
 	}
 	if len(localCfg.Commands) > 0 {
-		statusFn(iostream.LevelInfo, fmt.Sprintf("running locally: %s", commandNames(localCfg.Commands)))
+		rec.Status(iostream.LevelInfo, fmt.Sprintf("running locally: %s", commandNames(localCfg.Commands)))
 	}
 	var combined validate.Result
 	var runErr error
@@ -901,13 +901,13 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 		if wsErr != nil {
 			return validate.Result{}, missingWorkspace(sidecarID, dest, commandNames(remoteCfg.Commands), wsErr)
 		}
-		r, err := validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, statusFn, streams)
+		r, err := validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, rec.Status, streams)
 		combined.Passed += r.Passed
 		combined.Total += r.Total
 		runErr = err
 	}
 	if len(localCfg.Commands) > 0 {
-		r, err := mapValidateError(validate.RunAll(ctx, workDir, localCfg, envVars, statusFn, streams))
+		r, err := mapValidateError(validate.RunAll(ctx, workDir, localCfg, envVars, rec.Status, streams))
 		combined.Passed += r.Passed
 		combined.Total += r.Total
 		if err != nil {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -639,7 +639,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 			streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", cmdName)))
 		}
 		if sidecarID != "" && allRemote {
-			execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, rec, streams)
+			execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, rec.SetCommandID, streams)
 			if err != nil {
 				return validate.Result{}, err
 			}
@@ -650,7 +650,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 
 	// All-remote execution (--remote flag): send everything to the sidecar.
 	if sidecarID != "" && allRemote {
-		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, rec, streams)
+		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, rec.SetCommandID, streams)
 		if err != nil {
 			return validate.Result{}, err
 		}
@@ -663,7 +663,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 		if name != "" {
 			if cmd := cfg.FindCommand(name); cmd != nil && cmd.Remote {
 				rec.Status(iostream.LevelInfo, fmt.Sprintf("running %s on sidecar %s", name, sidecarID))
-				execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, rec, streams)
+				execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, rec.SetCommandID, streams)
 				if err != nil {
 					return validate.Result{}, err
 				}
@@ -819,9 +819,13 @@ func reapAbandonedSidecars(ctx context.Context, client *circleci.Client, workDir
 // command shows progress instead of going silent for minutes. The returned
 // stdout and stderr are therefore always empty — callers print output only when
 // it was not already streamed, so there is nothing left for them to do.
+//
+// Pass rec.SetCommandID for setCommandID when each exec's command ID should be
+// recorded on the event log. Pass nil for probe-only use (e.g. WorkspaceExists)
+// where the exec result should not touch the recorder.
 func newExecFn(
 	ctx context.Context, client *circleci.Client, sidecarID, workdir string,
-	envVars map[string]string, rc config.ResolvedConfig, rec *eventlog.Recorder, streams iostream.Streams,
+	envVars map[string]string, rc config.ResolvedConfig, setCommandID func(string), streams iostream.Streams,
 ) (func(context.Context, string) (string, string, int, error), string, error) {
 	cwd, _ := os.Getwd()
 	_, repo, _ := gitremote.DetectOrgAndRepo(cwd)
@@ -848,12 +852,15 @@ func newExecFn(
 	execFn := func(ctx context.Context, script string) (string, string, int, error) {
 		result, err := client.Exec(ctx, sidecarID, "sh", []string{"-c", script}, merged, onOutput)
 		if err != nil {
-			// result is nil on all error paths; clear any stale pending ID so it
-			// is not attributed to a different command's event later.
-			rec.SetCommandID("")
+			if setCommandID != nil {
+				// result is nil on all error paths; clear any stale pending ID.
+				setCommandID("")
+			}
 			return "", "", 0, err
 		}
-		rec.SetCommandID(result.CommandID)
+		if setCommandID != nil {
+			setCommandID(result.CommandID)
+		}
 		return "", "", result.ExitCode, nil
 	}
 	return execFn, dest, nil
@@ -892,14 +899,18 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 	var combined validate.Result
 	var runErr error
 	if len(remoteCfg.Commands) > 0 {
-		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, rec, streams)
+		// Probe with a plain exec fn so the workspace check never touches the
+		// recorder — there is no real command to attribute the probe's ID to.
+		probeExecFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, nil, streams)
 		if err != nil {
 			return validate.Result{}, unreachableSidecar(sidecarID, commandNames(remoteCfg.Commands), err)
 		}
-		wsErr := validate.WorkspaceExists(ctx, execFn, dest)
-		rec.SetCommandID("") // workspace probe's ID should not stamp a real command's event
-		if wsErr != nil {
+		if wsErr := validate.WorkspaceExists(ctx, probeExecFn, dest); wsErr != nil {
 			return validate.Result{}, missingWorkspace(sidecarID, dest, commandNames(remoteCfg.Commands), wsErr)
+		}
+		execFn, _, err := newExecFn(ctx, client, sidecarID, workdir, envVars, rc, rec.SetCommandID, streams)
+		if err != nil {
+			return validate.Result{}, unreachableSidecar(sidecarID, commandNames(remoteCfg.Commands), err)
 		}
 		r, err := validate.RunRemote(ctx, execFn, remoteCfg, "", dest, workDir, rec.Status, streams)
 		combined.Passed += r.Passed

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -154,7 +154,7 @@ func TestOpenAPIExecPassesEnvVars(t *testing.T) {
 
 	envVars := map[string]string{"FOO": "bar", "BAZ": "qux"}
 	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	execFn, _, err := newExecFn(context.Background(), client, "sidecar-123", "", envVars, config.ResolvedConfig{}, streams)
+	execFn, _, err := newExecFn(context.Background(), client, "sidecar-123", "", envVars, config.ResolvedConfig{}, &eventlog.Recorder{}, streams)
 	assert.NilError(t, err)
 
 	_, _, _, err = execFn(context.Background(), "echo hello")

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -154,7 +154,7 @@ func TestOpenAPIExecPassesEnvVars(t *testing.T) {
 
 	envVars := map[string]string{"FOO": "bar", "BAZ": "qux"}
 	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	execFn, _, err := newExecFn(context.Background(), client, "sidecar-123", "", envVars, config.ResolvedConfig{}, &eventlog.Recorder{}, streams)
+	execFn, _, err := newExecFn(context.Background(), client, "sidecar-123", "", envVars, config.ResolvedConfig{}, nil, streams)
 	assert.NilError(t, err)
 
 	_, _, _, err = execFn(context.Background(), "echo hello")

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -44,6 +44,11 @@ type Event struct {
 	Final  bool `json:"final,omitempty"`
 	Passed int  `json:"passed,omitempty"`
 	Total  int  `json:"total,omitempty"`
+
+	// CommandID is the sandbox-provisioner ID of the remote exec that produced
+	// this event, set on pass/fail events for commands that ran on the sidecar.
+	// Use GET /api/v3/sidecar/commands/{id}/output to replay the run's output.
+	CommandID string `json:"command_id,omitempty"`
 }
 
 // Outcome reports whether e is the event that closes an operation, and the
@@ -155,9 +160,10 @@ func (l *Log) Append(e Event) error {
 // every event with the operation it belongs to. Status records an ordinary
 // event; Final records the one that closes the operation.
 type Recorder struct {
-	log   *Log
-	inner iostream.StatusFunc
-	tag   Event
+	log              *Log
+	inner            iostream.StatusFunc
+	tag              Event
+	pendingCommandID string
 }
 
 // Recorder returns a Recorder that reports through inner and appends each call
@@ -186,6 +192,14 @@ func Record(dataDir string, fn iostream.StatusFunc, op Op, sidecarID, sidecarNam
 	return el.Recorder(fn, op, sidecarID, sidecarName, branch)
 }
 
+// SetCommandID records the sandbox-provisioner command ID of the exec that just
+// finished. The next pass/fail event for that command will carry this ID.
+// Pass "" when an exec failed without reporting an ID so a stale one from a
+// prior exec is not attributed to it.
+func (r *Recorder) SetCommandID(id string) {
+	r.pendingCommandID = id
+}
+
 // Status reports an ordinary event, one that leaves the operation open.
 func (r *Recorder) Status(level iostream.Level, msg string) {
 	r.record(level, msg, false, 0, 0)
@@ -210,6 +224,12 @@ func (r *Recorder) record(level iostream.Level, msg string, final bool, passed, 
 	e.Level = levelStr(level)
 	e.Msg = msg
 	e.Final, e.Passed, e.Total = final, passed, total
+	// Attach the pending command ID to the per-command pass/fail event. Final
+	// events are run-wide summaries that belong to no single command.
+	if !final && (level == iostream.LevelDone || level == iostream.LevelError) {
+		e.CommandID = r.pendingCommandID
+		r.pendingCommandID = ""
+	}
 	_ = r.log.Append(e)
 }
 

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -163,6 +163,7 @@ type Recorder struct {
 	log              *Log
 	inner            iostream.StatusFunc
 	tag              Event
+	mu               sync.Mutex
 	pendingCommandID string
 }
 
@@ -197,6 +198,8 @@ func Record(dataDir string, fn iostream.StatusFunc, op Op, sidecarID, sidecarNam
 // Pass "" when an exec failed without reporting an ID so a stale one from a
 // prior exec is not attributed to it.
 func (r *Recorder) SetCommandID(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.pendingCommandID = id
 }
 
@@ -227,8 +230,10 @@ func (r *Recorder) record(level iostream.Level, msg string, final bool, passed, 
 	// Attach the pending command ID to the per-command pass/fail event. Final
 	// events are run-wide summaries that belong to no single command.
 	if !final && (level == iostream.LevelDone || level == iostream.LevelError) {
+		r.mu.Lock()
 		e.CommandID = r.pendingCommandID
 		r.pendingCommandID = ""
+		r.mu.Unlock()
 	}
 	_ = r.log.Append(e)
 }

--- a/internal/eventlog/eventlog_test.go
+++ b/internal/eventlog/eventlog_test.go
@@ -193,6 +193,82 @@ func TestRecorderNilInner(t *testing.T) {
 	rec.Status(iostream.LevelInfo, "should not panic")
 }
 
+func TestSetCommandIDStampsTerminalEvent(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := l.Recorder(nil, OpValidate, "sc-id", "my-sc", "main")
+
+	rec.Status(iostream.LevelInfo, "$ go test ./...")
+	rec.SetCommandID("cmd-abc123")
+	rec.Status(iostream.LevelError, "test  12s (remote)") // per-command fail event
+	rec.Status(iostream.LevelError, "0/1 passed  12s")    // run-wide summary, no command
+
+	got, err := l.Recent(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 events, got %d", len(got))
+	}
+	if got[0].CommandID != "" {
+		t.Errorf("info event CommandID = %q, want empty", got[0].CommandID)
+	}
+	if got[1].CommandID != "cmd-abc123" {
+		t.Errorf("terminal event CommandID = %q, want %q", got[1].CommandID, "cmd-abc123")
+	}
+	if got[2].CommandID != "" {
+		t.Errorf("summary event CommandID = %q, want empty (ID already consumed)", got[2].CommandID)
+	}
+}
+
+func TestSetCommandIDConsumedOnce(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := l.Recorder(nil, OpValidate, "sc-id", "my-sc", "main")
+	rec.SetCommandID("cmd-1")
+	rec.Status(iostream.LevelDone, "test  3s (remote)")
+	rec.Status(iostream.LevelDone, "lint  1s (remote)") // second command: no ID set yet
+
+	got, err := l.Recent(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].CommandID != "cmd-1" {
+		t.Errorf("first event CommandID = %q, want %q", got[0].CommandID, "cmd-1")
+	}
+	if got[1].CommandID != "" {
+		t.Errorf("second event CommandID = %q, want empty", got[1].CommandID)
+	}
+}
+
+func TestSetCommandIDNotOnFinalEvent(t *testing.T) {
+	dir := t.TempDir()
+	l, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := l.Recorder(nil, OpValidate, "sc-id", "my-sc", "main")
+	rec.SetCommandID("cmd-abc")
+	rec.Final(iostream.LevelDone, "1/1 passed  3s", 1, 1)
+
+	got, err := l.Recent(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].CommandID != "" {
+		t.Errorf("Final event CommandID = %q, want empty", got[0].CommandID)
+	}
+}
+
 func TestLevelStr(t *testing.T) {
 	tests := []struct {
 		in   iostream.Level


### PR DESCRIPTION
## Summary

- Adds `command_id` to `Event` — populated on the per-command pass/fail event for commands that ran on a sidecar, linking to the command's output via `GET /api/v3/sidecar/commands/{id}/output`
- Adds `Recorder.SetCommandID(id)` — called by `newExecFn` after each remote exec; `record()` attaches the pending ID to the next `LevelDone`/`LevelError` Status call and clears it, so each exec stamps exactly its own terminal event and never a run-wide summary
- Threads `*eventlog.Recorder` through `newExecFn`, `runValidate`, and `runSplitCommands`; clears the workspace probe's ID after `WorkspaceExists` so it cannot leak onto a real command's event
- Removes the redundant `statusFn` parameter from `runValidate` and `runSplitCommands` — both already receive `*eventlog.Recorder`, which exposes `Status` directly

## Test plan

- [ ] New eventlog tests: ID stamps the right event, ID consumed once, ID not placed on `Final`
- [ ] Full test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)