### PR TITLE
Score the risk - judge it against this repo's history

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -419,6 +419,13 @@ GET  /validate/collect?root=<path>                 → {tasks}
   until something commits — five 100-line turns read as 500 by the fifth — and
   resets to nothing when anything does, validated or not. A snapshot is content,
   so neither happens.
+- **History tightens, never loosens.** `riskHistory` keeps each project's
+  finished runs (`risk-history.jsonl`: sizes and verdicts, no paths, no content)
+  and answers what an absolute threshold cannot — is this change large *for this
+  repo*, and do changes this size fail here. It can hold a run the rules would
+  have released and raise a score; it can never release one or lower a score. A
+  codebase where every change is enormous must not teach the daemon that
+  enormous is fine.
 - **The snapshot never touches the developer's repository state.** It stages into
   a throwaway index (`GIT_INDEX_FILE` in a temp file, seeded from the real index
   for its stat cache, without which every file is re-hashed per call). The

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -85,6 +85,29 @@ blocks as it always did.
 
 With no daemon running nothing changes: every hook run is blocking.
 
+### The risk score
+
+Every judgement also produces a 0–100 score, the facts behind it, and any
+advice that follows. A low-risk change prints nothing — it is the common case,
+and a number printed every turn is a number nobody reads. Anything else says so:
+
+```
+  validating now: large change since the last passing run, 2100 lines, over the 500-line limit
+  risk 92/100 high — 2100 lines (60), 3 files (6), last run failed (25)
+  2100 lines across 3 files is past the point where checks can run in the background; committing it in parts would get each piece checked sooner
+```
+
+The score is a report, not the decision. Release still turns on the facts
+themselves, because a threshold on lines can be argued with and a threshold on
+a composite cannot — nobody can tell you whether 47 should have been 52. What
+the score is for is the questions one bit cannot answer: which of two changes
+is riskier, and whether there is anything worth advising about either.
+
+Advice is only given where there is something to do about it. "Commit in parts"
+is actionable for 2,000 lines across nine files and impossible for 2,000 lines
+in one generated file, so a single-file change is told nothing rather than
+something it cannot act on.
+
 ## Result Caching
 
 In hook mode only, a successful `chunk validate` run is cached. If the hook

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -108,6 +108,24 @@ is actionable for 2,000 lines across nine files and impossible for 2,000 lines
 in one generated file, so a single-file change is told nothing rather than
 something it cannot act on.
 
+### Relative to this repo
+
+Five hundred lines is a rewrite in one codebase and a Tuesday in another, so
+each project's finished runs are kept in `risk-history.jsonl` in its data
+directory — sizes and verdicts, no paths and no content — and used for the
+questions an absolute threshold cannot answer:
+
+- whether a change is large *for this repo* (it raises the score), and
+- whether changes this size usually fail here. Once a project has at least five
+  comparable runs and half of them failed, a change the rules would have
+  released is held instead.
+
+What history is allowed to do is deliberately one-directional: it can make the
+daemon more cautious, never less. A repo whose changes are all enormous must
+not thereby teach it that enormous is fine — that is how a heuristic learns its
+way into missing failures. And an explicit `asyncValidate: always` still wins,
+because history is a heuristic and that setting is an instruction.
+
 ## Result Caching
 
 In hook mode only, a successful `chunk validate` run is cached. If the hook

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -709,17 +709,38 @@ func reportDelegatedValidate(resp watchd.ValidateResponse, streams iostream.Stre
 	if resp.TaskID != "" {
 		streams.ErrPrintf("  %s\n", ui.ErrDim(fmt.Sprintf(
 			"validating in the background: %s (%s)", shortTaskID(resp.TaskID), resp.Reason)))
+		reportRisk(resp.Risk, streams)
 		return nil
 	}
 	if resp.Reason != "" {
 		streams.ErrPrintf("  %s\n", ui.ErrDim("validating now: "+resp.Reason))
 	}
+	reportRisk(resp.Risk, streams)
 	_, _ = streams.Out.Write([]byte(resp.Stdout))
 	_, _ = streams.Err.Write([]byte(resp.Stderr))
 	if resp.ExitCode != 0 {
 		return &silentExitError{code: resp.ExitCode}
 	}
 	return nil
+}
+
+// reportRisk writes the daemon's judgement of the change, when it is worth
+// saying.
+//
+// A low-risk change gets no line. It is the common case, it is what everyone
+// expects, and a score printed on every turn is how a number stops being read
+// at all. Advice is printed whenever there is any, since advice exists only
+// where there is something to act on.
+func reportRisk(risk *watchd.RiskSummary, streams iostream.Streams) {
+	if risk == nil {
+		return
+	}
+	if risk.Band != watchd.BandLow {
+		streams.ErrPrintf("  %s\n", ui.ErrDim(risk.String()))
+	}
+	if risk.Advice != "" {
+		streams.ErrPrintf("  %s\n", ui.ErrDim(risk.Advice))
+	}
 }
 
 // tryHookDelegate delegates a hook-invoked validate run to the daemon before

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -1005,3 +1005,32 @@ func TestDetectHookReadsTheEventName(t *testing.T) {
 	assert.Equal(t, hook.stopHookActive, true)
 	assert.Equal(t, hook.event, "Stop")
 }
+
+// A low-risk change gets no score line: it is the common case, and a number
+// printed every turn is a number nobody reads. Advice is printed whenever
+// there is any.
+func TestReportDelegatedValidatePrintsRiskOnlyWhenItMatters(t *testing.T) {
+	var quiet bytes.Buffer
+	assert.NilError(t, reportDelegatedValidate(watchd.ValidateResponse{
+		Risk: &watchd.RiskSummary{Score: 12, Band: watchd.BandLow, Parts: []string{"12 lines (1)"}},
+	}, iostream.Streams{Out: &quiet, Err: &quiet}))
+	assert.Equal(t, quiet.String(), "", "a low-risk change was narrated")
+
+	var loud bytes.Buffer
+	err := reportDelegatedValidate(watchd.ValidateResponse{
+		Reason:   "large change, 2000 lines, over the 500-line limit",
+		ExitCode: 1,
+		Risk: &watchd.RiskSummary{
+			Score:  92,
+			Band:   watchd.BandHigh,
+			Parts:  []string{"2000 lines (60)", "3 files (6)"},
+			Advice: "committing it in parts would get each piece checked sooner",
+		},
+	}, iostream.Streams{Out: &loud, Err: &loud})
+
+	assert.Assert(t, err != nil)
+	out := loud.String()
+	assert.Assert(t, strings.Contains(out, "risk 92/100 high"), "got %q", out)
+	assert.Assert(t, strings.Contains(out, "2000 lines (60)"), "got %q", out)
+	assert.Assert(t, strings.Contains(out, "committing it in parts"), "got %q", out)
+}

--- a/internal/watchd/daemon.go
+++ b/internal/watchd/daemon.go
@@ -53,6 +53,9 @@ type daemon struct {
 	// risk remembers which projects owe a blocking run, and is consulted before
 	// releasing a caller.
 	risk *riskMemory
+	// hist is what past runs say about each project, for the questions an
+	// absolute threshold cannot answer.
+	hist *riskHistory
 }
 
 // RunDaemon is the watch daemon entry point, called by the hidden _daemon subcommand.
@@ -103,6 +106,7 @@ func RunDaemon(ctx context.Context, client *circleci.Client, authMessage string,
 		res:       newResourceSampler(client),
 		tasks:     newTaskStore(ctx),
 		risk:      newRiskMemory(),
+		hist:      newRiskHistory(),
 	}
 	// A background run is the one run with nobody to report a failure to, so what
 	// it concluded is remembered here and blocks the run after it.

--- a/internal/watchd/daemon_test.go
+++ b/internal/watchd/daemon_test.go
@@ -32,6 +32,7 @@ func newTestDaemon() *daemon {
 		res:   newResourceSampler(nil),
 		tasks: newTaskStore(context.Background()),
 		risk:  newRiskMemory(),
+		hist:  newRiskHistory(),
 	}
 	d.tasks.onFinish = d.risk.record
 	return d

--- a/internal/watchd/history.go
+++ b/internal/watchd/history.go
@@ -1,0 +1,223 @@
+package watchd
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+)
+
+// historyFile is where a project's finished validate runs are kept, alongside
+// its event log.
+const historyFile = "risk-history.jsonl"
+
+// maxHistory is how many recent runs are kept per project. Enough to say
+// something about a repo's habits, short enough that a habit which has changed
+// stops counting fairly quickly.
+const maxHistory = 200
+
+// minSimilar is how many comparable runs a project needs before its history is
+// allowed to influence anything. Below it, one unlucky afternoon would look
+// like a pattern.
+const minSimilar = 5
+
+// unusuallyLarge is the percentile past which a change counts as large *for
+// this repo*, whatever it measures in absolute lines.
+const unusuallyLarge = 90
+
+// historyRecord is one finished validate run.
+//
+// It records the change, not the diff: sizes and a verdict, no paths and no
+// content. That is all the questions this store answers need, and it keeps a
+// file that lives in the project's data directory from becoming a copy of the
+// developer's code.
+type historyRecord struct {
+	At     time.Time `json:"at"`
+	Lines  int       `json:"lines"`
+	Files  int       `json:"files"`
+	Inert  bool      `json:"inert,omitempty"`
+	Passed bool      `json:"passed"`
+}
+
+// riskHistory remembers how validate runs have gone for each project.
+//
+// It exists to answer the question an absolute threshold cannot: is this change
+// risky *for this repo*. Five hundred lines is a rewrite in one codebase and a
+// Tuesday in another, and "which of these two changes is riskier" has no answer
+// at all without something to compare against.
+//
+// What it is allowed to do with that answer is deliberately one-directional:
+// history can make the daemon more cautious, never less. A repo whose changes
+// are all enormous must not thereby teach the daemon that enormous is fine —
+// that is how a heuristic learns its way into missing failures. So history can
+// hold a run the rules would have released, and can raise a score, and can do
+// nothing else.
+type riskHistory struct {
+	mu     sync.Mutex
+	loaded map[string][]historyRecord // canonical project root → recent runs, oldest first
+}
+
+func newRiskHistory() *riskHistory {
+	return &riskHistory{loaded: make(map[string][]historyRecord)}
+}
+
+// record files how a run went. Best-effort: a project with no writable data
+// directory keeps working, it just learns nothing.
+func (h *riskHistory) record(root string, risk RiskSummary, passed bool) {
+	if root == "" {
+		return
+	}
+	rec := historyRecord{
+		At:     time.Now(),
+		Lines:  risk.Lines,
+		Files:  risk.Files,
+		Inert:  risk.Inert,
+		Passed: passed,
+	}
+	canonical := config.CanonicalProjectRoot(root)
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	recs := append(h.load(canonical, root), rec)
+	if len(recs) > maxHistory {
+		recs = recs[len(recs)-maxHistory:]
+	}
+	h.loaded[canonical] = recs
+	h.append(root, rec)
+}
+
+// evidence summarises what this project's past runs say about a change of this
+// size. A project with too little history reports nothing, which every caller
+// reads as "no opinion".
+func (h *riskHistory) evidence(root string, risk RiskSummary) historyEvidence {
+	if root == "" {
+		return historyEvidence{}
+	}
+	canonical := config.CanonicalProjectRoot(root)
+
+	h.mu.Lock()
+	recs := h.load(canonical, root)
+	h.mu.Unlock()
+
+	if len(recs) < minSimilar {
+		return historyEvidence{}
+	}
+
+	var ev historyEvidence
+	smaller := 0
+	for _, r := range recs {
+		if r.Lines < risk.Lines {
+			smaller++
+		}
+		// Comparable means within a factor of two either way. A band rather than
+		// an exact size, because no two changes are the same size and a rule that
+		// needs them to be would never fire.
+		if r.Lines*2 >= risk.Lines && risk.Lines*2 >= r.Lines {
+			ev.Similar++
+			if !r.Passed {
+				ev.Failed++
+			}
+		}
+	}
+	ev.Percentile = smaller * 100 / len(recs)
+	return ev
+}
+
+// load returns the records for a canonical root, reading them off disk once.
+// Callers hold h.mu.
+func (h *riskHistory) load(canonical, root string) []historyRecord {
+	if recs, ok := h.loaded[canonical]; ok {
+		return recs
+	}
+	recs := readHistory(root)
+	h.loaded[canonical] = recs
+	return recs
+}
+
+// append adds one record to the project's history file.
+func (h *riskHistory) append(root string, rec historyRecord) {
+	dir, err := config.ProjectDataDir(root)
+	if err != nil {
+		return
+	}
+	line, err := json.Marshal(rec)
+	if err != nil {
+		return
+	}
+	// The data directory is created on demand, like the event log's: a project
+	// the daemon has never written to does not have one yet.
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(filepath.Join(dir, historyFile), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = f.Write(append(line, '\n'))
+}
+
+// readHistory reads the most recent records for root, newest last. A missing or
+// unreadable file is an empty history, not an error: nothing here is worth
+// failing a validate run over.
+func readHistory(root string) []historyRecord {
+	dir, err := config.ProjectDataDir(root)
+	if err != nil {
+		return nil
+	}
+	f, err := os.Open(filepath.Join(dir, historyFile))
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+
+	var recs []historyRecord
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var rec historyRecord
+		// A truncated final line — a daemon killed mid-write — is skipped rather
+		// than stopping the read, so one bad line costs one record.
+		if err := json.Unmarshal(scanner.Bytes(), &rec); err != nil {
+			continue
+		}
+		recs = append(recs, rec)
+	}
+	if len(recs) > maxHistory {
+		recs = recs[len(recs)-maxHistory:]
+	}
+	sort.SliceStable(recs, func(i, j int) bool { return recs[i].At.Before(recs[j].At) })
+	return recs
+}
+
+// historyEvidence is what a project's past runs say about a change like the one
+// in hand. The zero value means "no opinion", which is what too little history
+// produces.
+type historyEvidence struct {
+	// Similar is how many recent runs measured a change of comparable size, and
+	// Failed how many of those failed.
+	Similar int
+	Failed  int
+	// Percentile is the share of recent changes smaller than this one, 0–100.
+	Percentile int
+}
+
+// suggestsCaution reports whether comparable changes have failed often enough
+// here that this one is worth waiting for.
+//
+// Half is the line. Below it, holding every run would punish a repo for having
+// any failures at all; at or above it, "this size of change usually fails here"
+// is a fact about the repo worth acting on.
+func (e historyEvidence) suggestsCaution() bool {
+	return e.Similar >= minSimilar && e.Failed*2 >= e.Similar
+}
+
+// unusual reports whether this change is large for this repo, whatever it
+// measures in absolute lines.
+func (e historyEvidence) unusual() bool {
+	return e.Similar > 0 && e.Percentile >= unusuallyLarge
+}

--- a/internal/watchd/history_test.go
+++ b/internal/watchd/history_test.go
@@ -1,0 +1,145 @@
+package watchd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/config"
+)
+
+// historyProject returns a fresh history store and a project root whose data
+// directory is inside the test's temp dir.
+func historyProject(t *testing.T) (*riskHistory, string) {
+	t.Helper()
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
+	return newRiskHistory(), t.TempDir()
+}
+
+// fill records n runs of the given size, failing the first failed of them.
+func fill(h *riskHistory, root string, n, lines, failed int) {
+	for i := 0; i < n; i++ {
+		h.record(root, RiskSummary{Lines: lines, Files: 1}, i >= failed)
+	}
+}
+
+// A repo with almost no history has no opinion, whatever that history says.
+// One unlucky afternoon is not a pattern.
+func TestHistoryStaysQuietUntilThereIsEnoughOfIt(t *testing.T) {
+	h, root := historyProject(t)
+	fill(h, root, minSimilar-1, 100, minSimilar-1)
+
+	ev := h.evidence(root, RiskSummary{Lines: 100})
+	assert.DeepEqual(t, ev, historyEvidence{})
+	assert.Equal(t, ev.suggestsCaution(), false)
+}
+
+func TestHistoryReportsFailuresAmongComparableChanges(t *testing.T) {
+	h, root := historyProject(t)
+	fill(h, root, 6, 100, 4)
+
+	ev := h.evidence(root, RiskSummary{Lines: 100})
+	assert.Equal(t, ev.Similar, 6)
+	assert.Equal(t, ev.Failed, 4)
+	assert.Equal(t, ev.suggestsCaution(), true)
+}
+
+// Comparable means within a factor of two. Without a band no two changes would
+// ever be the same size and the rule would never fire; with an unbounded one a
+// three-line change would be judged by a rewrite.
+func TestHistoryOnlyComparesChangesOfComparableSize(t *testing.T) {
+	h, root := historyProject(t)
+	fill(h, root, 8, 1000, 8)
+
+	ev := h.evidence(root, RiskSummary{Lines: 10})
+	assert.Equal(t, ev.Similar, 0, "a 10-line change was judged by 1000-line ones")
+	assert.Equal(t, ev.suggestsCaution(), false)
+}
+
+func TestHistoryReportsWhereAChangeSitsForThisRepo(t *testing.T) {
+	h, root := historyProject(t)
+	fill(h, root, 9, 10, 0)
+
+	assert.Equal(t, h.evidence(root, RiskSummary{Lines: 500}).Percentile, 100)
+	assert.Equal(t, h.evidence(root, RiskSummary{Lines: 1}).Percentile, 0)
+}
+
+// The record survives the daemon that wrote it: a restart forgets the debt and
+// the baseline, but what a repo's runs have historically done is worth keeping.
+func TestHistoryIsReadBackFromDisk(t *testing.T) {
+	h, root := historyProject(t)
+	fill(h, root, 6, 100, 4)
+
+	fresh := newRiskHistory()
+	ev := fresh.evidence(root, RiskSummary{Lines: 100})
+	assert.Equal(t, ev.Similar, 6)
+	assert.Equal(t, ev.Failed, 4)
+}
+
+// A daemon killed mid-write leaves a half-line. One bad line costs one record,
+// not the whole history.
+func TestHistorySkipsATruncatedLine(t *testing.T) {
+	h, root := historyProject(t)
+	fill(h, root, 6, 100, 4)
+
+	dir, err := config.ProjectDataDir(root)
+	assert.NilError(t, err)
+	path := filepath.Join(dir, historyFile)
+	data, err := os.ReadFile(path)
+	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(path, []byte(string(data)+`{"at":"2026-`), 0o600))
+
+	ev := newRiskHistory().evidence(root, RiskSummary{Lines: 100})
+	assert.Equal(t, ev.Similar, 6)
+}
+
+// It records sizes and a verdict, never paths or content: the file sits in the
+// project's data directory and has no business becoming a copy of the code.
+func TestHistoryRecordsNoCode(t *testing.T) {
+	h, root := historyProject(t)
+	h.record(root, RiskSummary{Lines: 12, Files: 2, Inert: true}, true)
+
+	dir, err := config.ProjectDataDir(root)
+	assert.NilError(t, err)
+	data, err := os.ReadFile(filepath.Join(dir, historyFile))
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(string(data), `"lines":12`), "got %s", data)
+	assert.Assert(t, !strings.Contains(string(data), "/"), "a path leaked into history: %s", data)
+}
+
+// History tightens and never loosens. A repo where every change is enormous
+// must not teach the daemon that enormous is fine.
+func TestHistoryCannotReleaseALargeChange(t *testing.T) {
+	ev := historyEvidence{Similar: 20, Failed: 0, Percentile: 5}
+	d := decideRisk(auto, false, sourceChange(5000), nil, ev)
+	assert.Equal(t, d.async, false, "history released a change the rules held")
+}
+
+// And it does hold one the rules would have released.
+func TestHistoryHoldsASmallChangeThatUsuallyFailsHere(t *testing.T) {
+	ev := historyEvidence{Similar: 8, Failed: 6, Percentile: 50}
+	d := decideRisk(auto, false, sourceChange(20), nil, ev)
+	assert.Equal(t, d.async, false)
+	assert.Assert(t, strings.Contains(d.reason, "6 of the last 8"), "reason was %q", d.reason)
+}
+
+// An explicit setting still wins: history is a heuristic and "always" is an
+// instruction.
+func TestHistoryDoesNotOverrideModeAlways(t *testing.T) {
+	p := asyncPolicy{mode: config.AsyncValidateAlways, maxLines: DefaultAsyncMaxLines}
+	ev := historyEvidence{Similar: 8, Failed: 8, Percentile: 99}
+	assert.Equal(t, decideRisk(p, false, sourceChange(20), nil, ev).async, true)
+}
+
+// Being unusual for this repo raises the score without deciding anything.
+func TestAnUnusuallyLargeChangeScoresHigher(t *testing.T) {
+	normal := scoreChange(500, false, change(100, "a.go"), nil, historyEvidence{Similar: 6, Percentile: 40})
+	unusual := scoreChange(500, false, change(100, "a.go"), nil, historyEvidence{Similar: 6, Percentile: 95})
+
+	assert.Equal(t, unusual.Score, normal.Score+unusualWeight)
+	assert.Assert(t, strings.Contains(strings.Join(unusual.Parts, ", "), "larger than 95%"),
+		"parts were %v", unusual.Parts)
+}

--- a/internal/watchd/risk.go
+++ b/internal/watchd/risk.go
@@ -112,7 +112,7 @@ type riskDecision struct {
 // deliberately lopsided. Anything it cannot measure, and anything that has
 // recently failed, is made to block — the direction that costs a developer time
 // rather than the direction that costs them a missed failure.
-func decideRisk(p asyncPolicy, owesBlockingRun bool, ch gitutil.Changes, chErr error) riskDecision {
+func decideRisk(p asyncPolicy, owesBlockingRun bool, ch gitutil.Changes, chErr error, hist historyEvidence) riskDecision {
 	since := ""
 	if ch.Baseline != "" && ch.Baseline != gitutil.BaselineHead {
 		since = " since the last passing run"
@@ -122,7 +122,7 @@ func decideRisk(p asyncPolicy, owesBlockingRun bool, ch gitutil.Changes, chErr e
 		limit = DefaultAsyncMaxLines
 	}
 
-	risk := scoreChange(limit, owesBlockingRun, ch, chErr)
+	risk := scoreChange(limit, owesBlockingRun, ch, chErr, hist)
 
 	switch p.mode {
 	case config.AsyncValidateNever:
@@ -154,12 +154,30 @@ func decideRisk(p asyncPolicy, owesBlockingRun bool, ch gitutil.Changes, chErr e
 		return riskDecision{risk: risk}
 	}
 	if allInert(ch.Paths) {
-		return riskDecision{async: true, reason: "only docs and text changed", risk: risk}
+		return tighten(riskDecision{async: true, reason: "only docs and text changed", risk: risk}, hist)
 	}
 	if ch.Lines < limit {
-		return riskDecision{async: true, reason: fmt.Sprintf("small change%s, %s", since, lineCount(ch.Lines)), risk: risk}
+		return tighten(riskDecision{async: true, reason: fmt.Sprintf("small change%s, %s", since, lineCount(ch.Lines)), risk: risk}, hist)
 	}
 	return riskDecision{reason: fmt.Sprintf("large change%s, %s, over the %d-line limit", since, lineCount(ch.Lines), limit), risk: risk}
+}
+
+// tighten holds a run the rules would have released, when this repo's own
+// history says changes like it usually fail.
+//
+// Applied to the release paths only, and only under the auto mode, so history
+// is never able to loosen anything: a project whose changes are all enormous
+// cannot teach the daemon that enormous is fine, and a project that set
+// "always" is not quietly overridden. The worst a wrong tightening does is make
+// somebody wait for a run that was going to pass.
+func tighten(d riskDecision, hist historyEvidence) riskDecision {
+	if !d.async || !hist.suggestsCaution() {
+		return d
+	}
+	d.async = false
+	d.reason = fmt.Sprintf("%d of the last %d changes this size failed here, so this one blocks",
+		hist.Failed, hist.Similar)
+	return d
 }
 
 // lineCount renders a line total for a human, singular included.
@@ -262,24 +280,30 @@ func (m *riskMemory) baseline(root string) string {
 // assessRisk measures root and decides whether a run against it can be
 // released. Everything it needs comes from the project on disk and what the
 // daemon remembers, so a caller only has to name the project.
-//
-// The measurement is taken from the last tree that passed its checks when there
-// is one, and from HEAD when there is not — a daemon that has just started, or a
-// project whose runs have never passed. Falling back rather than refusing keeps
-// the first run after a restart working; it measures a larger change than the
-// incremental one, which errs towards making somebody wait.
 func (d *daemon) assessRisk(root string) riskDecision {
 	policy := policyFor(root)
 	owes := d.risk.owesBlockingRun(root)
 
+	ch, err := d.measure(root)
+	// The evidence lookup needs the size, and the size is what the measurement
+	// just produced, so the facts are read first and the judgement made once.
+	hist := d.hist.evidence(root, RiskSummary{Lines: ch.Lines, Files: len(ch.Paths)})
+	return decideRisk(policy, owes, ch, err, hist)
+}
+
+// measure reads how far root has moved from the last state that passed its
+// checks, or from HEAD when there is no such state — a daemon that has just
+// started, or a project whose runs have never passed. Falling back rather than
+// refusing keeps the first run after a restart working; it measures a larger
+// change than the incremental one, which errs towards making somebody wait.
+func (d *daemon) measure(root string) (gitutil.Changes, error) {
 	if base := d.risk.baseline(root); base != "" {
 		ch, err := gitutil.ChangesBetween(root, base)
 		if err == nil {
-			return decideRisk(policy, owes, ch, nil)
+			return ch, nil
 		}
 		// The snapshot is gone — collected by git's gc, or the repo has moved
 		// under it. Measuring against HEAD is worse but still true.
 	}
-	ch, err := gitutil.WorkingChanges(root)
-	return decideRisk(policy, owes, ch, err)
+	return gitutil.WorkingChanges(root)
 }

--- a/internal/watchd/risk.go
+++ b/internal/watchd/risk.go
@@ -99,6 +99,9 @@ type riskDecision struct {
 	// output. It is filled either way: "why did that block" is asked at least as
 	// often as "why did that not".
 	reason string
+	// risk summarises the change the decision was made about. It travels with
+	// every decision, including the ones reached without consulting it.
+	risk RiskSummary
 }
 
 // decideRisk judges whether a validate run against a measured tree can be
@@ -119,42 +122,44 @@ func decideRisk(p asyncPolicy, owesBlockingRun bool, ch gitutil.Changes, chErr e
 		limit = DefaultAsyncMaxLines
 	}
 
+	risk := scoreChange(limit, owesBlockingRun, ch, chErr)
+
 	switch p.mode {
 	case config.AsyncValidateNever:
-		return riskDecision{reason: "background validation is off for this project"}
+		return riskDecision{reason: "background validation is off for this project", risk: risk}
 	case config.AsyncValidateAlways:
 		// Ahead of the failure debt below on purpose: a project that has asked for
 		// every run to be backgrounded has opted out of the blocking safety net,
 		// and quietly overriding that would make the setting a suggestion.
-		return riskDecision{async: true, reason: "background validation is always on for this project"}
+		return riskDecision{async: true, reason: "background validation is always on for this project", risk: risk}
 	}
 
 	// A failure the developer has not been shown the resolution of yet. The next
 	// run blocks so it lands where a hook can act on it, and the debt clears as
 	// soon as a run passes.
 	if owesBlockingRun {
-		return riskDecision{reason: "the last run failed, so this one blocks"}
+		return riskDecision{reason: "the last run failed, so this one blocks", risk: risk}
 	}
 
 	if chErr != nil {
 		// The tree could not be measured, so nothing is known about how large this
 		// change is. Guessing small is the one answer that could lose a failure.
-		return riskDecision{reason: fmt.Sprintf("change size unavailable: %v", chErr)}
+		return riskDecision{reason: fmt.Sprintf("change size unavailable: %v", chErr), risk: risk}
 	}
 	if ch.Empty() {
 		// Nothing to validate, so nothing to wait for: the run skips immediately,
 		// and backgrounding it would spend a task and a later report on a run that
 		// does no work. No reason either — nothing was held back that a developer
 		// would want explained, and a line on every clean turn is just noise.
-		return riskDecision{}
+		return riskDecision{risk: risk}
 	}
 	if allInert(ch.Paths) {
-		return riskDecision{async: true, reason: "only docs and text changed"}
+		return riskDecision{async: true, reason: "only docs and text changed", risk: risk}
 	}
 	if ch.Lines < limit {
-		return riskDecision{async: true, reason: fmt.Sprintf("small change%s, %s", since, lineCount(ch.Lines))}
+		return riskDecision{async: true, reason: fmt.Sprintf("small change%s, %s", since, lineCount(ch.Lines)), risk: risk}
 	}
-	return riskDecision{reason: fmt.Sprintf("large change%s, %s, over the %d-line limit", since, lineCount(ch.Lines), limit)}
+	return riskDecision{reason: fmt.Sprintf("large change%s, %s, over the %d-line limit", since, lineCount(ch.Lines), limit), risk: risk}
 }
 
 // lineCount renders a line total for a human, singular included.

--- a/internal/watchd/risk_test.go
+++ b/internal/watchd/risk_test.go
@@ -28,28 +28,28 @@ func sourceChange(lines int) gitutil.Changes {
 }
 
 func TestASmallChangeIsBackgrounded(t *testing.T) {
-	d := decideRisk(auto, false, sourceChange(42), nil)
+	d := decideRisk(auto, false, sourceChange(42), nil, historyEvidence{})
 	assert.Equal(t, d.async, true)
 	assert.Assert(t, strings.Contains(d.reason, "42 lines"), "reason was %q", d.reason)
 }
 
 func TestALargeChangeBlocks(t *testing.T) {
-	d := decideRisk(auto, false, sourceChange(912), nil)
+	d := decideRisk(auto, false, sourceChange(912), nil, historyEvidence{})
 	assert.Equal(t, d.async, false)
 	assert.Assert(t, strings.Contains(d.reason, "912 lines"), "reason was %q", d.reason)
 }
 
 // The limit is a ceiling, not a target: a change exactly on it waits.
 func TestAChangeOnTheLimitBlocks(t *testing.T) {
-	assert.Equal(t, decideRisk(auto, false, sourceChange(DefaultAsyncMaxLines), nil).async, false)
-	assert.Equal(t, decideRisk(auto, false, sourceChange(DefaultAsyncMaxLines-1), nil).async, true)
+	assert.Equal(t, decideRisk(auto, false, sourceChange(DefaultAsyncMaxLines), nil, historyEvidence{}).async, false, historyEvidence{})
+	assert.Equal(t, decideRisk(auto, false, sourceChange(DefaultAsyncMaxLines-1), nil, historyEvidence{}).async, true, historyEvidence{})
 }
 
 // Size is only consulted for changes that could plausibly fail a check. A docs
 // rewrite is backgrounded however long it is.
 func TestADocsOnlyChangeIsBackgroundedAtAnySize(t *testing.T) {
 	ch := gitutil.Changes{Paths: []string{"README.md", "docs/CLI.md", "LICENSE"}, Lines: 5000}
-	d := decideRisk(auto, false, ch, nil)
+	d := decideRisk(auto, false, ch, nil, historyEvidence{})
 	assert.Equal(t, d.async, true)
 	assert.Equal(t, d.reason, "only docs and text changed")
 }
@@ -57,13 +57,13 @@ func TestADocsOnlyChangeIsBackgroundedAtAnySize(t *testing.T) {
 // One source file in among the docs is a source change.
 func TestOneSourceFileAmongTheDocsIsJudgedOnSize(t *testing.T) {
 	ch := gitutil.Changes{Paths: []string{"README.md", "internal/cmd/validate.go"}, Lines: 5000}
-	assert.Equal(t, decideRisk(auto, false, ch, nil).async, false)
+	assert.Equal(t, decideRisk(auto, false, ch, nil, historyEvidence{}).async, false, historyEvidence{})
 }
 
 // A tree that cannot be measured says nothing about how large the change is,
 // and guessing small is the one answer that could lose a failure.
 func TestAnUnmeasurableChangeBlocks(t *testing.T) {
-	d := decideRisk(auto, false, gitutil.Changes{}, errors.New("not a repo"))
+	d := decideRisk(auto, false, gitutil.Changes{}, errors.New("not a repo"), historyEvidence{})
 	assert.Equal(t, d.async, false)
 	assert.Assert(t, strings.Contains(d.reason, "not a repo"), "reason was %q", d.reason)
 }
@@ -72,7 +72,7 @@ func TestAnUnmeasurableChangeBlocks(t *testing.T) {
 // task and a later report on a run that does no work, so it stays here — and
 // says nothing, because there is nothing a developer would want told.
 func TestACleanTreeIsNotBackgrounded(t *testing.T) {
-	d := decideRisk(auto, false, gitutil.Changes{}, nil)
+	d := decideRisk(auto, false, gitutil.Changes{}, nil, historyEvidence{})
 	assert.Equal(t, d.async, false)
 	assert.Equal(t, d.reason, "")
 }
@@ -80,7 +80,7 @@ func TestACleanTreeIsNotBackgrounded(t *testing.T) {
 // The blocking safety net: a failure nobody was waiting for makes the next run
 // one somebody is waiting for, however small the change.
 func TestAProjectThatOwesABlockingRunGetsOne(t *testing.T) {
-	d := decideRisk(auto, true, sourceChange(1), nil)
+	d := decideRisk(auto, true, sourceChange(1), nil, historyEvidence{})
 	assert.Equal(t, d.async, false)
 	assert.Assert(t, strings.Contains(d.reason, "last run failed"), "reason was %q", d.reason)
 }
@@ -88,12 +88,12 @@ func TestAProjectThatOwesABlockingRunGetsOne(t *testing.T) {
 func TestModeNeverBlocksEvenADocsChange(t *testing.T) {
 	p := asyncPolicy{mode: config.AsyncValidateNever, maxLines: DefaultAsyncMaxLines}
 	ch := gitutil.Changes{Paths: []string{"README.md"}, Lines: 2}
-	assert.Equal(t, decideRisk(p, false, ch, nil).async, false)
+	assert.Equal(t, decideRisk(p, false, ch, nil, historyEvidence{}).async, false, historyEvidence{})
 }
 
 func TestModeAlwaysBackgroundsALargeChange(t *testing.T) {
 	p := asyncPolicy{mode: config.AsyncValidateAlways, maxLines: DefaultAsyncMaxLines}
-	assert.Equal(t, decideRisk(p, false, sourceChange(100000), nil).async, true)
+	assert.Equal(t, decideRisk(p, false, sourceChange(100000), nil, historyEvidence{}).async, true, historyEvidence{})
 }
 
 // An explicit setting beats the heuristic that would otherwise override it:
@@ -102,7 +102,7 @@ func TestModeAlwaysBackgroundsALargeChange(t *testing.T) {
 // suggestion.
 func TestModeAlwaysOutranksTheFailureDebt(t *testing.T) {
 	p := asyncPolicy{mode: config.AsyncValidateAlways, maxLines: DefaultAsyncMaxLines}
-	assert.Equal(t, decideRisk(p, true, sourceChange(1), nil).async, true)
+	assert.Equal(t, decideRisk(p, true, sourceChange(1), nil, historyEvidence{}).async, true, historyEvidence{})
 }
 
 // Always means always, including for a tree whose size could not be read: the
@@ -110,19 +110,19 @@ func TestModeAlwaysOutranksTheFailureDebt(t *testing.T) {
 // answer for a project that has already given one.
 func TestModeAlwaysBackgroundsAnUnmeasurableChange(t *testing.T) {
 	p := asyncPolicy{mode: config.AsyncValidateAlways, maxLines: DefaultAsyncMaxLines}
-	assert.Equal(t, decideRisk(p, false, gitutil.Changes{}, errors.New("nope")).async, true)
+	assert.Equal(t, decideRisk(p, false, gitutil.Changes{}, errors.New("nope"), historyEvidence{}).async, true, historyEvidence{})
 }
 
 func TestAProjectCanRaiseItsOwnLimit(t *testing.T) {
 	p := asyncPolicy{mode: config.AsyncValidateAuto, maxLines: 2000}
-	assert.Equal(t, decideRisk(p, false, sourceChange(912), nil).async, true)
+	assert.Equal(t, decideRisk(p, false, sourceChange(912), nil, historyEvidence{}).async, true, historyEvidence{})
 }
 
 // A nonsensical limit falls back to the default rather than backgrounding
 // nothing at all.
 func TestANonPositiveLimitFallsBackToTheDefault(t *testing.T) {
 	p := asyncPolicy{mode: config.AsyncValidateAuto, maxLines: -1}
-	assert.Equal(t, decideRisk(p, false, sourceChange(42), nil).async, true)
+	assert.Equal(t, decideRisk(p, false, sourceChange(42), nil, historyEvidence{}).async, true, historyEvidence{})
 }
 
 func TestAllInert(t *testing.T) {

--- a/internal/watchd/score.go
+++ b/internal/watchd/score.go
@@ -1,0 +1,150 @@
+package watchd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
+)
+
+// Risk score bands. They exist so a caller can act on the score without
+// hard-coding a number, and so the number itself stays arguable: a band is a
+// claim about caution, not a probability of failure.
+const (
+	BandLow    = "low"
+	BandMedium = "medium"
+	BandHigh   = "high"
+)
+
+// Score weights. Each is the most its fact can contribute, so a reader can work
+// out where a total came from without running the code.
+const (
+	sizeWeight  = 60 // a change at the line limit
+	filesWeight = 20 // a change touching filesBreadth files or more
+	debtWeight  = 25 // the last run failed
+	inertCeil   = 10 // the most a docs-and-text change can score
+	filesSpread = 10 // files at which breadth is maxed out
+)
+
+// RiskSummary is what the daemon made of a change, as reported to a caller.
+//
+// It is deliberately not just a number. A score on its own cannot be argued
+// with — "risk 62" invites either trust or dismissal and supports neither — so
+// the facts it was built from travel with it, and the advice that follows from
+// them is spelled out rather than left to be inferred.
+type RiskSummary struct {
+	// Score is 0–100. Higher means more caution: bigger, broader, or already
+	// failing. It does not decide anything on its own; see decideRisk.
+	Score int `json:"score"`
+	// Band is Score bucketed into BandLow, BandMedium or BandHigh.
+	Band string `json:"band"`
+	// Parts are the facts behind the score, each with what it contributed.
+	Parts []string `json:"parts,omitempty"`
+	// Advice is what a developer or agent could do about it, or "" when there is
+	// nothing useful to say.
+	Advice string `json:"advice,omitempty"`
+}
+
+// scoreChange summarises how much caution a change deserves.
+//
+// The score is a report, not the decision. decideRisk still answers "who waits"
+// from the facts themselves, because a threshold on lines can be argued with in
+// review and a threshold on a composite cannot: nobody can tell you whether 47
+// should have been 52. What the score is for is the questions one bit cannot
+// answer — which of two changes is riskier, whether a change is unusual for this
+// repo, and whether there is anything worth advising about it.
+func scoreChange(limit int, owesBlockingRun bool, ch gitutil.Changes, chErr error) RiskSummary {
+	if chErr != nil {
+		// Nothing is known about this change. The top of the scale is the only
+		// honest answer, and it is the same direction decideRisk takes.
+		return RiskSummary{
+			Score: 100,
+			Band:  BandHigh,
+			Parts: []string{fmt.Sprintf("change size unavailable: %v (100)", chErr)},
+		}
+	}
+	if ch.Empty() {
+		return RiskSummary{Score: 0, Band: BandLow, Parts: []string{"no changes (0)"}}
+	}
+
+	var (
+		score int
+		parts []string
+	)
+
+	size := ch.Lines * sizeWeight / max(limit, 1)
+	if size > sizeWeight {
+		size = sizeWeight
+	}
+	score += size
+	parts = append(parts, fmt.Sprintf("%s (%d)", lineCount(ch.Lines), size))
+
+	breadth := len(ch.Paths) * filesWeight / filesSpread
+	if breadth > filesWeight {
+		breadth = filesWeight
+	}
+	score += breadth
+	parts = append(parts, fmt.Sprintf("%s (%d)", fileCount(len(ch.Paths)), breadth))
+
+	// Applied as a ceiling rather than a discount: a docs change is not a small
+	// source change, it is a change nothing should fail on, and a thousand lines
+	// of it should not out-score three lines of Go.
+	if allInert(ch.Paths) && score > inertCeil {
+		score = inertCeil
+		parts = append(parts, fmt.Sprintf("docs and text only (ceiling %d)", inertCeil))
+	}
+
+	if owesBlockingRun {
+		score += debtWeight
+		parts = append(parts, fmt.Sprintf("last run failed (%d)", debtWeight))
+	}
+
+	if score > 100 {
+		score = 100
+	}
+	return RiskSummary{Score: score, Band: band(score), Parts: parts, Advice: advise(limit, ch, chErr)}
+}
+
+func band(score int) string {
+	switch {
+	case score >= 80:
+		return BandHigh
+	case score >= 50:
+		return BandMedium
+	default:
+		return BandLow
+	}
+}
+
+// advise says what could be done about a change, or nothing.
+//
+// Only size and breadth produce advice, and only together. "Commit in parts" is
+// actionable for 2,000 lines across nine files and useless for 2,000 lines in
+// one generated file, so a single-file change gets no suggestion rather than an
+// impossible one. Nothing is advised about a failing run or an unmeasurable
+// tree either: the run itself is about to say more than any advice could.
+func advise(limit int, ch gitutil.Changes, chErr error) string {
+	if chErr != nil || ch.Lines < limit || len(ch.Paths) < 2 || allInert(ch.Paths) {
+		return ""
+	}
+	return fmt.Sprintf(
+		"%s across %s is past the point where checks can run in the background; "+
+			"committing it in parts would get each piece checked sooner",
+		lineCount(ch.Lines), fileCount(len(ch.Paths)))
+}
+
+// fileCount renders a file total for a human, singular included.
+func fileCount(n int) string {
+	if n == 1 {
+		return "1 file"
+	}
+	return fmt.Sprintf("%d files", n)
+}
+
+// String renders a summary as one line of terminal output.
+func (r RiskSummary) String() string {
+	if len(r.Parts) == 0 {
+		return fmt.Sprintf("risk %d/100 %s", r.Score, r.Band)
+	}
+	return fmt.Sprintf("risk %d/100 %s — %s", r.Score, r.Band, strings.Join(r.Parts, ", "))
+}

--- a/internal/watchd/score.go
+++ b/internal/watchd/score.go
@@ -24,6 +24,10 @@ const (
 	debtWeight  = 25 // the last run failed
 	inertCeil   = 10 // the most a docs-and-text change can score
 	filesSpread = 10 // files at which breadth is maxed out
+	// Both of these come from the project's own history, and both only ever add
+	// — see riskHistory for why history is allowed to tighten and never loosen.
+	unusualWeight = 10 // large for this repo, whatever it measures in lines
+	historyWeight = 20 // changes this size usually fail here
 )
 
 // RiskSummary is what the daemon made of a change, as reported to a caller.
@@ -36,6 +40,12 @@ type RiskSummary struct {
 	// Score is 0–100. Higher means more caution: bigger, broader, or already
 	// failing. It does not decide anything on its own; see decideRisk.
 	Score int `json:"score"`
+	// Lines and Files are what was measured, kept apart from the score so a
+	// caller can compare two changes without unpicking one.
+	Lines int `json:"lines"`
+	Files int `json:"files"`
+	// Inert reports that every changed path was docs or text.
+	Inert bool `json:"inert,omitempty"`
 	// Band is Score bucketed into BandLow, BandMedium or BandHigh.
 	Band string `json:"band"`
 	// Parts are the facts behind the score, each with what it contributed.
@@ -53,7 +63,7 @@ type RiskSummary struct {
 // should have been 52. What the score is for is the questions one bit cannot
 // answer — which of two changes is riskier, whether a change is unusual for this
 // repo, and whether there is anything worth advising about it.
-func scoreChange(limit int, owesBlockingRun bool, ch gitutil.Changes, chErr error) RiskSummary {
+func scoreChange(limit int, owesBlockingRun bool, ch gitutil.Changes, chErr error, hist historyEvidence) RiskSummary {
 	if chErr != nil {
 		// Nothing is known about this change. The top of the scale is the only
 		// honest answer, and it is the same direction decideRisk takes.
@@ -71,6 +81,7 @@ func scoreChange(limit int, owesBlockingRun bool, ch gitutil.Changes, chErr erro
 		score int
 		parts []string
 	)
+	inert := allInert(ch.Paths)
 
 	size := ch.Lines * sizeWeight / max(limit, 1)
 	if size > sizeWeight {
@@ -89,7 +100,7 @@ func scoreChange(limit int, owesBlockingRun bool, ch gitutil.Changes, chErr erro
 	// Applied as a ceiling rather than a discount: a docs change is not a small
 	// source change, it is a change nothing should fail on, and a thousand lines
 	// of it should not out-score three lines of Go.
-	if allInert(ch.Paths) && score > inertCeil {
+	if inert && score > inertCeil {
 		score = inertCeil
 		parts = append(parts, fmt.Sprintf("docs and text only (ceiling %d)", inertCeil))
 	}
@@ -99,10 +110,30 @@ func scoreChange(limit int, owesBlockingRun bool, ch gitutil.Changes, chErr erro
 		parts = append(parts, fmt.Sprintf("last run failed (%d)", debtWeight))
 	}
 
+	// What this repo's own history says. It can only raise the score, never
+	// lower one: a codebase where every change is enormous must not thereby
+	// teach the daemon that enormous is fine.
+	if hist.unusual() {
+		score += unusualWeight
+		parts = append(parts, fmt.Sprintf("larger than %d%% of recent changes here (%d)", hist.Percentile, unusualWeight))
+	}
+	if hist.suggestsCaution() {
+		score += historyWeight
+		parts = append(parts, fmt.Sprintf("%d of the last %d changes this size failed here (%d)", hist.Failed, hist.Similar, historyWeight))
+	}
+
 	if score > 100 {
 		score = 100
 	}
-	return RiskSummary{Score: score, Band: band(score), Parts: parts, Advice: advise(limit, ch, chErr)}
+	return RiskSummary{
+		Score:  score,
+		Lines:  ch.Lines,
+		Files:  len(ch.Paths),
+		Inert:  inert,
+		Band:   band(score),
+		Parts:  parts,
+		Advice: advise(limit, ch, chErr),
+	}
 }
 
 func band(score int) string {

--- a/internal/watchd/score_test.go
+++ b/internal/watchd/score_test.go
@@ -15,8 +15,8 @@ func change(lines int, paths ...string) gitutil.Changes {
 }
 
 func TestScoreRisesWithSize(t *testing.T) {
-	small := scoreChange(500, false, change(10, "main.go"), nil)
-	big := scoreChange(500, false, change(400, "main.go"), nil)
+	small := scoreChange(500, false, change(10, "main.go"), nil, historyEvidence{})
+	big := scoreChange(500, false, change(400, "main.go"), nil, historyEvidence{})
 
 	assert.Assert(t, small.Score < big.Score, "%d is not below %d", small.Score, big.Score)
 	assert.Equal(t, small.Band, BandLow)
@@ -25,22 +25,22 @@ func TestScoreRisesWithSize(t *testing.T) {
 // Size is capped, so a change ten times the limit does not swamp everything
 // else the score is made of.
 func TestScoreSizeIsCapped(t *testing.T) {
-	at := scoreChange(500, false, change(500, "main.go"), nil)
-	way := scoreChange(500, false, change(50000, "main.go"), nil)
+	at := scoreChange(500, false, change(500, "main.go"), nil, historyEvidence{})
+	way := scoreChange(500, false, change(50000, "main.go"), nil, historyEvidence{})
 	assert.Equal(t, at.Score, way.Score)
 }
 
 func TestScoreRisesWithBreadth(t *testing.T) {
-	narrow := scoreChange(500, false, change(100, "a.go"), nil)
-	wide := scoreChange(500, false, change(100, "a.go", "b.go", "c.go", "d.go", "e.go"), nil)
+	narrow := scoreChange(500, false, change(100, "a.go"), nil, historyEvidence{})
+	wide := scoreChange(500, false, change(100, "a.go", "b.go", "c.go", "d.go", "e.go"), nil, historyEvidence{})
 	assert.Assert(t, wide.Score > narrow.Score, "%d is not above %d", wide.Score, narrow.Score)
 }
 
 // A docs change is not a small source change, it is a change nothing should
 // fail on. A thousand lines of it must not out-score three lines of Go.
 func TestADocsChangeIsCappedBelowASmallSourceChange(t *testing.T) {
-	docs := scoreChange(500, false, change(5000, "README.md", "docs/CLI.md"), nil)
-	source := scoreChange(500, false, change(3, "main.go"), nil)
+	docs := scoreChange(500, false, change(5000, "README.md", "docs/CLI.md"), nil, historyEvidence{})
+	source := scoreChange(500, false, change(3, "main.go"), nil, historyEvidence{})
 
 	assert.Equal(t, docs.Score, inertCeil)
 	assert.Equal(t, docs.Band, BandLow)
@@ -48,8 +48,8 @@ func TestADocsChangeIsCappedBelowASmallSourceChange(t *testing.T) {
 }
 
 func TestAFailedLastRunAddsToTheScore(t *testing.T) {
-	clean := scoreChange(500, false, change(100, "main.go"), nil)
-	owing := scoreChange(500, true, change(100, "main.go"), nil)
+	clean := scoreChange(500, false, change(100, "main.go"), nil, historyEvidence{})
+	owing := scoreChange(500, true, change(100, "main.go"), nil, historyEvidence{})
 
 	assert.Equal(t, owing.Score, clean.Score+debtWeight)
 	assert.Assert(t, strings.Contains(strings.Join(owing.Parts, " "), "last run failed"),
@@ -59,27 +59,28 @@ func TestAFailedLastRunAddsToTheScore(t *testing.T) {
 // Nothing known means the top of the scale. It is the same direction the
 // release decision takes, for the same reason.
 func TestAnUnmeasurableChangeScoresHighest(t *testing.T) {
-	s := scoreChange(500, false, gitutil.Changes{}, errors.New("not a repo"))
+	s := scoreChange(500, false, gitutil.Changes{}, errors.New("not a repo"), historyEvidence{})
 	assert.Equal(t, s.Score, 100)
 	assert.Equal(t, s.Band, BandHigh)
 }
 
 func TestAnEmptyChangeScoresZero(t *testing.T) {
-	s := scoreChange(500, false, gitutil.Changes{Baseline: gitutil.BaselineHead}, nil)
+	s := scoreChange(500, false, gitutil.Changes{Baseline: gitutil.BaselineHead}, nil, historyEvidence{})
 	assert.Equal(t, s.Score, 0)
 	assert.Equal(t, s.Band, BandLow)
 }
 
 func TestScoreIsNeverOverAHundred(t *testing.T) {
 	s := scoreChange(500, true, change(100000,
-		"a.go", "b.go", "c.go", "d.go", "e.go", "f.go", "g.go", "h.go", "i.go", "j.go", "k.go"), nil)
+		"a.go", "b.go", "c.go", "d.go", "e.go", "f.go", "g.go", "h.go", "i.go", "j.go", "k.go"),
+		nil, historyEvidence{Similar: 10, Failed: 9, Percentile: 99})
 	assert.Equal(t, s.Score, 100)
 }
 
 // The parts are the point: a score you cannot take apart is a score nobody can
 // argue with.
 func TestScorePartsNameTheFactsBehindIt(t *testing.T) {
-	s := scoreChange(500, false, change(912, "a.go", "b.go"), nil)
+	s := scoreChange(500, false, change(912, "a.go", "b.go"), nil, historyEvidence{})
 	joined := strings.Join(s.Parts, ", ")
 	assert.Assert(t, strings.Contains(joined, "912 lines"), "got %q", joined)
 	assert.Assert(t, strings.Contains(joined, "2 files"), "got %q", joined)
@@ -90,14 +91,14 @@ func TestScorePartsNameTheFactsBehindIt(t *testing.T) {
 // files and is impossible in one, so a single-file change is told nothing
 // rather than something it cannot do.
 func TestAdviceOnlyWhereThereIsSomethingToDo(t *testing.T) {
-	across := scoreChange(500, false, change(2000, "a.go", "b.go", "c.go"), nil)
+	across := scoreChange(500, false, change(2000, "a.go", "b.go", "c.go"), nil, historyEvidence{})
 	assert.Assert(t, strings.Contains(across.Advice, "committing it in parts"), "got %q", across.Advice)
 
 	for name, s := range map[string]RiskSummary{
-		"one file":      scoreChange(500, false, change(2000, "generated.go"), nil),
-		"under limit":   scoreChange(500, false, change(100, "a.go", "b.go"), nil),
-		"docs and text": scoreChange(500, false, change(5000, "a.md", "b.md"), nil),
-		"unmeasurable":  scoreChange(500, false, gitutil.Changes{}, errors.New("nope")),
+		"one file":      scoreChange(500, false, change(2000, "generated.go"), nil, historyEvidence{}),
+		"under limit":   scoreChange(500, false, change(100, "a.go", "b.go"), nil, historyEvidence{}),
+		"docs and text": scoreChange(500, false, change(5000, "a.md", "b.md"), nil, historyEvidence{}),
+		"unmeasurable":  scoreChange(500, false, gitutil.Changes{}, errors.New("nope"), historyEvidence{}),
 	} {
 		assert.Equal(t, s.Advice, "", "advice was given for %s", name)
 	}
@@ -108,12 +109,12 @@ func TestAdviceOnlyWhereThereIsSomethingToDo(t *testing.T) {
 // composite cannot.
 func TestTheScoreDoesNotDecideWhoWaits(t *testing.T) {
 	// Medium score, still released: 400 lines across 5 files is under the limit.
-	d := decideRisk(auto, false, change(400, "a.go", "b.go", "c.go", "d.go", "e.go"), nil)
+	d := decideRisk(auto, false, change(400, "a.go", "b.go", "c.go", "d.go", "e.go"), nil, historyEvidence{})
 	assert.Equal(t, d.async, true)
 	assert.Equal(t, d.risk.Band, BandMedium)
 
 	// Low score, still held: nothing about three lines is risky, but the last
 	// run failed and that is what decides.
-	held := decideRisk(auto, true, change(3, "main.go"), nil)
+	held := decideRisk(auto, true, change(3, "main.go"), nil, historyEvidence{})
 	assert.Equal(t, held.async, false)
 }

--- a/internal/watchd/score_test.go
+++ b/internal/watchd/score_test.go
@@ -1,0 +1,119 @@
+package watchd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
+)
+
+func change(lines int, paths ...string) gitutil.Changes {
+	return gitutil.Changes{Paths: paths, Lines: lines, Baseline: gitutil.BaselineHead}
+}
+
+func TestScoreRisesWithSize(t *testing.T) {
+	small := scoreChange(500, false, change(10, "main.go"), nil)
+	big := scoreChange(500, false, change(400, "main.go"), nil)
+
+	assert.Assert(t, small.Score < big.Score, "%d is not below %d", small.Score, big.Score)
+	assert.Equal(t, small.Band, BandLow)
+}
+
+// Size is capped, so a change ten times the limit does not swamp everything
+// else the score is made of.
+func TestScoreSizeIsCapped(t *testing.T) {
+	at := scoreChange(500, false, change(500, "main.go"), nil)
+	way := scoreChange(500, false, change(50000, "main.go"), nil)
+	assert.Equal(t, at.Score, way.Score)
+}
+
+func TestScoreRisesWithBreadth(t *testing.T) {
+	narrow := scoreChange(500, false, change(100, "a.go"), nil)
+	wide := scoreChange(500, false, change(100, "a.go", "b.go", "c.go", "d.go", "e.go"), nil)
+	assert.Assert(t, wide.Score > narrow.Score, "%d is not above %d", wide.Score, narrow.Score)
+}
+
+// A docs change is not a small source change, it is a change nothing should
+// fail on. A thousand lines of it must not out-score three lines of Go.
+func TestADocsChangeIsCappedBelowASmallSourceChange(t *testing.T) {
+	docs := scoreChange(500, false, change(5000, "README.md", "docs/CLI.md"), nil)
+	source := scoreChange(500, false, change(3, "main.go"), nil)
+
+	assert.Equal(t, docs.Score, inertCeil)
+	assert.Equal(t, docs.Band, BandLow)
+	assert.Assert(t, docs.Score >= source.Score, "docs %d, source %d", docs.Score, source.Score)
+}
+
+func TestAFailedLastRunAddsToTheScore(t *testing.T) {
+	clean := scoreChange(500, false, change(100, "main.go"), nil)
+	owing := scoreChange(500, true, change(100, "main.go"), nil)
+
+	assert.Equal(t, owing.Score, clean.Score+debtWeight)
+	assert.Assert(t, strings.Contains(strings.Join(owing.Parts, " "), "last run failed"),
+		"parts were %v", owing.Parts)
+}
+
+// Nothing known means the top of the scale. It is the same direction the
+// release decision takes, for the same reason.
+func TestAnUnmeasurableChangeScoresHighest(t *testing.T) {
+	s := scoreChange(500, false, gitutil.Changes{}, errors.New("not a repo"))
+	assert.Equal(t, s.Score, 100)
+	assert.Equal(t, s.Band, BandHigh)
+}
+
+func TestAnEmptyChangeScoresZero(t *testing.T) {
+	s := scoreChange(500, false, gitutil.Changes{Baseline: gitutil.BaselineHead}, nil)
+	assert.Equal(t, s.Score, 0)
+	assert.Equal(t, s.Band, BandLow)
+}
+
+func TestScoreIsNeverOverAHundred(t *testing.T) {
+	s := scoreChange(500, true, change(100000,
+		"a.go", "b.go", "c.go", "d.go", "e.go", "f.go", "g.go", "h.go", "i.go", "j.go", "k.go"), nil)
+	assert.Equal(t, s.Score, 100)
+}
+
+// The parts are the point: a score you cannot take apart is a score nobody can
+// argue with.
+func TestScorePartsNameTheFactsBehindIt(t *testing.T) {
+	s := scoreChange(500, false, change(912, "a.go", "b.go"), nil)
+	joined := strings.Join(s.Parts, ", ")
+	assert.Assert(t, strings.Contains(joined, "912 lines"), "got %q", joined)
+	assert.Assert(t, strings.Contains(joined, "2 files"), "got %q", joined)
+	assert.Assert(t, strings.Contains(s.String(), "risk "), "got %q", s.String())
+}
+
+// Advice has to be actionable. Splitting up a change makes sense across several
+// files and is impossible in one, so a single-file change is told nothing
+// rather than something it cannot do.
+func TestAdviceOnlyWhereThereIsSomethingToDo(t *testing.T) {
+	across := scoreChange(500, false, change(2000, "a.go", "b.go", "c.go"), nil)
+	assert.Assert(t, strings.Contains(across.Advice, "committing it in parts"), "got %q", across.Advice)
+
+	for name, s := range map[string]RiskSummary{
+		"one file":      scoreChange(500, false, change(2000, "generated.go"), nil),
+		"under limit":   scoreChange(500, false, change(100, "a.go", "b.go"), nil),
+		"docs and text": scoreChange(500, false, change(5000, "a.md", "b.md"), nil),
+		"unmeasurable":  scoreChange(500, false, gitutil.Changes{}, errors.New("nope")),
+	} {
+		assert.Equal(t, s.Advice, "", "advice was given for %s", name)
+	}
+}
+
+// The score reports, it does not decide. Release still turns on the facts,
+// because a line threshold can be argued with in review and a threshold on a
+// composite cannot.
+func TestTheScoreDoesNotDecideWhoWaits(t *testing.T) {
+	// Medium score, still released: 400 lines across 5 files is under the limit.
+	d := decideRisk(auto, false, change(400, "a.go", "b.go", "c.go", "d.go", "e.go"), nil)
+	assert.Equal(t, d.async, true)
+	assert.Equal(t, d.risk.Band, BandMedium)
+
+	// Low score, still held: nothing about three lines is risky, but the last
+	// run failed and that is what decides.
+	held := decideRisk(auto, true, change(3, "main.go"), nil)
+	assert.Equal(t, held.async, false)
+}

--- a/internal/watchd/validate.go
+++ b/internal/watchd/validate.go
@@ -101,7 +101,10 @@ func (d *daemon) handleAsyncValidate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	taskID, err := d.startValidateTask(req.ValidateRequest)
+	// No risk summary: this is the explicit --async path, where the caller has
+	// already decided and nothing was judged. Nothing is recorded in history
+	// either, which keeps that record to the runs the daemon actually judged.
+	taskID, err := d.startValidateTask(req.ValidateRequest, nil)
 	if err != nil {
 		// The tree could not be fingerprinted, so staleness would be undetectable.
 		// Reported as a conflict rather than a server error: nothing is broken,
@@ -123,7 +126,7 @@ func (d *daemon) handleAsyncValidate(w http.ResponseWriter, r *http.Request) {
 // still takes the lock, so two background runs queue behind each other exactly
 // as two synchronous ones do; what changes is who waits, not how many run at
 // once.
-func (d *daemon) startValidateTask(req ValidateRequest) (string, error) {
+func (d *daemon) startValidateTask(req ValidateRequest, risk *RiskSummary) (string, error) {
 	// Detached from the request: the caller is about to disconnect, and an async
 	// run that died with the connection that started it would be pointless. The
 	// store's parent context bounds it instead, so it ends with the daemon.
@@ -156,6 +159,9 @@ func (d *daemon) startValidateTask(req ValidateRequest) (string, error) {
 			// whether this *result* can be reported, which is a different
 			// question from which state is known to be good.
 			d.risk.recordGreen(req.ProjectRoot, before)
+		}
+		if risk != nil {
+			d.hist.record(req.ProjectRoot, *risk, exitCode == 0)
 		}
 		// stderr carries the progress lines and the tally; stdout is usually
 		// empty for a validate run. Both are kept so whoever collects the result
@@ -200,7 +206,7 @@ func (d *daemon) handleValidate(w http.ResponseWriter, r *http.Request) {
 		summary := decision.risk
 		risk = &summary
 		if decision.async {
-			if taskID, err := d.startValidateTask(req); err == nil {
+			if taskID, err := d.startValidateTask(req, risk); err == nil {
 				writeValidateJSON(w, ValidateResponse{TaskID: taskID, Reason: reason, Risk: risk})
 				return
 			}
@@ -223,14 +229,14 @@ func (d *daemon) handleValidate(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx = envctx.WithEnv(ctx, req.Env)
 
-	resp := d.runValidateNow(ctx, req)
+	resp := d.runValidateNow(ctx, req, risk)
 	resp.Reason = reason
 	resp.Risk = risk
 	writeValidateJSON(w, resp)
 }
 
 // runValidateNow runs req to completion while the caller waits.
-func (d *daemon) runValidateNow(ctx context.Context, req ValidateRequest) ValidateResponse {
+func (d *daemon) runValidateNow(ctx context.Context, req ValidateRequest, risk *RiskSummary) ValidateResponse {
 	var before string
 	if req.ProjectRoot != "" {
 		before, _ = gitutil.SnapshotTree(req.ProjectRoot)
@@ -256,6 +262,9 @@ func (d *daemon) runValidateNow(ctx context.Context, req ValidateRequest) Valida
 		d.risk.record(req.ProjectRoot, exitCode == 0)
 		if exitCode == 0 {
 			d.risk.recordGreen(req.ProjectRoot, before)
+		}
+		if risk != nil {
+			d.hist.record(req.ProjectRoot, *risk, exitCode == 0)
 		}
 	}
 

--- a/internal/watchd/validate.go
+++ b/internal/watchd/validate.go
@@ -52,6 +52,10 @@ type ValidateResponse struct {
 	// running it here. Nothing has run yet: ExitCode is zero because there is no
 	// exit code, and the result is collected on a later turn.
 	TaskID string `json:"task_id,omitempty"`
+	// Risk is what the daemon made of the change: a score, the facts behind it,
+	// and any advice. Nil when the caller never offered to be released, since
+	// then no change was judged.
+	Risk *RiskSummary `json:"risk,omitempty"`
 	// Reason says why the run was released or held, in words a caller can print
 	// as one line. Empty when the caller never offered to be released, since
 	// then there was no decision to explain.
@@ -189,12 +193,15 @@ func (d *daemon) handleValidate(w http.ResponseWriter, r *http.Request) {
 	// offered to be released must not first queue behind whatever run is already
 	// in flight, since that wait is the whole thing being avoided.
 	reason := ""
+	var risk *RiskSummary
 	if req.AllowAsync && req.ProjectRoot != "" {
 		decision := d.assessRisk(req.ProjectRoot)
 		reason = decision.reason
+		summary := decision.risk
+		risk = &summary
 		if decision.async {
 			if taskID, err := d.startValidateTask(req); err == nil {
-				writeValidateJSON(w, ValidateResponse{TaskID: taskID, Reason: reason})
+				writeValidateJSON(w, ValidateResponse{TaskID: taskID, Reason: reason, Risk: risk})
 				return
 			}
 			// The tree cannot be fingerprinted, so a background result could not be
@@ -218,6 +225,7 @@ func (d *daemon) handleValidate(w http.ResponseWriter, r *http.Request) {
 
 	resp := d.runValidateNow(ctx, req)
 	resp.Reason = reason
+	resp.Risk = risk
 	writeValidateJSON(w, resp)
 }
 


### PR DESCRIPTION
This PR got merged into #581 (hence why it says 'Merged.')


<!-- stack -->
**Stack** — merges bottom-up; each PR's diff is against the one above it in this list:

1. #573 — Write chunk validate results to the filesystem
1. #580 — Track async validation tasks and discard stale results
1. #581 — Add risk assessment to the daemon
1. #583 — Score the risk, and judge it against this repo's history  ← **this PR**
1. #584 — Measure trees git can't answer for, and run checks in a snapshot

---
## Summary

#581 released or held a run and said one thing about why. That answers "who waits" and nothing else — not which of two changes is riskier, not whether one is unusual for this repo, not what to do about it.

- **A score with its workings.** Every judgement carries a 0–100 `RiskSummary`: size against the limit (capped), breadth in files, a ceiling for docs and text so a thousand lines of markdown cannot out-score three lines of Go, and the failure debt on top.
- **It reports, it does not decide.** Release still turns on the facts, because a line threshold can be argued with in review and a composite cannot — nobody can tell you whether 47 should have been 52. The facts travel with the number for the same reason.
- **Advice only where it is actionable.** Splitting up a change makes sense across several files and is impossible in one, so 2,000 lines in a generated file is told nothing rather than something it cannot do.
- **Relative to this repo.** 500 lines is a rewrite in one codebase and a Tuesday in another, so each project's finished runs are kept in `risk-history.jsonl` — sizes and verdicts, no paths, no content — and answer what a threshold cannot: is this large *here*, and do changes this size fail *here*.
- **History tightens, never loosens.** It can hold a run the rules would have released and raise a score; it can never release one. A repo whose changes are all enormous must not teach the daemon that enormous is fine. `asyncValidate: always` still wins over it.
- A low-risk change prints no score line — a number printed every turn is a number nobody reads.

Stacked on #581.

## Test plan

- `task test` (`-race`) and `task lint` green.
- Score: size and breadth, the docs ceiling sitting below a three-line Go change, the debt, the 100 cap, parts naming their own facts, advice only where actionable, and that the score decides nothing.
- History: quiet until there is enough of it, the factor-of-two comparison band, percentile, read back from disk, a truncated line skipped, no code in the record, cannot release a large change, does hold a small one that usually fails here.
- Client: a low-risk change is not narrated; a high-risk one prints score and advice.

