### PR TITLE
Fix chunk upgrade replacing the binary with the bash completion script

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,7 +5,7 @@ version: 2
 
 before:
   hooks:
-    - go run . completion bash --output share/bash-completion/completions/chunk
+    - go run . completion bash --output share/bash-completion/completions/chunk.bash
     - go run . completion zsh --output share/zsh/site-functions/_chunk
 
 builds:
@@ -50,8 +50,10 @@ archives:
     files:
       - LICENSE
       - README.md
-      - src: ./share/bash-completion/completions/chunk
-        dst: share/bash-completion/completions/chunk
+      # Suffixed so no archive entry shares a base name with the binary:
+      # consumers that match on base name alone must not find this first.
+      - src: ./share/bash-completion/completions/chunk.bash
+        dst: share/bash-completion/completions/chunk.bash
       - src: ./share/zsh/site-functions/_chunk
         dst: share/zsh/site-functions/_chunk
 
@@ -85,7 +87,7 @@ brews:
       system "#{bin}/chunk"
     install: |
       bin.install "chunk"
-      bash_completion.install "share/bash-completion/completions/chunk"
+      bash_completion.install "share/bash-completion/completions/chunk.bash" => "chunk"
       zsh_completion.install "share/zsh/site-functions/_chunk"
 
 # Nix package (for NUR - Nix User Repository)

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -140,17 +140,6 @@ func PlatformAssetName() string {
 	return fmt.Sprintf("chunk-cli_%s_%s.tar.gz", osName, archName)
 }
 
-// isBinaryEntry reports whether a tar entry is the chunk executable at the
-// root of the archive. Matching on filepath.Base alone is not enough: release
-// archives also ship share/bash-completion/completions/chunk, which sorts
-// ahead of the binary and would otherwise be installed in its place.
-func isBinaryEntry(hdr *tar.Header) bool {
-	if hdr.Typeflag != tar.TypeReg {
-		return false
-	}
-	return filepath.Clean(hdr.Name) == "chunk"
-}
-
 func downloadAndReplace(client *http.Client, url, installPath string) error {
 	resp, err := client.Get(url) //nolint:gosec // URL comes from GitHub release API response for a known repo
 	if err != nil {
@@ -177,7 +166,9 @@ func downloadAndReplace(client *http.Client, url, installPath string) error {
 		if err != nil {
 			return fmt.Errorf("read tar: %w", err)
 		}
-		if !isBinaryEntry(hdr) {
+		// Match the archive root exactly, not by base name: nothing stops the
+		// archive shipping a nested file called "chunk" ahead of the binary.
+		if hdr.Typeflag != tar.TypeReg || filepath.Clean(hdr.Name) != "chunk" {
 			continue
 		}
 

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -140,6 +140,17 @@ func PlatformAssetName() string {
 	return fmt.Sprintf("chunk-cli_%s_%s.tar.gz", osName, archName)
 }
 
+// isBinaryEntry reports whether a tar entry is the chunk executable at the
+// root of the archive. Matching on filepath.Base alone is not enough: release
+// archives also ship share/bash-completion/completions/chunk, which sorts
+// ahead of the binary and would otherwise be installed in its place.
+func isBinaryEntry(hdr *tar.Header) bool {
+	if hdr.Typeflag != tar.TypeReg {
+		return false
+	}
+	return filepath.Clean(hdr.Name) == "chunk"
+}
+
 func downloadAndReplace(client *http.Client, url, installPath string) error {
 	resp, err := client.Get(url) //nolint:gosec // URL comes from GitHub release API response for a known repo
 	if err != nil {
@@ -166,7 +177,7 @@ func downloadAndReplace(client *http.Client, url, installPath string) error {
 		if err != nil {
 			return fmt.Errorf("read tar: %w", err)
 		}
-		if filepath.Base(hdr.Name) != "chunk" {
+		if !isBinaryEntry(hdr) {
 			continue
 		}
 

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -15,23 +15,38 @@ import (
 	"testing"
 )
 
-// makeTarGz returns a .tar.gz containing a single file named "chunk" with the given content.
+// makeTarGz returns a .tar.gz laid out like a real release archive: the
+// binary is the last entry, and an unrelated file whose base name is also
+// "chunk" (the bash completion script) precedes it.
 func makeTarGz(t *testing.T, content []byte) []byte {
 	t.Helper()
 	var buf bytes.Buffer
 	gz := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gz)
 
-	hdr := &tar.Header{
-		Name: "chunk",
-		Mode: 0o755,
-		Size: int64(len(content)),
+	entries := []struct {
+		name string
+		body []byte
+	}{
+		{"LICENSE", []byte("MIT\n")},
+		{"README.md", []byte("# chunk\n")},
+		{"share/bash-completion/completions/chunk", []byte("# bash completion for chunk\n")},
+		{"share/zsh/site-functions/_chunk", []byte("#compdef chunk\n")},
+		{"chunk", content},
 	}
-	if err := tw.WriteHeader(hdr); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := tw.Write(content); err != nil {
-		t.Fatal(err)
+	for _, e := range entries {
+		hdr := &tar.Header{
+			Name:     e.name,
+			Typeflag: tar.TypeReg,
+			Mode:     0o755,
+			Size:     int64(len(e.body)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(e.body); err != nil {
+			t.Fatal(err)
+		}
 	}
 	if err := tw.Close(); err != nil {
 		t.Fatal(err)

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -15,9 +15,10 @@ import (
 	"testing"
 )
 
-// makeTarGz returns a .tar.gz laid out like a real release archive: the
-// binary is the last entry, and an unrelated file whose base name is also
-// "chunk" (the bash completion script) precedes it.
+// makeTarGz returns a .tar.gz laid out like a release archive, with the binary
+// last. It deliberately includes a nested file whose base name is also "chunk":
+// packaging no longer ships one, but the reader must not depend on that, so
+// this pins it against regressing to base-name matching.
 func makeTarGz(t *testing.T, content []byte) []byte {
 	t.Helper()
 	var buf bytes.Buffer
@@ -32,6 +33,7 @@ func makeTarGz(t *testing.T, content []byte) []byte {
 		{"README.md", []byte("# chunk\n")},
 		{"share/bash-completion/completions/chunk", []byte("# bash completion for chunk\n")},
 		{"share/zsh/site-functions/_chunk", []byte("#compdef chunk\n")},
+		{"docs/chunk", []byte("not the binary either\n")},
 		{"chunk", content},
 	}
 	for _, e := range entries {


### PR DESCRIPTION
## Problem

A user ran `chunk upgrade` and every subsequent `chunk` command failed:

```
/opt/homebrew/bin/chunk: line 129: syntax error near unexpected token `<'
/opt/homebrew/bin/chunk: line 129: `        done < <(compgen -W "${out}" -- "$cur")'
```

`chunk upgrade` had overwritten the binary with the bash completion script. The reported version never moved either, because the replacement reports nothing — which is why this needed a user report to surface rather than showing up as a failed upgrade.

## Cause: two archive entries share a base name

Release archives contain two different files whose last path segment is `chunk`:

| entry | contents |
|---|---|
| `share/bash-completion/completions/chunk` | 43 KB of ASCII shell script |
| `chunk` | the 14 MB binary |

The completion file is named after the command because that filename is bash's lazy-loading lookup key. `downloadAndReplace` selected the entry to install by base name and returned on the first hit, and goreleaser emits `archives.files` ahead of the built binary:

```
LICENSE                                    Base != chunk  -> continue
README.md                                  Base != chunk  -> continue
share/bash-completion/completions/chunk    Base == chunk  -> INSTALL, return
share/zsh/site-functions/_chunk                           (never reached)
chunk                                                     (never reached)
```

Deterministic, not a race: every non-Homebrew `chunk upgrade` installed the script. It has no shebang (first line is a comment), so the shell ran it as `sh`, which does not support the `done < <(...)` process substitution on line 129 — matching the report verbatim.

## Fix

**Packaging (`.goreleaser.yaml`) — the actual fix.** Ship the completion as `chunk.bash` and let Homebrew rename it on install, so no archive entry shares a base name with the binary:

```yaml
- go run . completion bash --output share/bash-completion/completions/chunk.bash
  ...
  bash_completion.install "share/bash-completion/completions/chunk.bash" => "chunk"
```

This is the convention among goreleaser + cobra CLIs — every Charmbracelet tool (`gum`, `glow`, `mods`, `vhs`, …) does exactly this, and chunk's un-suffixed layout was the deviation. The `=> "chunk"` rename is core Homebrew DSL; the installed path and filename are unchanged, so lazy loading still works and nothing changes for users.

Crucially, **this fixes clients we cannot update.** The upgrader always fetches the latest release, so an older `chunk` still matching on base name will now find only the binary. Users on affected versions are repaired by their next `chunk upgrade`.

**Reader (`internal/upgrade/upgrade.go`) — defense in depth.** Match the archive root exactly:

```go
if hdr.Typeflag != tar.TypeReg || filepath.Clean(hdr.Name) != "chunk" {
    continue
}
```

Not load-bearing now that the collision is gone, but it changes the failure mode if the archive layout ever regresses: `chunk binary not found in archive` and an aborted upgrade, instead of silently bricking the binary while reporting the old version.

## Testing

`makeTarGz` built a single-entry archive containing only `chunk`, which is why the suite never caught this. It now mirrors a release archive and deliberately keeps nested `chunk`-named entries, pinning the reader against regressing to base-name matching. Reverting the reader change fails `TestRun/success` with `got "# bash completion for chunk\n"` — the exact reported symptom.

Scope worth naming: that fixture is hand-written, so it guards the Go predicate but **not** the packaging side. Reintroducing a colliding entry in `.goreleaser.yaml` would keep the suite green. Enforcing that would mean running `goreleaser build` in CI and asserting on the resulting archive; left out of this PR.

## Notes for the reviewer

- The `src`/`dst`/`install` changes must ship together — the formula is generated into `homebrew-circleci`, so a partial change would leave it referencing a path the archive no longer contains. goreleaser isn't installed locally, so **the archive layout is unverified until a release or CI dry-run**; worth a look at the first release archive.
- `share/` is gitignored and generated by the `before` hooks, so there's no stale artifact under the old name.
- Users currently broken cannot self-heal until a release carries this, since the corrupted `chunk` can't run `chunk upgrade`. `brew upgrade chunk` fixes Homebrew installs meanwhile.
- The Homebrew guard in `Run` landed in v0.7.160; the reporter was on 0.7.138, so nothing stopped the in-place clobber. Homebrew installs are refused on current versions, but non-brew installs still hit this.
- **Separate pre-existing bug, not addressed here:** `PlatformAssetName` always appends `.tar.gz`, but Windows ships `.zip`, so `chunk upgrade` on Windows always fails with `no release asset found for platform`. It fails safely, and `downloadAndReplace` is gzip/tar-only, so a zip path would be needed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)