### PR TITLE
Write chunk validate results to the filesystem

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -207,6 +207,14 @@ chunk
   Non-interactive sessions (agents, CI) should set `orgID` in project config or
   pass `--org-id` / `CIRCLECI_ORG_ID`.
 - `watch` requires a TTY — it exits with an error if stdout is not a terminal. It polls sidecar state every 5 seconds and keeps an in-memory window of the 300 most recent event log entries. Use `j`/`k` or `↑`/`↓` to select a sidecar, `q` or `Esc` to quit. By default it watches every project it knows about; pass `--focus` to watch only the current directory. Running `watch` in a project also registers that project so future runs find it. `--all` is deprecated — it is now the default.
+- **Nothing is streamed to the daemon; results are always read from disk.** Every
+  `validate` run writes its events to the project's event log and registers the
+  project (a `project-root` breadcrumb in the same data directory) whether or not
+  a daemon is running and whether or not a sidecar is involved. The daemon
+  discovers projects from those breadcrumbs and replays each log from the start,
+  so a run made with no dashboard open — a `--local` run, or one in a repo that
+  has never had a sidecar — is there in full the next time `watch` opens, under
+  the project's `local` row.
 - **`watch` rows are per branch, except when they cannot be.** A branch's local runs
   are folded into its sidecar's row, so one row shows both kinds of run along with
   sync state. A branch with more than one sidecar — two agent sessions in one

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -207,14 +207,16 @@ chunk
   Non-interactive sessions (agents, CI) should set `orgID` in project config or
   pass `--org-id` / `CIRCLECI_ORG_ID`.
 - `watch` requires a TTY — it exits with an error if stdout is not a terminal. It polls sidecar state every 5 seconds and keeps an in-memory window of the 300 most recent event log entries. Use `j`/`k` or `↑`/`↓` to select a sidecar, `q` or `Esc` to quit. By default it watches every project it knows about; pass `--focus` to watch only the current directory. Running `watch` in a project also registers that project so future runs find it. `--all` is deprecated — it is now the default.
-- **Nothing is streamed to the daemon; results are always read from disk.** Every
-  `validate` run writes its events to the project's event log and registers the
-  project (a `project-root` breadcrumb in the same data directory) whether or not
-  a daemon is running and whether or not a sidecar is involved. The daemon
-  discovers projects from those breadcrumbs and replays each log from the start,
-  so a run made with no dashboard open — a `--local` run, or one in a repo that
-  has never had a sidecar — is there in full the next time `watch` opens, under
-  the project's `local` row.
+- **Run results are read from disk, not sent to the daemon.** Every `validate` run
+  writes its events to the project's event log and registers the project (a
+  `project-root` breadcrumb in the same data directory) whether or not a daemon
+  is running and whether or not a sidecar is involved. The daemon discovers
+  projects from those breadcrumbs and replays each log from the start, so a run
+  made with no dashboard open — a `--local` run, or one in a repo that has never
+  had a sidecar — is there in full the next time `watch` opens, under the
+  project's `local` row. (Remote command *output* is the exception: it is
+  registered with the daemon live and buffered in memory, keyed by the same
+  project root, so it too is only listed for a project that has been registered.)
 - **`watch` rows are per branch, except when they cannot be.** A branch's local runs
   are folded into its sidecar's row, so one row shows both kinds of run along with
   sync state. A branch with more than one sidecar — two agent sessions in one

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -281,13 +281,18 @@ chunk watch  1 sidecar  main@a3f9e12                      15:04:32
   ↑/↓ j/k  select  ·  q  quit
 ```
 
-`watch` shows every project you've watched before, not just the current one:
+`watch` shows every project you've watched or validated in before, not just the current one:
 
 ```bash
-chunk watch                   # all projects you've watched before
+chunk watch                   # all projects chunk has seen
 chunk watch --focus           # current directory only
 chunk watch /path/to/other    # add another project
 ```
+
+You don't have to have the dashboard open at the time. Every `chunk validate` run
+records its results to disk — including a purely local run, in a project that has
+never had a sidecar — so runs you made with no dashboard open are waiting for you
+the next time you open one, under a `local` row for the project.
 
 `watch` requires a TTY — it will not run in a non-interactive shell (CI, pipes).
 

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -448,8 +448,6 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		// the IsDaemonCompatible check and the POST (connection refused), and the
 		// daemon lacks the /validate endpoint because it is from an older build
 		// (404). Both fall through to inline execution.
-		// daemon disappeared between the IsDaemonRunning check and the POST;
-		// fall through to inline execution.
 	}
 
 	// allRemote is true unless --local is passed explicitly. opts.remote is

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -541,12 +541,15 @@ func newValidateRecorder(statusFn iostream.StatusFunc, sidecarID string, activeS
 	}
 	// A missing data dir leaves the recorder reporting without recording.
 	dataDir, _ := config.ProjectDataDir(workDir)
-	// Register the project alongside the log about to be written to it. Nothing
-	// is streamed to the watch daemon — it reads these same files — and only
-	// saving sidecar state used to register a project, so a run with no sidecar
-	// (--local, or a repo with no remote commands) logged its results where no
-	// daemon would ever look for them. Best-effort: a run still records without
-	// the breadcrumb, and still reports without the log.
+	// Register the project alongside the log about to be written to it. A run's
+	// results are never sent to the watch daemon — it reads this same log off
+	// disk — and only saving sidecar state used to register a project, so a run
+	// with no sidecar (--local, or a repo with no remote commands) logged its
+	// results where no daemon would ever look for them. Registered remote
+	// commands were reached the same way: the daemon buffers their output under a
+	// project root it lists only once it has discovered that project.
+	// Best-effort: a run still records without the breadcrumb, and still reports
+	// without the log.
 	_ = sidecar.RegisterProjectRoot(dataDir, workDir)
 	return eventlog.Record(dataDir, statusFn, op, sidecarID, scName, sidecar.CurrentBranch(workDir))
 }

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -540,6 +540,13 @@ func newValidateRecorder(statusFn iostream.StatusFunc, sidecarID string, activeS
 	}
 	// A missing data dir leaves the recorder reporting without recording.
 	dataDir, _ := config.ProjectDataDir(workDir)
+	// Register the project alongside the log about to be written to it. Nothing
+	// is streamed to the watch daemon — it reads these same files — and only
+	// saving sidecar state used to register a project, so a run with no sidecar
+	// (--local, or a repo with no remote commands) logged its results where no
+	// daemon would ever look for them. Best-effort: a run still records without
+	// the breadcrumb, and still reports without the log.
+	_ = sidecar.RegisterProjectRoot(dataDir, workDir)
 	return eventlog.Record(dataDir, statusFn, op, sidecarID, scName, sidecar.CurrentBranch(workDir))
 }
 

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -278,6 +279,48 @@ func TestValidateLocalFlagOverridesRemoteConfig(t *testing.T) {
 	combined := outBuf.String() + errBuf.String()
 	assert.Assert(t, strings.Contains(combined, "ran-locally"),
 		"--local must execute commands locally even when Remote:true, got: %q", combined)
+}
+
+// A run with no sidecar is the only record of itself: nothing is streamed to the
+// watch daemon, which reads this same on-disk log. Registering the project is
+// what tells the daemon the log exists at all, so a run that skips it leaves
+// results nothing will ever show.
+func TestValidateLocalRunRegistersProjectForTheDaemon(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
+	t.Setenv(config.EnvCircleToken, "")
+	t.Setenv(config.EnvCircleCIToken, "")
+
+	dir := t.TempDir()
+	assert.NilError(t, config.SaveProjectConfig(dir, &config.ProjectConfig{
+		Commands: []config.Command{{Name: "test", Run: "echo ran-locally"}},
+	}))
+
+	var outBuf, errBuf bytes.Buffer
+	root := newTestRootCmd()
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"validate", "--local", "--project", dir})
+	assert.NilError(t, root.Execute())
+
+	roots, err := sidecar.AllProjectRoots()
+	assert.NilError(t, err)
+	assert.Assert(t, slices.Contains(roots, dir),
+		"a local run must register the project it logged to, got: %v", roots)
+
+	// And the run it recorded there closes with a tally, so a daemon that starts
+	// afterwards has a result to show rather than an open-ended run.
+	dataDir, err := config.ProjectDataDir(dir)
+	assert.NilError(t, err)
+	log, err := eventlog.Open(dataDir)
+	assert.NilError(t, err)
+	events, err := log.Recent(10)
+	assert.NilError(t, err)
+	assert.Assert(t, len(events) > 0, "the run recorded no events")
+	passed, total, ok := events[len(events)-1].Outcome()
+	assert.Assert(t, ok, "last event does not close the run: %+v", events[len(events)-1])
+	assert.Equal(t, passed, 1)
+	assert.Equal(t, total, 1)
 }
 
 func TestValidateEnvFlagBadValue(t *testing.T) {

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -308,9 +308,13 @@ func TestValidateLocalRunRegistersProjectForTheDaemon(t *testing.T) {
 	root.SetArgs([]string{"validate", "--local", "--project", dir})
 	assert.NilError(t, root.Execute())
 
+	// Canonical, because that is what registration writes and the daemon keys on:
+	// a darwin temp dir arrives here as /var/... and resolves to /private/var/...
+	canonical, err := filepath.EvalSymlinks(dir)
+	assert.NilError(t, err)
 	roots, err := sidecar.AllProjectRoots()
 	assert.NilError(t, err)
-	assert.Assert(t, slices.Contains(roots, dir),
+	assert.Assert(t, slices.Contains(roots, canonical),
 		"a local run must register the project it logged to, got: %v", roots)
 
 	// And the run it recorded there closes with a tally, so a daemon that starts

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -61,7 +61,11 @@ func newWatchCmd() *cobra.Command {
 					return fmt.Errorf("watch: invalid path %q: %w", root, err)
 				}
 				if gitRoot := gitutil.TopLevelCtx(cmd.Context(), abs); gitRoot != "" {
-					abs = gitRoot
+					// Canonicalised because --focus sends these roots to the daemon as a
+					// filter, and the daemon keys projects by the canonical spelling. Git
+					// happens to answer with a resolved path on darwin, so a mismatch here
+					// would be invisible on one platform and an empty dashboard on another.
+					abs = config.CanonicalProjectRoot(gitRoot)
 				} else {
 					// Skip non-git paths: nothing to watch and no sidecar to find.
 					continue

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -77,9 +77,7 @@ func newWatchCmd() *cobra.Command {
 				}
 
 				// Register this project so future runs discover it.
-				if err := os.MkdirAll(dataDir, 0o755); err == nil {
-					_ = os.WriteFile(filepath.Join(dataDir, "project-root"), []byte(abs), 0o644)
-				}
+				_ = sidecar.RegisterProjectRoot(dataDir, abs)
 
 				el, err := eventlog.Open(dataDir)
 				if err != nil {

--- a/internal/cmd/watch_test.go
+++ b/internal/cmd/watch_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -60,4 +61,32 @@ func TestWatchAllFlagIsDeprecatedButAccepted(t *testing.T) {
 	all := cmd.Flags().Lookup("all")
 	assert.Assert(t, all != nil, "--all should still parse for existing invocations")
 	assert.Assert(t, all.Deprecated != "", "--all should be marked deprecated")
+}
+
+// --focus sends these roots to the daemon as a filter, and the daemon keys
+// projects by the canonical spelling, so a root that reaches it unresolved
+// matches nothing and the dashboard comes back empty. Git answers with a
+// resolved path on darwin, which would hide this on the platform it was
+// developed on.
+func TestWatchRootsAreCanonicalForTheDaemonFilter(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
+
+	base := t.TempDir()
+	target := filepath.Join(base, "project")
+	assert.NilError(t, os.MkdirAll(target, 0o755))
+	link := filepath.Join(base, "link")
+	assert.NilError(t, os.Symlink(target, link))
+
+	canonical := config.CanonicalProjectRoot(target)
+	assert.Equal(t, config.CanonicalProjectRoot(link), canonical,
+		"both spellings must canonicalise to one root")
+
+	// What registration writes, and so what the daemon reports, for either.
+	dataDir, err := config.ProjectDataDir(link)
+	assert.NilError(t, err)
+	assert.NilError(t, sidecar.RegisterProjectRoot(dataDir, link))
+	roots, err := sidecar.AllProjectRoots()
+	assert.NilError(t, err)
+	assert.DeepEqual(t, roots, []string{canonical})
 }

--- a/internal/cmd/watch_test.go
+++ b/internal/cmd/watch_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"os"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -9,16 +8,21 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
 )
 
 // registerProject writes the project-root breadcrumb chunk drops for every
-// project it has seen, so AllProjectRoots discovers root.
-func registerProject(t *testing.T, root string) {
+// project it has seen, so AllProjectRoots discovers root. It returns the root as
+// AllProjectRoots reports it — canonical, symlinks resolved — which is not the
+// string passed in when the path runs through one (every darwin temp dir does).
+func registerProject(t *testing.T, root string) string {
 	t.Helper()
 	dataDir, err := config.ProjectDataDir(root)
 	assert.NilError(t, err)
-	assert.NilError(t, os.MkdirAll(dataDir, 0o755))
-	assert.NilError(t, os.WriteFile(filepath.Join(dataDir, "project-root"), []byte(root), 0o644))
+	assert.NilError(t, sidecar.RegisterProjectRoot(dataDir, root))
+	canonical, err := filepath.EvalSymlinks(root)
+	assert.NilError(t, err)
+	return canonical
 }
 
 func TestWatchRootsDefaultsToAllKnownProjects(t *testing.T) {
@@ -26,12 +30,12 @@ func TestWatchRootsDefaultsToAllKnownProjects(t *testing.T) {
 	t.Setenv(config.EnvXDGDataHome, t.TempDir())
 
 	cwd, other := t.TempDir(), t.TempDir()
-	registerProject(t, other)
+	knownRoot := registerProject(t, other)
 
 	roots, err := watchRoots(cwd, false, nil)
 	assert.NilError(t, err)
 	assert.Assert(t, slices.Contains(roots, cwd), "cwd should always be watched: %v", roots)
-	assert.Assert(t, slices.Contains(roots, other), "known project should be watched by default: %v", roots)
+	assert.Assert(t, slices.Contains(roots, knownRoot), "known project should be watched by default: %v", roots)
 }
 
 func TestWatchRootsFocusLimitsToCwdAndArgs(t *testing.T) {
@@ -39,7 +43,7 @@ func TestWatchRootsFocusLimitsToCwdAndArgs(t *testing.T) {
 	t.Setenv(config.EnvXDGDataHome, t.TempDir())
 
 	cwd, other, explicit := t.TempDir(), t.TempDir(), t.TempDir()
-	registerProject(t, other)
+	_ = registerProject(t, other)
 
 	roots, err := watchRoots(cwd, true, []string{explicit})
 	assert.NilError(t, err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -55,6 +55,34 @@ func TestProjectDataDir_CollisionFree(t *testing.T) {
 	assert.Assert(t, dSlash != dHyphen, "paths that differ only by separator vs hyphen must not collide: %s", dSlash)
 }
 
+// --- CanonicalProjectRoot ---
+
+// An empty root is not a project, and must not be canonicalised into one.
+// filepath.Clean("") is ".", which stats clean against the process's working
+// directory and so survives every check a reader makes before treating a root
+// as real — leaving state that belongs to no project filed under one that does.
+func TestCanonicalProjectRoot_EmptyStaysEmpty(t *testing.T) {
+	assert.Equal(t, CanonicalProjectRoot(""), "")
+}
+
+func TestCanonicalProjectRoot_ResolvesSymlinks(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "project")
+	assert.NilError(t, os.MkdirAll(target, 0o755))
+	link := filepath.Join(base, "link")
+	assert.NilError(t, os.Symlink(target, link))
+
+	resolved, err := filepath.EvalSymlinks(target)
+	assert.NilError(t, err)
+	assert.Equal(t, CanonicalProjectRoot(link), resolved)
+}
+
+// A root that no longer exists cannot be resolved, and the cleaned path is
+// still more useful to a caller than an error it has nowhere to put.
+func TestCanonicalProjectRoot_FallsBackToClean(t *testing.T) {
+	assert.Equal(t, CanonicalProjectRoot("/no/such/dir/../dir"), "/no/such/dir")
+}
+
 // --- Dir / Path ---
 
 func TestDir_XDGSet(t *testing.T) {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -45,6 +45,27 @@ func AppData() (string, error) {
 	return filepath.Join(dh, appName), nil
 }
 
+// CanonicalProjectRoot returns projectRoot in the spelling everything that keys
+// state by a project agrees on: cleaned, with symlinks resolved, falling back to
+// the cleaned path when it cannot be resolved (a root that no longer exists,
+// most often) so callers always get a usable path.
+//
+// It exists because a project has more than one name. The same repo is
+// /tmp/x to a shell and /private/tmp/x to git on darwin, and the two used to be
+// filed apart: ProjectDataDir hashed the resolved path while the project
+// breadcrumb and registered commands carried whatever the caller was handed. One
+// project then read as two — duplicate rows over a single log — or, for a
+// command registered under the unresolved name, as output belonging to no
+// project at all. Anything that keys by project root must run it through here.
+func CanonicalProjectRoot(projectRoot string) string {
+	clean := filepath.Clean(projectRoot)
+	resolved, err := filepath.EvalSymlinks(clean)
+	if err != nil {
+		return clean
+	}
+	return resolved
+}
+
 // ProjectDataDir returns the per-project data directory keyed by projectRoot.
 // The directory name is the hex-encoded SHA-256 of the real absolute path
 // (symlinks resolved via EvalSymlinks, falling back to filepath.Clean), which
@@ -61,10 +82,7 @@ func ProjectDataDir(projectRoot string) (string, error) {
 		return "", err
 	}
 	clean := filepath.Clean(projectRoot)
-	resolved := clean
-	if r, err := filepath.EvalSymlinks(clean); err == nil {
-		resolved = r
-	}
+	resolved := CanonicalProjectRoot(projectRoot)
 	newDir := filepath.Join(base, fmt.Sprintf("%x", sha256.Sum256([]byte(resolved))))
 
 	// Only attempt migration when the symlink actually changed the path.

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -48,7 +48,11 @@ func AppData() (string, error) {
 // CanonicalProjectRoot returns projectRoot in the spelling everything that keys
 // state by a project agrees on: cleaned, with symlinks resolved, falling back to
 // the cleaned path when it cannot be resolved (a root that no longer exists,
-// most often) so callers always get a usable path.
+// most often) so callers always get a usable path. The empty string is returned
+// unchanged: filepath.Clean would turn it into ".", a root that passes every
+// existence check by standing for whatever directory the process happens to be
+// running in, and so files state belonging to no project under one that reads
+// as real.
 //
 // It exists because a project has more than one name. The same repo is
 // /tmp/x to a shell and /private/tmp/x to git on darwin, and the two used to be
@@ -58,6 +62,9 @@ func AppData() (string, error) {
 // command registered under the unresolved name, as output belonging to no
 // project at all. Anything that keys by project root must run it through here.
 func CanonicalProjectRoot(projectRoot string) string {
+	if projectRoot == "" {
+		return ""
+	}
 	clean := filepath.Clean(projectRoot)
 	resolved, err := filepath.EvalSymlinks(clean)
 	if err != nil {

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -231,19 +231,7 @@ func RegisterProjectRoot(dataDir, root string) error {
 	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dataDir, projectRootFile), []byte(canonicalRoot(root)), 0o644)
-}
-
-// canonicalRoot resolves symlinks in root, leaving it as given when it cannot be
-// resolved (a root that no longer exists, most often) so callers always get a
-// usable path. This matches how ProjectDataDir keys its directories, which is
-// what makes the two agree on what one project is.
-func canonicalRoot(root string) string {
-	resolved, err := filepath.EvalSymlinks(root)
-	if err != nil {
-		return root
-	}
-	return resolved
+	return os.WriteFile(filepath.Join(dataDir, projectRootFile), []byte(config.CanonicalProjectRoot(root)), 0o644)
 }
 
 // AllProjectRoots returns the roots of all projects chunk has recorded state
@@ -273,7 +261,7 @@ func AllProjectRoots() ([]string, error) {
 		if readErr != nil {
 			continue
 		}
-		root := canonicalRoot(strings.TrimSpace(string(data)))
+		root := config.CanonicalProjectRoot(strings.TrimSpace(string(data)))
 		if root == "" || seen[root] {
 			continue
 		}

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -168,7 +168,7 @@ func SaveActiveTo(ctx context.Context, dir string, a ActiveSidecar) error {
 	}
 	pruneRekeyedState(dir, path, a.SidecarIDs)
 	// Write a breadcrumb so chunk watch can discover this project.
-	_ = os.WriteFile(filepath.Join(dir, "project-root"), []byte(root), 0o644)
+	_ = RegisterProjectRoot(dir, root)
 	return nil
 }
 
@@ -204,8 +204,31 @@ func pruneRekeyedState(dir, keep string, sidecarIDs []string) {
 	}
 }
 
-// AllProjectRoots returns the roots of all projects that have ever saved a
-// sidecar state, by reading the breadcrumb files written by SaveActiveTo.
+// projectRootFile names the breadcrumb that maps a project data directory back
+// to the project it holds state for. It is the only way the watch daemon
+// discovers projects, so a data directory without one is invisible to it
+// however much it holds.
+const projectRootFile = "project-root"
+
+// RegisterProjectRoot writes the breadcrumb that makes root discoverable by
+// AllProjectRoots, and so by the watch daemon and its dashboard. dataDir must be
+// the data directory for root, since the daemon derives one from the other.
+//
+// Every write of project state should call this, not just sidecar state: a
+// project whose only activity is a local validate run has results worth showing
+// and, without the breadcrumb, no way to be found.
+func RegisterProjectRoot(dataDir, root string) error {
+	if dataDir == "" || root == "" {
+		return nil
+	}
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dataDir, projectRootFile), []byte(root), 0o644)
+}
+
+// AllProjectRoots returns the roots of all projects chunk has recorded state
+// for, by reading the breadcrumb files written by RegisterProjectRoot.
 func AllProjectRoots() ([]string, error) {
 	base, err := config.AppData()
 	if err != nil {
@@ -224,7 +247,7 @@ func AllProjectRoots() ([]string, error) {
 		if !e.IsDir() {
 			continue
 		}
-		crumb := filepath.Join(base, e.Name(), "project-root")
+		crumb := filepath.Join(base, e.Name(), projectRootFile)
 		data, readErr := os.ReadFile(crumb)
 		if readErr != nil {
 			continue

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -217,6 +217,13 @@ const projectRootFile = "project-root"
 // Every write of project state should call this, not just sidecar state: a
 // project whose only activity is a local validate run has results worth showing
 // and, without the breadcrumb, no way to be found.
+//
+// The root is canonicalised before it is written, because the callers disagree
+// about how to spell one: a validate run passes the working directory it was
+// given, while chunk watch passes git's top-level, which on macOS comes back
+// through /private. Both hash to the same data directory, so the breadcrumb
+// would flip between spellings as each wrote it, and a reader that keys on the
+// string sees one project as two sharing a single log.
 func RegisterProjectRoot(dataDir, root string) error {
 	if dataDir == "" || root == "" {
 		return nil
@@ -224,11 +231,25 @@ func RegisterProjectRoot(dataDir, root string) error {
 	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dataDir, projectRootFile), []byte(root), 0o644)
+	return os.WriteFile(filepath.Join(dataDir, projectRootFile), []byte(canonicalRoot(root)), 0o644)
+}
+
+// canonicalRoot resolves symlinks in root, leaving it as given when it cannot be
+// resolved (a root that no longer exists, most often) so callers always get a
+// usable path. This matches how ProjectDataDir keys its directories, which is
+// what makes the two agree on what one project is.
+func canonicalRoot(root string) string {
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return root
+	}
+	return resolved
 }
 
 // AllProjectRoots returns the roots of all projects chunk has recorded state
-// for, by reading the breadcrumb files written by RegisterProjectRoot.
+// for, by reading the breadcrumb files written by RegisterProjectRoot. Roots are
+// canonicalised and de-duplicated on the way out, so breadcrumbs written before
+// RegisterProjectRoot canonicalised them cannot list one project twice.
 func AllProjectRoots() ([]string, error) {
 	base, err := config.AppData()
 	if err != nil {
@@ -252,7 +273,7 @@ func AllProjectRoots() ([]string, error) {
 		if readErr != nil {
 			continue
 		}
-		root := strings.TrimSpace(string(data))
+		root := canonicalRoot(strings.TrimSpace(string(data)))
 		if root == "" || seen[root] {
 			continue
 		}

--- a/internal/sidecar/active.go
+++ b/internal/sidecar/active.go
@@ -210,6 +210,15 @@ func pruneRekeyedState(dir, keep string, sidecarIDs []string) {
 // however much it holds.
 const projectRootFile = "project-root"
 
+// ProjectRootPath returns the path of the breadcrumb RegisterProjectRoot writes
+// for the project whose data directory is dataDir. It is exported for tests in
+// other packages that have to write a breadcrumb RegisterProjectRoot will not —
+// an uncanonicalised spelling, most often — so that renaming the file breaks
+// them loudly instead of leaving them passing over a project no reader finds.
+func ProjectRootPath(dataDir string) string {
+	return filepath.Join(dataDir, projectRootFile)
+}
+
 // RegisterProjectRoot writes the breadcrumb that makes root discoverable by
 // AllProjectRoots, and so by the watch daemon and its dashboard. dataDir must be
 // the data directory for root, since the daemon derives one from the other.
@@ -231,7 +240,7 @@ func RegisterProjectRoot(dataDir, root string) error {
 	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dataDir, projectRootFile), []byte(config.CanonicalProjectRoot(root)), 0o644)
+	return os.WriteFile(ProjectRootPath(dataDir), []byte(config.CanonicalProjectRoot(root)), 0o644)
 }
 
 // AllProjectRoots returns the roots of all projects chunk has recorded state
@@ -256,7 +265,7 @@ func AllProjectRoots() ([]string, error) {
 		if !e.IsDir() {
 			continue
 		}
-		crumb := filepath.Join(base, e.Name(), projectRootFile)
+		crumb := ProjectRootPath(filepath.Join(base, e.Name()))
 		data, readErr := os.ReadFile(crumb)
 		if readErr != nil {
 			continue

--- a/internal/sidecar/active_test.go
+++ b/internal/sidecar/active_test.go
@@ -472,3 +472,43 @@ func TestRemoveActiveSidecar_ClearsWhenLastMemberRemoved(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, got == nil)
 }
+
+// One project must not read as two. ProjectDataDir keys a data directory by the
+// resolved path, so a symlinked spelling of a root and a real one share it — but
+// the watch daemon keys projects by the breadcrumb string, and the writers
+// disagree about the spelling: a validate run passes the working directory it
+// was given, chunk watch passes git's top-level. Left as written, the two
+// spellings listed one log as two projects, which the dashboard drew as
+// duplicate rows.
+func TestProjectRootRegistrationCanonicalisesTheRoot(t *testing.T) {
+	setupXDGData(t)
+
+	base := t.TempDir()
+	target := filepath.Join(base, "project")
+	assert.NilError(t, os.MkdirAll(target, 0o755))
+	link := filepath.Join(base, "link")
+	assert.NilError(t, os.Symlink(target, link))
+
+	// Resolved rather than compared against target: on darwin the temp directory
+	// itself sits behind /var → /private/var, so target is not already canonical.
+	want, err := filepath.EvalSymlinks(target)
+	assert.NilError(t, err)
+
+	dataDir, err := config.ProjectDataDir(link)
+	assert.NilError(t, err)
+	assert.NilError(t, RegisterProjectRoot(dataDir, link))
+
+	crumb, err := os.ReadFile(filepath.Join(dataDir, projectRootFile))
+	assert.NilError(t, err)
+	assert.Equal(t, string(crumb), want)
+
+	roots, err := AllProjectRoots()
+	assert.NilError(t, err)
+	assert.DeepEqual(t, roots, []string{want})
+
+	// A breadcrumb written before this canonicalised anything still lists once.
+	assert.NilError(t, os.WriteFile(filepath.Join(dataDir, projectRootFile), []byte(link), 0o644))
+	roots, err = AllProjectRoots()
+	assert.NilError(t, err)
+	assert.DeepEqual(t, roots, []string{want})
+}

--- a/internal/sidecar/active_test.go
+++ b/internal/sidecar/active_test.go
@@ -498,7 +498,7 @@ func TestProjectRootRegistrationCanonicalisesTheRoot(t *testing.T) {
 	assert.NilError(t, err)
 	assert.NilError(t, RegisterProjectRoot(dataDir, link))
 
-	crumb, err := os.ReadFile(filepath.Join(dataDir, projectRootFile))
+	crumb, err := os.ReadFile(ProjectRootPath(dataDir))
 	assert.NilError(t, err)
 	assert.Equal(t, string(crumb), want)
 
@@ -507,7 +507,7 @@ func TestProjectRootRegistrationCanonicalisesTheRoot(t *testing.T) {
 	assert.DeepEqual(t, roots, []string{want})
 
 	// A breadcrumb written before this canonicalised anything still lists once.
-	assert.NilError(t, os.WriteFile(filepath.Join(dataDir, projectRootFile), []byte(link), 0o644))
+	assert.NilError(t, os.WriteFile(ProjectRootPath(dataDir), []byte(link), 0o644))
 	roots, err = AllProjectRoots()
 	assert.NilError(t, err)
 	assert.DeepEqual(t, roots, []string{want})

--- a/internal/watchd/daemon_test.go
+++ b/internal/watchd/daemon_test.go
@@ -7,6 +7,11 @@ import (
 	"time"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
+	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
+	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
 )
 
 // TestDaemonRoundTrip starts the daemon in-process, waits for it to accept
@@ -47,6 +52,42 @@ func TestDaemonRoundTrip(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("daemon did not shut down within 5s after context cancel")
 	}
+}
+
+// Results recorded while no daemon was running are the reason the log is on
+// disk at all. A daemon starting afterwards has only the breadcrumb to go on —
+// no sidecar state, no connection to the run that wrote it — and must replay
+// what is already in the log rather than only what arrives after it starts.
+func TestPollReplaysResultsRecordedWhileTheDaemonWasDown(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	root := t.TempDir()
+	dataDir, err := config.ProjectDataDir(root)
+	assert.NilError(t, err)
+	assert.NilError(t, sidecar.RegisterProjectRoot(dataDir, root))
+
+	log, err := eventlog.Open(dataDir)
+	assert.NilError(t, err)
+	rec := log.Recorder(nil, eventlog.OpValidate, "", "", "main")
+	rec.Status(iostream.LevelInfo, "$ echo hi")
+	rec.Final(iostream.LevelDone, "1/1 passed  113ms", 1, 1)
+
+	d := &daemon{projects: make(map[string]*projectState)}
+	d.poll()
+
+	snap := d.snapshot(nil)
+	assert.Equal(t, len(snap.Projects), 1, "the registered project was not discovered")
+	p := snap.Projects[0]
+	assert.Equal(t, p.Root, root)
+	assert.Equal(t, len(p.Events), 2, "events predating the daemon were dropped")
+	passed, total, ok := p.Events[1].Outcome()
+	assert.Assert(t, ok, "the closing event did not survive the round trip")
+	assert.Equal(t, passed, 1)
+	assert.Equal(t, total, 1)
+
+	// The run had no sidecar, so it is the synthesised local row in the dashboard
+	// that carries it — there must be no sidecar state invented for it here.
+	assert.Equal(t, len(p.Sidecars), 0)
 }
 
 func TestBuildID_distinguishesBuildsTheVersionCannot(t *testing.T) {

--- a/internal/watchd/daemon_test.go
+++ b/internal/watchd/daemon_test.go
@@ -78,7 +78,7 @@ func TestDaemonRoundTrip(t *testing.T) {
 // no sidecar state, no connection to the run that wrote it — and must replay
 // what is already in the log rather than only what arrives after it starts.
 func TestPollReplaysResultsRecordedWhileTheDaemonWasDown(t *testing.T) {
-	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
 
 	root := t.TempDir()
 	dataDir, err := config.ProjectDataDir(root)
@@ -153,7 +153,7 @@ func TestEnsureLaunched_leavesAReachableDaemonAlone(t *testing.T) {
 	// The daemon polls every known project before it serves, and every project
 	// costs a git call. Pointed at the developer's real data directory that first
 	// poll can outlast the wait below, so keep it hermetic.
-	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -226,7 +226,7 @@ func TestStopForCredentialChangeIsANoopWithNoDaemon(t *testing.T) {
 // spelling is flipped between polls the way a validate run and chunk watch used
 // to flip it.
 func TestPollListsOneProjectPerRootHoweverItIsSpelled(t *testing.T) {
-	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
 
 	base := t.TempDir()
 	target := filepath.Join(base, "project")
@@ -273,7 +273,7 @@ func TestPollListsOneProjectPerRootHoweverItIsSpelled(t *testing.T) {
 // canonicalises, which for any repo reached through a symlink files a command's
 // output where the dashboard will never look for it.
 func TestPollListsCommandsRegisteredUnderAnUnresolvedRoot(t *testing.T) {
-	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
 
 	base := t.TempDir()
 	target := filepath.Join(base, "project")

--- a/internal/watchd/daemon_test.go
+++ b/internal/watchd/daemon_test.go
@@ -250,3 +250,33 @@ func TestPollListsOneProjectPerRootHoweverItIsSpelled(t *testing.T) {
 	// The log is not read twice into one project either.
 	assert.Equal(t, len(snap.Projects[0].Events), 1)
 }
+
+// A registered command is filed under the project root its client sent, and
+// listed under the root the daemon discovered — so the two have to be the same
+// spelling. The clients send an unresolved working directory while discovery
+// canonicalises, which for any repo reached through a symlink files a command's
+// output where the dashboard will never look for it.
+func TestPollListsCommandsRegisteredUnderAnUnresolvedRoot(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	base := t.TempDir()
+	target := filepath.Join(base, "project")
+	assert.NilError(t, os.MkdirAll(target, 0o755))
+	link := filepath.Join(base, "link")
+	assert.NilError(t, os.Symlink(target, link))
+
+	dataDir, err := config.ProjectDataDir(target)
+	assert.NilError(t, err)
+	assert.NilError(t, sidecar.RegisterProjectRoot(dataDir, target))
+
+	d := &daemon{projects: make(map[string]*projectState), out: newOutputStore(context.Background())}
+	// What a validate run on a repo reached through the symlink registers.
+	d.out.register(reg("cmd-1", link), immediateStream([]string{"output\n"}, 0))
+	waitForFinish(t, d.out, "cmd-1")
+	d.poll()
+
+	snap := d.snapshot(nil)
+	assert.Equal(t, len(snap.Projects), 1)
+	assert.Equal(t, len(snap.Projects[0].Commands), 1,
+		"a command registered through a symlinked root must still be listed")
+}

--- a/internal/watchd/daemon_test.go
+++ b/internal/watchd/daemon_test.go
@@ -248,7 +248,7 @@ func TestPollListsOneProjectPerRootHoweverItIsSpelled(t *testing.T) {
 	assert.NilError(t, err)
 	log.Recorder(nil, eventlog.OpValidate, "", "", "").Final(iostream.LevelDone, "1/1 passed", 1, 1)
 
-	crumb := filepath.Join(dataDir, "project-root")
+	crumb := sidecar.ProjectRootPath(dataDir)
 	d := newTestDaemon()
 
 	// Registered through the symlink, then rewritten as the resolved path — the

--- a/internal/watchd/daemon_test.go
+++ b/internal/watchd/daemon_test.go
@@ -200,3 +200,53 @@ func TestStopForCredentialChangeIsANoopWithNoDaemon(t *testing.T) {
 	t.Setenv("CHUNK_WATCHD_DIR", t.TempDir())
 	StopForCredentialChange()
 }
+
+// The duplicate rows this guards against were found by hand: one project drawn
+// twice, the two rows sharing a single event log. The daemon keys projects by
+// the breadcrumb string while ProjectDataDir keys the directory by the resolved
+// path, so two spellings of one root share a log but count as two projects. It
+// took a symlinked path to see it, which on darwin is every temp directory and
+// on linux is none — so the symlink here is built rather than assumed, and the
+// spelling is flipped between polls the way a validate run and chunk watch used
+// to flip it.
+func TestPollListsOneProjectPerRootHoweverItIsSpelled(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	base := t.TempDir()
+	target := filepath.Join(base, "project")
+	assert.NilError(t, os.MkdirAll(target, 0o755))
+	link := filepath.Join(base, "link")
+	assert.NilError(t, os.Symlink(target, link))
+
+	canonical, err := filepath.EvalSymlinks(target)
+	assert.NilError(t, err)
+
+	// One data directory, reached through either spelling.
+	dataDir, err := config.ProjectDataDir(link)
+	assert.NilError(t, err)
+	viaTarget, err := config.ProjectDataDir(target)
+	assert.NilError(t, err)
+	assert.Equal(t, dataDir, viaTarget, "both spellings must share one data directory")
+
+	log, err := eventlog.Open(dataDir)
+	assert.NilError(t, err)
+	log.Recorder(nil, eventlog.OpValidate, "", "", "").Final(iostream.LevelDone, "1/1 passed", 1, 1)
+
+	crumb := filepath.Join(dataDir, "project-root")
+	d := &daemon{projects: make(map[string]*projectState), out: newOutputStore(context.Background())}
+
+	// Registered through the symlink, then rewritten as the resolved path — the
+	// two writers' spellings, in the order a developer hits them.
+	assert.NilError(t, sidecar.RegisterProjectRoot(dataDir, link))
+	d.poll()
+	assert.NilError(t, os.WriteFile(crumb, []byte(target), 0o644))
+	d.poll()
+	assert.NilError(t, os.WriteFile(crumb, []byte(link), 0o644))
+	d.poll()
+
+	snap := d.snapshot(nil)
+	assert.Equal(t, len(snap.Projects), 1, "one project listed once, got %d", len(snap.Projects))
+	assert.Equal(t, snap.Projects[0].Root, canonical)
+	// The log is not read twice into one project either.
+	assert.Equal(t, len(snap.Projects[0].Events), 1)
+}

--- a/internal/watchd/daemon_test.go
+++ b/internal/watchd/daemon_test.go
@@ -72,7 +72,9 @@ func TestPollReplaysResultsRecordedWhileTheDaemonWasDown(t *testing.T) {
 	rec.Status(iostream.LevelInfo, "$ echo hi")
 	rec.Final(iostream.LevelDone, "1/1 passed  113ms", 1, 1)
 
-	d := &daemon{projects: make(map[string]*projectState)}
+	// Built like RunDaemon builds it, output store included: poll reads the store
+	// for every project, so a daemon assembled by hand without one panics there.
+	d := &daemon{projects: make(map[string]*projectState), out: newOutputStore(context.Background())}
 	d.poll()
 
 	snap := d.snapshot(nil)

--- a/internal/watchd/daemon_test.go
+++ b/internal/watchd/daemon_test.go
@@ -3,6 +3,7 @@ package watchd
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -65,6 +66,9 @@ func TestPollReplaysResultsRecordedWhileTheDaemonWasDown(t *testing.T) {
 	dataDir, err := config.ProjectDataDir(root)
 	assert.NilError(t, err)
 	assert.NilError(t, sidecar.RegisterProjectRoot(dataDir, root))
+	// Registration canonicalises, so this is the spelling the daemon reports.
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	assert.NilError(t, err)
 
 	log, err := eventlog.Open(dataDir)
 	assert.NilError(t, err)
@@ -80,7 +84,7 @@ func TestPollReplaysResultsRecordedWhileTheDaemonWasDown(t *testing.T) {
 	snap := d.snapshot(nil)
 	assert.Equal(t, len(snap.Projects), 1, "the registered project was not discovered")
 	p := snap.Projects[0]
-	assert.Equal(t, p.Root, root)
+	assert.Equal(t, p.Root, canonicalRoot)
 	assert.Equal(t, len(p.Events), 2, "events predating the daemon were dropped")
 	passed, total, ok := p.Events[1].Outcome()
 	assert.Assert(t, ok, "the closing event did not survive the round trip")

--- a/internal/watchd/ipc_test.go
+++ b/internal/watchd/ipc_test.go
@@ -11,6 +11,8 @@ import (
 
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
 )
 
 // startTestDaemon runs a real daemon over a real Unix socket in a temp dir and
@@ -39,7 +41,7 @@ func startTestDaemonWithAuth(t *testing.T, authMessage string) {
 	t.Setenv("CHUNK_WATCHD_DIR", dir)
 	// Keep the first poll hermetic: pointed at a real data dir it makes a git
 	// call per known project and can outlast the wait below.
-	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)

--- a/internal/watchd/output.go
+++ b/internal/watchd/output.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
 )
 
 const (
@@ -208,6 +209,11 @@ func (s *outputStore) register(reg CommandReg, stream streamFn) {
 	if reg.CommandID == "" {
 		return
 	}
+	// Canonicalised here rather than at each client: the clients send the working
+	// directory they were handed, project discovery canonicalises, and a command
+	// filed under a spelling no project carries is output the dashboard cannot
+	// reach. Doing it on ingest also covers clients built before this.
+	reg.ProjectRoot = config.CanonicalProjectRoot(reg.ProjectRoot)
 	s.mu.Lock()
 	if _, exists := s.cmds[reg.CommandID]; exists {
 		s.mu.Unlock()

--- a/internal/watchd/output_test.go
+++ b/internal/watchd/output_test.go
@@ -373,3 +373,19 @@ func TestBufferAppendExactlyCapDropsOnlyPrior(t *testing.T) {
 	assert.Check(t, cmp.Equal(string(chunk.Data), strings.Repeat("b", MaxCommandBytes)))
 	assert.Check(t, cmp.Equal(chunk.NextOffset, int64(10+MaxCommandBytes)))
 }
+
+// A client that sends no project root has nothing the dashboard can file its
+// output under, and canonicalising the empty string used to invent one: Clean
+// turns it into ".", which the daemon then treats as a project root like any
+// other — it stats clean against its own working directory, so it is listed,
+// and it collects the output of every command that arrived without a root.
+func TestOutputStoreRegistrationWithNoRootIsNotFiledUnderARelativeRoot(t *testing.T) {
+	s := newOutputStore(context.Background())
+	s.register(reg("cmd-1", ""), immediateStream([]string{"output\n"}, 0))
+	waitForFinish(t, s, "cmd-1")
+
+	assert.Check(t, cmp.Len(s.commandsFor("."), 0),
+		`a rootless command must not be listed under "."`)
+	// It is still recorded, so the dashboard can say the command exists.
+	assert.Check(t, s.read("cmd-1", 0).Found)
+}


### PR DESCRIPTION
<!-- stack -->
**Standalone** — based on `main`, merges in any order.

This was the base of the #580 → #581 → #584 stack. That series no longer depends on it: the only pieces it borrowed (`config.CanonicalProjectRoot` and the `newTestDaemon` test helper) are now carried in #580, so whichever of the two lands second drops its copy.

---

## Summary

`chunk validate` results never showed up in `chunk watch` for a project that had never had a sidecar.

Nothing was ever lost — every run already writes to `events.jsonl`, and the daemon reads those files off disk. What was missing was **discovery**: the daemon only finds a project by its `project-root` breadcrumb, and only saving sidecar state wrote one. So `--local` runs, and repos with no remote commands, logged somewhere nothing would ever look. Now every run registers its project. The same gap was hiding buffered remote command output (#552), which is keyed by project root too.

Registering everywhere then exposed a second bug, spotted in the real dashboard: one project drawn as two rows over one log, because `ProjectDataDir` keys by the *resolved* path while the daemon keys by the breadcrumb *string*, and different writers spelled roots differently. An audit found two more instances of the same thing. All of them now go through one rule, `config.CanonicalProjectRoot`.

## Test plan

Every test below was confirmed to fail with the change it covers reverted.

- [x] A `--local` run registers its project and closes with a 1/1 tally; a breadcrumb plus a log and no sidecar state is discovered and replayed.
- [x] One project however its root is spelled — including breadcrumbs written before this change — and commands registered through a symlinked root are still listed (`got 0` before the fix).
- [x] `--focus` roots match the keys the daemon reports.
- [x] Real dashboard through a pty: `--local` and hook runs in sidecar-less repos render `✓ 1/1` and `✗ 0/1`; control case with the breadcrumb removed shows "No activity yet".
- [x] `task test` (1558), `task lint`, `task ci:diff`, CI green.

