### PR TITLE
Emit structured JSON for Stop hook success

### DIFF
--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -568,9 +568,9 @@ func writeSidecarState(t *testing.T, e *testenv.TestEnv, projectRoot, sessionID,
 	assert.NilError(t, os.WriteFile(filepath.Join(dir, filename), data, 0o644))
 }
 
-// TestValidateHookMode_SuccessLine verifies that the "chunk validate passed"
-// success line is written to stderr after a clean hook run.
-func TestValidateHookMode_SuccessLine(t *testing.T) {
+// TestValidateHookMode_SuccessResponse verifies that a successful hook run
+// reports completion using Claude Code's structured JSON response format.
+func TestValidateHookMode_SuccessResponse(t *testing.T) {
 	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
 	// writeProjectConfig leaves an untracked file → dirty tree → hook runs.
 	writeProjectConfig(t, workDir, "", "true")
@@ -580,8 +580,17 @@ func TestValidateHookMode_SuccessLine(t *testing.T) {
 		hookStdin(t, "test-session-success-line", false))
 
 	assert.Equal(t, result.ExitCode, 0, "expected exit 0 for passing hook; stderr: %s", result.Stderr)
-	assert.Assert(t, strings.Contains(result.Stdout, "chunk validate passed"),
-		"expected 'chunk validate passed' in stdout; got stdout: %s stderr: %s", result.Stdout, result.Stderr)
+	var response struct {
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	assert.NilError(t, json.Unmarshal([]byte(result.Stdout), &response),
+		"stdout must be one valid JSON response; got stdout: %s stderr: %s", result.Stdout, result.Stderr)
+	assert.Equal(t, response.HookSpecificOutput.HookEventName, "Stop")
+	assert.Assert(t, strings.Contains(response.HookSpecificOutput.AdditionalContext, "chunk validate passed"),
+		"expected completion context; got stdout: %s stderr: %s", result.Stdout, result.Stderr)
 }
 
 // TestValidateHookMode_SetupErrorFlushedToStderr verifies that when setup fails

--- a/acceptance/validate_test.go
+++ b/acceptance/validate_test.go
@@ -62,6 +62,20 @@ func hookStdin(t *testing.T, sessionID string, stopHookActive bool) []byte {
 	return data
 }
 
+func hookAdditionalContext(t *testing.T, stdout string) string {
+	t.Helper()
+	var response struct {
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	assert.NilError(t, json.Unmarshal([]byte(stdout), &response),
+		"stdout must be one valid JSON hook response; got: %s", stdout)
+	assert.Equal(t, response.HookSpecificOutput.HookEventName, "Stop")
+	return response.HookSpecificOutput.AdditionalContext
+}
+
 // commitAll stages and commits all files in dir.
 func commitAll(t *testing.T, dir, message string) {
 	t.Helper()
@@ -106,6 +120,20 @@ func TestValidateHookMode_CleanTree(t *testing.T) {
 
 	assert.Equal(t, result.ExitCode, 0,
 		"expected exit 0 (skipped) for clean tree; stderr: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(hookAdditionalContext(t, result.Stdout), "working tree is clean"),
+		"expected clean-tree context; got stdout: %s", result.Stdout)
+}
+
+func TestValidateHookMode_NoConfig(t *testing.T) {
+	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
+	assert.NilError(t, os.WriteFile(filepath.Join(workDir, "dirty.txt"), []byte("changed"), 0o644))
+	env := testenv.NewTestEnv(t)
+	result := binary.RunCLIWithStdin(t, []string{"validate"}, env, workDir,
+		hookStdin(t, "test-session-no-config", false))
+
+	assert.Equal(t, result.ExitCode, 0, "expected exit 0 for unconfigured hook; stderr: %s", result.Stderr)
+	assert.Assert(t, strings.Contains(hookAdditionalContext(t, result.Stdout), "no validation commands configured"),
+		"expected unconfigured context; got stdout: %s", result.Stdout)
 }
 
 func TestValidateRunDryRun(t *testing.T) {
@@ -573,24 +601,19 @@ func writeSidecarState(t *testing.T, e *testenv.TestEnv, projectRoot, sessionID,
 func TestValidateHookMode_SuccessResponse(t *testing.T) {
 	workDir := gitrepo.SetupGitRepo(t, "test-org", "test-repo")
 	// writeProjectConfig leaves an untracked file → dirty tree → hook runs.
-	writeProjectConfig(t, workDir, "", "true")
+	writeProjectConfig(t, workDir, "", "echo validation-command-output")
 
 	env := testenv.NewTestEnv(t)
 	result := binary.RunCLIWithStdin(t, []string{"validate", "--local"}, env, workDir,
 		hookStdin(t, "test-session-success-line", false))
 
 	assert.Equal(t, result.ExitCode, 0, "expected exit 0 for passing hook; stderr: %s", result.Stderr)
-	var response struct {
-		HookSpecificOutput struct {
-			HookEventName     string `json:"hookEventName"`
-			AdditionalContext string `json:"additionalContext"`
-		} `json:"hookSpecificOutput"`
-	}
-	assert.NilError(t, json.Unmarshal([]byte(result.Stdout), &response),
-		"stdout must be one valid JSON response; got stdout: %s stderr: %s", result.Stdout, result.Stderr)
-	assert.Equal(t, response.HookSpecificOutput.HookEventName, "Stop")
-	assert.Assert(t, strings.Contains(response.HookSpecificOutput.AdditionalContext, "chunk validate passed"),
+	assert.Assert(t, strings.Contains(hookAdditionalContext(t, result.Stdout), "chunk validate passed"),
 		"expected completion context; got stdout: %s stderr: %s", result.Stdout, result.Stderr)
+	assert.Assert(t, !strings.Contains(result.Stdout, "validation-command-output"),
+		"command output must not contaminate hook JSON; got stdout: %s", result.Stdout)
+	assert.Assert(t, strings.Contains(result.Stderr, "validation-command-output"),
+		"command output must be written to stderr; got stderr: %s", result.Stderr)
 }
 
 // TestValidateHookMode_SetupErrorFlushedToStderr verifies that when setup fails

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -55,6 +55,30 @@ type hookContext struct {
 	stopHookActive bool
 }
 
+type hookResponse struct {
+	HookSpecificOutput hookSpecificOutput `json:"hookSpecificOutput"`
+}
+
+type hookSpecificOutput struct {
+	HookEventName     string `json:"hookEventName"`
+	AdditionalContext string `json:"additionalContext"`
+}
+
+// writeStopHookResponse writes the Claude Code hook response format also
+// understood by Codex and Cursor. Hook stdout must contain JSON only; progress
+// and command output continue to use stderr.
+func writeStopHookResponse(w io.Writer, message string) error {
+	if err := json.NewEncoder(w).Encode(hookResponse{
+		HookSpecificOutput: hookSpecificOutput{
+			HookEventName:     "Stop",
+			AdditionalContext: message,
+		},
+	}); err != nil {
+		return fmt.Errorf("write Stop hook response: %w", err)
+	}
+	return nil
+}
+
 // detectHook reads the Claude Code hook JSON payload from r when r is not a
 // terminal. Returns nil if not running as a Stop hook.
 func detectHook(r io.Reader) *hookContext {
@@ -596,8 +620,7 @@ func finishValidate(cmd *cobra.Command, hook *hookContext, execErr error, start 
 	}
 	hookErr := validate.WrapHookResult(hook.sessionID, execErr, maxAttempts, streams.Err)
 	if hookErr == nil && execErr == nil {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.Success(fmt.Sprintf("chunk validate passed (%s)", elapsed)))
-		return nil
+		return writeStopHookResponse(cmd.OutOrStdout(), fmt.Sprintf("chunk validate passed (%s)", elapsed))
 	}
 	return hookErr
 }

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -375,7 +375,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return hookErr
 	}
 	if skip {
-		return nil
+		return writeStopHookResponse(cmd.OutOrStdout(), "chunk validate skipped (working tree is clean)")
 	}
 	statusFn := newStatusFunc(streams)
 	insecureStorage := insecureStorageFlag(cmd)
@@ -402,7 +402,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	cfg, err := config.LoadProjectConfig(workDir)
 	if (err != nil || !cfg.HasCommands()) && opts.inlineCmd == "" {
 		if hook != nil {
-			return nil // no config in hook context: skip silently
+			return writeStopHookResponse(cmd.OutOrStdout(), "chunk validate skipped (no validation commands configured)")
 		}
 		return &userError{
 			msg:        msgValidateNotConfigured,

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -47,6 +47,16 @@ func runValidateHook(t *testing.T, workDir string) (stdout, stderr string, err e
 	return outBuf.String(), errBuf.String(), err
 }
 
+func TestWriteStopHookResponse(t *testing.T) {
+	var out bytes.Buffer
+	assert.NilError(t, writeStopHookResponse(&out, "validation completed: 2/2 passed"))
+
+	var response hookResponse
+	assert.NilError(t, json.Unmarshal(out.Bytes(), &response))
+	assert.Equal(t, response.HookSpecificOutput.HookEventName, "Stop")
+	assert.Equal(t, response.HookSpecificOutput.AdditionalContext, "validation completed: 2/2 passed")
+}
+
 func TestValidateHookExitsOneWhenCircleCITokenMissingAndRemoteCommands(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv(config.EnvCircleToken, "")

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -57,6 +57,17 @@ func TestWriteStopHookResponse(t *testing.T) {
 	assert.Equal(t, response.HookSpecificOutput.AdditionalContext, "validation completed: 2/2 passed")
 }
 
+func TestValidateHookNoConfigWritesResponse(t *testing.T) {
+	isolateConfig(t)
+	stdout, _, err := runValidateHook(t, t.TempDir())
+	assert.NilError(t, err)
+
+	var response hookResponse
+	assert.NilError(t, json.Unmarshal([]byte(stdout), &response))
+	assert.Equal(t, response.HookSpecificOutput.HookEventName, "Stop")
+	assert.Equal(t, response.HookSpecificOutput.AdditionalContext, "chunk validate skipped (no validation commands configured)")
+}
+
 func TestValidateHookExitsOneWhenCircleCITokenMissingAndRemoteCommands(t *testing.T) {
 	isolateConfig(t)
 	t.Setenv(config.EnvCircleToken, "")
@@ -331,7 +342,7 @@ const skipMsg = "skipped (no changes since last successful run)"
 // not assert on the error, so failing runs can be exercised too.
 // --local is passed so the tests focus on hook caching semantics rather than
 // remote routing — caching is orthogonal to where commands run.
-func runActiveStopHook(t *testing.T, dir string) (stderr string, err error) {
+func runActiveStopHookOutput(t *testing.T, dir string) (stdout, stderr string, err error) {
 	t.Helper()
 	var outBuf, errBuf bytes.Buffer
 	root := newTestRootCmd()
@@ -340,7 +351,13 @@ func runActiveStopHook(t *testing.T, dir string) (stderr string, err error) {
 	root.SetIn(strings.NewReader(activeStopHookPayload))
 	root.SetArgs([]string{"validate", "--local", "--project", dir})
 	err = root.Execute()
-	return errBuf.String(), err
+	return outBuf.String(), errBuf.String(), err
+}
+
+func runActiveStopHook(t *testing.T, dir string) (stderr string, err error) {
+	t.Helper()
+	_, stderr, err = runActiveStopHookOutput(t, dir)
+	return stderr, err
 }
 
 // countingCommand returns a command that appends a line to a marker file each
@@ -400,8 +417,13 @@ func TestValidateHookCacheHitResetsAttempts(t *testing.T) {
 	// A failure at some other tree state leaves a count of 1 behind.
 	assert.Equal(t, validate.TrackFailedAttempt(sessionID, nil), 1)
 
-	second := run()
+	stdout, second, err := runActiveStopHookOutput(t, dir)
+	assert.NilError(t, err)
 	assert.Assert(t, strings.Contains(second, skipMsg), "second run must hit the cache, got: %q", second)
+	var response hookResponse
+	assert.NilError(t, json.Unmarshal([]byte(stdout), &response))
+	assert.Assert(t, strings.Contains(response.HookSpecificOutput.AdditionalContext, "chunk validate passed"),
+		"cache hit must return a successful hook response, got: %q", stdout)
 
 	// The hit cleared the counter, so the next failure is attempt 1 again.
 	assert.Equal(t, validate.TrackFailedAttempt(sessionID, nil), 1)


### PR DESCRIPTION
## Summary

- emit successful Stop hook results using Claude Code's nested `hookSpecificOutput` JSON format
- keep validation progress and command output on stderr so stdout remains valid JSON
- add unit and acceptance coverage for the response contract

The nested response format is also supported by Codex and Cursor.

## Test plan

- `go test -race ./...`
- `golangci-lint run ./internal/cmd ./acceptance`