### PR TITLE
Gate keychain reads on insecureStorage

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,7 +167,7 @@ func configFileSource() string {
 	return SourceConfigFile
 }
 
-func resolveCircleCIToken(env EnvVars, cfg UserConfig) (string, string) {
+func resolveCircleCIToken(env EnvVars, cfg UserConfig, insecureStorage bool) (string, string) {
 	switch {
 	case env.CircleToken != "":
 		return env.CircleToken, "Environment variable (" + EnvCircleToken + ")"
@@ -175,6 +175,8 @@ func resolveCircleCIToken(env EnvVars, cfg UserConfig) (string, string) {
 		return env.CircleCIToken, "Environment variable (" + EnvCircleCIToken + ")"
 	case cfg.CircleCIToken != "":
 		return cfg.CircleCIToken, configFileSource()
+	case insecureStorage:
+		return "", ""
 	default:
 		if token, err := keyring.Get(keyring.ServiceCircleCI(env.CircleCIBaseURL)); err == nil {
 			return token, keyring.SourceKeychain
@@ -183,7 +185,7 @@ func resolveCircleCIToken(env EnvVars, cfg UserConfig) (string, string) {
 	return "", ""
 }
 
-func resolveAnthropicAPIKey(flagAPIKey string, env EnvVars, cfg UserConfig) (string, string) {
+func resolveAnthropicAPIKey(flagAPIKey string, env EnvVars, cfg UserConfig, insecureStorage bool) (string, string) {
 	switch {
 	case flagAPIKey != "":
 		return flagAPIKey, "Flag"
@@ -191,6 +193,8 @@ func resolveAnthropicAPIKey(flagAPIKey string, env EnvVars, cfg UserConfig) (str
 		return env.AnthropicAPIKey, "Environment variable"
 	case cfg.AnthropicAPIKey != "":
 		return cfg.AnthropicAPIKey, configFileSource()
+	case insecureStorage:
+		return "", ""
 	default:
 		if apiKey, err := keyring.Get(keyring.ServiceAnthropic(env.AnthropicBaseURL)); err == nil {
 			return apiKey, keyring.SourceKeychain
@@ -199,12 +203,14 @@ func resolveAnthropicAPIKey(flagAPIKey string, env EnvVars, cfg UserConfig) (str
 	return "", ""
 }
 
-func resolveGitHubToken(env EnvVars, cfg UserConfig) (string, string) {
+func resolveGitHubToken(env EnvVars, cfg UserConfig, insecureStorage bool) (string, string) {
 	switch {
 	case env.GitHubToken != "":
 		return env.GitHubToken, "Environment variable (" + EnvGitHubToken + ")"
 	case cfg.GitHubToken != "":
 		return cfg.GitHubToken, configFileSource()
+	case insecureStorage:
+		return "", ""
 	default:
 		if token, err := keyring.Get(keyring.ServiceGitHub(env.GitHubAPIURL)); err == nil {
 			return token, keyring.SourceKeychain
@@ -350,9 +356,9 @@ func GetUserID() uuid.UUID {
 // Resolve computes the final config from flags, env, file, and keychain.
 // Priority for API key: flag > env > config file > keychain > (none).
 // Priority for model: flag > env > config file > default.
-// insecureStorage affects credential writes elsewhere, but reads always use the
-// same precedence order.
-func Resolve(flagAPIKey, flagModel string, _ bool) (ResolvedConfig, error) {
+// insecureStorage excludes the keychain from the read path, so callers that
+// opted out of secure storage never touch it.
+func Resolve(flagAPIKey, flagModel string, insecureStorage bool) (ResolvedConfig, error) {
 	cfg, err := Load()
 
 	env, envErr := LoadEnv(context.Background())
@@ -364,9 +370,9 @@ func Resolve(flagAPIKey, flagModel string, _ bool) (ResolvedConfig, error) {
 		AnalyzeModel: AnalyzeModel,
 		PromptModel:  PromptModel,
 	}
-	rc.CircleCIToken, rc.CircleCITokenSource = resolveCircleCIToken(env, cfg)
-	rc.AnthropicAPIKey, rc.AnthropicAPIKeySource = resolveAnthropicAPIKey(flagAPIKey, env, cfg)
-	rc.GitHubToken, rc.GitHubTokenSource = resolveGitHubToken(env, cfg)
+	rc.CircleCIToken, rc.CircleCITokenSource = resolveCircleCIToken(env, cfg, insecureStorage)
+	rc.AnthropicAPIKey, rc.AnthropicAPIKeySource = resolveAnthropicAPIKey(flagAPIKey, env, cfg, insecureStorage)
+	rc.GitHubToken, rc.GitHubTokenSource = resolveGitHubToken(env, cfg, insecureStorage)
 
 	switch {
 	case flagModel != "":
@@ -395,7 +401,7 @@ func Resolve(flagAPIKey, flagModel string, _ bool) (ResolvedConfig, error) {
 // ResolveCircleCI returns only the CircleCI-related config needed by sidecar
 // commands. It intentionally skips Anthropic and GitHub resolution so callers
 // that only need CircleCI auth avoid unrelated keyring work.
-func ResolveCircleCI(_ bool) (ResolvedConfig, error) {
+func ResolveCircleCI(insecureStorage bool) (ResolvedConfig, error) {
 	cfg, err := Load()
 	if err != nil {
 		return ResolvedConfig{}, err
@@ -415,7 +421,7 @@ func ResolveCircleCI(_ bool) (ResolvedConfig, error) {
 		UseSSHIdentityFile: cfg.UseSSHIdentityFile,
 		Notifications:      cfg.Notifications,
 	}
-	rc.CircleCIToken, rc.CircleCITokenSource = resolveCircleCIToken(env, cfg)
+	rc.CircleCIToken, rc.CircleCITokenSource = resolveCircleCIToken(env, cfg, insecureStorage)
 	return rc, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -377,14 +377,39 @@ func TestResolveCircleCI_ConfigFile(t *testing.T) {
 	assert.Equal(t, rc.GitHubToken, "")
 }
 
-func TestResolve_ReadsKeychainWhenInsecureStorageTrue(t *testing.T) {
+func TestResolve_ReadsKeychainWhenSecureStorage(t *testing.T) {
 	setupTempConfig(t)
 	assert.NilError(t, keyring.Set(keyring.ServiceCircleCI("https://circleci.com"), "cci-from-keychain"))
 
-	rc, err := ResolveCircleCI(true)
+	rc, err := ResolveCircleCI(false)
 	assert.NilError(t, err)
 	assert.Equal(t, rc.CircleCIToken, "cci-from-keychain")
 	assert.Equal(t, rc.CircleCITokenSource, keyring.SourceKeychain)
+}
+
+// insecureStorage opts out of the keychain for reads as well as writes, so a
+// stored credential must be invisible to Resolve. Without this the keychain is
+// consulted on every resolve, which makes tests reach the developer's real
+// keychain whenever no env var or config file supplies a credential.
+func TestResolve_SkipsKeychainWhenInsecureStorage(t *testing.T) {
+	setupTempConfig(t)
+	assert.NilError(t, keyring.Set(keyring.ServiceCircleCI("https://circleci.com"), "cci-from-keychain"))
+	assert.NilError(t, keyring.Set(keyring.ServiceAnthropic("https://api.anthropic.com"), "ant-from-keychain"))
+	assert.NilError(t, keyring.Set(keyring.ServiceGitHub("https://api.github.com"), "gh-from-keychain"))
+
+	rc, err := ResolveCircleCI(true)
+	assert.NilError(t, err)
+	assert.Equal(t, rc.CircleCIToken, "")
+	assert.Equal(t, rc.CircleCITokenSource, "")
+
+	full, err := Resolve("", "", true)
+	assert.NilError(t, err)
+	assert.Equal(t, full.CircleCIToken, "")
+	assert.Equal(t, full.CircleCITokenSource, "")
+	assert.Equal(t, full.AnthropicAPIKey, "")
+	assert.Equal(t, full.AnthropicAPIKeySource, "")
+	assert.Equal(t, full.GitHubToken, "")
+	assert.Equal(t, full.GitHubTokenSource, "")
 }
 
 // --- ValidConfigKeys ---


### PR DESCRIPTION
## Summary

- `config.Resolve` and `config.ResolveCircleCI` accepted an `insecureStorage bool` and discarded it (`_ bool`), so `resolveCircleCIToken`, `resolveAnthropicAPIKey` and `resolveGitHubToken` fell through to `keyring.Get` unconditionally. All 32 call sites were dutifully passing the flag into a no-op.
- Consequence: any path that resolves credentials with no env var and no config file entry reads the keychain. That is why unit tests reach a developer's real keychain, and why the misses in #565 were easy to make.
- Fix names the parameter and threads it into the three resolvers, each gaining `case insecureStorage: return "", ""` ahead of the keychain fallback. `--insecure-storage` now means the same thing on reads as it does on writes.
- `TestResolve_ReadsKeychainWhenInsecureStorageTrue` was asserting the bug - the name says insecure storage, the body expected a keychain read. Renamed to `TestResolve_ReadsKeychainWhenSecureStorage` passing `false`, and paired with `TestResolve_SkipsKeychainWhenInsecureStorage` covering all three credentials through both entry points.

Nothing else needed touching: `internal/cmd/auth.go` already gated its presence checks correctly, and `internal/config` is the only other keyring importer.

This is the structural equivalent of what `circleci-cli` does, where `secureStorage` is a mandatory parameter on every config entry point and `cmdutil.IsSecureStorage` is the single decision point. Complements #565 rather than conflicting - no shared files.

Remote validated on a sidecar: 1500 tests pass, lint clean. The new test fails when `config.go` alone is reverted.