### PR TITLE
Drop --identity-file and SSH agent support; standardize on chunk_ai key

### DIFF
--- a/acceptance/parallel_sessions_test.go
+++ b/acceptance/parallel_sessions_test.go
@@ -23,10 +23,9 @@ import (
 // talks to. Two runs against one sessionEnv stand in for two agent sessions open
 // in the same working tree.
 type sessionEnv struct {
-	cci          *fakes.FakeCircleCI
-	env          *testenv.TestEnv
-	workDir      string
-	identityFile string
+	cci     *fakes.FakeCircleCI
+	env     *testenv.TestEnv
+	workDir string
 }
 
 func newSessionEnv(t *testing.T) *sessionEnv {
@@ -42,18 +41,17 @@ func newSessionEnv(t *testing.T) *sessionEnv {
 	cfg := `{"commands":[{"name":"test","run":"echo test","remote":true}]}`
 	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), []byte(cfg), 0o644))
 
-	sshDir := filepath.Join(t.TempDir(), ".ssh")
-	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
-	identityFile := filepath.Join(sshDir, "chunk_ai")
-	assert.NilError(t, generateTestSSHKey(t, identityFile))
-
 	// One HOME across both runs, so they share the state directory the way two
 	// sessions on one machine do.
 	env := testenv.NewTestEnv(t)
 	env.CircleCIURL = srv.URL
 	env.Extra["CIRCLECI_ORG_ID"] = "org-aaa"
 
-	return &sessionEnv{cci: cci, env: env, workDir: workDir, identityFile: identityFile}
+	sshDir := filepath.Join(env.HomeDir, ".ssh")
+	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
+	assert.NilError(t, generateTestSSHKey(t, filepath.Join(sshDir, "chunk_ai")))
+
+	return &sessionEnv{cci: cci, env: env, workDir: workDir}
 }
 
 // validateAs runs `chunk validate` as the given agent session, identified the way
@@ -61,7 +59,7 @@ func newSessionEnv(t *testing.T) *sessionEnv {
 func (e *sessionEnv) validateAs(t *testing.T, sessionID string) {
 	t.Helper()
 	e.env.Extra[session.EnvClaudeSessionID] = sessionID
-	result := binary.RunCLI(t, []string{"validate", "--identity-file", e.identityFile}, e.env, e.workDir)
+	result := binary.RunCLI(t, []string{"validate"}, e.env, e.workDir)
 	assert.Assert(t, result.ExitCode != 0, "expected failure because no SSH server is running; stderr: %s", result.Stderr)
 }
 
@@ -115,7 +113,7 @@ func TestSessionCreatesOwnSidecarAlways(t *testing.T) {
 	e := newSessionEnv(t)
 
 	// No session ID: this is a human running the command.
-	result := binary.RunCLI(t, []string{"validate", "--identity-file", e.identityFile}, e.env, e.workDir)
+	result := binary.RunCLI(t, []string{"validate"}, e.env, e.workDir)
 	assert.Assert(t, result.ExitCode != 0, "expected failure because no SSH server is running")
 	assert.Equal(t, e.createdSidecars(t), 1)
 

--- a/acceptance/sidecar_snapshot_select_test.go
+++ b/acceptance/sidecar_snapshot_select_test.go
@@ -73,16 +73,15 @@ func runValidateForSnapshotSelection(t *testing.T, snapshots []fakes.Snapshot, s
 	}
 	writeRemoteCommandConfig(t, workDir)
 
-	sshDir := filepath.Join(t.TempDir(), ".ssh")
-	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
-	identityFile := filepath.Join(sshDir, "chunk_ai")
-	assert.NilError(t, generateTestSSHKey(t, identityFile))
-
 	env := testenv.NewTestEnv(t)
 	env.CircleCIURL = srv.URL
 	env.Extra["CIRCLECI_ORG_ID"] = "org-aaa"
 
-	binary.RunCLI(t, []string{"validate", "--identity-file", identityFile}, env, workDir)
+	sshDir := filepath.Join(env.HomeDir, ".ssh")
+	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
+	assert.NilError(t, generateTestSSHKey(t, filepath.Join(sshDir, "chunk_ai")))
+
+	binary.RunCLI(t, []string{"validate"}, env, workDir)
 	return cci
 }
 

--- a/acceptance/sidecar_test.go
+++ b/acceptance/sidecar_test.go
@@ -376,35 +376,23 @@ func TestSidecarsSyncCheckoutFlagRemoved(t *testing.T) {
 		"--checkout must be an unknown flag; got: %s", combined)
 }
 
-// TestSidecarsSshSyncFlags verifies that SSH/sync flags are accepted and
+// TestSidecarsSshFlags verifies that SSH --identity-file is accepted and
 // code progresses past flag parsing (fails at SSH step, not at parsing).
-func TestSidecarsSshSyncFlags(t *testing.T) {
-	tests := []struct {
-		name string
-		args []string
-	}{
-		{"ssh identity-file", []string{"sidecar", "ssh", "--sidecar-id", "sb-111", "--identity-file", "/tmp/fake-key"}},
-		{"sync identity-file", []string{"sidecar", "sync", "--sidecar-id", "sb-111", "--identity-file", "/tmp/fake-key"}},
-	}
+func TestSidecarsSshFlags(t *testing.T) {
+	cci := fakes.NewFakeCircleCI()
+	srv := httptest.NewServer(cci)
+	defer srv.Close()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cci := fakes.NewFakeCircleCI()
-			srv := httptest.NewServer(cci)
-			defer srv.Close()
+	env := testenv.NewTestEnv(t)
+	env.CircleCIURL = srv.URL
 
-			env := testenv.NewTestEnv(t)
-			env.CircleCIURL = srv.URL
+	result := binary.RunCLI(t, []string{"sidecar", "ssh", "--sidecar-id", "sb-111", "--identity-file", "/tmp/fake-key"}, env, env.HomeDir)
 
-			result := binary.RunCLI(t, tt.args, env, env.HomeDir)
-
-			// Commands should fail at SSH key step, not at flag parsing
-			assert.Assert(t, result.ExitCode != 0, "expected non-zero exit (SSH fails)")
-			combined := result.Stdout + result.Stderr
-			assert.Assert(t, strings.Contains(combined, "SSH key not found"),
-				"expected SSH key error (proves flags accepted), got: %s", combined)
-		})
-	}
+	// Should fail at SSH key step, not at flag parsing
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit (SSH fails)")
+	combined := result.Stdout + result.Stderr
+	assert.Assert(t, strings.Contains(combined, "SSH key not found"),
+		"expected SSH key error (proves flags accepted), got: %s", combined)
 }
 
 func TestSidecarsExecWithArgs(t *testing.T) {

--- a/acceptance/sidecar_test.go
+++ b/acceptance/sidecar_test.go
@@ -376,9 +376,9 @@ func TestSidecarsSyncCheckoutFlagRemoved(t *testing.T) {
 		"--checkout must be an unknown flag; got: %s", combined)
 }
 
-// TestSidecarsSshFlags verifies that SSH --identity-file is accepted and
-// code progresses past flag parsing (fails at SSH step, not at parsing).
-func TestSidecarsSshFlags(t *testing.T) {
+// TestSidecarsSshNoKey verifies that `sidecar ssh` fails with a clear error
+// when no default key exists at ~/.ssh/chunk_ai.
+func TestSidecarsSshNoKey(t *testing.T) {
 	cci := fakes.NewFakeCircleCI()
 	srv := httptest.NewServer(cci)
 	defer srv.Close()
@@ -386,13 +386,13 @@ func TestSidecarsSshFlags(t *testing.T) {
 	env := testenv.NewTestEnv(t)
 	env.CircleCIURL = srv.URL
 
-	result := binary.RunCLI(t, []string{"sidecar", "ssh", "--sidecar-id", "sb-111", "--identity-file", "/tmp/fake-key"}, env, env.HomeDir)
+	// No key at env.HomeDir/.ssh/chunk_ai — the default path.
+	result := binary.RunCLI(t, []string{"sidecar", "ssh", "--sidecar-id", "sb-111"}, env, env.HomeDir)
 
-	// Should fail at SSH key step, not at flag parsing
-	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit (SSH fails)")
+	assert.Assert(t, result.ExitCode != 0, "expected non-zero exit (SSH key missing)")
 	combined := result.Stdout + result.Stderr
 	assert.Assert(t, strings.Contains(combined, "SSH key not found"),
-		"expected SSH key error (proves flags accepted), got: %s", combined)
+		"expected SSH key not found error, got: %s", combined)
 }
 
 func TestSidecarsExecWithArgs(t *testing.T) {

--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -388,19 +388,16 @@ func TestValidateRunRemoteUsesSSH(t *testing.T) {
 	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
 	writeProjectConfig(t, workDir, "echo install", "echo test")
 
-	// Write a temporary SSH keypair so OpenSession can register a key.
-	sshDir := filepath.Join(t.TempDir(), ".ssh")
-	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
-	identityFile := filepath.Join(sshDir, "chunk_ai")
-	assert.NilError(t, generateTestSSHKey(t, identityFile))
-
 	env := testenv.NewTestEnv(t)
 	env.CircleCIURL = srv.URL
+
+	sshDir := filepath.Join(env.HomeDir, ".ssh")
+	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
+	assert.NilError(t, generateTestSSHKey(t, filepath.Join(sshDir, "chunk_ai")))
 
 	result := binary.RunCLI(t, []string{
 		"validate",
 		"--sidecar-id", "sidecar-123",
-		"--identity-file", identityFile,
 	}, env, workDir)
 
 	// SSH connection to 127.0.0.1:2222 will fail — that's expected.
@@ -441,16 +438,15 @@ func TestValidateSidecarImageNoActiveSidecarAutoCreates(t *testing.T) {
 	assert.NilError(t, err)
 	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), data, 0o644))
 
-	sshDir := filepath.Join(t.TempDir(), ".ssh")
-	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
-	identityFile := filepath.Join(sshDir, "chunk_ai")
-	assert.NilError(t, generateTestSSHKey(t, identityFile))
-
 	env := testenv.NewTestEnv(t)
 	env.CircleCIURL = srv.URL
 	env.Extra["CIRCLECI_ORG_ID"] = "org-aaa"
 
-	result := binary.RunCLI(t, []string{"validate", "--identity-file", identityFile}, env, workDir)
+	sshDir := filepath.Join(env.HomeDir, ".ssh")
+	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
+	assert.NilError(t, generateTestSSHKey(t, filepath.Join(sshDir, "chunk_ai")))
+
+	result := binary.RunCLI(t, []string{"validate"}, env, workDir)
 
 	// No real SSH server is running so sync will fail — that's expected.
 	assert.Assert(t, result.ExitCode != 0, "expected failure because no SSH server is running")
@@ -499,18 +495,16 @@ func TestValidateHookAutoCreatesSidecarFromSidecarImage(t *testing.T) {
 	assert.NilError(t, err)
 	assert.NilError(t, os.WriteFile(filepath.Join(chunkDir, "config.json"), data, 0o644))
 
-	sshDir := filepath.Join(t.TempDir(), ".ssh")
-	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
-	identityFile := filepath.Join(sshDir, "chunk_ai")
-	assert.NilError(t, generateTestSSHKey(t, identityFile))
-
 	env := testenv.NewTestEnv(t)
 	env.CircleCIURL = srv.URL
 	env.Extra["CIRCLECI_ORG_ID"] = "org-aaa"
 
+	sshDir := filepath.Join(env.HomeDir, ".ssh")
+	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
+	assert.NilError(t, generateTestSSHKey(t, filepath.Join(sshDir, "chunk_ai")))
+
 	result := binary.RunCLIWithStdin(t, []string{
 		"validate",
-		"--identity-file", identityFile,
 	}, env, workDir, hookStdin(t, "test-session-sidecar-image", false))
 
 	assert.Assert(t, result.ExitCode != 0, "expected failure because no SSH server is running")
@@ -601,17 +595,16 @@ func TestValidateHookMode_SetupErrorFlushedToStderr(t *testing.T) {
 	// Dirty tree ensures the hook actually runs.
 	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "dirty.txt"), []byte("x"), 0o644))
 
-	sshDir := filepath.Join(t.TempDir(), ".ssh")
-	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
-	identityFile := filepath.Join(sshDir, "chunk_ai")
-	assert.NilError(t, generateTestSSHKey(t, identityFile))
-
 	env := testenv.NewTestEnv(t)
 	env.CircleCIURL = srv.URL
 	env.Extra["CIRCLECI_ORG_ID"] = "org-aaa"
 
+	sshDir := filepath.Join(env.HomeDir, ".ssh")
+	assert.NilError(t, os.MkdirAll(sshDir, 0o700))
+	assert.NilError(t, generateTestSSHKey(t, filepath.Join(sshDir, "chunk_ai")))
+
 	result := binary.RunCLIWithStdin(t, []string{
-		"validate", "--identity-file", identityFile,
+		"validate",
 	}, env, workDir, hookStdin(t, "test-session-setup-err", false))
 
 	assert.Assert(t, result.ExitCode != 0, "expected failure; stderr: %s", result.Stderr)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -70,7 +70,6 @@ chunk
 │   --mark-remote                   # Mark [name] (or all commands) remote in config, then exit
 │   --sidecar-id <id>               # Remote execution in specific sidecar
 │   --org-id <id>                   # Organization ID (used when creating a new sidecar)
-│   --identity-file <path>          # SSH identity file for sidecar
 │   --workdir <path>                # Working directory on sidecar
 │   --project <path>                # Override project directory
 │   -e / --env KEY=VALUE            # Set env var in remote sidecar session (repeatable)
@@ -82,7 +81,6 @@ chunk
 │       --timeout <seconds>         # Per-command timeout when the command sets none (0 for no limit)
 │       --org-id <id>               # Organization ID
 │       --image <id>                # Snapshot image ID (default: validation.sidecarImage)
-│       --identity-file <path>      # SSH identity file
 │       --workdir <path>            # Remote working directory
 │
 ├── sidecar
@@ -108,12 +106,10 @@ chunk
 │   │   --public-key-file <path>    # Path to public key file
 │   ├── ssh                         # SSH into sidecar (stdin forwarded when piped)
 │   │   --sidecar-id <id>           # Sidecar ID (defaults to active sidecar)
-│   │   --identity-file <path>      # SSH identity file
 │   │   -e / --env KEY=VALUE        # Set env var in remote session (repeatable)
 │   │   --env-file <path>           # Env file to load (default: .env.local; pass a path to override)
 │   ├── sync                        # Sync files to sidecar
 │   │   --sidecar-id <id>           # Sidecar ID (defaults to active sidecar)
-│   │   --identity-file <path>      # SSH identity file
 │   │   --workdir <path>            # Destination path on sidecar (auto-detected when omitted)
 │   │   --checkout                  # Sync via git checkout/patch instead of bundle (requires branch pushed to GitHub)
 │   ├── env                         # Detect tech stack and print environment spec as JSON
@@ -127,7 +123,6 @@ chunk
 │   │   --sidecar-id <id>           # Sidecar ID (defaults to active sidecar)
 │   │   --org-id <id>               # Organization ID (used when creating a new sidecar)
 │   │   --name <name>               # Sidecar name (used when creating a new sidecar)
-│   │   --identity-file <path>      # SSH identity file
 │   │   --skip-sync                 # Skip syncing files to the sidecar
 │   │   --force                     # Re-detect environment even if cached
 │   │   -e / --env KEY=VALUE        # Set env var in remote sidecar session (repeatable)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -230,6 +230,18 @@ To fall back to the git checkout/patch approach (requires the branch to be pushe
 chunk sidecar sync --checkout
 ```
 
+### SSH key management
+
+chunk generates and manages its own SSH keypair at `~/.ssh/chunk_ai`. The public key is registered with each sidecar automatically when you first sync or SSH in — you do not need to create keys, run `ssh-add`, or pass an identity file.
+
+If sync or SSH fails with `permission denied (publickey)`, re-register the key:
+
+```bash
+chunk sidecar add-ssh-key --public-key-file ~/.ssh/chunk_ai.pub
+```
+
+If the key is missing or corrupted, delete `~/.ssh/chunk_ai*` and chunk will regenerate the pair on next use.
+
 ### Environment setup
 
 Auto-detect your tech stack and save it to config:

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -55,14 +55,13 @@ func newConfigShowCmd() *cobra.Command {
 					Source string `json:"source,omitempty"`
 				}
 				type configOutput struct {
-					Model              configEntry `json:"model"`
-					AnthropicAPIKey    configEntry `json:"anthropicAPIKey"`
-					CircleCIToken      configEntry `json:"circleCIToken"`
-					GitHubToken        configEntry `json:"gitHubToken"`
-					OrgID              configEntry `json:"orgID"`
-					UseSSHIdentityFile bool        `json:"useSSHIdentityFile"`
-					Telemetry          bool        `json:"telemetry"`
-					Notifications      bool        `json:"notifications"`
+					Model           configEntry `json:"model"`
+					AnthropicAPIKey configEntry `json:"anthropicAPIKey"`
+					CircleCIToken   configEntry `json:"circleCIToken"`
+					GitHubToken     configEntry `json:"gitHubToken"`
+					OrgID           configEntry `json:"orgID"`
+					Telemetry       bool        `json:"telemetry"`
+					Notifications   bool        `json:"notifications"`
 				}
 				maskOrEmpty := func(key string) string {
 					if key == "" {
@@ -71,14 +70,13 @@ func newConfigShowCmd() *cobra.Command {
 					return config.MaskKey(key)
 				}
 				return iostream.PrintJSON(io.Out, configOutput{
-					Model:              configEntry{Value: rc.Model, Source: rc.ModelSource},
-					AnthropicAPIKey:    configEntry{Value: maskOrEmpty(rc.AnthropicAPIKey), Source: rc.AnthropicAPIKeySource},
-					CircleCIToken:      configEntry{Value: maskOrEmpty(rc.CircleCIToken), Source: rc.CircleCITokenSource},
-					GitHubToken:        configEntry{Value: maskOrEmpty(rc.GitHubToken), Source: rc.GitHubTokenSource},
-					OrgID:              configEntry{Value: orgID, Source: orgIDSource},
-					UseSSHIdentityFile: rc.UseSSHIdentityFile,
-					Telemetry:          telemetryEnabled,
-					Notifications:      userCfg.Notifications,
+					Model:           configEntry{Value: rc.Model, Source: rc.ModelSource},
+					AnthropicAPIKey: configEntry{Value: maskOrEmpty(rc.AnthropicAPIKey), Source: rc.AnthropicAPIKeySource},
+					CircleCIToken:   configEntry{Value: maskOrEmpty(rc.CircleCIToken), Source: rc.CircleCITokenSource},
+					GitHubToken:     configEntry{Value: maskOrEmpty(rc.GitHubToken), Source: rc.GitHubTokenSource},
+					OrgID:           configEntry{Value: orgID, Source: orgIDSource},
+					Telemetry:       telemetryEnabled,
+					Notifications:   userCfg.Notifications,
 				})
 			}
 
@@ -109,7 +107,6 @@ func newConfigShowCmd() *cobra.Command {
 				io.Printf("%s %s\n", ui.Label("orgID:", w), ui.Dim("(not set)"))
 			}
 
-			io.Printf("%s %v\n", ui.Label("useSSHIdentityFile:", w), rc.UseSSHIdentityFile)
 			io.Printf("%s %v\n", ui.Label("telemetry:", w), telemetryEnabled)
 			io.Printf("%s %v\n", ui.Label("notifications:", w), userCfg.Notifications)
 
@@ -126,7 +123,7 @@ func newConfigSetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "set <key> <value>",
 		Short: "Set a config value",
-		Long:  "Set a config value. Use 'chunk auth set <provider>' to store credentials with validation.\n\nUser keys: model, useSSHIdentityFile, telemetry, notifications\nProject keys: orgID, validation.sidecarImage",
+		Long:  "Set a config value. Use 'chunk auth set <provider>' to store credentials with validation.\n\nUser keys: model, telemetry, notifications\nProject keys: orgID, validation.sidecarImage",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			io := iostream.FromCmd(cmd)
@@ -162,7 +159,7 @@ func newConfigSetCmd() *cobra.Command {
 			if !config.ValidConfigKeys[key] {
 				return &userError{
 					msg:    fmt.Sprintf("Unknown config key: %q.", key),
-					detail: "Supported keys: model, useSSHIdentityFile, telemetry, notifications, orgID, validation.sidecarImage.",
+					detail: "Supported keys: model, telemetry, notifications, orgID, validation.sidecarImage.",
 					errMsg: fmt.Sprintf("unknown config key %q", key),
 				}
 			}
@@ -175,12 +172,6 @@ func newConfigSetCmd() *cobra.Command {
 			switch key {
 			case "model":
 				cfg.Model = value
-			case "useSSHIdentityFile":
-				b, err := parseBoolValue("useSSHIdentityFile", value)
-				if err != nil {
-					return err
-				}
-				cfg.UseSSHIdentityFile = b
 			case "telemetry":
 				b, err := parseBoolValue("telemetry", value)
 				if err != nil {

--- a/internal/cmd/execregister_test.go
+++ b/internal/cmd/execregister_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/eventlog"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
-	"github.com/CircleCI-Public/chunk-cli/internal/testing/gitrepo"
 	"github.com/CircleCI-Public/chunk-cli/internal/watchd"
 )
 
@@ -207,7 +206,6 @@ func TestProbeRunsWithoutRegistering(t *testing.T) {
 func TestProbeExecFnDoesNotRegister(t *testing.T) {
 	regs := captureRegistrations(t)
 	client := newFakeSidecarClient(t)
-	t.Chdir(gitrepo.SetupGitRepo(t, "test-org", "test-repo"))
 
 	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
 	probeExecFn, _, err := newExecFn(

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -73,7 +73,6 @@ Environment Variables:
   CIRCLECI_BASE_URL               CircleCI API URL [default: https://circleci.com]
   ANTHROPIC_BASE_URL              Anthropic API URL [default: https://api.anthropic.com]
   GITHUB_API_URL                  GitHub API URL [default: https://api.github.com]
-  SSH_AUTH_SOCK                   SSH agent socket for sidecar key auth
   CHUNK_SESSION_ID                Agent session identity; keeps parallel sessions on separate sidecars
                                   (read from CLAUDE_CODE_SESSION_ID when unset)
   NO_COLOR                        Disable colored output

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -483,7 +483,7 @@ func newSidecarAddSSHKeyCmd() *cobra.Command {
 }
 
 func newSidecarSSHCmd() *cobra.Command {
-	var sidecarID, identityFile, envFile string
+	var sidecarID, envFile string
 	var envVarsFlag []string
 
 	cmd := &cobra.Command{
@@ -495,7 +495,6 @@ func newSidecarSSHCmd() *cobra.Command {
 			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
 				return err
 			}
-			authSock := os.Getenv(config.EnvSSHAuthSock)
 			insecureStorage := insecureStorageFlag(cmd)
 			rc, _ := config.Resolve("", "", insecureStorage)
 			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, ui.PromptHidden)
@@ -514,7 +513,7 @@ func newSidecarSSHCmd() *cobra.Command {
 			if fi, statErr := os.Stdin.Stat(); statErr == nil && fi.Mode()&os.ModeCharDevice == 0 {
 				stdin = os.Stdin
 			}
-			err = sidecar.SSH(cmd.Context(), client, sidecarID, identityFile, authSock, args, envVars, io, stdin)
+			err = sidecar.SSH(cmd.Context(), client, sidecarID, args, envVars, io, stdin)
 			if err != nil {
 				if err := sshSessionError(err); err != nil {
 					return err
@@ -532,7 +531,6 @@ func newSidecarSSHCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&sidecarID, "sidecar-id", "", "Sidecar ID (defaults to active sidecar)")
-	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file")
 	cmd.Flags().StringArrayVarP(&envVarsFlag, "env", "e", nil, "KEY=VALUE pairs to set in the remote session (repeatable)")
 	cmd.Flags().StringVar(&envFile, "env-file", defaultEnvFile, "Env file to load (default: .env.local; pass a path to override)")
 
@@ -975,7 +973,7 @@ func newSidecarSnapshotListCmd() *cobra.Command {
 }
 
 func newSidecarSetupCmd() *cobra.Command {
-	var sidecarID, orgID, name, identityFile, dir string
+	var sidecarID, orgID, name, dir string
 	var skipSync, force bool
 	var envVarsFlag []string
 	var envFile string
@@ -999,7 +997,6 @@ Example:
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			streams := iostream.FromCmd(cmd)
 			status := newStatusFunc(streams)
-			authSock := os.Getenv("SSH_AUTH_SOCK")
 
 			insecureStorage := insecureStorageFlag(cmd)
 			rc, _ := config.Resolve("", "", insecureStorage)
@@ -1051,8 +1048,8 @@ Example:
 					}
 				}
 
-				// Step 3: Ensure SSH key exists (generate if missing and no explicit key given).
-				if err := sidecarSetupEnsureSSHKey(identityFile, status); err != nil {
+				// Step 3: Ensure SSH key exists (generate if missing).
+				if err := sidecarSetupEnsureSSHKey(status); err != nil {
 					return err
 				}
 
@@ -1071,14 +1068,12 @@ Example:
 
 				// Step 6: Run setup steps over SSH.
 				opts := sidecarRunSetupOpts{
-					client:       client,
-					sidecarID:    sidecarID,
-					identityFile: identityFile,
-					authSock:     authSock,
-					env:          env,
-					envVars:      envVars,
-					streams:      streams,
-					status:       status,
+					client:    client,
+					sidecarID: sidecarID,
+					env:       env,
+					envVars:   envVars,
+					streams:   streams,
+					status:    status,
 				}
 				if err := sidecarSetupRunSetup(cmd.Context(), opts); err != nil {
 					return err
@@ -1126,7 +1121,6 @@ Example:
 	cmd.Flags().StringVar(&sidecarID, "sidecar-id", "", "Sidecar ID (defaults to active sidecar)")
 	cmd.Flags().StringVar(&orgID, "org-id", "", "Organization ID (used when creating a new sidecar)")
 	cmd.Flags().StringVar(&name, "name", "", "Sidecar name (used when creating a new sidecar)")
-	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file")
 	cmd.Flags().BoolVar(&skipSync, "skip-sync", false, "Skip syncing files to the sidecar")
 	cmd.Flags().BoolVar(&force, "force", false, "Re-detect environment even if cached in .chunk/config.json")
 	cmd.Flags().StringArrayVarP(&envVarsFlag, "env", "e", nil, "KEY=VALUE pairs to set in remote sidecar session (repeatable)")
@@ -1177,10 +1171,7 @@ func sidecarSetupResolveSidecar(
 	return sc.ID, sc.Name, nil
 }
 
-func sidecarSetupEnsureSSHKey(identityFile string, status iostream.StatusFunc) error {
-	if identityFile != "" {
-		return nil
-	}
+func sidecarSetupEnsureSSHKey(status iostream.StatusFunc) error {
 	keyPath, err := sidecar.DefaultKeyPath()
 	if err != nil {
 		return &userError{msg: "Could not determine SSH key path.", err: err}
@@ -1218,14 +1209,12 @@ func sidecarSetupSync(
 }
 
 type sidecarRunSetupOpts struct {
-	client       *circleci.Client
-	sidecarID    string
-	identityFile string
-	authSock     string
-	env          *envbuilder.Environment
-	envVars      map[string]string
-	streams      iostream.Streams
-	status       iostream.StatusFunc
+	client    *circleci.Client
+	sidecarID string
+	env       *envbuilder.Environment
+	envVars   map[string]string
+	streams   iostream.Streams
+	status    iostream.StatusFunc
 }
 
 func sidecarSetupRunSetup(ctx context.Context, opts sidecarRunSetupOpts) error {
@@ -1249,7 +1238,7 @@ func sidecarSetupRunSetup(ctx context.Context, opts sidecarRunSetupOpts) error {
 			continue
 		}
 		opts.status(iostream.LevelStep, fmt.Sprintf("Running setup step %q: %s", step.Name, step.Command))
-		session, err := sidecar.OpenSession(ctx, opts.client, opts.sidecarID, opts.identityFile, opts.authSock, false)
+		session, err := sidecar.OpenSession(ctx, opts.client, opts.sidecarID, false)
 		if err != nil {
 			if sessErr := sshSessionError(err); sessErr != nil {
 				return sessErr

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -540,7 +540,7 @@ func newSidecarSSHCmd() *cobra.Command {
 }
 
 func newSidecarSyncCmd() *cobra.Command {
-	var sidecarID, identityFile, workdir string
+	var sidecarID, workdir string
 
 	cmd := &cobra.Command{
 		Use:   "sync",
@@ -550,7 +550,6 @@ func newSidecarSyncCmd() *cobra.Command {
 			if err := resolveSidecarID(cmd.Context(), &sidecarID); err != nil {
 				return err
 			}
-			authSock := os.Getenv(config.EnvSSHAuthSock)
 			insecureStorage := insecureStorageFlag(cmd)
 			rc, _ := config.Resolve("", "", insecureStorage)
 			client, err := ensureCircleCIClient(cmd.Context(), cmd, rc, io, ui.PromptHidden)
@@ -569,7 +568,7 @@ func newSidecarSyncCmd() *cobra.Command {
 				}
 				syncFn = eventlog.Record(dataDir, syncFn, eventlog.OpSync, sidecarID, scName, sidecar.CurrentBranch(cwd)).Status
 			}
-			err = sidecar.RsyncSync(cmd.Context(), client, sidecarID, identityFile, authSock, workdir, cwd, syncFn)
+			err = sidecar.RsyncSync(cmd.Context(), client, sidecarID, workdir, cwd, syncFn)
 			if err != nil {
 				if err := sshSessionError(err); err != nil {
 					return err
@@ -590,7 +589,6 @@ func newSidecarSyncCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&sidecarID, "sidecar-id", "", "Sidecar ID (defaults to active sidecar)")
-	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file")
 	cmd.Flags().StringVar(&workdir, "workdir", "", "Destination path on sidecar (defaults to /home/user/<basename> when omitted)")
 
 	return cmd
@@ -1060,7 +1058,7 @@ Example:
 
 				// Step 4: Sync files to sidecar.
 				if !skipSync {
-					if err := sidecarSetupSync(cmd.Context(), client, sidecarID, identityFile, authSock, dir, rc.CircleCITokenSource, status); err != nil {
+					if err := sidecarSetupSync(cmd.Context(), client, sidecarID, dir, rc.CircleCITokenSource, status); err != nil {
 						return err
 					}
 				}
@@ -1200,13 +1198,13 @@ func sidecarSetupEnsureSSHKey(identityFile string, status iostream.StatusFunc) e
 func sidecarSetupSync(
 	ctx context.Context,
 	client *circleci.Client,
-	sidecarID, identityFile, authSock string,
+	sidecarID string,
 	cwd string,
 	tokenSource string,
 	status iostream.StatusFunc,
 ) error {
 	status(iostream.LevelStep, "Syncing files to sidecar...")
-	err := sidecar.RsyncSync(ctx, client, sidecarID, identityFile, authSock, "", cwd, status)
+	err := sidecar.RsyncSync(ctx, client, sidecarID, "", cwd, status)
 	if err == nil {
 		return nil
 	}

--- a/internal/cmd/usererr.go
+++ b/internal/cmd/usererr.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
-	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
 )
 
@@ -163,7 +162,7 @@ func sshSessionError(err error) error {
 	if e, ok := errors.AsType[*sidecar.KeyNotFoundError](err); ok {
 		return newUserError(fmt.Sprintf("SSH key not found: %s", e.Path)).
 			withCode("ssh.key_not_found").
-			withSuggestion(fmt.Sprintf("Generate one with: ssh-keygen -t ed25519 -f %s\nOr pass --identity-file to use an existing key.", e.Path)).
+			withSuggestion(fmt.Sprintf("Generate one with: ssh-keygen -t ed25519 -f %s", e.Path)).
 			withExitCode(ExitBadArgs).
 			wrap(err)
 	}
@@ -171,13 +170,6 @@ func sshSessionError(err error) error {
 		return newUserError(fmt.Sprintf("SSH public key not found: %s", e.KeyPath)).
 			withCode("ssh.public_key_not_found").
 			withSuggestion(fmt.Sprintf("Generate a new keypair with: ssh-keygen -t ed25519 -f %s", e.IdentityFile)).
-			withExitCode(ExitBadArgs).
-			wrap(err)
-	}
-	if errors.Is(err, sidecar.ErrAuthSockNotSet) {
-		return newUserError("SSH agent not available.").
-			withCode("ssh.auth_sock_not_set").
-			withSuggestion("Set " + config.EnvSSHAuthSock + " or pass --identity-file.").
 			withExitCode(ExitBadArgs).
 			wrap(err)
 	}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -149,21 +149,20 @@ func reportSkippedAutofix(skipped []string, streams iostream.Streams) {
 }
 
 type validateOpts struct {
-	sidecarID    string
-	identityFile string
-	workdir      string
-	orgID        string
-	dryRun       bool
-	list         bool
-	save         bool
-	remote       bool
-	local        bool
-	markRemote   bool
-	jsonOut      bool
-	inlineCmd    string
-	projectDir   string
-	envVarsFlag  []string
-	envFile      string
+	sidecarID   string
+	workdir     string
+	orgID       string
+	dryRun      bool
+	list        bool
+	save        bool
+	remote      bool
+	local       bool
+	markRemote  bool
+	jsonOut     bool
+	inlineCmd   string
+	projectDir  string
+	envVarsFlag []string
+	envFile     string
 }
 
 func newValidateCmd() *cobra.Command {
@@ -191,7 +190,6 @@ func newValidateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.local, "local", false, "Run commands locally instead of on sidecar")
 	cmd.Flags().StringVar(&opts.sidecarID, "sidecar-id", "", "Sidecar ID for remote execution")
 	cmd.Flags().StringVar(&opts.orgID, "org-id", "", "Organization ID (used when creating a new sidecar)")
-	cmd.Flags().StringVar(&opts.identityFile, "identity-file", "", "SSH identity file (uses ssh-agent or ~/.ssh/chunk_ai when omitted)")
 	cmd.Flags().StringVar(&opts.workdir, "workdir", "", "Working directory on sidecar (reads from sidecar.json, defaults to /home/user/<repo>)")
 	cmd.Flags().BoolVar(&opts.markRemote, "mark-remote", false, "Mark [name] (or every command) as remote in .chunk/config.json and exit")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Show commands without executing")

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -300,7 +300,7 @@ func loadSidecarEnvVars(ctx context.Context, client *circleci.Client, opts *vali
 	if opts.sidecarID == "" {
 		return envVars, nil
 	}
-	if err := syncToSidecar(ctx, client, opts.sidecarID, opts.identityFile, opts.workdir, statusFn, streams); err != nil {
+	if err := syncToSidecar(ctx, client, opts.sidecarID, opts.workdir, statusFn, streams); err != nil {
 		return nil, err
 	}
 	return envVars, nil
@@ -735,13 +735,12 @@ func setupRemote(ctx context.Context, client *circleci.Client, opts *validateOpt
 	return false, nil
 }
 
-func syncToSidecar(ctx context.Context, client *circleci.Client, sidecarID, identityFile, workdir string, statusFn iostream.StatusFunc, streams iostream.Streams) error {
-	authSock := os.Getenv(config.EnvSSHAuthSock)
+func syncToSidecar(ctx context.Context, client *circleci.Client, sidecarID, workdir string, statusFn iostream.StatusFunc, streams iostream.Streams) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return &userError{msg: "Could not sync to sidecar.", err: err}
 	}
-	if err := sidecar.RsyncSync(ctx, client, sidecarID, identityFile, authSock, workdir, cwd, statusFn); err != nil {
+	if err := sidecar.RsyncSync(ctx, client, sidecarID, workdir, cwd, statusFn); err != nil {
 		return sidecarSyncError(ctx, client, sidecarID, err, streams)
 	}
 	return nil

--- a/internal/cmd/validate_exec_register_test.go
+++ b/internal/cmd/validate_exec_register_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
 	"github.com/CircleCI-Public/chunk-cli/internal/iostream"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
-	"github.com/CircleCI-Public/chunk-cli/internal/testing/gitrepo"
 )
 
 // The remote exec path now submits, registers the command with the watch daemon,
@@ -29,7 +28,6 @@ import (
 func TestExecFnWithoutDaemonBehavesIdentically(t *testing.T) {
 	// An empty watchd dir: no socket, so every registration fails to connect.
 	t.Setenv("CHUNK_WATCHD_DIR", t.TempDir())
-	t.Chdir(gitrepo.SetupGitRepo(t, "test-org", "test-repo"))
 
 	cci := fakes.NewFakeCircleCI()
 	srv := httptest.NewServer(cci)
@@ -68,7 +66,6 @@ func TestExecFnWithoutDaemonBehavesIdentically(t *testing.T) {
 // registration that follows it.
 func TestExecFnSubmitFailureIsReported(t *testing.T) {
 	t.Setenv("CHUNK_WATCHD_DIR", t.TempDir())
-	t.Chdir(gitrepo.SetupGitRepo(t, "test-org", "test-repo"))
 
 	// A server that rejects everything, so SubmitExec fails.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -157,7 +157,7 @@ func TestOpenAPIExecPassesEnvVars(t *testing.T) {
 
 	envVars := map[string]string{"FOO": "bar", "BAZ": "qux"}
 	streams := iostream.Streams{Out: io.Discard, Err: io.Discard}
-	execFn, _, err := newExecFn(context.Background(), client, "sidecar-123", "", envVars, config.ResolvedConfig{}, nil, streams)
+	execFn, _, err := newExecFn(context.Background(), client, "sidecar-123", "/home/user/test-repo", envVars, config.ResolvedConfig{}, nil, streams)
 	assert.NilError(t, err)
 
 	_, _, _, err = execFn(context.Background(), "echo hello")

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
 	"github.com/CircleCI-Public/chunk-cli/internal/sidecar"
 	"github.com/CircleCI-Public/chunk-cli/internal/testing/fakes"
-	"github.com/CircleCI-Public/chunk-cli/internal/testing/gitrepo"
 	"github.com/CircleCI-Public/chunk-cli/internal/validate"
 )
 
@@ -148,7 +147,6 @@ func TestHostForwardEnv(t *testing.T) {
 
 func TestOpenAPIExecPassesEnvVars(t *testing.T) {
 	isolateConfig(t)
-	t.Chdir(gitrepo.SetupGitRepo(t, "test-org", "test-repo"))
 
 	cci := fakes.NewFakeCircleCI()
 	srv := httptest.NewServer(cci)

--- a/internal/cmd/validate_variants.go
+++ b/internal/cmd/validate_variants.go
@@ -18,7 +18,7 @@ import (
 )
 
 func newValidateVariantsCmd() *cobra.Command {
-	var name, orgID, image, identityFile, workdir string
+	var name, orgID, image, workdir string
 	var parallel, timeout int
 
 	cmd := &cobra.Command{
@@ -123,17 +123,14 @@ func newValidateVariantsCmd() *cobra.Command {
 				statusFn(iostream.LevelInfo, fmt.Sprintf("swept %d orphaned variant sidecar(s) from a previous run", swept))
 			}
 
-			authSock := os.Getenv(config.EnvSSHAuthSock)
 			results, err := variants.Run(ctx, client, vs, variants.Options{
-				OrgID:        resolvedOrgID,
-				Image:        image,
-				IdentityFile: identityFile,
-				AuthSock:     authSock,
-				Workspace:    workspace,
-				CWD:          workDir,
-				Parallel:     parallel,
-				Commands:     variantCommands(cmds, workDir, timeout),
-				StatusFn:     statusFn,
+				OrgID:     resolvedOrgID,
+				Image:     image,
+				Workspace: workspace,
+				CWD:       workDir,
+				Parallel:  parallel,
+				Commands:  variantCommands(cmds, workDir, timeout),
+				StatusFn:  statusFn,
 			})
 			if err != nil {
 				return &userError{msg: "Variants run failed.", err: err}
@@ -155,7 +152,6 @@ func newValidateVariantsCmd() *cobra.Command {
 		"Per-command timeout in seconds, used when the command sets none (0 for no limit)")
 	cmd.Flags().StringVar(&orgID, "org-id", "", "Organization ID")
 	cmd.Flags().StringVar(&image, "image", "", "Snapshot image ID (default: validation.sidecarImage from config)")
-	cmd.Flags().StringVar(&identityFile, "identity-file", "", "SSH identity file")
 	cmd.Flags().StringVar(&workdir, "workdir", "", "Remote working directory")
 
 	return cmd

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,7 +68,6 @@ const (
 const (
 	EnvHome          = "HOME"
 	EnvShell         = "SHELL"
-	EnvSSHAuthSock   = "SSH_AUTH_SOCK"
 	EnvNoColor       = "NO_COLOR"
 	EnvXDGConfigHome = "XDG_CONFIG_HOME"
 	EnvXDGStateHome  = "XDG_STATE_HOME"
@@ -97,11 +96,11 @@ type EnvVars struct {
 	CircleCIOrgID    string `env:"CIRCLECI_ORG_ID"`
 	Home             string `env:"HOME"`
 	Shell            string `env:"SHELL"`
-	SSHAuthSock      string `env:"SSH_AUTH_SOCK"`
 	NoColor          string `env:"NO_COLOR"`
-	XDGConfigHome    string `env:"XDG_CONFIG_HOME"`
-	XDGStateHome     string `env:"XDG_STATE_HOME"`
-	XDGDataHome      string `env:"XDG_DATA_HOME"`
+
+	XDGConfigHome string `env:"XDG_CONFIG_HOME"`
+	XDGStateHome  string `env:"XDG_STATE_HOME"`
+	XDGDataHome   string `env:"XDG_DATA_HOME"`
 }
 
 // LoadEnv populates an EnvVars struct from the process environment.
@@ -115,13 +114,12 @@ func LoadEnv(ctx context.Context) (EnvVars, error) {
 
 // UserConfig is the on-disk JSON config.
 type UserConfig struct {
-	AnthropicAPIKey    string `json:"anthropicAPIKey,omitempty"`
-	CircleCIToken      string `json:"circleCIToken,omitempty"`
-	CircleCIUserID     string `json:"circleCIUserID,omitempty"`
-	GitHubToken        string `json:"gitHubToken,omitempty"`
-	Model              string `json:"model,omitempty"`
-	UseSSHIdentityFile bool   `json:"useSSHIdentityFile,omitempty"`
-	InstanceID         string `json:"instanceID,omitempty"`
+	AnthropicAPIKey string `json:"anthropicAPIKey,omitempty"`
+	CircleCIToken   string `json:"circleCIToken,omitempty"`
+	CircleCIUserID  string `json:"circleCIUserID,omitempty"`
+	GitHubToken     string `json:"gitHubToken,omitempty"`
+	Model           string `json:"model,omitempty"`
+	InstanceID      string `json:"instanceID,omitempty"`
 
 	// Telemetry is the persisted telemetry preference: true enables it,
 	// false disables it. nil means no preference has been set, in which
@@ -153,7 +151,6 @@ type ResolvedConfig struct {
 	ModelSource           string
 	AnalyzeModel          string
 	PromptModel           string
-	UseSSHIdentityFile    bool
 	Notifications         bool
 }
 
@@ -392,7 +389,6 @@ func Resolve(flagAPIKey, flagModel string, insecureStorage bool) (ResolvedConfig
 	rc.CircleCIBaseURL = env.CircleCIBaseURL
 	rc.AnthropicBaseURL = env.AnthropicBaseURL
 	rc.GitHubAPIURL = env.GitHubAPIURL
-	rc.UseSSHIdentityFile = cfg.UseSSHIdentityFile
 	rc.Notifications = cfg.Notifications
 
 	return rc, err
@@ -413,13 +409,12 @@ func ResolveCircleCI(insecureStorage bool) (ResolvedConfig, error) {
 	}
 
 	rc := ResolvedConfig{
-		AnalyzeModel:       AnalyzeModel,
-		PromptModel:        PromptModel,
-		CircleCIBaseURL:    env.CircleCIBaseURL,
-		AnthropicBaseURL:   env.AnthropicBaseURL,
-		GitHubAPIURL:       env.GitHubAPIURL,
-		UseSSHIdentityFile: cfg.UseSSHIdentityFile,
-		Notifications:      cfg.Notifications,
+		AnalyzeModel:     AnalyzeModel,
+		PromptModel:      PromptModel,
+		CircleCIBaseURL:  env.CircleCIBaseURL,
+		AnthropicBaseURL: env.AnthropicBaseURL,
+		GitHubAPIURL:     env.GitHubAPIURL,
+		Notifications:    cfg.Notifications,
 	}
 	rc.CircleCIToken, rc.CircleCITokenSource = resolveCircleCIToken(env, cfg, insecureStorage)
 	return rc, nil
@@ -451,10 +446,9 @@ func ResolveOrgID(workDir string) (value, source string) {
 // Credentials (anthropicAPIKey, circleCIToken) are intentionally excluded —
 // users should use "auth set" which validates before storing.
 var ValidConfigKeys = map[string]bool{
-	"model":              true,
-	"useSSHIdentityFile": true,
-	"telemetry":          true,
-	"notifications":      true,
+	"model":         true,
+	"telemetry":     true,
+	"notifications": true,
 }
 
 // ValidProjectConfigKeys are the keys accepted by "config set" that write to

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -416,7 +416,6 @@ func TestResolve_SkipsKeychainWhenInsecureStorage(t *testing.T) {
 
 func TestValidConfigKeys(t *testing.T) {
 	assert.Assert(t, ValidConfigKeys["model"])
-	assert.Assert(t, ValidConfigKeys["useSSHIdentityFile"])
 	assert.Assert(t, ValidConfigKeys["telemetry"])
 	assert.Assert(t, !ValidConfigKeys["anthropicAPIKey"])
 	assert.Assert(t, !ValidConfigKeys["badkey"])

--- a/internal/sidecar/errors.go
+++ b/internal/sidecar/errors.go
@@ -12,8 +12,6 @@ var (
 	ErrPublicKeyRequired = errors.New("public key is required")
 	// ErrPrivateKeyProvided indicates a private key was given where a public key was expected.
 	ErrPrivateKeyProvided = errors.New("provided key is a private key")
-	// ErrAuthSockNotSet indicates the SSH agent socket is not configured.
-	ErrAuthSockNotSet = errors.New("ssh auth socket not set")
 )
 
 // KeyNotFoundError indicates the SSH private key file does not exist.

--- a/internal/sidecar/pool.go
+++ b/internal/sidecar/pool.go
@@ -24,17 +24,15 @@ type PoolEntry struct {
 
 // Pool manages a fixed set of sidecars as a work queue for parallel tasks.
 type Pool struct {
-	free         chan *PoolEntry
-	updates      chan struct{}
-	ids          []string
-	entries      []*PoolEntry
-	client       *circleci.Client
-	workDir      string
-	orgID        string
-	image        string
-	name         string
-	identityFile string
-	authSock     string
+	free    chan *PoolEntry
+	updates chan struct{}
+	ids     []string
+	entries []*PoolEntry
+	client  *circleci.Client
+	workDir string
+	orgID   string
+	image   string
+	name    string
 
 	mu           sync.Mutex
 	pendingSyncs int
@@ -84,7 +82,7 @@ func NewPool(
 	ctx context.Context,
 	client *circleci.Client,
 	n int,
-	name, orgID, image, identityFile, authSock, workDir string,
+	name, orgID, image, workDir string,
 	status iostream.StatusFunc,
 ) (*Pool, error) {
 	_, repo, err := gitremote.DetectOrgAndRepo(workDir)
@@ -104,14 +102,14 @@ func NewPool(
 		lastSyncedRef = state.LastSyncedRef
 	}
 
-	return assemblePool(ctx, client, n, name, orgID, image, identityFile, authSock, repoPath, workDir, existingIDs, lastSyncedRef, status)
+	return assemblePool(ctx, client, n, name, orgID, image, repoPath, workDir, existingIDs, lastSyncedRef, status)
 }
 
 func assemblePool(
 	ctx context.Context,
 	client *circleci.Client,
 	n int,
-	name, orgID, image, identityFile, authSock, repoPath, workDir string,
+	name, orgID, image, repoPath, workDir string,
 	existingIDs []string,
 	lastSyncedRef string,
 	status iostream.StatusFunc,
@@ -124,7 +122,7 @@ func assemblePool(
 			swg.Add(1)
 			go func(i int, id string) {
 				defer swg.Done()
-				staleFlags[i] = IsDefinitelyStale(ctx, client, id, identityFile, authSock)
+				staleFlags[i] = IsDefinitelyStale(ctx, client, id)
 			}(i, id)
 		}
 		swg.Wait()
@@ -163,7 +161,7 @@ func assemblePool(
 		}
 		status(iostream.LevelInfo, fmt.Sprintf("created sidecar %d (%s)", seedIdx, seed.ID))
 
-		headRef, err := bundleSyncFanOutSince(ctx, client, []string{seed.ID}, identityFile, authSock, repoPath, workDir, "", true, status)
+		headRef, err := bundleSyncFanOutSince(ctx, client, []string{seed.ID}, repoPath, workDir, "", true, status)
 		if err != nil {
 			cleanCtx := context.Background()
 			_ = client.DeleteSidecar(cleanCtx, seed.ID)
@@ -247,8 +245,6 @@ func assemblePool(
 		orgID:        orgID,
 		image:        image,
 		name:         name,
-		identityFile: identityFile,
-		authSock:     authSock,
 		pendingSyncs: len(aliveExisting),
 	}
 
@@ -292,7 +288,7 @@ func (p *Pool) Rebuild(ctx context.Context, dead *PoolEntry, status iostream.Sta
 		return nil, fmt.Errorf("rebuild: create sidecar: %w", err)
 	}
 
-	if err := BundleSyncFanOut(ctx, p.client, []string{sc.ID}, p.identityFile, p.authSock, dead.RepoPath, p.workDir, true, status); err != nil {
+	if err := BundleSyncFanOut(ctx, p.client, []string{sc.ID}, dead.RepoPath, p.workDir, true, status); err != nil {
 		_ = p.client.DeleteSidecar(ctx, sc.ID)
 		return nil, fmt.Errorf("rebuild: sync: %w", err)
 	}
@@ -360,7 +356,7 @@ func (p *Pool) startBackgroundSync(ctx context.Context, sidecarIDs []string, pre
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			err := syncPreparedSidecar(ctx, p.client, id, p.identityFile, p.authSock, false, prepared)
+			err := syncPreparedSidecar(ctx, p.client, id, false, prepared)
 			p.finishSync(entry, err)
 		}(id, entry)
 	}

--- a/internal/sidecar/pool_test.go
+++ b/internal/sidecar/pool_test.go
@@ -125,12 +125,13 @@ type poolTestEnv struct {
 	cl      *circleci.Client
 	cci     *fakes.FakeCircleCI
 	workDir string
-	keyFile string
 }
 
 func setupPoolTest(t *testing.T) poolTestEnv {
 	t.Helper()
-	keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+	homeDir := t.TempDir()
+	t.Setenv(config.EnvHome, homeDir)
+	pubKey := fakes.GenerateSSHKeypairAt(t, filepath.Join(homeDir, ".ssh", "chunk_ai"))
 	sshSrv := fakes.NewSSHServer(t, pubKey)
 	sshSrv.SetResult("", 0)
 
@@ -143,8 +144,7 @@ func setupPoolTest(t *testing.T) poolTestEnv {
 	assert.NilError(t, err)
 
 	workDir := gitrepo.SetupGitRepo(t, "my-org", "my-repo")
-	t.Setenv(config.EnvHome, t.TempDir())
-	return poolTestEnv{cl: cl, cci: cci, workDir: workDir, keyFile: keyFile}
+	return poolTestEnv{cl: cl, cci: cci, workDir: workDir}
 }
 
 func countPoolRequests(cci *fakes.FakeCircleCI, method, path string) int {
@@ -175,7 +175,7 @@ func TestAssemblePool_CreatesAndSyncsAll(t *testing.T) {
 	t.Chdir(env.workDir)
 
 	pool, err := assemblePool(context.Background(), env.cl, 2, "validate", "org-1", "ubuntu:22.04",
-		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, nil, "", func(iostream.Level, string) {})
+		DefaultWorkspace("my-repo"), env.workDir, nil, "", func(iostream.Level, string) {})
 	assert.NilError(t, err)
 	assert.Equal(t, len(pool.ids), 2)
 
@@ -197,7 +197,7 @@ func TestAssemblePool_CreateFailure_ReturnsError(t *testing.T) {
 	env.cci.CreateStatusCode = 500
 
 	_, err := assemblePool(context.Background(), env.cl, 2, "validate", "org-1", "ubuntu:22.04",
-		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, nil, "", func(iostream.Level, string) {})
+		DefaultWorkspace("my-repo"), env.workDir, nil, "", func(iostream.Level, string) {})
 	assert.Assert(t, err != nil)
 	assert.Equal(t, countPoolDeletes(env.cci), 0)
 }
@@ -207,7 +207,7 @@ func TestAssemblePool_PartialCreateFailure_CleansUp(t *testing.T) {
 	env.cci.CreateErrorAfter = 1
 
 	_, err := assemblePool(context.Background(), env.cl, 2, "validate", "org-1", "ubuntu:22.04",
-		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, nil, "", func(iostream.Level, string) {})
+		DefaultWorkspace("my-repo"), env.workDir, nil, "", func(iostream.Level, string) {})
 	assert.Assert(t, err != nil)
 	assert.Equal(t, countPoolDeletes(env.cci), 1)
 	assert.Equal(t, len(env.cci.Sidecars), 0)
@@ -219,7 +219,7 @@ func TestAssemblePool_SyncFailure_CleansUp(t *testing.T) {
 	env.cci.AddKeyStatusCode = 500
 
 	_, err := assemblePool(context.Background(), env.cl, 2, "validate", "org-1", "ubuntu:22.04",
-		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, nil, "", func(iostream.Level, string) {})
+		DefaultWorkspace("my-repo"), env.workDir, nil, "", func(iostream.Level, string) {})
 	assert.Assert(t, err != nil)
 	assert.Equal(t, countPoolDeletes(env.cci), 1)
 	assert.Equal(t, len(env.cci.Sidecars), 0)
@@ -231,7 +231,7 @@ func TestAssemblePool_StaleExisting_ReplacedAutomatically(t *testing.T) {
 	env.cci.StaleIDs = map[string]bool{"stale-sb-1": true, "stale-sb-2": true}
 
 	pool, err := assemblePool(context.Background(), env.cl, 2, "validate", "org-1", "ubuntu:22.04",
-		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, []string{"stale-sb-1", "stale-sb-2"}, "", func(iostream.Level, string) {})
+		DefaultWorkspace("my-repo"), env.workDir, []string{"stale-sb-1", "stale-sb-2"}, "", func(iostream.Level, string) {})
 	assert.NilError(t, err)
 	assert.Equal(t, len(pool.ids), 2)
 	assert.Equal(t, countPoolDeletes(env.cci), 3)
@@ -242,7 +242,7 @@ func TestAssemblePool_ReuseExisting_OnlyCreatesGap(t *testing.T) {
 	t.Chdir(env.workDir)
 
 	pool, err := assemblePool(context.Background(), env.cl, 2, "validate", "org-1", "ubuntu:22.04",
-		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, []string{"existing-sb-1"}, "", func(iostream.Level, string) {})
+		DefaultWorkspace("my-repo"), env.workDir, []string{"existing-sb-1"}, "", func(iostream.Level, string) {})
 	assert.NilError(t, err)
 	assert.Equal(t, len(pool.ids), 2)
 	assert.Equal(t, countPoolRequests(env.cci, "POST", createSidecarPath), 1)
@@ -254,13 +254,13 @@ func TestPool_Rebuild(t *testing.T) {
 	t.Chdir(env.workDir)
 
 	pool := &Pool{
-		client:       env.cl,
-		orgID:        "org-1",
-		image:        "ubuntu:22.04",
-		name:         "validate",
-		identityFile: env.keyFile,
-		workDir:      env.workDir,
-		free:         make(chan *PoolEntry, 1),
+		client: env.cl,
+		orgID:  "org-1",
+		image:  "ubuntu:22.04",
+		name:   "validate",
+
+		workDir: env.workDir,
+		free:    make(chan *PoolEntry, 1),
 	}
 	dead := &PoolEntry{ID: "dead-sb-1", RepoPath: DefaultWorkspace("my-repo")}
 
@@ -298,7 +298,7 @@ func TestPool_100Sidecars_NoGoroutineLeak(t *testing.T) {
 	noopStatus := iostream.StatusFunc(func(_ iostream.Level, _ string) {})
 
 	pool, err := assemblePool(ctx, env.cl, n, "validate", "org-1", "ubuntu:22.04",
-		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, nil, "", noopStatus)
+		DefaultWorkspace("my-repo"), env.workDir, nil, "", noopStatus)
 	assert.NilError(t, err)
 	assert.Equal(t, len(pool.ids), n)
 	releasePoolEntries(pool, drainPoolEntries(ctx, t, pool, n))
@@ -308,7 +308,7 @@ func TestPool_100Sidecars_NoGoroutineLeak(t *testing.T) {
 	baseline := runtime.NumGoroutine()
 
 	pool2, err := assemblePool(ctx, env.cl, n, "validate", "org-1", "ubuntu:22.04",
-		env.keyFile, "", DefaultWorkspace("my-repo"), env.workDir, pool.ids, "", noopStatus)
+		DefaultWorkspace("my-repo"), env.workDir, pool.ids, "", noopStatus)
 	assert.NilError(t, err)
 	assert.Equal(t, len(pool2.ids), n)
 	releasePoolEntries(pool2, drainPoolEntries(ctx, t, pool2, n))

--- a/internal/sidecar/rsync.go
+++ b/internal/sidecar/rsync.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -24,29 +25,39 @@ import (
 // are excluded. workdir overrides the destination path; defaults to
 // /home/user/<basename of cwd>.
 func RsyncSync(ctx context.Context,
-	client *circleci.Client, sidecarID, identityFile, authSock, workdir, cwd string,
+	client *circleci.Client, sidecarID, workdir, cwd string,
 	status iostream.StatusFunc) error {
 
-	return rsyncTo(ctx, client, sidecarID, identityFile, authSock, workdir, cwd, true, status)
+	return rsyncTo(ctx, client, sidecarID, workdir, cwd, true, status)
 }
 
 // RsyncSyncEphemeral syncs like RsyncSync but neither reads nor writes the
 // active sidecar file. workdir is required.
 func RsyncSyncEphemeral(ctx context.Context,
-	client *circleci.Client, sidecarID, identityFile, authSock, workdir, cwd string,
+	client *circleci.Client, sidecarID, workdir, cwd string,
 	status iostream.StatusFunc) error {
 
 	if workdir == "" {
 		return fmt.Errorf("rsync: workdir is required for an ephemeral sync")
 	}
-	return rsyncTo(ctx, client, sidecarID, identityFile, authSock, workdir, cwd, false, status)
+	return rsyncTo(ctx, client, sidecarID, workdir, cwd, false, status)
 }
 
 func rsyncTo(ctx context.Context, client *circleci.Client,
-	sidecarID, identityFile, authSock, workdir, cwd string, persist bool,
+	sidecarID, workdir, cwd string, persist bool,
 	status iostream.StatusFunc) error {
 
-	sess, err := OpenSession(ctx, client, sidecarID, identityFile, authSock, false)
+	keyPath, err := DefaultKeyPath()
+	if err != nil {
+		return fmt.Errorf("rsync: resolve key path: %w", err)
+	}
+	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+		if err := GenerateKeyPair(keyPath); err != nil {
+			return fmt.Errorf("rsync: generate SSH key: %w", err)
+		}
+	}
+
+	sess, err := OpenSession(ctx, client, sidecarID, keyPath, "", false)
 	if err != nil {
 		return fmt.Errorf("rsync: open session: %w", err)
 	}
@@ -86,7 +97,7 @@ func rsyncTo(ctx context.Context, client *circleci.Client,
 		return fmt.Errorf("rsync: mkdir %s: %s", repoPath, result.Stderr)
 	}
 
-	localAddr, stopProxy, err := startSSHProxy(ctx, sess)
+	localAddr, stopProxy, proxyErr, err := startSSHProxy(ctx, sess)
 	if err != nil {
 		return fmt.Errorf("rsync: start SSH proxy: %w", err)
 	}
@@ -97,21 +108,17 @@ func rsyncTo(ctx context.Context, client *circleci.Client,
 		return fmt.Errorf("rsync: parse proxy addr: %w", err)
 	}
 
-	sshArgs := []string{"ssh", "-p", port,
+	// Pass the key path directly without shell quoting — rsync tokenizes -e by
+	// whitespace and calls execve, so ShellEscape would embed literal quotes in
+	// the filename and cause SSH to reject it.
+	sshCmd := strings.Join([]string{
+		"ssh", "-p", port,
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",
-		"-o", "IdentitiesOnly=yes", // prevent agent key flood before explicit key is tried
+		"-o", "IdentitiesOnly=yes",
+		"-i", keyPath,
 		"-q",
-	}
-	if sess.IdentityFile != "" {
-		// Pass path directly — rsync tokenizes -e by whitespace and calls execve,
-		// so shell quoting (ShellEscape) would embed literal quote characters in
-		// the filename and cause ssh to fall through to agent keys.
-		sshArgs = append(sshArgs, "-i", sess.IdentityFile)
-	} else if sess.UseAgent && sess.AuthSock != "" {
-		sshArgs = append(sshArgs, "-o", "IdentitiesOnly=no")
-	}
-	sshCmd := strings.Join(sshArgs, " ")
+	}, " ")
 
 	src := strings.TrimRight(cwd, "/") + "/"
 	dst := fmt.Sprintf("%s@127.0.0.1:%s", defaultSSHUser, repoPath)
@@ -127,10 +134,22 @@ func rsyncTo(ctx context.Context, client *circleci.Client,
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		detail := strings.TrimSpace(stderr.String())
-		if detail != "" {
-			return fmt.Errorf("rsync: %w\n%s", err, detail)
+		var proxyDetail string
+		select {
+		case pe := <-proxyErr:
+			proxyDetail = pe.Error()
+		default:
 		}
-		return fmt.Errorf("rsync: %w", err)
+		switch {
+		case detail != "" && proxyDetail != "":
+			return fmt.Errorf("rsync: %w\n%s\nproxy: %s", err, detail, proxyDetail)
+		case proxyDetail != "":
+			return fmt.Errorf("rsync: %w\nproxy: %s", err, proxyDetail)
+		case detail != "":
+			return fmt.Errorf("rsync: %w\n%s", err, detail)
+		default:
+			return fmt.Errorf("rsync: %w", err)
+		}
 	}
 
 	status(iostream.LevelDone, "Synced")
@@ -139,13 +158,15 @@ func rsyncTo(ctx context.Context, client *circleci.Client,
 
 // startSSHProxy starts a local TCP listener on a random port and bridges each
 // incoming connection to the sidecar's WebSocket SSH tunnel. Returns the local
-// address and a stop function.
-func startSSHProxy(ctx context.Context, sess *Session) (addr string, stop func(), err error) {
+// address, a stop function, and a channel that receives the first proxy-level
+// error (non-blocking send, capacity 1).
+func startSSHProxy(ctx context.Context, sess *Session) (addr string, stop func(), proxyErr <-chan error, err error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return "", nil, fmt.Errorf("listen: %w", err)
+		return "", nil, nil, fmt.Errorf("listen: %w", err)
 	}
 
+	errCh := make(chan error, 1)
 	proxyCtx, cancel := context.WithCancel(ctx)
 
 	go func() {
@@ -154,24 +175,29 @@ func startSSHProxy(ctx context.Context, sess *Session) (addr string, stop func()
 			if acceptErr != nil {
 				return
 			}
-			go bridgeConn(proxyCtx, conn, sess)
+			go bridgeConn(proxyCtx, conn, sess, errCh)
 		}
 	}()
 
 	return ln.Addr().String(), func() {
 		cancel()
 		_ = ln.Close()
-	}, nil
+	}, errCh, nil
 }
 
 // bridgeConn forwards a TCP connection transparently to the sidecar's
 // WebSocket SSH tunnel, enabling standard SSH clients (and rsync --rsh) to
-// connect without WebSocket awareness.
-func bridgeConn(ctx context.Context, tcpConn net.Conn, sess *Session) {
+// connect without WebSocket awareness. Dial failures are sent to errCh so
+// callers can include them in error messages instead of seeing a silent close.
+func bridgeConn(ctx context.Context, tcpConn net.Conn, sess *Session, errCh chan<- error) {
 	defer func() { _ = tcpConn.Close() }()
 
 	wsURL, _, err := toWebSocketURL(sess.URL)
 	if err != nil {
+		select {
+		case errCh <- fmt.Errorf("build WebSocket URL: %w", err):
+		default:
+		}
 		return
 	}
 
@@ -189,6 +215,10 @@ func bridgeConn(ctx context.Context, tcpConn net.Conn, sess *Session) {
 		if resp != nil {
 			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
+		}
+		select {
+		case errCh <- fmt.Errorf("websocket connect to %s: %w", wsURL, err):
+		default:
 		}
 		return
 	}

--- a/internal/sidecar/rsync.go
+++ b/internal/sidecar/rsync.go
@@ -51,13 +51,16 @@ func rsyncTo(ctx context.Context, client *circleci.Client,
 	if err != nil {
 		return fmt.Errorf("rsync: resolve key path: %w", err)
 	}
-	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+	if _, err := os.Stat(keyPath); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("rsync: stat SSH key: %w", err)
+		}
 		if err := GenerateKeyPair(keyPath); err != nil {
 			return fmt.Errorf("rsync: generate SSH key: %w", err)
 		}
 	}
 
-	sess, err := OpenSession(ctx, client, sidecarID, keyPath, "", false)
+	sess, err := OpenSession(ctx, client, sidecarID, false)
 	if err != nil {
 		return fmt.Errorf("rsync: open session: %w", err)
 	}

--- a/internal/sidecar/session.go
+++ b/internal/sidecar/session.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -17,10 +16,8 @@ import (
 	"time"
 
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/circleci"
-	"github.com/CircleCI-Public/chunk-cli/internal/closer"
 )
 
 const (
@@ -75,43 +72,26 @@ func GenerateKeyPair(path string) error {
 // Each call to ExecOverSSH opens and closes its own SSH connection.
 type Session struct {
 	URL          string // WebSocket tunnel URL (ws:// or wss://)
-	IdentityFile string // path to SSH private key (empty when using agent)
+	IdentityFile string // path to SSH private key (~/.ssh/chunk_ai)
 	KnownHosts   string // path to known_hosts file
-	UseAgent     bool   // true when authenticating via ssh-agent
-	AuthSock     string // SSH_AUTH_SOCK path (only used when UseAgent is true)
-}
-
-// readProbeKey resolves the SSH public key to use for a staleness probe.
-func readProbeKey(ctx context.Context, authSock, identityFile string) (string, error) {
-	if identityFile == "" && authSock != "" {
-		if pubKey, err := agentPublicKey(ctx, authSock); err == nil {
-			return pubKey, nil
-		}
-	}
-	if identityFile == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		identityFile = filepath.Join(home, ".ssh", defaultKeyName)
-	}
-	data, err := os.ReadFile(identityFile + ".pub")
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(data)), nil
 }
 
 // IsDefinitelyStale probes sidecarID with a single AddSSHKey attempt under a
 // short timeout. It returns true only when the provisioner responds 404.
-func IsDefinitelyStale(ctx context.Context, client *circleci.Client, sidecarID, identityFile, authSock string) bool {
+func IsDefinitelyStale(ctx context.Context, client *circleci.Client, sidecarID string) bool {
 	probeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
-	pubKey, err := readProbeKey(probeCtx, authSock, identityFile)
+	keyPath, err := DefaultKeyPath()
 	if err != nil {
 		return false
 	}
+	data, err := os.ReadFile(keyPath + ".pub")
+	if err != nil {
+		return false
+	}
+	pubKey := strings.TrimSpace(string(data))
+
 	_, err = client.AddSSHKey(probeCtx, sidecarID, pubKey)
 	if err == nil {
 		return false
@@ -146,36 +126,16 @@ func addSSHKey(ctx context.Context, client *circleci.Client, sidecarID, pubKey s
 	return nil, lastErr
 }
 
-// OpenSession registers an SSH key with the sidecar and returns session info.
-// authSock is the SSH_AUTH_SOCK path; when non-empty and no identityFile is
-// given, the agent is tried first. retryOn404 should be true only for freshly
-// created sidecars where a 404 can be transient.
-func OpenSession(ctx context.Context, client *circleci.Client, sidecarID, identityFile, authSock string, retryOn404 bool) (*Session, error) {
+// OpenSession registers the default SSH key (~/.ssh/chunk_ai) with the sidecar
+// and returns session info. retryOn404 should be true only for freshly created
+// sidecars where a 404 can be transient.
+func OpenSession(ctx context.Context, client *circleci.Client, sidecarID string, retryOn404 bool) (*Session, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("resolve home directory: %w", err)
 	}
 	sshDir := filepath.Join(home, ".ssh")
-
-	if identityFile == "" && authSock != "" {
-		pubKey, err := agentPublicKey(ctx, authSock)
-		if err == nil {
-			resp, err := addSSHKey(ctx, client, sidecarID, pubKey, retryOn404)
-			if err != nil {
-				return nil, fmt.Errorf("register SSH key: %w", err)
-			}
-			return &Session{
-				URL:        resp.URL,
-				UseAgent:   true,
-				AuthSock:   authSock,
-				KnownHosts: filepath.Join(sshDir, knownHostsFile),
-			}, nil
-		}
-	}
-
-	if identityFile == "" {
-		identityFile = filepath.Join(sshDir, defaultKeyName)
-	}
+	identityFile := filepath.Join(sshDir, defaultKeyName)
 
 	if _, err := os.Stat(identityFile); err != nil {
 		return nil, &KeyNotFoundError{Path: identityFile}
@@ -201,37 +161,4 @@ func OpenSession(ctx context.Context, client *circleci.Client, sidecarID, identi
 		IdentityFile: identityFile,
 		KnownHosts:   filepath.Join(sshDir, knownHostsFile),
 	}, nil
-}
-
-// agentPublicKey returns the first public key from the running ssh-agent
-// in authorized_keys format, or an error if the agent is unavailable.
-func agentPublicKey(ctx context.Context, authSock string) (_ string, err error) {
-	ag, conn, err := dialAgent(ctx, authSock)
-	if err != nil {
-		return "", err
-	}
-	defer closer.ErrorHandler(conn, &err)
-
-	keys, err := ag.List()
-	if err != nil {
-		return "", fmt.Errorf("list agent keys: %w", err)
-	}
-	if len(keys) == 0 {
-		return "", fmt.Errorf("ssh-agent has no keys")
-	}
-	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(keys[0]))), nil
-}
-
-// dialAgent connects to the ssh-agent at the given socket path and returns
-// the agent client and the underlying connection. The caller must close conn.
-func dialAgent(ctx context.Context, authSock string) (agent.ExtendedAgent, net.Conn, error) {
-	if authSock == "" {
-		return nil, nil, ErrAuthSockNotSet
-	}
-	var d net.Dialer
-	conn, err := d.DialContext(ctx, "unix", authSock)
-	if err != nil {
-		return nil, nil, fmt.Errorf("connect to ssh-agent: %w", err)
-	}
-	return agent.NewClient(conn), conn, nil
 }

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -48,8 +48,8 @@ func AddSSHKey(ctx context.Context, client *circleci.Client, sidecarID, publicKe
 // SSH opens a session and either runs a command or starts an interactive shell.
 // stdin is forwarded to the remote command when non-nil; callers should pass
 // os.Stdin when the process stdin is a pipe, nil otherwise.
-func SSH(ctx context.Context, client *circleci.Client, sidecarID, identityFile, authSock string, args []string, envVars map[string]string, streams iostream.Streams, stdin io.Reader) error {
-	session, err := OpenSession(ctx, client, sidecarID, identityFile, authSock, false)
+func SSH(ctx context.Context, client *circleci.Client, sidecarID string, args []string, envVars map[string]string, streams iostream.Streams, stdin io.Reader) error {
+	session, err := OpenSession(ctx, client, sidecarID, false)
 	if err != nil {
 		return err
 	}

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -34,8 +34,8 @@ func TestOpenSessionDefaultKeyFallback(t *testing.T) {
 	cl := newClient(t, srv.URL)
 	ctx := context.Background()
 
-	// Both identityFile and authSock are empty — should attempt default key path.
-	_, err := sidecar.OpenSession(ctx, cl, "sb-1", "", "", false)
+	// Should attempt default key path (~/.ssh/chunk_ai).
+	_, err := sidecar.OpenSession(ctx, cl, "sb-1", false)
 	assert.Assert(t, err != nil)
 	assert.Assert(t, strings.Contains(err.Error(), "chunk_ai"),
 		"expected default key name in error, got: %v", err)

--- a/internal/sidecar/ssh.go
+++ b/internal/sidecar/ssh.go
@@ -270,19 +270,10 @@ func InteractiveShell(ctx context.Context, session *Session, envVars map[string]
 	return sess.Wait()
 }
 
-// sshAuth returns the appropriate SSH auth method and a cleanup function.
-// The caller must call cleanup when the SSH session is done.
-func sshAuth(ctx context.Context, session *Session) (ssh.AuthMethod, func(), error) {
+// sshAuth returns the SSH auth method for the session's identity file.
+// The returned cleanup function is a no-op but kept for interface symmetry.
+func sshAuth(_ context.Context, session *Session) (ssh.AuthMethod, func(), error) {
 	noop := func() {}
-
-	if session.UseAgent {
-		ag, conn, err := dialAgent(ctx, session.AuthSock)
-		if err != nil {
-			return nil, noop, err
-		}
-		return ssh.PublicKeysCallback(ag.Signers), func() { _ = conn.Close() }, nil
-	}
-
 	privateKeyData, err := os.ReadFile(session.IdentityFile)
 	if err != nil {
 		return nil, noop, fmt.Errorf("read private key: %w", err)

--- a/internal/sidecar/sync.go
+++ b/internal/sidecar/sync.go
@@ -74,8 +74,8 @@ func persistWorkspace(ctx context.Context, workspace string) error {
 // then resets to the remote base and applies a patch of local changes.
 // workdir overrides the destination path; defaults to /home/user/<repo>.
 func Sync(ctx context.Context,
-	client *circleci.Client, sidecarID, identityFile, authSock, workdir string, status iostream.StatusFunc) error {
-	return syncTo(ctx, client, sidecarID, identityFile, authSock, workdir, true, status)
+	client *circleci.Client, sidecarID, workdir string, status iostream.StatusFunc) error {
+	return syncTo(ctx, client, sidecarID, workdir, true, status)
 }
 
 // SyncEphemeral synchronises like Sync but neither reads nor writes the active
@@ -84,19 +84,19 @@ func Sync(ctx context.Context,
 // workdir is required for the same reason: there is no shared state to fall
 // back on, so each caller must name its own destination.
 func SyncEphemeral(ctx context.Context,
-	client *circleci.Client, sidecarID, identityFile, authSock, workdir string, status iostream.StatusFunc) error {
+	client *circleci.Client, sidecarID, workdir string, status iostream.StatusFunc) error {
 	if workdir == "" {
 		return fmt.Errorf("sync: workdir is required for an ephemeral sync")
 	}
-	return syncTo(ctx, client, sidecarID, identityFile, authSock, workdir, false, status)
+	return syncTo(ctx, client, sidecarID, workdir, false, status)
 }
 
 // syncTo backs Sync and SyncEphemeral. persist controls whether the resolved
 // workspace is read from and written back to the active-sidecar file.
 func syncTo(ctx context.Context, client *circleci.Client,
-	sidecarID, identityFile, authSock, workdir string, persist bool, status iostream.StatusFunc) error {
+	sidecarID, workdir string, persist bool, status iostream.StatusFunc) error {
 
-	session, err := OpenSession(ctx, client, sidecarID, identityFile, authSock, false)
+	session, err := OpenSession(ctx, client, sidecarID, false)
 	if err != nil {
 		return err
 	}
@@ -151,12 +151,12 @@ func syncTo(ctx context.Context, client *circleci.Client,
 // BundleSync synchronises local commits and working-tree changes to a sidecar
 // using a git bundle, without requiring the branch to be pushed.
 func BundleSync(ctx context.Context,
-	client *circleci.Client, sidecarID, identityFile, authSock, workdir, cwd string, retryOn404 bool, status iostream.StatusFunc) error {
+	client *circleci.Client, sidecarID, workdir, cwd string, retryOn404 bool, status iostream.StatusFunc) error {
 	prepared, err := prepareBundleSync(workdir, cwd, "", 1, status)
 	if err != nil {
 		return err
 	}
-	if err := syncPreparedSidecar(ctx, client, sidecarID, identityFile, authSock, retryOn404, prepared); err != nil {
+	if err := syncPreparedSidecar(ctx, client, sidecarID, retryOn404, prepared); err != nil {
 		return err
 	}
 	if err := persistWorkspace(ctx, prepared.repoPath); err != nil {
@@ -168,8 +168,8 @@ func BundleSync(ctx context.Context,
 
 // BundleSyncFanOut synchronises a local working tree to multiple sidecars in
 // parallel using a full or incremental bundle.
-func BundleSyncFanOut(ctx context.Context, client *circleci.Client, sidecarIDs []string, identityFile, authSock, workdir, cwd string, retryOn404 bool, status iostream.StatusFunc) error {
-	_, err := bundleSyncFanOutSince(ctx, client, sidecarIDs, identityFile, authSock, workdir, cwd, "", retryOn404, status)
+func BundleSyncFanOut(ctx context.Context, client *circleci.Client, sidecarIDs []string, workdir, cwd string, retryOn404 bool, status iostream.StatusFunc) error {
+	_, err := bundleSyncFanOutSince(ctx, client, sidecarIDs, workdir, cwd, "", retryOn404, status)
 	return err
 }
 
@@ -185,7 +185,7 @@ type preparedBundleSync struct {
 // bundleSyncFanOutSince synchronises a local working tree to multiple sidecars
 // in parallel. It returns the local HEAD ref that all successful targets were
 // synced to.
-func bundleSyncFanOutSince(ctx context.Context, client *circleci.Client, sidecarIDs []string, identityFile, authSock, workdir, cwd, baseRef string, retryOn404 bool, status iostream.StatusFunc) (string, error) {
+func bundleSyncFanOutSince(ctx context.Context, client *circleci.Client, sidecarIDs []string, workdir, cwd, baseRef string, retryOn404 bool, status iostream.StatusFunc) (string, error) {
 	prepared, err := prepareBundleSync(workdir, cwd, baseRef, len(sidecarIDs), status)
 	if err != nil {
 		return "", err
@@ -206,7 +206,7 @@ func bundleSyncFanOutSince(ctx context.Context, client *circleci.Client, sidecar
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			if err := syncPreparedSidecar(ctx, client, id, identityFile, authSock, retryOn404, prepared); err != nil {
+			if err := syncPreparedSidecar(ctx, client, id, retryOn404, prepared); err != nil {
 				errs[i] = fmt.Errorf("sidecar %s: %w", id, err)
 			}
 		}(i, id)
@@ -268,8 +268,8 @@ func prepareBundleSync(workdir, cwd, baseRef string, sidecarCount int, status io
 	}, nil
 }
 
-func syncPreparedSidecar(ctx context.Context, client *circleci.Client, sidecarID, identityFile, authSock string, retryOn404 bool, prepared *preparedBundleSync) error {
-	sess, err := OpenSession(ctx, client, sidecarID, identityFile, authSock, retryOn404)
+func syncPreparedSidecar(ctx context.Context, client *circleci.Client, sidecarID string, retryOn404 bool, prepared *preparedBundleSync) error {
+	sess, err := OpenSession(ctx, client, sidecarID, retryOn404)
 	if err != nil {
 		return fmt.Errorf("open session: %w", err)
 	}

--- a/internal/sidecar/target.go
+++ b/internal/sidecar/target.go
@@ -14,12 +14,10 @@ import (
 // Target represents operations against one sidecar.
 // It is the base unit that higher-level coordination, including pools, builds on.
 type Target struct {
-	Client       *circleci.Client
-	SidecarID    string
-	IdentityFile string
-	AuthSock     string
-	Workdir      string
-	RetryOn404   bool
+	Client     *circleci.Client
+	SidecarID  string
+	Workdir    string
+	RetryOn404 bool
 }
 
 type WorkspaceNotFoundError struct {
@@ -54,9 +52,9 @@ func (t Target) ResolveWorkspace(ctx context.Context, cwd string) (string, error
 
 func (t Target) Sync(ctx context.Context, cwd string, useBundle bool, status iostream.StatusFunc) error {
 	if useBundle {
-		return BundleSync(ctx, t.Client, t.SidecarID, t.IdentityFile, t.AuthSock, t.Workdir, cwd, t.RetryOn404, status)
+		return BundleSync(ctx, t.Client, t.SidecarID, t.Workdir, cwd, t.RetryOn404, status)
 	}
-	return syncCheckout(ctx, t.Client, t.SidecarID, t.IdentityFile, t.AuthSock, t.Workdir, cwd, status)
+	return syncCheckout(ctx, t.Client, t.SidecarID, t.Workdir, cwd, status)
 }
 
 func (t Target) ExecRunner(ctx context.Context, cwd string, envVars map[string]string, streams iostream.Streams) (func(context.Context, string) (string, string, int, error), string, error) {
@@ -100,8 +98,8 @@ func (t Target) ReadyExecRunner(ctx context.Context, cwd string, envVars map[str
 	return execFn, dest, nil
 }
 
-func syncCheckout(ctx context.Context, client *circleci.Client, sidecarID, identityFile, authSock, workdir, cwd string, status iostream.StatusFunc) error {
-	session, err := OpenSession(ctx, client, sidecarID, identityFile, authSock, false)
+func syncCheckout(ctx context.Context, client *circleci.Client, sidecarID, workdir, cwd string, status iostream.StatusFunc) error {
+	session, err := OpenSession(ctx, client, sidecarID, false)
 	if err != nil {
 		return err
 	}

--- a/internal/testing/fakes/ssh.go
+++ b/internal/testing/fakes/ssh.go
@@ -72,6 +72,39 @@ func GenerateSSHKeypair(t *testing.T) (keyFile string, pubKey ssh.PublicKey) {
 	return keyPath, sshPub
 }
 
+// GenerateSSHKeypairAt generates an ed25519 keypair at the given path (private
+// key at path, public key at path+".pub") and returns the parsed public key.
+// The destination directory is created if it does not exist.
+func GenerateSSHKeypairAt(t *testing.T, path string) ssh.PublicKey {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+	if err := os.WriteFile(path, privPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pubLine := ssh.MarshalAuthorizedKey(sshPub)
+	if err := os.WriteFile(path+".pub", pubLine, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return sshPub
+}
+
 // NewSSHServer starts a WebSocket+SSH server that accepts connections
 // authenticated with authorizedKey. The server is shut down automatically
 // when the test ends.

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -442,7 +442,9 @@ func TestRunRemoteSSH(t *testing.T) {
 	}
 
 	t.Run("success", func(t *testing.T) {
-		keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+		homeDir := t.TempDir()
+		t.Setenv(config.EnvHome, homeDir)
+		pubKey := fakes.GenerateSSHKeypairAt(t, filepath.Join(homeDir, ".ssh", "chunk_ai"))
 		sshSrv := fakes.NewSSHServer(t, pubKey)
 		sshSrv.SetResult("hello from remote\n", 0)
 
@@ -451,9 +453,8 @@ func TestRunRemoteSSH(t *testing.T) {
 		cciSrv := httptest.NewServer(cci)
 		defer cciSrv.Close()
 
-		t.Setenv(config.EnvHome, t.TempDir())
 		client := newCCIClient(t, cciSrv.URL)
-		session, err := sidecar.OpenSession(context.Background(), client, "sidecar-123", keyFile, "", false)
+		session, err := sidecar.OpenSession(context.Background(), client, "sidecar-123", false)
 		assert.NilError(t, err)
 
 		cfg := &config.ProjectConfig{Commands: []config.Command{
@@ -470,7 +471,9 @@ func TestRunRemoteSSH(t *testing.T) {
 	})
 
 	t.Run("non-zero exit code", func(t *testing.T) {
-		keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+		homeDir := t.TempDir()
+		t.Setenv(config.EnvHome, homeDir)
+		pubKey := fakes.GenerateSSHKeypairAt(t, filepath.Join(homeDir, ".ssh", "chunk_ai"))
 		sshSrv := fakes.NewSSHServer(t, pubKey)
 		sshSrv.SetResult("", 1)
 
@@ -479,9 +482,8 @@ func TestRunRemoteSSH(t *testing.T) {
 		cciSrv := httptest.NewServer(cci)
 		defer cciSrv.Close()
 
-		t.Setenv(config.EnvHome, t.TempDir())
 		client := newCCIClient(t, cciSrv.URL)
-		session, err := sidecar.OpenSession(context.Background(), client, "sidecar-123", keyFile, "", false)
+		session, err := sidecar.OpenSession(context.Background(), client, "sidecar-123", false)
 		assert.NilError(t, err)
 
 		cfg := &config.ProjectConfig{Commands: []config.Command{
@@ -494,7 +496,9 @@ func TestRunRemoteSSH(t *testing.T) {
 	})
 
 	t.Run("multiple commands stop on first failure", func(t *testing.T) {
-		keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+		homeDir := t.TempDir()
+		t.Setenv(config.EnvHome, homeDir)
+		pubKey := fakes.GenerateSSHKeypairAt(t, filepath.Join(homeDir, ".ssh", "chunk_ai"))
 		sshSrv := fakes.NewSSHServer(t, pubKey)
 		sshSrv.SetResult("", 1)
 
@@ -503,9 +507,8 @@ func TestRunRemoteSSH(t *testing.T) {
 		cciSrv := httptest.NewServer(cci)
 		defer cciSrv.Close()
 
-		t.Setenv(config.EnvHome, t.TempDir())
 		client := newCCIClient(t, cciSrv.URL)
-		session, err := sidecar.OpenSession(context.Background(), client, "sidecar-123", keyFile, "", false)
+		session, err := sidecar.OpenSession(context.Background(), client, "sidecar-123", false)
 		assert.NilError(t, err)
 
 		cfg := &config.ProjectConfig{Commands: []config.Command{

--- a/internal/variants/exec_test.go
+++ b/internal/variants/exec_test.go
@@ -3,6 +3,7 @@ package variants
 import (
 	"context"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -24,7 +25,9 @@ func discardStatus(_ iostream.Level, _ string) {}
 func newSession(t *testing.T, exitFor func(command string) (string, int)) (*sidecar.Session, *fakes.SSHServer) {
 	t.Helper()
 
-	keyFile, pubKey := fakes.GenerateSSHKeypair(t)
+	homeDir := t.TempDir()
+	t.Setenv(config.EnvHome, homeDir)
+	pubKey := fakes.GenerateSSHKeypairAt(t, filepath.Join(homeDir, ".ssh", "chunk_ai"))
 	sshSrv := fakes.NewSSHServer(t, pubKey)
 	sshSrv.SetResultFn(exitFor)
 
@@ -33,13 +36,10 @@ func newSession(t *testing.T, exitFor func(command string) (string, int)) (*side
 	api := httptest.NewServer(cci)
 	t.Cleanup(api.Close)
 
-	// OpenSession resolves known_hosts under HOME; keep it in a temp dir.
-	t.Setenv(config.EnvHome, t.TempDir())
-
 	client, err := circleci.NewClient(circleci.Config{Token: "fake-token", BaseURL: api.URL})
 	assert.NilError(t, err)
 
-	session, err := sidecar.OpenSession(context.Background(), client, "sc-1", keyFile, "", false)
+	session, err := sidecar.OpenSession(context.Background(), client, "sc-1", false)
 	assert.NilError(t, err)
 	return session, sshSrv
 }

--- a/internal/variants/variants.go
+++ b/internal/variants/variants.go
@@ -171,7 +171,7 @@ func runVariant(ctx context.Context, client *circleci.Client, v Variant, opts Op
 	}()
 
 	opts.StatusFn(iostream.LevelInfo, fmt.Sprintf("[%s] syncing", v.ID))
-	if err := sidecar.RsyncSyncEphemeral(ctx, client, sc.ID, opts.IdentityFile, opts.AuthSock, opts.Workspace, opts.CWD, opts.StatusFn); err != nil {
+	if err := sidecar.RsyncSyncEphemeral(ctx, client, sc.ID, opts.Workspace, opts.CWD, opts.StatusFn); err != nil {
 		base.Error = fmt.Sprintf("sync: %v", err)
 		return base
 	}

--- a/internal/variants/variants.go
+++ b/internal/variants/variants.go
@@ -88,15 +88,13 @@ type Result struct {
 
 // Options holds all configuration for running variants.
 type Options struct {
-	OrgID        string
-	Image        string
-	IdentityFile string
-	AuthSock     string
-	Workspace    string // remote working directory, must be non-empty
-	CWD          string // local source directory to sync from
-	Parallel     int    // max concurrent sidecars (default 5)
-	Commands     []Command
-	StatusFn     iostream.StatusFunc
+	OrgID     string
+	Image     string
+	Workspace string // remote working directory, must be non-empty
+	CWD       string // local source directory to sync from
+	Parallel  int    // max concurrent sidecars (default 5)
+	Commands  []Command
+	StatusFn  iostream.StatusFunc
 }
 
 // Run executes all variants in parallel and returns results in input order.
@@ -176,7 +174,7 @@ func runVariant(ctx context.Context, client *circleci.Client, v Variant, opts Op
 		return base
 	}
 
-	session, err := sidecar.OpenSession(ctx, client, sc.ID, opts.IdentityFile, opts.AuthSock, false)
+	session, err := sidecar.OpenSession(ctx, client, sc.ID, false)
 	if err != nil {
 		base.Error = fmt.Sprintf("open session: %v", err)
 		return base


### PR DESCRIPTION
## Summary

- `rsync` and all other SSH paths now unconditionally use `~/.ssh/chunk_ai`, which chunk auto-generates and registers with the sidecar — removes the fragile `UseAgent`/`IdentitiesOnly=no` branch that had no file path to give rsync's SSH subprocess
- `bridgeConn` now sends WebSocket dial errors to a buffered channel rather than closing silently; a failed proxy connection is surfaced in the returned error instead of appearing as \"0 bytes received so far\"
- Drops `--identity-file` from all commands (`validate`, `validate variants`, `sidecar ssh`, `sidecar setup`, `sidecar sync`)
- Drops SSH agent (`SSH_AUTH_SOCK` / `--auth-sock`) support — chunk never needed it once it started generating its own key
- Removes `useSSHIdentityFile` config key (was stored but never acted upon)
- Simplifies `OpenSession`, `Sync`, `BundleSync`, pool assembly — all identity/agent parameters removed
- Documents automatic SSH key management in `docs/GETTING_STARTED.md` and removes `--identity-file` from `docs/CLI.md`

Fixes #559.

## Test plan

- [x] `task test` passes (all 1550 tests green)
- [x] `task lint` passes (0 issues)
- [ ] `chunk sidecar sync` works end-to-end with the `chunk_ai` key
- [ ] Reproducer from #559 (rsync exit 255 / "0 bytes received") is resolved
- [ ] `chunk sidecar ssh --identity-file` correctly errors as unknown flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)