### PR TITLE
Keep internal/cmd tests off the real keychain

### DIFF
--- a/internal/cmd/auth_test.go
+++ b/internal/cmd/auth_test.go
@@ -14,7 +14,7 @@ func TestAuthSignupAlreadyAuthenticated(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv(config.EnvCircleToken, "test-token-abc")
 
-	cmd := newAuthSignupCmd()
+	cmd := insecureStorageCmd(newAuthSignupCmd())
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 

--- a/internal/cmd/authhelper_test.go
+++ b/internal/cmd/authhelper_test.go
@@ -28,6 +28,38 @@ func isolateConfig(t *testing.T) {
 	t.Setenv(config.EnvXDGConfigHome, filepath.Join(home, ".config"))
 	t.Setenv(config.EnvChunkSessionID, "")
 	t.Setenv(session.EnvClaudeSessionID, "")
+	// Keychain service keys are derived from these base URLs, which otherwise
+	// default to production. Point them at an unroutable host so a test that
+	// reaches the keychain cannot read the developer's own credentials. Tests
+	// needing a real endpoint override these after calling isolateConfig.
+	t.Setenv(config.EnvCircleCIBaseURL, unroutableBaseURL)
+	t.Setenv(config.EnvAnthropicBaseURL, unroutableBaseURL)
+	t.Setenv(config.EnvGitHubAPIURL, unroutableBaseURL)
+}
+
+// unroutableBaseURL is in the RFC 5737 TEST-NET-1 range: never a real service,
+// and never a keychain service key holding a real credential.
+const unroutableBaseURL = "http://192.0.2.1"
+
+// insecureStorageCmd registers the root's --insecure-storage flag on a detached
+// subcommand and turns it on. Tests construct subcommands without a root, so
+// the persistent flag does not exist and insecureStorageFlag would report
+// false, sending credential resolution to the real keychain.
+func insecureStorageCmd(cmd *cobra.Command) *cobra.Command {
+	cmd.Flags().Bool("insecure-storage", false, "")
+	_ = cmd.Flags().Set("insecure-storage", "true")
+	return cmd
+}
+
+// newTestRootCmd builds the real root command with --insecure-storage turned
+// on, so credential resolution uses the config file rather than the developer's
+// keychain. Set it rather than prepending to each test's args: the flag then
+// cannot be forgotten at a call site, and every test keeps the args it means to
+// exercise. Tests must use this in place of NewRootCmd.
+func newTestRootCmd() *cobra.Command {
+	root := NewRootCmd("test")
+	_ = root.PersistentFlags().Set("insecure-storage", "true")
+	return root
 }
 
 func randToken(prefix string) string {
@@ -45,11 +77,7 @@ func noTTYPrompter(_ string) (string, error) {
 }
 
 func testCmd() *cobra.Command {
-	cmd := &cobra.Command{}
-	cmd.Flags().Bool("insecure-storage", false, "")
-	// Use insecure (config file) storage in tests to avoid hitting the system keychain.
-	_ = cmd.Flags().Set("insecure-storage", "true")
-	return cmd
+	return insecureStorageCmd(&cobra.Command{})
 }
 
 func TestEnsureCircleCIClient_NoTTY(t *testing.T) {
@@ -170,4 +198,20 @@ func TestEnsureCircleCIClient_EmptyToken(t *testing.T) {
 	var ue *userError
 	assert.Assert(t, errors.As(err, &ue))
 	assert.Assert(t, strings.Contains(ue.Suggestion(), "CIRCLE_TOKEN"), "expected suggestion about CIRCLE_TOKEN, got: %s", ue.Suggestion())
+}
+
+// A subcommand built without a root has no --insecure-storage flag, so
+// insecureStorageFlag reports false and credential resolution falls through to
+// the keychain. insecureStorageCmd is what keeps tests off it.
+func TestInsecureStorageFlagRequiresRegistration(t *testing.T) {
+	assert.Equal(t, insecureStorageFlag(&cobra.Command{}), false)
+	assert.Equal(t, insecureStorageFlag(insecureStorageCmd(&cobra.Command{})), true)
+}
+
+// Registering the flag without turning it on is the trap org_test.go fell into:
+// the flag exists, cobra accepts it, and resolution still uses the keychain.
+func TestInsecureStorageFlagRegisteredButUnsetIsFalse(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("insecure-storage", false, "")
+	assert.Equal(t, insecureStorageFlag(cmd), false)
 }

--- a/internal/cmd/hook_test.go
+++ b/internal/cmd/hook_test.go
@@ -14,7 +14,7 @@ import (
 
 func runHooksCmd(t *testing.T, dir string, args ...string) (string, string, error) {
 	t.Helper()
-	root := NewRootCmd("test")
+	root := newTestRootCmd()
 	var out, errOut bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&errOut)
@@ -75,7 +75,7 @@ func TestValidateHookPath_HooksDisabled(t *testing.T) {
 	t.Setenv(config.EnvChunkHooksDisabled, "1")
 
 	dir := t.TempDir()
-	root := NewRootCmd("test")
+	root := newTestRootCmd()
 	var errOut bytes.Buffer
 	root.SetErr(&errOut)
 	root.SetArgs([]string{"validate", "--project", dir})

--- a/internal/cmd/org_test.go
+++ b/internal/cmd/org_test.go
@@ -25,7 +25,7 @@ func TestOrgCreateHappyPath(t *testing.T) {
 	t.Setenv(config.EnvCircleToken, "test-token")
 	t.Setenv(config.EnvCircleCIBaseURL, srv.URL)
 
-	cmd := newOrgCreateCmd()
+	cmd := insecureStorageCmd(newOrgCreateCmd())
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 
@@ -55,7 +55,7 @@ func TestOrgCreateAPIError(t *testing.T) {
 	t.Setenv(config.EnvCircleToken, "test-token")
 	t.Setenv(config.EnvCircleCIBaseURL, srv.URL)
 
-	cmd := newOrgCreateCmd()
+	cmd := insecureStorageCmd(newOrgCreateCmd())
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 
@@ -78,7 +78,7 @@ func TestOrgCreateRequiresAuth(t *testing.T) {
 	t.Setenv(config.EnvCircleToken, "")
 	t.Setenv(config.EnvCircleCIToken, "")
 
-	cmd := newOrgCreateCmd()
+	cmd := insecureStorageCmd(newOrgCreateCmd())
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 
@@ -97,7 +97,7 @@ func TestOrgCreateRequiresAuth(t *testing.T) {
 }
 
 func TestOrgCreateRequiresName(t *testing.T) {
-	cmd := newOrgCreateCmd()
+	cmd := insecureStorageCmd(newOrgCreateCmd())
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 
@@ -123,8 +123,7 @@ func TestOrgListTableOutput(t *testing.T) {
 		{ID: "org-def", Name: "otherorg", VCSType: "circleci"},
 	}
 
-	cmd := newOrgListCmd()
-	cmd.Flags().Bool("insecure-storage", false, "")
+	cmd := insecureStorageCmd(newOrgListCmd())
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 
@@ -145,8 +144,7 @@ func TestOrgListJSONOutput(t *testing.T) {
 		{ID: "org-abc", Name: "myorg", VCSType: "github"},
 	}
 
-	cmd := newOrgListCmd()
-	cmd.Flags().Bool("insecure-storage", false, "")
+	cmd := insecureStorageCmd(newOrgListCmd())
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 	cmd.SetArgs([]string{"--json"})
@@ -167,8 +165,7 @@ func TestOrgListJSONOutput(t *testing.T) {
 func TestOrgListJSONEmpty(t *testing.T) {
 	setupOrgListFake(t)
 
-	cmd := newOrgListCmd()
-	cmd.Flags().Bool("insecure-storage", false, "")
+	cmd := insecureStorageCmd(newOrgListCmd())
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 	cmd.SetArgs([]string{"--json"})
@@ -188,8 +185,7 @@ func TestOrgListJSONEmpty(t *testing.T) {
 func TestOrgListEmpty(t *testing.T) {
 	setupOrgListFake(t)
 
-	cmd := newOrgListCmd()
-	cmd.Flags().Bool("insecure-storage", false, "")
+	cmd := insecureStorageCmd(newOrgListCmd())
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 
@@ -208,8 +204,7 @@ func TestOrgListRequiresAuth(t *testing.T) {
 	t.Setenv(config.EnvCircleToken, "")
 	t.Setenv(config.EnvCircleCIToken, "")
 
-	cmd := newOrgListCmd()
-	cmd.Flags().Bool("insecure-storage", false, "")
+	cmd := insecureStorageCmd(newOrgListCmd())
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 

--- a/internal/cmd/sidecar_test.go
+++ b/internal/cmd/sidecar_test.go
@@ -36,9 +36,7 @@ func TestSidecarCreateUsesImageFromConfig(t *testing.T) {
 		Validation: &config.ValidationConfig{SidecarImage: "snap-from-config"},
 	}))
 
-	cmd := newSidecarCreateCmd()
-	cmd.Flags().Bool("insecure-storage", false, "")
-	_ = cmd.Flags().Set("insecure-storage", "true")
+	cmd := insecureStorageCmd(newSidecarCreateCmd())
 	cmd.SetArgs([]string{"--org-id", "org-abc"})
 	assert.NilError(t, cmd.Execute())
 

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -35,11 +35,14 @@ const hookPayload = `{"session_id":"test-session-001","stop_hook_active":false}`
 func runValidateHook(t *testing.T, workDir string) (stdout, stderr string, err error) {
 	t.Helper()
 	var outBuf, errBuf bytes.Buffer
-	root := NewRootCmd("test")
+	root := newTestRootCmd()
 	root.SetOut(&outBuf)
 	root.SetErr(&errBuf)
 	root.SetIn(strings.NewReader(hookPayload))
-	root.SetArgs([]string{"validate", "--project", workDir})
+	// Prepend --insecure-storage so the hook resolves credentials from the
+	// config file, never the developer's keychain. This goes through the real
+	// root command, so the flag has to arrive as an argument.
+	root.SetArgs([]string{"--insecure-storage", "validate", "--project", workDir})
 	err = root.Execute()
 	return outBuf.String(), errBuf.String(), err
 }
@@ -179,7 +182,7 @@ func TestValidateNoConfigShowsSkillHint(t *testing.T) {
 	dir := t.TempDir()
 
 	var outBuf, errBuf bytes.Buffer
-	root := NewRootCmd("test")
+	root := newTestRootCmd()
 	root.SetOut(&outBuf)
 	root.SetErr(&errBuf)
 	root.SetArgs([]string{"validate", "--project", dir})
@@ -211,7 +214,7 @@ func TestValidateDefaultsToRemote(t *testing.T) {
 	}))
 
 	var outBuf, errBuf bytes.Buffer
-	root := NewRootCmd("test")
+	root := newTestRootCmd()
 	root.SetOut(&outBuf)
 	root.SetErr(&errBuf)
 	root.SetArgs([]string{"validate", "--project", dir})
@@ -238,7 +241,7 @@ func TestValidateLocalFlagRunsLocally(t *testing.T) {
 	}))
 
 	var outBuf, errBuf bytes.Buffer
-	root := NewRootCmd("test")
+	root := newTestRootCmd()
 	root.SetOut(&outBuf)
 	root.SetErr(&errBuf)
 	root.SetArgs([]string{"validate", "--local", "--project", dir})
@@ -265,7 +268,7 @@ func TestValidateLocalFlagOverridesRemoteConfig(t *testing.T) {
 	}))
 
 	var outBuf, errBuf bytes.Buffer
-	root := NewRootCmd("test")
+	root := newTestRootCmd()
 	root.SetOut(&outBuf)
 	root.SetErr(&errBuf)
 	root.SetArgs([]string{"validate", "--local", "--project", dir})
@@ -290,7 +293,7 @@ func TestValidateEnvFlagBadValue(t *testing.T) {
 		0o644,
 	))
 
-	cmd := newValidateCmd()
+	cmd := insecureStorageCmd(newValidateCmd())
 	cmd.SetOut(os.Stderr)
 	cmd.SetErr(os.Stderr)
 	cmd.SetArgs([]string{"--project", dir, "--env", "BADVALUE"})
@@ -316,7 +319,7 @@ const skipMsg = "skipped (no changes since last successful run)"
 func runActiveStopHook(t *testing.T, dir string) (stderr string, err error) {
 	t.Helper()
 	var outBuf, errBuf bytes.Buffer
-	root := NewRootCmd("test")
+	root := newTestRootCmd()
 	root.SetOut(&outBuf)
 	root.SetErr(&errBuf)
 	root.SetIn(strings.NewReader(activeStopHookPayload))
@@ -680,7 +683,7 @@ func TestSidecarAutoNameNoSessionLongBranch(t *testing.T) {
 func runValidateListCLI(t *testing.T, workDir string) (stdout, stderr string, err error) {
 	t.Helper()
 	var outBuf, errBuf bytes.Buffer
-	root := NewRootCmd("test")
+	root := newTestRootCmd()
 	root.SetOut(&outBuf)
 	root.SetErr(&errBuf)
 	root.SetArgs([]string{"validate", "--list", "--project", workDir})
@@ -691,7 +694,7 @@ func runValidateListCLI(t *testing.T, workDir string) (stdout, stderr string, er
 func runMarkRemoteCLI(t *testing.T, workDir string, extraArgs ...string) (stdout, stderr string, err error) {
 	t.Helper()
 	var outBuf, errBuf bytes.Buffer
-	root := NewRootCmd("test")
+	root := newTestRootCmd()
 	root.SetOut(&outBuf)
 	root.SetErr(&errBuf)
 	root.SetArgs(append([]string{"validate", "--mark-remote", "--project", workDir}, extraArgs...))


### PR DESCRIPTION
## Summary

#566 gated keychain reads on `insecureStorage`, but the `internal/cmd` tests never reach that gate. They build detached subcommands, so the root's persistent `--insecure-storage` flag does not exist and `insecureStorageFlag` reports false. `org_test.go` registered a stand-in flag to stop cobra rejecting the unknown name, but left it defaulted `false`, which selects the keychain branch.

It stayed hidden because `keyring.Get` maps every error to `ErrNotFound`, so a denial is indistinguishable from no credential. Linux CI has no Secret Service, and macOS denies the `go test` binary via the keychain item's ACL. Where a developer has granted access the read succeeds and their real token leaks into tests asserting the unauthenticated path - which is what Rob was hitting.

## Approach

Structural, mirroring `circleci-cli`, which never needs to mock the keyring. No `MockInit`, and `internal/keyring` is untouched.

- `insecureStorageCmd` gives the register-then-enable idiom already present in `authhelper_test.go` and `sidecar_test.go` one definition, used by the nine sites that were missing the enable.
- `newTestRootCmd` replaces ten inline `NewRootCmd("test")` calls and enables the flag on the real persistent flag set, so no call site can forget it. Same move as the acceptance harness in `internal/testing/binary`.
- `isolateConfig` points the three base URLs at TEST-NET-1 (`192.0.2.1`). Keychain service keys derive from the base URL, so a future missed site looks up `com.circleci.chunk:circleci:http://192.0.2.1` - a key that cannot hold a real credential. This is the layer that makes it durable rather than just correct today.

Two new tests pin the flag plumbing, including the registered-but-unset trap that caused this.

## Verification

Temporarily instrumented `keyring.Get` to log every caller with its test name, then ran the full suite and worked the list down. 19 reads across `org_test.go`, `auth_test.go` and `validate_test.go` before; **zero** from `internal/cmd` and `internal/authprompt` after. `internal/keyring` restored pristine.

`internal/config` still reads, but into its own `MockInit` provider - every resolving test there goes through `setupTempConfig`, so it is not order-dependent. Left alone.

`task lint` clean, `task test` 1502 tests pass. Test-only change, no production code.