### PR TITLE
Add sidecar pool primitives

### DIFF
--- a/acceptance/sidecar_snapshot_test.go
+++ b/acceptance/sidecar_snapshot_test.go
@@ -63,7 +63,7 @@ func TestSidecarSnapshotCreateUsesActiveSidecar(t *testing.T) {
 	env.CircleCIURL = srv.URL
 	workDir := t.TempDir()
 
-	// create sidecar → sets active sidecar to "sidecar-new-123"
+	// create sidecar → sets active sidecar to "sidecar-new-1"
 	result := binary.RunCLI(t, []string{
 		"sidecar", "create",
 		"--org-id", "org-aaa",
@@ -85,7 +85,7 @@ func TestSidecarSnapshotCreateUsesActiveSidecar(t *testing.T) {
 	var body map[string]interface{}
 	err := json.Unmarshal(snapReqs[0].Body, &body)
 	assert.NilError(t, err)
-	assert.Equal(t, body["data"].(map[string]any)["references"].(map[string]any)["sidecar_instance"].(map[string]any)["id"], "sidecar-new-123",
+	assert.Equal(t, body["data"].(map[string]any)["references"].(map[string]any)["sidecar_instance"].(map[string]any)["id"], "sidecar-new-1",
 		"expected active sidecar ID in request body")
 
 	// After a successful snapshot, the source sidecar should have been deleted

--- a/acceptance/sidecar_test.go
+++ b/acceptance/sidecar_test.go
@@ -127,7 +127,7 @@ func TestSidecarsCreateHappyPath(t *testing.T) {
 	}, env, env.HomeDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Assert(t, strings.Contains(result.Stderr, "sidecar-new-123"),
+	assert.Assert(t, strings.Contains(result.Stderr, "sidecar-new-1"),
 		"expected sidecar ID in stderr, got: %s", result.Stderr)
 	assert.Assert(t, strings.Contains(result.Stderr, "my-new-sidecar"),
 		"expected sidecar name in stderr, got: %s", result.Stderr)
@@ -535,14 +535,14 @@ func TestSidecarsCreateSetsActiveSidecar(t *testing.T) {
 	}, env, workDir)
 
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
-	assert.Assert(t, strings.Contains(result.Stderr, "Set sidecar-new-123 as active sidecar"),
+	assert.Assert(t, strings.Contains(result.Stderr, "Set sidecar-new-1 as active sidecar"),
 		"expected active sidecar message, got: %s", result.Stderr)
 
 	// current should show the sidecar set by create
 	result = binary.RunCLI(t, []string{"sidecar", "current"}, env, workDir)
 	assert.Equal(t, result.ExitCode, 0, "stderr: %s", result.Stderr)
 	combined := result.Stdout + result.Stderr
-	assert.Assert(t, strings.Contains(combined, "sidecar-new-123"),
+	assert.Assert(t, strings.Contains(combined, "sidecar-new-1"),
 		"expected sidecar ID from current, got: %s", combined)
 }
 

--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -535,7 +535,7 @@ func TestValidateHookAutoCreatesSidecarFromSidecarImage(t *testing.T) {
 	assert.Equal(t, org["id"], "org-aaa", "expected org from CIRCLECI_ORG_ID")
 
 	// AddSSHKey must be called on the newly created sidecar — proves it was used.
-	addKeyReqs := filterByPath(reqs, "/api/v3/sidecar/instances/sidecar-new-123/ssh/add-key")
+	addKeyReqs := filterByPath(reqs, "/api/v3/sidecar/instances/sidecar-new-1/ssh/add-key")
 	assert.Equal(t, len(addKeyReqs), 1, "expected 1 add-key request for newly created sidecar; got: %v", reqs)
 }
 

--- a/internal/circleci/circleci_test.go
+++ b/internal/circleci/circleci_test.go
@@ -119,8 +119,8 @@ func TestCreateSidecar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if sb.ID != "sidecar-new-123" {
-		t.Errorf("expected ID sidecar-new-123, got %s", sb.ID)
+	if sb.ID != "sidecar-new-1" {
+		t.Errorf("expected ID sidecar-new-1, got %s", sb.ID)
 	}
 	if sb.Name != "my-sidecar" {
 		t.Errorf("expected name my-sidecar, got %s", sb.Name)

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -1251,7 +1251,7 @@ func sidecarSetupRunSetup(ctx context.Context, opts sidecarRunSetupOpts) error {
 			continue
 		}
 		opts.status(iostream.LevelStep, fmt.Sprintf("Running setup step %q: %s", step.Name, step.Command))
-		session, err := sidecar.OpenSession(ctx, opts.client, opts.sidecarID, opts.identityFile, opts.authSock)
+		session, err := sidecar.OpenSession(ctx, opts.client, opts.sidecarID, opts.identityFile, opts.authSock, false)
 		if err != nil {
 			if sessErr := sshSessionError(err); sessErr != nil {
 				return sessErr

--- a/internal/sidecar/pool.go
+++ b/internal/sidecar/pool.go
@@ -1,0 +1,406 @@
+package sidecar
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+)
+
+// PoolEntry is a single ready-to-use sidecar checked out from a Pool.
+type PoolEntry struct {
+	ID       string
+	RepoPath string
+	Client   *circleci.Client
+}
+
+// Pool manages a fixed set of sidecars as a work queue for parallel tasks.
+type Pool struct {
+	free         chan *PoolEntry
+	updates      chan struct{}
+	ids          []string
+	entries      []*PoolEntry
+	client       *circleci.Client
+	workDir      string
+	orgID        string
+	image        string
+	name         string
+	identityFile string
+	authSock     string
+
+	mu           sync.Mutex
+	pendingSyncs int
+	checkedOut   int
+	syncErr      error
+}
+
+type poolState struct {
+	SidecarIDs    []string `json:"sidecar_ids"`
+	RepoPath      string   `json:"repo_path"`
+	LastSyncedRef string   `json:"last_synced_ref,omitempty"`
+}
+
+func poolStatePath(workDir, name string) string {
+	return filepath.Join(workDir, ".chunk", name+"-pool.json")
+}
+
+func loadPoolState(workDir, name string) (*poolState, error) {
+	data, err := os.ReadFile(poolStatePath(workDir, name))
+	if err != nil {
+		return nil, err
+	}
+	var state poolState
+	return &state, json.Unmarshal(data, &state)
+}
+
+func savePoolState(workDir, name string, state *poolState) error {
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal pool state: %w", err)
+	}
+	path := poolStatePath(workDir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create pool state directory: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write pool state: %w", err)
+	}
+	return nil
+}
+
+func clearPoolState(workDir, name string) {
+	_ = os.Remove(poolStatePath(workDir, name))
+}
+
+func NewPool(
+	ctx context.Context,
+	client *circleci.Client,
+	n int,
+	name, orgID, image, identityFile, authSock, workDir string,
+	status iostream.StatusFunc,
+) (*Pool, error) {
+	_, repo, err := gitremote.DetectOrgAndRepo(workDir)
+	if err != nil {
+		return nil, fmt.Errorf("pool: detect repo: %w", err)
+	}
+	repoPath := DefaultWorkspace(repo)
+
+	var existingIDs []string
+	var lastSyncedRef string
+	if state, err := loadPoolState(workDir, name); err == nil && len(state.SidecarIDs) > 0 {
+		reuse := state.SidecarIDs
+		if len(reuse) > n {
+			reuse = reuse[:n]
+		}
+		existingIDs = reuse
+		lastSyncedRef = state.LastSyncedRef
+	}
+
+	return assemblePool(ctx, client, n, name, orgID, image, identityFile, authSock, repoPath, workDir, existingIDs, lastSyncedRef, status)
+}
+
+func assemblePool(
+	ctx context.Context,
+	client *circleci.Client,
+	n int,
+	name, orgID, image, identityFile, authSock, repoPath, workDir string,
+	existingIDs []string,
+	lastSyncedRef string,
+	status iostream.StatusFunc,
+) (*Pool, error) {
+	aliveExisting := existingIDs[:0:0]
+	if len(existingIDs) > 0 {
+		staleFlags := make([]bool, len(existingIDs))
+		var swg sync.WaitGroup
+		for i, id := range existingIDs {
+			swg.Add(1)
+			go func(i int, id string) {
+				defer swg.Done()
+				staleFlags[i] = IsDefinitelyStale(ctx, client, id, identityFile, authSock)
+			}(i, id)
+		}
+		swg.Wait()
+
+		var staleIDs []string
+		for i, id := range existingIDs {
+			if staleFlags[i] {
+				staleIDs = append(staleIDs, id)
+				continue
+			}
+			aliveExisting = append(aliveExisting, id)
+		}
+
+		cleanCtx := context.Background()
+		if len(staleIDs) > 0 {
+			var delWg sync.WaitGroup
+			for _, id := range staleIDs {
+				delWg.Add(1)
+				go func(id string) {
+					defer delWg.Done()
+					status(iostream.LevelInfo, fmt.Sprintf("sidecar %s is stale, creating replacement...", id))
+					_ = client.DeleteSidecar(cleanCtx, id)
+				}(id)
+			}
+			delWg.Wait()
+		}
+	}
+
+	goodNew := make([]string, 0, n-len(aliveExisting))
+	newCount := n - len(aliveExisting)
+	if newCount > 0 {
+		seedIdx := len(aliveExisting)
+		seed, err := Create(ctx, client, orgID, fmt.Sprintf("%s-%d", name, seedIdx), image)
+		if err != nil {
+			return nil, fmt.Errorf("create sidecar %d: %w", seedIdx, err)
+		}
+		status(iostream.LevelInfo, fmt.Sprintf("created sidecar %d (%s)", seedIdx, seed.ID))
+
+		headRef, err := bundleSyncFanOutSince(ctx, client, []string{seed.ID}, identityFile, authSock, repoPath, workDir, "", true, status)
+		if err != nil {
+			cleanCtx := context.Background()
+			_ = client.DeleteSidecar(cleanCtx, seed.ID)
+			return nil, fmt.Errorf("pool seed sync: %w", err)
+		}
+		lastSyncedRef = headRef
+
+		if newCount == 1 {
+			goodNew = append(goodNew, seed.ID)
+		} else {
+			snap, err := client.CreateSnapshot(ctx, seed.ID, fmt.Sprintf("%s-seed-%d", name, time.Now().UTC().UnixNano()))
+			if err != nil {
+				cleanCtx := context.Background()
+				_ = client.DeleteSidecar(cleanCtx, seed.ID)
+				return nil, fmt.Errorf("pool snapshot: %w", err)
+			}
+			status(iostream.LevelInfo, fmt.Sprintf("created seed snapshot %s", snap.ID))
+
+			cloneIDs := make([]string, newCount)
+			cloneErrs := make([]error, newCount)
+			var wg sync.WaitGroup
+			for i := range cloneIDs {
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					idx := len(aliveExisting) + i
+					sc, err := Create(ctx, client, orgID, fmt.Sprintf("%s-%d", name, idx), snap.ID)
+					if err != nil {
+						cloneErrs[i] = fmt.Errorf("create sidecar %d from snapshot: %w", idx, err)
+						return
+					}
+					cloneIDs[i] = sc.ID
+					status(iostream.LevelInfo, fmt.Sprintf("created sidecar %d (%s)", idx, sc.ID))
+				}(i)
+			}
+			wg.Wait()
+
+			var errl []error
+			for i, err := range cloneErrs {
+				if err != nil {
+					errl = append(errl, err)
+					continue
+				}
+				if cloneIDs[i] != "" {
+					goodNew = append(goodNew, cloneIDs[i])
+					status(iostream.LevelInfo, fmt.Sprintf("replacement sidecar: %s", cloneIDs[i]))
+				}
+			}
+
+			cleanCtx := context.Background()
+			_ = client.DeleteSidecar(cleanCtx, seed.ID)
+			if len(errl) > 0 {
+				for _, id := range goodNew {
+					_ = client.DeleteSidecar(cleanCtx, id)
+				}
+				return nil, errors.Join(errl...)
+			}
+		}
+	}
+
+	allIDs := make([]string, 0, len(aliveExisting)+len(goodNew))
+	allIDs = append(allIDs, aliveExisting...)
+	allIDs = append(allIDs, goodNew...)
+
+	entries := make([]*PoolEntry, len(allIDs))
+	for i, id := range allIDs {
+		entries[i] = &PoolEntry{ID: id, RepoPath: repoPath, Client: client}
+	}
+
+	free := make(chan *PoolEntry, len(entries))
+	for _, entry := range entries[len(aliveExisting):] {
+		free <- entry
+	}
+	pool := &Pool{
+		free:         free,
+		updates:      make(chan struct{}, 1),
+		ids:          allIDs,
+		entries:      entries,
+		client:       client,
+		workDir:      workDir,
+		orgID:        orgID,
+		image:        image,
+		name:         name,
+		identityFile: identityFile,
+		authSock:     authSock,
+		pendingSyncs: len(aliveExisting),
+	}
+
+	if len(aliveExisting) == 0 {
+		if err := savePoolState(workDir, name, &poolState{SidecarIDs: allIDs, RepoPath: repoPath, LastSyncedRef: lastSyncedRef}); err != nil {
+			cleanCtx := context.Background()
+			for _, id := range allIDs {
+				_ = client.DeleteSidecar(cleanCtx, id)
+			}
+			return nil, fmt.Errorf("pool state: %w", err)
+		}
+		return pool, nil
+	}
+
+	status(iostream.LevelInfo, fmt.Sprintf("syncing to %d sidecars...", len(aliveExisting)))
+	prepared, err := prepareBundleSync(repoPath, workDir, lastSyncedRef, len(aliveExisting), status)
+	if err != nil {
+		cleanCtx := context.Background()
+		for _, id := range goodNew {
+			_ = client.DeleteSidecar(cleanCtx, id)
+		}
+		return nil, fmt.Errorf("pool sync: %w", err)
+	}
+	if err := savePoolState(workDir, name, &poolState{SidecarIDs: allIDs, RepoPath: repoPath, LastSyncedRef: lastSyncedRef}); err != nil {
+		cleanCtx := context.Background()
+		for _, id := range goodNew {
+			_ = client.DeleteSidecar(cleanCtx, id)
+		}
+		return nil, fmt.Errorf("pool state: %w", err)
+	}
+	pool.startBackgroundSync(ctx, aliveExisting, prepared, status)
+
+	return pool, nil
+}
+
+func (p *Pool) Rebuild(ctx context.Context, dead *PoolEntry, status iostream.StatusFunc) (*PoolEntry, error) {
+	_ = p.client.DeleteSidecar(ctx, dead.ID)
+
+	sc, err := Create(ctx, p.client, p.orgID, fmt.Sprintf("%s-rebuilt-%d", p.name, time.Now().UTC().UnixNano()), p.image)
+	if err != nil {
+		return nil, fmt.Errorf("rebuild: create sidecar: %w", err)
+	}
+
+	if err := BundleSyncFanOut(ctx, p.client, []string{sc.ID}, p.identityFile, p.authSock, dead.RepoPath, p.workDir, true, status); err != nil {
+		_ = p.client.DeleteSidecar(ctx, sc.ID)
+		return nil, fmt.Errorf("rebuild: sync: %w", err)
+	}
+
+	return &PoolEntry{ID: sc.ID, RepoPath: dead.RepoPath, Client: p.client}, nil
+}
+
+func (p *Pool) Acquire(ctx context.Context) (*PoolEntry, error) {
+	for {
+		p.mu.Lock()
+		if p.pendingSyncs == 0 && len(p.free) == 0 && p.checkedOut == 0 && p.syncErr != nil {
+			err := p.syncErr
+			p.mu.Unlock()
+			return nil, err
+		}
+		select {
+		case entry := <-p.free:
+			p.checkedOut++
+			p.mu.Unlock()
+			return entry, nil
+		default:
+			p.mu.Unlock()
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-p.updates:
+		}
+	}
+}
+
+func (p *Pool) Release(entry *PoolEntry) {
+	p.mu.Lock()
+	if p.checkedOut > 0 {
+		p.checkedOut--
+	}
+	p.free <- entry
+	p.mu.Unlock()
+	p.notifyUpdate()
+}
+
+func (p *Pool) Close(_ context.Context) {}
+
+func (p *Pool) Destroy(ctx context.Context) {
+	clearPoolState(p.workDir, p.name)
+	for _, id := range p.ids {
+		_ = p.client.DeleteSidecar(ctx, id)
+	}
+}
+
+func (p *Pool) startBackgroundSync(ctx context.Context, sidecarIDs []string, prepared *preparedBundleSync, status iostream.StatusFunc) {
+	parallelism := len(sidecarIDs)
+	if parallelism > bundleSyncFanOutConcurrency {
+		parallelism = bundleSyncFanOutConcurrency
+	}
+
+	sem := make(chan struct{}, parallelism)
+	var wg sync.WaitGroup
+	for i, id := range sidecarIDs {
+		entry := p.entries[i]
+		wg.Add(1)
+		go func(id string, entry *PoolEntry) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			err := syncPreparedSidecar(ctx, p.client, id, p.identityFile, p.authSock, false, prepared)
+			p.finishSync(entry, err)
+		}(id, entry)
+	}
+
+	go func() {
+		wg.Wait()
+		p.mu.Lock()
+		doneWithoutError := p.pendingSyncs == 0 && p.syncErr == nil
+		p.mu.Unlock()
+		if doneWithoutError {
+			if err := savePoolState(p.workDir, p.name, &poolState{
+				SidecarIDs:    p.ids,
+				RepoPath:      prepared.repoPath,
+				LastSyncedRef: prepared.headRef,
+			}); err != nil {
+				status(iostream.LevelWarn, fmt.Sprintf("could not save pool state: %v", err))
+			}
+			status(iostream.LevelDone, fmt.Sprintf("Synced %d sidecars", len(sidecarIDs)))
+		}
+		p.notifyUpdate()
+	}()
+}
+
+func (p *Pool) finishSync(entry *PoolEntry, err error) {
+	p.mu.Lock()
+	if err != nil {
+		p.syncErr = errors.Join(p.syncErr, fmt.Errorf("sidecar %s: %w", entry.ID, err))
+	} else {
+		p.free <- entry
+	}
+	if p.pendingSyncs > 0 {
+		p.pendingSyncs--
+	}
+	p.mu.Unlock()
+	p.notifyUpdate()
+}
+
+func (p *Pool) notifyUpdate() {
+	select {
+	case p.updates <- struct{}{}:
+	default:
+	}
+}

--- a/internal/sidecar/pool_test.go
+++ b/internal/sidecar/pool_test.go
@@ -1,0 +1,322 @@
+package sidecar
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/gitrepo"
+)
+
+func TestPoolStatePath(t *testing.T) {
+	assert.Equal(t, poolStatePath("/my/project", "validate"), "/my/project/.chunk/validate-pool.json")
+	assert.Equal(t, poolStatePath("/my/project", "mutate"), "/my/project/.chunk/mutate-pool.json")
+}
+
+func TestPoolStateRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	want := &poolState{
+		SidecarIDs:    []string{"sb-1", "sb-2", "sb-3"},
+		RepoPath:      "/home/user/myrepo",
+		LastSyncedRef: "deadbeef",
+	}
+	assert.NilError(t, savePoolState(dir, "validate", want))
+
+	got, err := loadPoolState(dir, "validate")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, got.SidecarIDs, want.SidecarIDs)
+	assert.Equal(t, got.RepoPath, want.RepoPath)
+	assert.Equal(t, got.LastSyncedRef, want.LastSyncedRef)
+}
+
+func TestSavePoolStateReturnsWriteError(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, ".chunk"), nil, 0o600))
+
+	err := savePoolState(dir, "validate", &poolState{SidecarIDs: []string{"sb-1"}})
+	assert.Assert(t, err != nil)
+}
+
+func TestPoolAcquireRelease(t *testing.T) {
+	entries := []*PoolEntry{{ID: "sb-1"}, {ID: "sb-2"}}
+	free := make(chan *PoolEntry, len(entries))
+	for _, entry := range entries {
+		free <- entry
+	}
+	pool := &Pool{free: free, ids: []string{"sb-1", "sb-2"}, entries: entries}
+
+	a, err := pool.Acquire(context.Background())
+	assert.NilError(t, err)
+	b, err := pool.Acquire(context.Background())
+	assert.NilError(t, err)
+	assert.Assert(t, a.ID != b.ID)
+
+	pool.Release(a)
+	pool.Release(b)
+	assert.Equal(t, len(pool.free), 2)
+}
+
+func TestPoolAcquireCancelledContext(t *testing.T) {
+	pool := &Pool{free: make(chan *PoolEntry, 1)}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := pool.Acquire(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestPoolAcquireReadyEntryWinsOverSyncError(t *testing.T) {
+	entry := &PoolEntry{ID: "sb-1"}
+	free := make(chan *PoolEntry, 1)
+	free <- entry
+	pool := &Pool{
+		free:    free,
+		updates: make(chan struct{}, 1),
+		syncErr: errors.New("background sync failed"),
+	}
+
+	got, err := pool.Acquire(context.Background())
+	assert.NilError(t, err)
+	assert.Equal(t, got, entry)
+}
+
+func TestPoolAcquireTerminalSyncErrorWhenNothingAvailable(t *testing.T) {
+	pool := &Pool{
+		free:    make(chan *PoolEntry, 1),
+		updates: make(chan struct{}, 1),
+		syncErr: errors.New("background sync failed"),
+	}
+
+	_, err := pool.Acquire(context.Background())
+	assert.Error(t, err, "background sync failed")
+}
+
+func TestPoolStateMarshalFormat(t *testing.T) {
+	dir := t.TempDir()
+
+	assert.NilError(t, savePoolState(dir, "validate", &poolState{
+		SidecarIDs: []string{"sb-1"},
+		RepoPath:   "/home/user/repo",
+	}))
+
+	raw, err := os.ReadFile(poolStatePath(dir, "validate"))
+	assert.NilError(t, err)
+
+	var m map[string]json.RawMessage
+	assert.NilError(t, json.Unmarshal(raw, &m))
+	assert.Assert(t, m["sidecar_ids"] != nil)
+	assert.Assert(t, m["repo_path"] != nil)
+}
+
+type poolTestEnv struct {
+	cl      *circleci.Client
+	cci     *fakes.FakeCircleCI
+	workDir string
+	keyFile string
+}
+
+func setupPoolTest(t *testing.T) poolTestEnv {
+	t.Helper()
+	keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+	sshSrv := fakes.NewSSHServer(t, pubKey)
+	sshSrv.SetResult("", 0)
+
+	cci := fakes.NewFakeCircleCI()
+	cci.AddKeyURL = sshSrv.Addr()
+	srv := httptest.NewServer(cci)
+	t.Cleanup(srv.Close)
+
+	cl, err := circleci.NewClient(circleci.Config{Token: "fake-token", BaseURL: srv.URL})
+	assert.NilError(t, err)
+
+	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
+	t.Setenv(config.EnvHome, t.TempDir())
+	return poolTestEnv{cl: cl, cci: cci, workDir: workDir, keyFile: keyFile}
+}
+
+func countPoolRequests(cci *fakes.FakeCircleCI, method, path string) int {
+	n := 0
+	for _, r := range cci.Recorder.AllRequests() {
+		if r.Method == method && r.URL.Path == path {
+			n++
+		}
+	}
+	return n
+}
+
+func countPoolDeletes(cci *fakes.FakeCircleCI) int {
+	n := 0
+	for _, r := range cci.Recorder.AllRequests() {
+		if r.Method == "DELETE" {
+			n++
+		}
+	}
+	return n
+}
+
+const createSidecarPath = "/api/v3/sidecar/instances"
+const createSnapshotPath = "/api/v3/sidecar/snapshots"
+
+func TestAssemblePool_CreatesAndSyncsAll(t *testing.T) {
+	env := setupPoolTest(t)
+	t.Chdir(env.workDir)
+
+	pool, err := assemblePool(context.Background(), env.cl, 2, "validate", "org-1", "ubuntu:22.04",
+		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, nil, "", func(iostream.Level, string) {})
+	assert.NilError(t, err)
+	assert.Equal(t, len(pool.ids), 2)
+
+	a, err := pool.Acquire(context.Background())
+	assert.NilError(t, err)
+	b, err := pool.Acquire(context.Background())
+	assert.NilError(t, err)
+	assert.Assert(t, a.ID != b.ID)
+	pool.Release(a)
+	pool.Release(b)
+
+	assert.Equal(t, countPoolRequests(env.cci, "POST", createSidecarPath), 3)
+	assert.Equal(t, countPoolRequests(env.cci, "POST", createSnapshotPath), 1)
+	assert.Equal(t, countPoolDeletes(env.cci), 1)
+}
+
+func TestAssemblePool_CreateFailure_ReturnsError(t *testing.T) {
+	env := setupPoolTest(t)
+	env.cci.CreateStatusCode = 500
+
+	_, err := assemblePool(context.Background(), env.cl, 2, "validate", "org-1", "ubuntu:22.04",
+		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, nil, "", func(iostream.Level, string) {})
+	assert.Assert(t, err != nil)
+	assert.Equal(t, countPoolDeletes(env.cci), 0)
+}
+
+func TestAssemblePool_PartialCreateFailure_CleansUp(t *testing.T) {
+	env := setupPoolTest(t)
+	env.cci.CreateErrorAfter = 1
+
+	_, err := assemblePool(context.Background(), env.cl, 2, "validate", "org-1", "ubuntu:22.04",
+		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, nil, "", func(iostream.Level, string) {})
+	assert.Assert(t, err != nil)
+	assert.Equal(t, countPoolDeletes(env.cci), 1)
+	assert.Equal(t, len(env.cci.Sidecars), 0)
+}
+
+func TestAssemblePool_SyncFailure_CleansUp(t *testing.T) {
+	env := setupPoolTest(t)
+	t.Chdir(env.workDir)
+	env.cci.AddKeyStatusCode = 500
+
+	_, err := assemblePool(context.Background(), env.cl, 2, "validate", "org-1", "ubuntu:22.04",
+		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, nil, "", func(iostream.Level, string) {})
+	assert.Assert(t, err != nil)
+	assert.Equal(t, countPoolDeletes(env.cci), 1)
+	assert.Equal(t, len(env.cci.Sidecars), 0)
+}
+
+func TestAssemblePool_StaleExisting_ReplacedAutomatically(t *testing.T) {
+	env := setupPoolTest(t)
+	t.Chdir(env.workDir)
+	env.cci.StaleIDs = map[string]bool{"stale-sb-1": true, "stale-sb-2": true}
+
+	pool, err := assemblePool(context.Background(), env.cl, 2, "validate", "org-1", "ubuntu:22.04",
+		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, []string{"stale-sb-1", "stale-sb-2"}, "", func(iostream.Level, string) {})
+	assert.NilError(t, err)
+	assert.Equal(t, len(pool.ids), 2)
+	assert.Equal(t, countPoolDeletes(env.cci), 3)
+}
+
+func TestAssemblePool_ReuseExisting_OnlyCreatesGap(t *testing.T) {
+	env := setupPoolTest(t)
+	t.Chdir(env.workDir)
+
+	pool, err := assemblePool(context.Background(), env.cl, 2, "validate", "org-1", "ubuntu:22.04",
+		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, []string{"existing-sb-1"}, "", func(iostream.Level, string) {})
+	assert.NilError(t, err)
+	assert.Equal(t, len(pool.ids), 2)
+	assert.Equal(t, countPoolRequests(env.cci, "POST", createSidecarPath), 1)
+	assert.Equal(t, countPoolDeletes(env.cci), 0)
+}
+
+func TestPool_Rebuild(t *testing.T) {
+	env := setupPoolTest(t)
+	t.Chdir(env.workDir)
+
+	pool := &Pool{
+		client:       env.cl,
+		orgID:        "org-1",
+		image:        "ubuntu:22.04",
+		name:         "validate",
+		identityFile: env.keyFile,
+		workDir:      env.workDir,
+		free:         make(chan *PoolEntry, 1),
+	}
+	dead := &PoolEntry{ID: "dead-sb-1", RepoPath: DefaultWorkspace("my-repo")}
+
+	entry, err := pool.Rebuild(context.Background(), dead, func(iostream.Level, string) {})
+	assert.NilError(t, err)
+	assert.Assert(t, entry.ID != dead.ID)
+	assert.Assert(t, entry.Client != nil)
+	assert.Equal(t, countPoolDeletes(env.cci), 1)
+	assert.Equal(t, countPoolRequests(env.cci, "POST", createSidecarPath), 1)
+}
+
+func drainPoolEntries(ctx context.Context, t *testing.T, pool *Pool, n int) []*PoolEntry {
+	t.Helper()
+	entries := make([]*PoolEntry, n)
+	for i := range entries {
+		entry, err := pool.Acquire(ctx)
+		assert.NilError(t, err)
+		entries[i] = entry
+	}
+	return entries
+}
+
+func releasePoolEntries(pool *Pool, entries []*PoolEntry) {
+	for _, entry := range entries {
+		pool.Release(entry)
+	}
+}
+
+func TestPool_100Sidecars_NoGoroutineLeak(t *testing.T) {
+	env := setupPoolTest(t)
+	t.Chdir(env.workDir)
+
+	const n = 100
+	ctx := context.Background()
+	noopStatus := iostream.StatusFunc(func(_ iostream.Level, _ string) {})
+
+	pool, err := assemblePool(ctx, env.cl, n, "validate", "org-1", "ubuntu:22.04",
+		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, nil, "", noopStatus)
+	assert.NilError(t, err)
+	assert.Equal(t, len(pool.ids), n)
+	releasePoolEntries(pool, drainPoolEntries(ctx, t, pool, n))
+
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	pool2, err := assemblePool(ctx, env.cl, n, "validate", "org-1", "ubuntu:22.04",
+		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, pool.ids, "", noopStatus)
+	assert.NilError(t, err)
+	assert.Equal(t, len(pool2.ids), n)
+	releasePoolEntries(pool2, drainPoolEntries(ctx, t, pool2, n))
+
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond)
+	afterSecond := runtime.NumGoroutine()
+	assert.Assert(t, afterSecond <= baseline+5,
+		"goroutine accumulation on second pool run: baseline=%d after=%d delta=%d",
+		baseline, afterSecond, afterSecond-baseline)
+}

--- a/internal/sidecar/rsync.go
+++ b/internal/sidecar/rsync.go
@@ -46,7 +46,7 @@ func rsyncTo(ctx context.Context, client *circleci.Client,
 	sidecarID, identityFile, authSock, workdir, cwd string, persist bool,
 	status iostream.StatusFunc) error {
 
-	sess, err := OpenSession(ctx, client, sidecarID, identityFile, authSock)
+	sess, err := OpenSession(ctx, client, sidecarID, identityFile, authSock, false)
 	if err != nil {
 		return fmt.Errorf("rsync: open session: %w", err)
 	}

--- a/internal/sidecar/session.go
+++ b/internal/sidecar/session.go
@@ -3,14 +3,18 @@ package sidecar
 import (
 	"context"
 	"crypto/ed25519"
-	"crypto/rand"
+	crand "crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
+	"math/rand/v2"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
@@ -42,7 +46,7 @@ func GenerateKeyPair(path string) error {
 		return fmt.Errorf("create .ssh directory: %w", err)
 	}
 
-	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	pub, priv, err := ed25519.GenerateKey(crand.Reader)
 	if err != nil {
 		return fmt.Errorf("generate key: %w", err)
 	}
@@ -77,21 +81,86 @@ type Session struct {
 	AuthSock     string // SSH_AUTH_SOCK path (only used when UseAgent is true)
 }
 
+// readProbeKey resolves the SSH public key to use for a staleness probe.
+func readProbeKey(ctx context.Context, authSock, identityFile string) (string, error) {
+	if identityFile == "" && authSock != "" {
+		if pubKey, err := agentPublicKey(ctx, authSock); err == nil {
+			return pubKey, nil
+		}
+	}
+	if identityFile == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		identityFile = filepath.Join(home, ".ssh", defaultKeyName)
+	}
+	data, err := os.ReadFile(identityFile + ".pub")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// IsDefinitelyStale probes sidecarID with a single AddSSHKey attempt under a
+// short timeout. It returns true only when the provisioner responds 404.
+func IsDefinitelyStale(ctx context.Context, client *circleci.Client, sidecarID, identityFile, authSock string) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	pubKey, err := readProbeKey(probeCtx, authSock, identityFile)
+	if err != nil {
+		return false
+	}
+	_, err = client.AddSSHKey(probeCtx, sidecarID, pubKey)
+	if err == nil {
+		return false
+	}
+	var se *circleci.StatusError
+	return errors.As(err, &se) && se.StatusCode == http.StatusNotFound
+}
+
+// addSSHKey registers a public key with the sidecar. When retryOn404 is true
+// it retries on 404 to absorb provisioner replica lag after creation.
+func addSSHKey(ctx context.Context, client *circleci.Client, sidecarID, pubKey string, retryOn404 bool) (*circleci.AddSSHKeyResponse, error) {
+	const maxAttempts = 4
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		resp, err := client.AddSSHKey(ctx, sidecarID, pubKey)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		var se *circleci.StatusError
+		if !errors.As(err, &se) || se.StatusCode != http.StatusNotFound || !retryOn404 || attempt >= maxAttempts-1 {
+			return nil, err
+		}
+		base := time.Duration(attempt+1) * 5 * time.Second
+		jitter := time.Duration(rand.N(int64(2 * time.Second))) //nolint:gosec
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(base + jitter):
+		}
+	}
+	return nil, lastErr
+}
+
 // OpenSession registers an SSH key with the sidecar and returns session info.
 // authSock is the SSH_AUTH_SOCK path; when non-empty and no identityFile is
-// given, the agent is tried first.
-func OpenSession(ctx context.Context, client *circleci.Client, sidecarID, identityFile, authSock string) (*Session, error) {
+// given, the agent is tried first. retryOn404 should be true only for freshly
+// created sidecars where a 404 can be transient.
+func OpenSession(ctx context.Context, client *circleci.Client, sidecarID, identityFile, authSock string, retryOn404 bool) (*Session, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("resolve home directory: %w", err)
 	}
 	sshDir := filepath.Join(home, ".ssh")
 
-	// When no identity file is specified, try the ssh-agent first.
 	if identityFile == "" && authSock != "" {
 		pubKey, err := agentPublicKey(ctx, authSock)
 		if err == nil {
-			resp, err := client.AddSSHKey(ctx, sidecarID, pubKey)
+			resp, err := addSSHKey(ctx, client, sidecarID, pubKey, retryOn404)
 			if err != nil {
 				return nil, fmt.Errorf("register SSH key: %w", err)
 			}
@@ -102,7 +171,6 @@ func OpenSession(ctx context.Context, client *circleci.Client, sidecarID, identi
 				KnownHosts: filepath.Join(sshDir, knownHostsFile),
 			}, nil
 		}
-		// Agent not available — fall back to default key file.
 	}
 
 	if identityFile == "" {
@@ -123,7 +191,7 @@ func OpenSession(ctx context.Context, client *circleci.Client, sidecarID, identi
 	}
 	pubKey := strings.TrimSpace(string(pubKeyData))
 
-	resp, err := client.AddSSHKey(ctx, sidecarID, pubKey)
+	resp, err := addSSHKey(ctx, client, sidecarID, pubKey, retryOn404)
 	if err != nil {
 		return nil, fmt.Errorf("register SSH key: %w", err)
 	}

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -49,7 +49,7 @@ func AddSSHKey(ctx context.Context, client *circleci.Client, sidecarID, publicKe
 // stdin is forwarded to the remote command when non-nil; callers should pass
 // os.Stdin when the process stdin is a pipe, nil otherwise.
 func SSH(ctx context.Context, client *circleci.Client, sidecarID, identityFile, authSock string, args []string, envVars map[string]string, streams iostream.Streams, stdin io.Reader) error {
-	session, err := OpenSession(ctx, client, sidecarID, identityFile, authSock)
+	session, err := OpenSession(ctx, client, sidecarID, identityFile, authSock, false)
 	if err != nil {
 		return err
 	}

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -35,7 +35,7 @@ func TestOpenSessionDefaultKeyFallback(t *testing.T) {
 	ctx := context.Background()
 
 	// Both identityFile and authSock are empty — should attempt default key path.
-	_, err := sidecar.OpenSession(ctx, cl, "sb-1", "", "")
+	_, err := sidecar.OpenSession(ctx, cl, "sb-1", "", "", false)
 	assert.Assert(t, err != nil)
 	assert.Assert(t, strings.Contains(err.Error(), "chunk_ai"),
 		"expected default key name in error, got: %v", err)
@@ -53,7 +53,7 @@ func TestCreate(t *testing.T) {
 
 	sb, err := sidecar.Create(ctx, cl, "org-1", "my-sidecar", "ubuntu:22.04")
 	assert.NilError(t, err)
-	assert.Equal(t, sb.ID, "sidecar-new-123")
+	assert.Equal(t, sb.ID, "sidecar-new-1")
 	assert.Equal(t, sb.Name, "my-sidecar")
 	assert.Equal(t, sb.OrgID, "org-1")
 }

--- a/internal/sidecar/sync.go
+++ b/internal/sidecar/sync.go
@@ -1,10 +1,26 @@
 package sidecar
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
+	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 )
+
+// bundleSyncFanOutConcurrency caps concurrent sidecar uploads during pool sync.
+// A full bundle can be tens of MB, so unbounded fan-out can exhaust local
+// memory or saturate the provider when hundreds of sidecars are prepared at once.
+const bundleSyncFanOutConcurrency = 8
 
 // sidecarHome returns the base home directory on the sidecar. It reads
 // CHUNK_SIDECAR_HOME so the default "/home/user" can be overridden when the
@@ -14,6 +30,12 @@ func sidecarHome() string {
 		return h
 	}
 	return "/home/user"
+}
+
+// DefaultWorkspace returns the default remote workspace path for a repo.
+// Use this when creating pool sidecars to avoid inheriting a stale saved path.
+func DefaultWorkspace(repo string) string {
+	return sidecarHome() + "/" + repo
 }
 
 // ResolveWorkspace determines the workspace path. Priority:
@@ -30,7 +52,7 @@ func ResolveWorkspace(ctx context.Context, cliWorkdir, repo string) (string, err
 	if repo == "" {
 		return "", fmt.Errorf("sync: cannot determine workspace: repo name is empty and no workspace is saved")
 	}
-	return sidecarHome() + "/" + repo, nil
+	return DefaultWorkspace(repo), nil
 }
 
 // persistWorkspace saves the resolved workspace back to the sidecar file if it
@@ -45,4 +67,526 @@ func persistWorkspace(ctx context.Context, workspace string) error {
 	}
 	active.Workspace = workspace
 	return SaveActive(ctx, *active)
+}
+
+// Sync synchronises local changes to a sidecar over SSH.
+// It ensures the workspace base exists, clones the repo into workdir if absent,
+// then resets to the remote base and applies a patch of local changes.
+// workdir overrides the destination path; defaults to /home/user/<repo>.
+func Sync(ctx context.Context,
+	client *circleci.Client, sidecarID, identityFile, authSock, workdir string, status iostream.StatusFunc) error {
+	return syncTo(ctx, client, sidecarID, identityFile, authSock, workdir, true, status)
+}
+
+// SyncEphemeral synchronises like Sync but neither reads nor writes the active
+// sidecar file. Callers that drive several sidecars concurrently would otherwise
+// race on that shared file and leave it naming whichever worker finished last.
+// workdir is required for the same reason: there is no shared state to fall
+// back on, so each caller must name its own destination.
+func SyncEphemeral(ctx context.Context,
+	client *circleci.Client, sidecarID, identityFile, authSock, workdir string, status iostream.StatusFunc) error {
+	if workdir == "" {
+		return fmt.Errorf("sync: workdir is required for an ephemeral sync")
+	}
+	return syncTo(ctx, client, sidecarID, identityFile, authSock, workdir, false, status)
+}
+
+// syncTo backs Sync and SyncEphemeral. persist controls whether the resolved
+// workspace is read from and written back to the active-sidecar file.
+func syncTo(ctx context.Context, client *circleci.Client,
+	sidecarID, identityFile, authSock, workdir string, persist bool, status iostream.StatusFunc) error {
+
+	session, err := OpenSession(ctx, client, sidecarID, identityFile, authSock, false)
+	if err != nil {
+		return err
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("sync: %w", err)
+	}
+
+	org, repo, err := gitremote.DetectOrgAndRepo(cwd)
+	if err != nil {
+		return &NoOriginRemoteError{Err: err}
+	}
+
+	repoPath := workdir
+	if persist {
+		repoPath, err = ResolveWorkspace(ctx, workdir, repo)
+		if err != nil {
+			return err
+		}
+		if err := persistWorkspace(ctx, repoPath); err != nil {
+			status(iostream.LevelWarn, fmt.Sprintf("Could not save workspace: %v", err))
+		}
+	}
+
+	err = syncWorkspace(ctx, status, org, repo, repoPath, session)
+	if err == nil {
+		status(iostream.LevelDone, "Synced")
+		return nil
+	}
+	if !errors.Is(err, errApplyFailed) {
+		return err
+	}
+
+	status(iostream.LevelWarn, fmt.Sprintf("Local %s/%s drifted from remote: %s (%s) - attempting clean",
+		org, repo, repoPath, err))
+
+	if result, err := ExecOverSSH(ctx, session, "rm -rf "+ShellEscape(repoPath), nil, nil); err != nil {
+		return fmt.Errorf("sync: rm %s: %w", repoPath, err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("sync: rm %s: %s", repoPath, result.Stderr)
+	}
+
+	if err := syncWorkspace(ctx, status, org, repo, repoPath, session); err != nil {
+		return fmt.Errorf("sync retry: %w", err)
+	}
+
+	status(iostream.LevelDone, "Synced")
+	return nil
+}
+
+// BundleSync synchronises local commits and working-tree changes to a sidecar
+// using a git bundle, without requiring the branch to be pushed.
+func BundleSync(ctx context.Context,
+	client *circleci.Client, sidecarID, identityFile, authSock, workdir, cwd string, retryOn404 bool, status iostream.StatusFunc) error {
+	prepared, err := prepareBundleSync(workdir, cwd, "", 1, status)
+	if err != nil {
+		return err
+	}
+	if err := syncPreparedSidecar(ctx, client, sidecarID, identityFile, authSock, retryOn404, prepared); err != nil {
+		return err
+	}
+	if err := persistWorkspace(ctx, prepared.repoPath); err != nil {
+		status(iostream.LevelWarn, fmt.Sprintf("Could not save workspace: %v", err))
+	}
+	status(iostream.LevelDone, "Synced")
+	return nil
+}
+
+// BundleSyncFanOut synchronises a local working tree to multiple sidecars in
+// parallel using a full or incremental bundle.
+func BundleSyncFanOut(ctx context.Context, client *circleci.Client, sidecarIDs []string, identityFile, authSock, workdir, cwd string, retryOn404 bool, status iostream.StatusFunc) error {
+	_, err := bundleSyncFanOutSince(ctx, client, sidecarIDs, identityFile, authSock, workdir, cwd, "", retryOn404, status)
+	return err
+}
+
+type preparedBundleSync struct {
+	repo     string
+	repoPath string
+	headRef  string
+	resetRef string
+	bundle   []byte
+	patch    string
+}
+
+// bundleSyncFanOutSince synchronises a local working tree to multiple sidecars
+// in parallel. It returns the local HEAD ref that all successful targets were
+// synced to.
+func bundleSyncFanOutSince(ctx context.Context, client *circleci.Client, sidecarIDs []string, identityFile, authSock, workdir, cwd, baseRef string, retryOn404 bool, status iostream.StatusFunc) (string, error) {
+	prepared, err := prepareBundleSync(workdir, cwd, baseRef, len(sidecarIDs), status)
+	if err != nil {
+		return "", err
+	}
+
+	parallelism := len(sidecarIDs)
+	if parallelism > bundleSyncFanOutConcurrency {
+		parallelism = bundleSyncFanOutConcurrency
+	}
+
+	errs := make([]error, len(sidecarIDs))
+	sem := make(chan struct{}, parallelism)
+	var wg sync.WaitGroup
+	for i, id := range sidecarIDs {
+		wg.Add(1)
+		go func(i int, id string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			if err := syncPreparedSidecar(ctx, client, id, identityFile, authSock, retryOn404, prepared); err != nil {
+				errs[i] = fmt.Errorf("sidecar %s: %w", id, err)
+			}
+		}(i, id)
+	}
+	wg.Wait()
+
+	if err := errors.Join(errs...); err != nil {
+		return "", err
+	}
+	status(iostream.LevelDone, fmt.Sprintf("Synced %d sidecars", len(sidecarIDs)))
+	return prepared.headRef, nil
+}
+
+func prepareBundleSync(workdir, cwd, baseRef string, sidecarCount int, status iostream.StatusFunc) (*preparedBundleSync, error) {
+	_, repo, repoErr := gitremote.DetectOrgAndRepo(cwd)
+	if repoErr != nil && workdir == "" {
+		return nil, &NoOriginRemoteError{Err: repoErr}
+	}
+
+	repoPath := workdir
+	if repoPath == "" {
+		repoPath = DefaultWorkspace(repo)
+	}
+
+	headRef, err := gitutil.HeadRef(cwd)
+	if err != nil {
+		return nil, fmt.Errorf("fan-out sync: %w", err)
+	}
+
+	resetRef := gitHeadRef
+	var bundle []byte
+	if baseRef == headRef {
+		status(iostream.LevelInfo, "No new commits since last sync.")
+	} else {
+		bundle, err = createBundle(baseRef, cwd)
+		if err != nil {
+			return nil, fmt.Errorf("fan-out sync: %w", err)
+		}
+		if baseRef == "" {
+			status(iostream.LevelInfo, fmt.Sprintf("Bundle ready (%d bytes), syncing to %d sidecars...", len(bundle), sidecarCount))
+		} else {
+			status(iostream.LevelInfo, fmt.Sprintf("Incremental bundle ready (%d bytes), syncing to %d sidecars...", len(bundle), sidecarCount))
+		}
+		resetRef = "FETCH_HEAD"
+	}
+
+	patch, err := generatePatch(headRef, cwd)
+	if err != nil {
+		return nil, fmt.Errorf("fan-out sync: %w", err)
+	}
+
+	return &preparedBundleSync{
+		repo:     repo,
+		repoPath: repoPath,
+		headRef:  headRef,
+		resetRef: resetRef,
+		bundle:   bundle,
+		patch:    patch,
+	}, nil
+}
+
+func syncPreparedSidecar(ctx context.Context, client *circleci.Client, sidecarID, identityFile, authSock string, retryOn404 bool, prepared *preparedBundleSync) error {
+	sess, err := OpenSession(ctx, client, sidecarID, identityFile, authSock, retryOn404)
+	if err != nil {
+		return fmt.Errorf("open session: %w", err)
+	}
+	return applyBundleToSidecar(ctx, sess, prepared.repo, prepared.repoPath, prepared.bundle, prepared.resetRef, prepared.patch)
+}
+
+func applyBundleToSidecar(ctx context.Context, sess *Session, repo, repoPath string, bundle []byte, resetRef, patch string) error {
+	if _, err := ensureRemoteRepo(ctx, sess, repoPath); err != nil {
+		return err
+	}
+	if len(bundle) > 0 {
+		if err := sendPreparedBundle(ctx, sess, repo, repoPath, bundle); err != nil {
+			return err
+		}
+	}
+	return resetCleanApply(ctx, sess, repoPath, resetRef, patch)
+}
+
+// ensureRemoteRepo ensures repoPath's parent exists and repoPath holds a git
+// repo. It returns true when the repo was freshly initialised.
+func ensureRemoteRepo(ctx context.Context, sess *Session, repoPath string) (bool, error) {
+	parentDir := filepath.Dir(repoPath)
+	if result, err := ExecOverSSH(ctx, sess, "mkdir -p "+ShellEscape(parentDir), nil, nil); err != nil {
+		return false, fmt.Errorf("mkdir: %w", err)
+	} else if result.ExitCode != 0 {
+		return false, fmt.Errorf("mkdir -p %s: %s", parentDir, result.Stderr)
+	}
+
+	testResult, err := ExecOverSSH(ctx, sess, "test -d "+ShellEscape(repoPath+"/.git"), nil, nil)
+	if err != nil {
+		return false, fmt.Errorf("check repo: %w", err)
+	}
+	if testResult.ExitCode == 0 {
+		return false, nil
+	}
+	if result, err := ExecOverSSH(ctx, sess, "git init "+ShellEscape(repoPath), nil, nil); err != nil {
+		return false, fmt.Errorf("git init: %w", err)
+	} else if result.ExitCode != 0 {
+		return false, fmt.Errorf("git init: %s", result.Stderr)
+	}
+	return true, nil
+}
+
+func sendPreparedBundle(ctx context.Context, sess *Session, repo, repoPath string, bundle []byte) error {
+	bundleName := repo
+	if bundleName == "" {
+		bundleName = "chunk"
+	}
+	bundlePath := fmt.Sprintf("/tmp/chunk-sync-%s.bundle", bundleName)
+	if result, err := ExecOverSSH(ctx, sess, "tee "+ShellEscape(bundlePath), bytes.NewReader(bundle), nil); err != nil {
+		return fmt.Errorf("write bundle: %w", err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("write bundle: %s", result.Stderr)
+	}
+
+	fetchCmd := fmt.Sprintf("git -C %s fetch %s HEAD", ShellEscape(repoPath), ShellEscape(bundlePath))
+	if result, err := ExecOverSSH(ctx, sess, fetchCmd, nil, nil); err != nil {
+		return fmt.Errorf("fetch: %w", err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("fetch: %s", result.Stderr)
+	}
+	return nil
+}
+
+func resetCleanApply(ctx context.Context, sess *Session, repoPath, resetRef, patch string) error {
+	resetCmd := fmt.Sprintf("git -C %s reset --hard %s", ShellEscape(repoPath), resetRef)
+	if result, err := ExecOverSSH(ctx, sess, resetCmd, nil, nil); err != nil {
+		return fmt.Errorf("reset: %w", err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("reset: %s", result.Stderr)
+	}
+
+	cleanCmd := fmt.Sprintf("git -C %s clean -fd", ShellEscape(repoPath))
+	if result, err := ExecOverSSH(ctx, sess, cleanCmd, nil, nil); err != nil {
+		return fmt.Errorf("clean: %w", err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("clean: %s", result.Stderr)
+	}
+
+	if patch != "" {
+		applyCmd := fmt.Sprintf("git -C %s apply --whitespace=nowarn", ShellEscape(repoPath))
+		if result, err := ExecOverSSH(ctx, sess, applyCmd, strings.NewReader(patch), nil); err != nil {
+			return fmt.Errorf("apply patch: %w", err)
+		} else if result.ExitCode != 0 {
+			return fmt.Errorf("apply patch: %s", result.Stderr)
+		}
+	}
+	return nil
+}
+
+var errApplyFailed = errors.New("apply failed")
+
+type RemoteBaseError struct {
+	Err error
+}
+
+func (e *RemoteBaseError) Error() string {
+	return fmt.Sprintf("resolve remote base: %v", e.Err)
+}
+
+func (e *RemoteBaseError) Unwrap() error {
+	return e.Err
+}
+
+func syncWorkspace(ctx context.Context, status iostream.StatusFunc, org, repo, repoPath string, sess *Session) error {
+	status(iostream.LevelInfo, fmt.Sprintf("Assessing %s/%s on remote: %s...", org, repo, repoPath))
+
+	parentDir := filepath.Dir(repoPath)
+	if result, err := ExecOverSSH(ctx, sess, "mkdir -p "+ShellEscape(parentDir), nil, nil); err != nil {
+		return fmt.Errorf("sync: mkdir %s: %w", parentDir, err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("sync: mkdir -p %s: %s", parentDir, result.Stderr)
+	}
+
+	testResult, err := ExecOverSSH(ctx, sess, "test -d "+ShellEscape(repoPath), nil, nil)
+	if err != nil {
+		return fmt.Errorf("sync: check repo dir: %w", err)
+	}
+	if testResult.ExitCode != 0 {
+		repoURL := fmt.Sprintf("https://github.com/%s/%s.git", org, repo)
+		var cloneCmd string
+		cwd := cwdOrDot()
+		if branchPushed(cwd) {
+			branch, err := gitutil.CurrentBranchIn(cwd)
+			if err != nil {
+				return fmt.Errorf("sync: %w", err)
+			}
+			cloneCmd = fmt.Sprintf("git clone --branch %s %s %s",
+				ShellEscape(branch), ShellEscape(repoURL), ShellEscape(repoPath),
+			)
+		} else {
+			status(iostream.LevelInfo, "Branch not pushed to remote; cloning default branch instead.")
+			cloneCmd = fmt.Sprintf("git clone %s %s",
+				ShellEscape(repoURL), ShellEscape(repoPath),
+			)
+		}
+
+		status(iostream.LevelInfo, fmt.Sprintf("Cloning %s/%s into %s...", org, repo, repoPath))
+		cloneResult, err := ExecOverSSH(ctx, sess, cloneCmd, nil, nil)
+		if err != nil {
+			return fmt.Errorf("sync: clone: %w", err)
+		}
+		if cloneResult.ExitCode != 0 {
+			detail := cloneResult.Stderr
+			if detail == "" {
+				detail = "git clone exited with a non-zero status"
+			}
+			return fmt.Errorf("sync: clone failed: %s", detail)
+		}
+	}
+
+	status(iostream.LevelInfo, fmt.Sprintf("Synchronising local %s/%s to remote: %s...", org, repo, repoPath))
+
+	status(iostream.LevelInfo, "Fetching remote refs on sidecar...")
+	fetchCmd := fmt.Sprintf("git -C %s fetch origin", ShellEscape(repoPath))
+	fetchResult, err := ExecOverSSH(ctx, sess, fetchCmd, nil, nil)
+	if err != nil {
+		return fmt.Errorf("sync: fetch: %w", err)
+	}
+	if fetchResult.ExitCode != 0 {
+		return fmt.Errorf("sync: fetch failed (exit code: %d): %s", fetchResult.ExitCode, fetchResult.Stderr)
+	}
+
+	base, err := mergeBase(cwdOrDot())
+	if err != nil {
+		return &RemoteBaseError{Err: err}
+	}
+
+	patch, err := generatePatch(base, cwdOrDot())
+	if err != nil {
+		return err
+	}
+	if patch == "" {
+		status(iostream.LevelInfo, "No local changes relative to remote base.")
+		return nil
+	}
+
+	status(iostream.LevelInfo, fmt.Sprintf("Synchronising %d bytes.", len(patch)))
+
+	resetCmd := fmt.Sprintf(
+		`sh -c "cd %s && git reset --hard %s && git clean -fd"`,
+		ShellEscape(repoPath), ShellEscape(base),
+	)
+	resetResult, err := ExecOverSSH(ctx, sess, resetCmd, nil, nil)
+	if err != nil {
+		return err
+	}
+	if resetResult.ExitCode != 0 {
+		detail := resetResult.Stderr
+		if detail == "" {
+			detail = "git reset exited with a non-zero status"
+		}
+		return fmt.Errorf("git reset failed (exit code: %d): %s", resetResult.ExitCode, detail)
+	}
+
+	applyCmd := fmt.Sprintf("git -C %s apply --whitespace=nowarn", ShellEscape(repoPath))
+	applyResult, err := ExecOverSSH(ctx, sess, applyCmd, strings.NewReader(patch), nil)
+	if err != nil {
+		return err
+	}
+	if applyResult.ExitCode != 0 {
+		detail := applyResult.Stderr
+		if detail == "" {
+			detail = "git apply exited with a non-zero status"
+		}
+		return fmt.Errorf("%w (exit code: %d): %s", errApplyFailed, applyResult.ExitCode, detail)
+	}
+	return nil
+}
+
+func createBundle(base, cwd string) ([]byte, error) {
+	var args []string
+	if base == "" {
+		args = []string{"bundle", "create", "-", gitHeadRef}
+	} else {
+		args = []string{"bundle", "create", "-", base + "..HEAD"}
+	}
+	cmd := exec.Command("git", args...)
+	cmd.Dir = cwd
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("create bundle: %w", err)
+	}
+	return out, nil
+}
+
+func generatePatch(base, cwd string) (string, error) {
+	lsCmd := exec.Command("git", "ls-files", "--others", "--exclude-standard")
+	lsCmd.Dir = cwd
+	lsOut, err := lsCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("list untracked files: %w", err)
+	}
+
+	untracked := splitNonEmpty(strings.TrimSpace(string(lsOut)))
+	if len(untracked) > 0 {
+		args := append([]string{"add", "-N", "--"}, untracked...)
+		addCmd := exec.Command("git", args...)
+		addCmd.Dir = cwd
+		if err := addCmd.Run(); err != nil {
+			return "", fmt.Errorf("stage untracked files: %w", err)
+		}
+		defer func() {
+			resetArgs := append([]string{"reset", gitHeadRef, "--"}, untracked...)
+			resetCmd := exec.Command("git", resetArgs...)
+			resetCmd.Dir = cwd
+			_ = resetCmd.Run()
+		}()
+	}
+
+	diffCmd := exec.Command("git", "diff", base, "--binary")
+	diffCmd.Dir = cwd
+	out, err := diffCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("generate diff: %w", err)
+	}
+	return string(out), nil
+}
+
+func branchPushed(cwd string) bool {
+	branch, err := gitutil.CurrentBranchIn(cwd)
+	if err != nil {
+		return false
+	}
+	ref := "refs/remotes/origin/" + branch
+	cmd := exec.Command("git", "rev-parse", "--verify", ref)
+	cmd.Dir = cwd
+	return cmd.Run() == nil
+}
+
+func mergeBase(cwd string) (string, error) {
+	cmd := exec.Command("git", "merge-base", "@{upstream}", "origin/HEAD")
+	cmd.Dir = cwd
+	out, err := cmd.Output()
+	if err == nil {
+		sha := strings.TrimSpace(string(out))
+		if sha != "" {
+			return sha, nil
+		}
+	}
+
+	cmd = exec.Command("git", "rev-parse", "origin/HEAD")
+	cmd.Dir = cwd
+	out, err = cmd.Output()
+	if err != nil {
+		verifyCmd := exec.Command("git", "rev-parse", "--verify", "@{upstream}")
+		verifyCmd.Dir = cwd
+		if verifyCmd.Run() == nil {
+			return "", fmt.Errorf("origin/HEAD is not set")
+		}
+		return "", fmt.Errorf("no upstream tracking branch or origin/HEAD found")
+	}
+	sha := strings.TrimSpace(string(out))
+	if sha == "" {
+		return "", fmt.Errorf("origin/HEAD is empty")
+	}
+	return sha, nil
+}
+
+func splitNonEmpty(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, "\n")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+func cwdOrDot() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	return cwd
 }

--- a/internal/sidecar/target.go
+++ b/internal/sidecar/target.go
@@ -1,0 +1,147 @@
+package sidecar
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/gitremote"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+)
+
+// Target represents operations against one sidecar.
+// It is the base unit that higher-level coordination, including pools, builds on.
+type Target struct {
+	Client       *circleci.Client
+	SidecarID    string
+	IdentityFile string
+	AuthSock     string
+	Workdir      string
+	RetryOn404   bool
+}
+
+type WorkspaceNotFoundError struct {
+	SidecarID string
+	Path      string
+}
+
+func (e *WorkspaceNotFoundError) Error() string {
+	if e.SidecarID != "" {
+		return fmt.Sprintf("workspace directory not found on sidecar %s: %s", e.SidecarID, e.Path)
+	}
+	return fmt.Sprintf("workspace directory not found on sidecar: %s", e.Path)
+}
+
+type TargetUnavailableError struct {
+	SidecarID string
+	Err       error
+}
+
+func (e *TargetUnavailableError) Error() string {
+	return fmt.Sprintf("sidecar %s unavailable: %v", e.SidecarID, e.Err)
+}
+
+func (e *TargetUnavailableError) Unwrap() error {
+	return e.Err
+}
+
+func (t Target) ResolveWorkspace(ctx context.Context, cwd string) (string, error) {
+	_, repo, _ := gitremote.DetectOrgAndRepo(cwd)
+	return ResolveWorkspace(ctx, t.Workdir, repo)
+}
+
+func (t Target) Sync(ctx context.Context, cwd string, useBundle bool, status iostream.StatusFunc) error {
+	if useBundle {
+		return BundleSync(ctx, t.Client, t.SidecarID, t.IdentityFile, t.AuthSock, t.Workdir, cwd, t.RetryOn404, status)
+	}
+	return syncCheckout(ctx, t.Client, t.SidecarID, t.IdentityFile, t.AuthSock, t.Workdir, cwd, status)
+}
+
+func (t Target) ExecRunner(ctx context.Context, cwd string, envVars map[string]string, streams iostream.Streams) (func(context.Context, string) (string, string, int, error), string, error) {
+	dest, err := t.ResolveWorkspace(ctx, cwd)
+	if err != nil {
+		return nil, "", err
+	}
+	execFn := func(ctx context.Context, script string) (string, string, int, error) {
+		var stdout, stderr bytes.Buffer
+		onOutput := func(stream string, data []byte) {
+			w := streams.Out
+			if stream == circleci.StreamStderr {
+				w = streams.Err
+				_, _ = stderr.Write(data)
+			} else {
+				_, _ = stdout.Write(data)
+			}
+			_, _ = w.Write(data)
+		}
+		result, err := t.Client.Exec(ctx, t.SidecarID, "sh", []string{"-c", script}, envVars, onOutput)
+		if err != nil {
+			return "", "", 0, err
+		}
+		return stdout.String(), stderr.String(), result.ExitCode, nil
+	}
+	return execFn, dest, nil
+}
+
+func (t Target) ReadyExecRunner(ctx context.Context, cwd string, envVars map[string]string, streams iostream.Streams) (func(context.Context, string) (string, string, int, error), string, error) {
+	execFn, dest, err := t.ExecRunner(ctx, cwd, envVars, streams)
+	if err != nil {
+		return nil, "", err
+	}
+	_, _, exitCode, err := execFn(ctx, "test -d "+ShellEscape(dest))
+	if err != nil {
+		return nil, "", &TargetUnavailableError{SidecarID: t.SidecarID, Err: fmt.Errorf("check workspace: %w", err)}
+	}
+	if exitCode != 0 {
+		return nil, "", &WorkspaceNotFoundError{SidecarID: t.SidecarID, Path: dest}
+	}
+	return execFn, dest, nil
+}
+
+func syncCheckout(ctx context.Context, client *circleci.Client, sidecarID, identityFile, authSock, workdir, cwd string, status iostream.StatusFunc) error {
+	session, err := OpenSession(ctx, client, sidecarID, identityFile, authSock, false)
+	if err != nil {
+		return err
+	}
+
+	org, repo, err := gitremote.DetectOrgAndRepo(cwd)
+	if err != nil {
+		return &NoOriginRemoteError{Err: err}
+	}
+
+	repoPath, err := ResolveWorkspace(ctx, workdir, repo)
+	if err != nil {
+		return err
+	}
+
+	if err := persistWorkspace(ctx, repoPath); err != nil {
+		status(iostream.LevelWarn, fmt.Sprintf("Could not save workspace: %v", err))
+	}
+
+	err = syncWorkspace(ctx, status, org, repo, repoPath, session)
+	if err == nil {
+		status(iostream.LevelDone, "Synced")
+		return nil
+	}
+	if !errors.Is(err, errApplyFailed) {
+		return err
+	}
+
+	status(iostream.LevelWarn, fmt.Sprintf("Local %s/%s drifted from remote: %s (%s) - attempting clean",
+		org, repo, repoPath, err))
+
+	if result, err := ExecOverSSH(ctx, session, "rm -rf "+ShellEscape(repoPath), nil, nil); err != nil {
+		return fmt.Errorf("sync: rm %s: %w", repoPath, err)
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("sync: rm %s: %s", repoPath, result.Stderr)
+	}
+
+	if err := syncWorkspace(ctx, status, org, repo, repoPath, session); err != nil {
+		return fmt.Errorf("sync retry: %w", err)
+	}
+
+	status(iostream.LevelDone, "Synced")
+	return nil
+}

--- a/internal/sidecar/target_test.go
+++ b/internal/sidecar/target_test.go
@@ -1,0 +1,50 @@
+package sidecar_test
+
+import (
+	"bytes"
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
+	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
+)
+
+func TestTargetExecRunnerReturnsAndStreamsOutput(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	cci.ExecResponse = &fakes.ExecResponse{
+		CommandID: "cmd-1",
+		Stdout:    "output\n",
+		Stderr:    "warning\n",
+		ExitCode:  3,
+	}
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
+
+	var out, errOut bytes.Buffer
+	target := sidecar.Target{
+		Client:    newClient(t, srv.URL),
+		SidecarID: "sb-1",
+		Workdir:   "/workspace/repo",
+	}
+	runner, dest, err := target.ExecRunner(context.Background(), t.TempDir(), nil, iostream.Streams{Out: &out, Err: &errOut})
+	assert.NilError(t, err)
+	assert.Equal(t, dest, "/workspace/repo")
+
+	stdout, stderr, exitCode, err := runner(context.Background(), "exit 3")
+	assert.NilError(t, err)
+	assert.Equal(t, stdout, "output\n")
+	assert.Equal(t, stderr, "warning\n")
+	assert.Equal(t, exitCode, 3)
+	assert.Equal(t, out.String(), stdout)
+	assert.Equal(t, errOut.String(), stderr)
+
+	stdout, stderr, exitCode, err = runner(context.Background(), "exit 3")
+	assert.NilError(t, err)
+	assert.Equal(t, stdout, "output\n")
+	assert.Equal(t, stderr, "warning\n")
+	assert.Equal(t, exitCode, 3)
+}

--- a/internal/testing/fakes/circleci.go
+++ b/internal/testing/fakes/circleci.go
@@ -77,6 +77,7 @@ type FakeCircleCI struct {
 	mu              sync.RWMutex
 	snapshotCounter int
 	orgCounter      int
+	sidecarCounter  int
 	Collaborations  []Collaboration
 	Projects        []Project
 	Sidecars        []Sidecar
@@ -91,6 +92,7 @@ type FakeCircleCI struct {
 	CollaborationsStatusCode int    // override for GET /me/collaborations
 	ListStatusCode           int    // override for GET /sidecar/instances
 	CreateStatusCode         int    // override for POST /sidecar/instances
+	CreateErrorAfter         int    // if > 0, fail creates after this many successes
 	DeleteStatusCode         int    // override for DELETE /sidecar/instances/:id
 	PruneStatusCode          int    // override for POST /sidecar/instances/prune
 	ExecStatusCode           int    // override for POST /sidecar/instances/:id/exec
@@ -105,12 +107,13 @@ type FakeCircleCI struct {
 	// interrupted connection where no SSE frames arrive at all, which the client
 	// must treat as a resume trigger rather than a failure.
 	EmptyStreamsBeforeExit   int
-	AddKeyStatusCode         int // override for POST /sidecar/instances/:id/ssh/add-key
-	CreateSnapshotStatusCode int // override for POST /sidecar/snapshots
-	GetSnapshotStatusCode    int // override for GET /sidecar/snapshots/:id
-	ListSnapshotsStatusCode  int // override for GET /sidecar/snapshots
-	GetCommandStatusCode     int // override for GET /sidecar/commands/:id
-	CreateOrgStatusCode      int // override for POST /api/v2/organization
+	AddKeyStatusCode         int             // override for POST /sidecar/instances/:id/ssh/add-key
+	StaleIDs                 map[string]bool // IDs that return 404 from the add-key endpoint
+	CreateSnapshotStatusCode int             // override for POST /sidecar/snapshots
+	GetSnapshotStatusCode    int             // override for GET /sidecar/snapshots/:id
+	ListSnapshotsStatusCode  int             // override for GET /sidecar/snapshots
+	GetCommandStatusCode     int             // override for GET /sidecar/commands/:id
+	CreateOrgStatusCode      int             // override for POST /api/v2/organization
 
 	// ExtraHeaders are added to every response. Use to inject Deprecation/Sunset
 	// headers without changing individual handler logic.
@@ -245,9 +248,14 @@ func (f *FakeCircleCI) handleCreateSidecar(c *gin.Context) {
 		return
 	}
 
-	f.mu.RLock()
+	f.mu.Lock()
+	f.sidecarCounter++
+	counter := f.sidecarCounter
 	statusCode := f.CreateStatusCode
-	f.mu.RUnlock()
+	if f.CreateErrorAfter > 0 && counter > f.CreateErrorAfter {
+		statusCode = http.StatusInternalServerError
+	}
+	f.mu.Unlock()
 	if statusCode != 0 {
 		c.JSON(statusCode, gin.H{"message": "API error"})
 		return
@@ -272,7 +280,7 @@ func (f *FakeCircleCI) handleCreateSidecar(c *gin.Context) {
 	}
 
 	sidecar := Sidecar{
-		ID:    "sidecar-new-123",
+		ID:    fmt.Sprintf("sidecar-new-%d", counter),
 		Name:  body.Data.Attributes.Name,
 		OrgID: body.Data.References.Org.ID,
 		Image: body.Data.Attributes.Image,
@@ -358,6 +366,10 @@ func (f *FakeCircleCI) handleAddSSHKey(c *gin.Context) {
 	}
 	f.mu.RLock()
 	defer f.mu.RUnlock()
+	if f.StaleIDs[c.Param("id")] {
+		c.JSON(http.StatusNotFound, gin.H{"message": "sidecar not found"})
+		return
+	}
 	if f.AddKeyStatusCode != 0 {
 		c.JSON(f.AddKeyStatusCode, gin.H{"message": "API error"})
 		return

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -453,7 +453,7 @@ func TestRunRemoteSSH(t *testing.T) {
 
 		t.Setenv(config.EnvHome, t.TempDir())
 		client := newCCIClient(t, cciSrv.URL)
-		session, err := sidecar.OpenSession(context.Background(), client, "sidecar-123", keyFile, "")
+		session, err := sidecar.OpenSession(context.Background(), client, "sidecar-123", keyFile, "", false)
 		assert.NilError(t, err)
 
 		cfg := &config.ProjectConfig{Commands: []config.Command{
@@ -481,7 +481,7 @@ func TestRunRemoteSSH(t *testing.T) {
 
 		t.Setenv(config.EnvHome, t.TempDir())
 		client := newCCIClient(t, cciSrv.URL)
-		session, err := sidecar.OpenSession(context.Background(), client, "sidecar-123", keyFile, "")
+		session, err := sidecar.OpenSession(context.Background(), client, "sidecar-123", keyFile, "", false)
 		assert.NilError(t, err)
 
 		cfg := &config.ProjectConfig{Commands: []config.Command{
@@ -505,7 +505,7 @@ func TestRunRemoteSSH(t *testing.T) {
 
 		t.Setenv(config.EnvHome, t.TempDir())
 		client := newCCIClient(t, cciSrv.URL)
-		session, err := sidecar.OpenSession(context.Background(), client, "sidecar-123", keyFile, "")
+		session, err := sidecar.OpenSession(context.Background(), client, "sidecar-123", keyFile, "", false)
 		assert.NilError(t, err)
 
 		cfg := &config.ProjectConfig{Commands: []config.Command{

--- a/internal/variants/exec_test.go
+++ b/internal/variants/exec_test.go
@@ -39,7 +39,7 @@ func newSession(t *testing.T, exitFor func(command string) (string, int)) (*side
 	client, err := circleci.NewClient(circleci.Config{Token: "fake-token", BaseURL: api.URL})
 	assert.NilError(t, err)
 
-	session, err := sidecar.OpenSession(context.Background(), client, "sc-1", keyFile, "")
+	session, err := sidecar.OpenSession(context.Background(), client, "sc-1", keyFile, "", false)
 	assert.NilError(t, err)
 	return session, sshSrv
 }

--- a/internal/variants/variants.go
+++ b/internal/variants/variants.go
@@ -176,7 +176,7 @@ func runVariant(ctx context.Context, client *circleci.Client, v Variant, opts Op
 		return base
 	}
 
-	session, err := sidecar.OpenSession(ctx, client, sc.ID, opts.IdentityFile, opts.AuthSock)
+	session, err := sidecar.OpenSession(ctx, client, sc.ID, opts.IdentityFile, opts.AuthSock, false)
 	if err != nil {
 		base.Error = fmt.Sprintf("open session: %v", err)
 		return base


### PR DESCRIPTION
- add reusable Pool and Target abstractions for sidecar coordination
- refactor sync and session setup for fanout, stale probing, and retry-aware SSH key registration
- extend fake CircleCI and tests to support deterministic pool creation and reuse