### PR TITLE
Isolate credential storage in tests

### DIFF
--- a/internal/authprompt/authprompt_test.go
+++ b/internal/authprompt/authprompt_test.go
@@ -6,9 +6,11 @@ import (
 	"encoding/hex"
 	"errors"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
+	gokeyring "github.com/zalando/go-keyring"
 	"gotest.tools/v3/assert"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/authprompt"
@@ -16,7 +18,12 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 )
 
-const insecureStorage = true // skip keychain in unit tests; use config file only
+const insecureStorage = true // write credentials to the config file in unit tests
+
+func TestMain(m *testing.M) {
+	gokeyring.MockInit()
+	os.Exit(m.Run())
+}
 
 func isolateConfig(t *testing.T) {
 	t.Helper()

--- a/internal/cmd/authhelper_test.go
+++ b/internal/cmd/authhelper_test.go
@@ -7,11 +7,13 @@ import (
 	"errors"
 	"io"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
+	gokeyring "github.com/zalando/go-keyring"
 	"gotest.tools/v3/assert"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
@@ -20,6 +22,11 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
 	"github.com/CircleCI-Public/chunk-cli/internal/ui"
 )
+
+func TestMain(m *testing.M) {
+	gokeyring.MockInit()
+	os.Exit(m.Run())
+}
 
 func isolateConfig(t *testing.T) {
 	t.Helper()
@@ -47,7 +54,7 @@ func noTTYPrompter(_ string) (string, error) {
 func testCmd() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Flags().Bool("insecure-storage", false, "")
-	// Use insecure (config file) storage in tests to avoid hitting the system keychain.
+	// Use config-file storage for credentials written by tests.
 	_ = cmd.Flags().Set("insecure-storage", "true")
 	return cmd
 }

--- a/internal/testing/env/env.go
+++ b/internal/testing/env/env.go
@@ -41,6 +41,9 @@ func (e *TestEnv) Environ() []string {
 		fmt.Sprintf("HOME=%s", e.HomeDir),
 		fmt.Sprintf("XDG_CONFIG_HOME=%s", configDir),
 		fmt.Sprintf("XDG_DATA_HOME=%s", dataDir),
+		// CLI subprocesses must not query the developer's DBus keyring when a
+		// test intentionally omits a credential.
+		"DBUS_SESSION_BUS_ADDRESS=unix:path=/nonexistent",
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 		"SHELL=/bin/zsh",
 		"NO_COLOR=1",


### PR DESCRIPTION
- Use go-keyring's in-memory backend in auth-related unit tests
- Prevent CLI acceptance subprocesses from reaching the desktop DBus keyring
- Keep --insecure-storage scoped to credential writes