### PR TITLE
Measure trees git can't answer for, and run checks in a snapshot

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -419,6 +419,13 @@ GET  /validate/collect?root=<path>                 → {tasks}
   until something commits — five 100-line turns read as 500 by the fifth — and
   resets to nothing when anything does, validated or not. A snapshot is content,
   so neither happens.
+- **A new run supersedes the live-tree run in flight.** A run is released because
+  the tree moved, so whatever is already running is validating code that is no
+  longer there and its result is headed for the bin; `taskStore.supersede`
+  cancels it rather than leaving two runs of the same commands queued behind each
+  other. A cancelled run records nothing — not a failure, not a known-good state
+  — because it concluded nothing. Snapshot-backed runs are exempt: their verdict
+  survives the tree moving, so they are the one thing here worth letting finish.
 - **A snapshot run is exempt from the clean-tree skip.** `gitutil.MaterializeTree`
   checks the snapshot out into a temp worktree (opt-in: `asyncValidateWorktree`),
   so the checks cannot be raced by an edit — and a result about a copy is

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -426,12 +426,37 @@ GET  /validate/collect?root=<path>                 → {tasks}
   have released and raise a score; it can never release one or lower a score. A
   codebase where every change is enormous must not teach the daemon that
   enormous is fine.
+- **Where git cannot answer, the daemon measures the tree itself.** A repository
+  with no commits has no HEAD to diff against, and a directory that was never one
+  has nothing at all; both used to be unmeasurable, and so blocked every run.
+  `filestate` walks and hashes instead (`Index`, `Changes`, `Digest`), which also
+  gives the staleness check an identity to compare against — see
+  `fingerprintTree`. It is the fallback, not the default: git knows what is
+  ignored, and knows how much of a modified file an edit touched, where
+  `filestate` can only tell that it changed and so counts the whole file. That
+  over-measures, which errs towards blocking.
 - **The snapshot never touches the developer's repository state.** It stages into
   a throwaway index (`GIT_INDEX_FILE` in a temp file, seeded from the real index
   for its stat cache, without which every file is re-hashed per call). The
   objects it writes are unreferenced, so git's `gc` may collect a baseline;
   `ChangesBetween` then errors and the assessment falls back to `HEAD`, which
   reads larger and so errs towards blocking.
+
+## Change Measurement (`internal/changeset/`, `internal/gitutil/`, `internal/filestate/`)
+
+`changeset.Changes` is the shape of one answer — how far a working tree has
+moved from an earlier state — and lives in its own package because there is more
+than one way to find it and they have to agree on what the answer looks like.
+
+- `gitutil` measures with git: `WorkingChanges` against HEAD, `SnapshotTree` and
+  `ChangesBetween` against an earlier uncommitted state.
+- `filestate` measures by walking and hashing, for trees git cannot answer for.
+
+The two are not equivalent, and the difference is documented where it bites:
+git knows what is ignored and how much of a modified file changed; `filestate`
+only knows a file changed, so it counts the file. Both err in the same
+direction — over-measuring, which makes somebody wait — because the opposite
+error is a change that reads smaller than it is and gets waved through.
 
 ## HTTP Client (`internal/httpcl/`)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -419,6 +419,15 @@ GET  /validate/collect?root=<path>                 → {tasks}
   until something commits — five 100-line turns read as 500 by the fifth — and
   resets to nothing when anything does, validated or not. A snapshot is content,
   so neither happens.
+- **A snapshot run is exempt from the clean-tree skip.** `gitutil.MaterializeTree`
+  checks the snapshot out into a temp worktree (opt-in: `asyncValidateWorktree`),
+  so the checks cannot be raced by an edit — and a result about a copy is
+  reported even when the live tree has moved, since it is still exactly true
+  about the state it ran against. The trap is that a fresh checkout is a *clean*
+  tree, and the Stop hook skips clean trees: without the exemption the run
+  executes nothing and reports a pass. `--attribute-to` is both the signal for
+  that exemption and what keeps the event log and the project breadcrumb under
+  the real repository rather than the copy.
 - **History tightens, never loosens.** `riskHistory` keeps each project's
   finished runs (`risk-history.jsonl`: sizes and verdicts, no paths, no content)
   and answers what an absolute threshold cannot — is this change large *for this

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -375,6 +375,7 @@ chunk
 | `validation.sidecarImage` | `.chunk/config.json` | Snapshot or image ID for sidecar bootstrap and validate (unset: a matching org snapshot is selected automatically) |
 | `asyncValidate` | `.chunk/config.json` | Whether hook runs may be validated in the background: `auto` (default), `always`, `never` |
 | `asyncValidateMaxLines` | `.chunk/config.json` | Largest change, in lines, still validated in the background under `auto` (default: 500) |
+| `asyncValidateWorktree` | `.chunk/config.json` | Run background checks in a checked-out snapshot so edits cannot make the result stale (`true`/`false`, default: `false` — a snapshot holds nothing gitignored) |
 
 `chunk config show` displays resolved user credentials and, when run from a
 project directory, the resolved `orgID` (env var takes precedence over project

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -85,6 +85,34 @@ blocks as it always did.
 
 With no daemon running nothing changes: every hook run is blocking.
 
+### Running the checks in a snapshot
+
+Background checks run against the live working tree by default, which means
+they are racing whoever is editing it. If the tree moves while they run, the
+answer describes code that is no longer there and gets thrown away.
+
+Setting `asyncValidateWorktree: true` runs them in a checked-out copy of the
+state being validated instead. The copy cannot move, so the answer stays true
+about the state it ran against — the state the agent's turn actually produced —
+and it is reported with that said rather than discarded:
+
+```
+chunk validate passed in the background (0192cf6e) — for the code as it was when that turn ended; the tree has changed since
+```
+
+It is off by default, for one reason: **a snapshot holds nothing git was told to
+ignore.** No installed dependencies, no build cache, no `.env.local`. For a
+project whose checks need any of those, every background run would report an
+environment failure as a code failure, which is worse than a discarded result.
+Projects whose checks run against source alone lose nothing by turning it on.
+
+Two smaller things to know. The copy is a real git worktree, so tools that ask
+git about it get answers; it is removed when the run ends, and a daemon killed
+mid-run leaves an entry that the next cleanup prunes. And remote commands in a
+snapshot run register their output under the copy, so the `chunk watch` logs
+pane will not show it — the event log and the run itself are still filed under
+the real project.
+
 ### The risk score
 
 Every judgement also produces a 0–100 score, the facts behind it, and any

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -108,6 +108,19 @@ is actionable for 2,000 lines across nine files and impossible for 2,000 lines
 in one generated file, so a single-file change is told nothing rather than
 something it cannot act on.
 
+### Trees git cannot answer for
+
+A repository with no commits has no `HEAD` to diff against, and a directory that
+was never a repository has nothing at all. Both used to be unmeasurable, which
+meant every run in them blocked. The daemon now walks and hashes such a tree
+itself, so a small change in a fresh repo reads as a small change.
+
+It is the fallback, not the default. Git knows what is ignored, and knows how
+much of a modified file an edit actually touched; hashing only knows that a file
+changed, so it counts the whole file — a one-line edit in a 900-line file reads
+as 900 lines. That over-measures, which makes you wait, rather than
+under-measuring, which would wave a change through.
+
 ### Relative to this repo
 
 Five hundred lines is a rewrite in one codebase and a Tuesday in another, so

--- a/internal/changeset/changeset.go
+++ b/internal/changeset/changeset.go
@@ -1,0 +1,57 @@
+// Package changeset holds the shape of an answer to one question: how far has a
+// working tree moved from an earlier state.
+//
+// It is a type and nothing else, in its own package, because there is more than
+// one way to find the answer and they must agree on what the answer looks like.
+// gitutil measures with git, which knows what is ignored and how much of a file
+// an edit touched. filestate measures by walking and hashing, for a tree git
+// cannot answer for. A caller deciding what to do about a change should not have
+// to know which of them produced it.
+package changeset
+
+const (
+	// BaselineHead is the Baseline of a change measured against the last commit.
+	BaselineHead = "HEAD"
+	// BaselineWholeTree is the Baseline of a change measured against nothing at
+	// all: there is no earlier state to compare with, so every file counts. It
+	// is what a repository with no commits yet, or no git at all, produces the
+	// first time it is measured.
+	BaselineWholeTree = "whole tree"
+)
+
+// Changes summarises how far a working tree has moved from a baseline: which
+// paths changed, and how much of them.
+//
+// It answers a different question from a fingerprint. A fingerprint says
+// whether the tree is the same tree as before; this says how big the change is
+// and what kind of files it touched — which is what a caller deciding how much
+// caution a change deserves needs to know.
+type Changes struct {
+	// Paths is every path reported as changed, relative to the repo root.
+	// Rename and copy entries name the destination only, since that is the file
+	// now on disk.
+	Paths []string
+	// Lines is how many lines the change touches: insertions plus deletions
+	// against the baseline for tracked files, and every line of a new file, all
+	// of which are new. Binary content contributes no lines — there are none to
+	// count — so a change can name paths and still report zero.
+	Lines int
+	// Baseline names what the change was measured against: BaselineHead, or an
+	// opaque identifier for an earlier state. A caller reporting a number has to
+	// be able to say what it is a number of, and the answers mean different
+	// things.
+	Baseline string
+}
+
+// Empty reports whether nothing has changed relative to the baseline.
+func (c Changes) Empty() bool { return len(c.Paths) == 0 }
+
+// Incremental reports whether the change was measured from an earlier state of
+// this same working tree, rather than from a commit or from nothing.
+//
+// It is the difference between "you have changed 40 lines since the last time
+// the checks passed" and "you are 40 lines from the last commit", which are the
+// same number about different things.
+func (c Changes) Incremental() bool {
+	return c.Baseline != "" && c.Baseline != BaselineHead && c.Baseline != BaselineWholeTree
+}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -194,6 +194,7 @@ type validateOpts struct {
 	async          bool   // run via the daemon without waiting for the result
 	collect        bool   // print finished background results and exit
 	noDaemon       bool   // bypasses daemon delegation; set by the daemon when calling in-process
+	attributeTo    string // project the results belong to, when commands run in a snapshot copy
 	hookSessionID  string // hook session ID forwarded from client to daemon subprocess
 	stopHookActive bool   // stop_hook_active forwarded from client to daemon subprocess
 }
@@ -238,6 +239,8 @@ func newValidateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.collect, "collect", false, "Print results of finished background runs and exit")
 	cmd.Flags().BoolVar(&opts.noDaemon, "no-daemon", false, "")
 	_ = cmd.Flags().MarkHidden("no-daemon")
+	cmd.Flags().StringVar(&opts.attributeTo, "attribute-to", "", "")
+	_ = cmd.Flags().MarkHidden("attribute-to")
 	cmd.Flags().StringVar(&opts.hookSessionID, "hook-session-id", "", "")
 	_ = cmd.Flags().MarkHidden("hook-session-id")
 	cmd.Flags().BoolVar(&opts.stopHookActive, "stop-hook-active", false, "")
@@ -254,7 +257,7 @@ func newValidateCmd() *cobra.Command {
 // in ambiguous cases.
 // Returns updated ctx and streams, a skip flag (true = return nil immediately),
 // and a non-nil error when the hook should exit with a non-zero code.
-func initHook(ctx context.Context, hook *hookContext, workDir string, tree gitutil.Worktree, treeErr error, streams iostream.Streams) (context.Context, iostream.Streams, bool, error) {
+func initHook(ctx context.Context, hook *hookContext, workDir string, tree gitutil.Worktree, treeErr error, snapshot bool, streams iostream.Streams) (context.Context, iostream.Streams, bool, error) {
 	if hook == nil {
 		return ctx, streams, false, nil
 	}
@@ -287,7 +290,12 @@ func initHook(ctx context.Context, hook *hookContext, workDir string, tree gitut
 	if treeErr != nil {
 		streams.ErrPrintf("  %s\n", ui.ErrDim(fmt.Sprintf("chunk validate: working tree state unavailable (%v); running everything, caching nothing", treeErr)))
 	}
-	if tree.Clean {
+	// A snapshot run is exempt from the clean-tree skip, and must be: the
+	// snapshot was checked out from the state being validated, so git sees a
+	// tree with nothing changed in it and "nothing changed" here means the
+	// opposite of what it usually means. Skipping would run no commands and
+	// report a pass — a green light for code nothing looked at.
+	if tree.Clean && !snapshot {
 		return ctx, streams, true, nil
 	}
 	return ctx, streams, false, nil
@@ -352,6 +360,30 @@ func maybeEnsureCircleCIClient(ctx context.Context, cmd *cobra.Command, rc confi
 	}
 	return ensureCircleCIClient(ctx, cmd, rc, streams, ui.PromptHidden)
 }
+
+// attributionRoot is the project a run's results belong to, which is not always
+// the directory the commands run in.
+//
+// They differ in one case: the daemon running background checks in a
+// checked-out snapshot. The copy is where the commands execute, and the real
+// repository is where the developer is watching for their results — so the
+// event log, the project breadcrumb the daemon discovers projects by, and the
+// branch a run is filed under all come from here rather than from the copy,
+// which is on a detached HEAD in a temp directory nobody is looking at.
+func (o *validateOpts) attributionRoot(workDir string) string {
+	if o.attributeTo != "" {
+		return o.attributeTo
+	}
+	return workDir
+}
+
+// snapshotRun reports whether the commands are running against a checked-out
+// copy of a project rather than the project itself.
+//
+// It reads off the attribution root for a reason: results belonging to a
+// different directory than the one being validated is exactly what a snapshot
+// run is, and the daemon is the only thing that arranges one.
+func (o *validateOpts) snapshotRun() bool { return o.attributeTo != "" }
 
 func resolveWorkDir(opts *validateOpts) (string, error) {
 	if opts.projectDir != "" {
@@ -421,7 +453,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 
 	var skip bool
 	var hookErr error
-	ctx, streams, skip, hookErr = initHook(ctx, hook, workDir, tree, treeErr, streams)
+	ctx, streams, skip, hookErr = initHook(ctx, hook, workDir, tree, treeErr, opts.snapshotRun(), streams)
 	if hookErr != nil {
 		return hookErr
 	}
@@ -470,7 +502,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 			// does rather than repeating that bookkeeping here: clearing the failure
 			// counter, and whatever else the success branch grows later.
 			n := len(cfg.Commands)
-			return finishValidate(cmd, hook, nil, start, cfg, validate.Result{Passed: n, Total: n}, newValidateRecorder(statusFn, "", nil, workDir, hook), streams, notifyFunc(rc.Notifications))
+			return finishValidate(cmd, hook, nil, start, cfg, validate.Result{Passed: n, Total: n}, newValidateRecorder(statusFn, "", nil, opts.attributionRoot(workDir), hook), streams, notifyFunc(rc.Notifications))
 		}
 	}
 
@@ -512,7 +544,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 	// loadSidecarEnvVars — so that sync and env-resolve events are captured.
 	// statusFn is kept so a replacement sidecar can get its own recorder rather
 	// than logging its events under the sidecar it replaced.
-	rec := newValidateRecorder(statusFn, opts.sidecarID, activeSidecar, workDir, hook)
+	rec := newValidateRecorder(statusFn, opts.sidecarID, activeSidecar, opts.attributionRoot(workDir), hook)
 
 	// Only load env vars and resolve secrets when a sidecar is actually
 	// being used — avoids parsing .env.local or hitting secrets APIs on
@@ -522,7 +554,7 @@ func runValidateCmdE(cmd *cobra.Command, args []string, opts *validateOpts) erro
 		return failBeforeRun(rec, start, err)
 	}
 
-	result, execErr := runValidate(ctx, circleCIClient, rc, workDir, name, opts.inlineCmd, opts.save, opts.sidecarID, opts.workdir, allRemote, envVars, cfg, rec, streams)
+	result, execErr := runValidate(ctx, circleCIClient, rc, workDir, opts.attributionRoot(workDir), name, opts.inlineCmd, opts.save, opts.sidecarID, opts.workdir, allRemote, envVars, cfg, rec, streams)
 	if execErr == nil && resultCache != nil {
 		if err := resultCache.Put(cacheKey, validate.CachedResult{CachedAt: time.Now()}); err != nil {
 			streams.ErrPrintf("  %s\n", ui.ErrDim(fmt.Sprintf("chunk validate: cache write failed: %v", err)))
@@ -560,7 +592,7 @@ func loadEnvVarsWithRetry(
 		// A replacement has none of the setup the old one had, so exec failures on
 		// it are real failures rather than grounds for falling back to local.
 		freshlyCreated = true
-		rec = newValidateRecorder(statusFn, opts.sidecarID, nil, workDir, hook)
+		rec = newValidateRecorder(statusFn, opts.sidecarID, nil, opts.attributionRoot(workDir), hook)
 		envVars, err = loadSidecarEnvVars(ctx, circleCIClient, opts, workDir, rec.Status, streams)
 	}
 	if err != nil {
@@ -579,7 +611,9 @@ func loadEnvVarsWithRetry(
 // newValidateRecorder returns the recorder that reports validate progress and
 // records it in the event log, for all runs both remote (sidecarID set) and
 // local (sidecarID empty).
-func newValidateRecorder(statusFn iostream.StatusFunc, sidecarID string, activeSidecar *sidecar.ActiveSidecar, workDir string, hook *hookContext) *eventlog.Recorder {
+// projectRoot is the repository the run belongs to, which is the working
+// directory for every ordinary run — see validateOpts.attributionRoot.
+func newValidateRecorder(statusFn iostream.StatusFunc, sidecarID string, activeSidecar *sidecar.ActiveSidecar, projectRoot string, hook *hookContext) *eventlog.Recorder {
 	scName := ""
 	if activeSidecar != nil && activeSidecar.ID() == sidecarID {
 		scName = activeSidecar.Name
@@ -589,8 +623,8 @@ func newValidateRecorder(statusFn iostream.StatusFunc, sidecarID string, activeS
 		op = eventlog.OpHook
 	}
 	// A missing data dir leaves the recorder reporting without recording.
-	dataDir, _ := config.ProjectDataDir(workDir)
-	return eventlog.Record(dataDir, statusFn, op, sidecarID, scName, sidecar.CurrentBranch(workDir))
+	dataDir, _ := config.ProjectDataDir(projectRoot)
+	return eventlog.Record(dataDir, statusFn, op, sidecarID, scName, sidecar.CurrentBranch(projectRoot))
 }
 
 // failBeforeRun closes the run after a failure that happened once the recorder
@@ -840,11 +874,20 @@ func runCollect(workDir string, streams iostream.Streams) error {
 		return err
 	}
 	for _, t := range tasks {
+		// A result the tree has moved past is only ever reported for a run that
+		// validated a snapshot, where the answer is still exactly true about the
+		// state it ran against. Saying which state that was is the difference
+		// between useful and misleading: the agent needs to know this is not a
+		// verdict on what it has since written.
+		as := ""
+		if t.Stale {
+			as = " — for the code as it was when that turn ended; the tree has changed since"
+		}
 		if t.Passed() {
-			streams.Printf("chunk validate passed in the background (%s)\n", shortTaskID(t.ID))
+			streams.Printf("chunk validate passed in the background (%s)%s\n", shortTaskID(t.ID), as)
 			continue
 		}
-		streams.Printf("chunk validate FAILED in the background (%s), exit status %d\n", shortTaskID(t.ID), t.ExitCode)
+		streams.Printf("chunk validate FAILED in the background (%s), exit status %d%s\n", shortTaskID(t.ID), t.ExitCode, as)
 		if t.Output != "" {
 			streams.Printf("%s\n", strings.TrimRight(t.Output, "\n"))
 		}
@@ -902,7 +945,7 @@ func runValidateDryRun(name, inlineCmd string, cfg *config.ProjectConfig, status
 // provided options. It is shared by both direct and hook invocations.
 // allRemote is true when --remote is passed explicitly (all commands run on the
 // sidecar); false means only commands with Remote:true are routed to the sidecar.
-func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, name, inlineCmd string, save bool, sidecarID string, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, rec *eventlog.Recorder, streams iostream.Streams) (validate.Result, error) {
+func runValidate(ctx context.Context, client *circleci.Client, rc config.ResolvedConfig, workDir, projectRoot, name, inlineCmd string, save bool, sidecarID string, workdir string, allRemote bool, envVars map[string]string, cfg *config.ProjectConfig, rec *eventlog.Recorder, streams iostream.Streams) (validate.Result, error) {
 	// --cmd: inline command (always local in per-command mode)
 	if inlineCmd != "" {
 		cmdName := name
@@ -916,7 +959,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 			streams.ErrPrintf("%s\n", ui.Success(fmt.Sprintf("Saved %s to .chunk/config.json", cmdName)))
 		}
 		if sidecarID != "" && allRemote {
-			execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, workDir, envVars, rc, rec.SetCommandID, streams)
+			execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, projectRoot, envVars, rc, rec.SetCommandID, streams)
 			if err != nil {
 				return validate.Result{}, err
 			}
@@ -927,7 +970,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 
 	// All-remote execution (--remote flag): send everything to the sidecar.
 	if sidecarID != "" && allRemote {
-		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, workDir, envVars, rc, rec.SetCommandID, streams)
+		execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, projectRoot, envVars, rc, rec.SetCommandID, streams)
 		if err != nil {
 			return validate.Result{}, err
 		}
@@ -940,7 +983,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 		if name != "" {
 			if cmd := cfg.FindCommand(name); cmd != nil && cmd.Remote {
 				rec.Status(iostream.LevelInfo, fmt.Sprintf("running %s on sidecar %s", name, sidecarID))
-				execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, workDir, envVars, rc, rec.SetCommandID, streams)
+				execFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, projectRoot, envVars, rc, rec.SetCommandID, streams)
 				if err != nil {
 					return validate.Result{}, err
 				}
@@ -949,7 +992,7 @@ func runValidate(ctx context.Context, client *circleci.Client, rc config.Resolve
 			rec.Status(iostream.LevelInfo, fmt.Sprintf("running %s locally (not marked remote)", name))
 			// Named command is not marked remote; fall through to local execution.
 		} else {
-			return runSplitCommands(ctx, client, sidecarID, workdir, workDir, envVars, rc, cfg, rec, streams)
+			return runSplitCommands(ctx, client, sidecarID, workdir, workDir, projectRoot, envVars, rc, cfg, rec, streams)
 		}
 	}
 
@@ -1204,7 +1247,7 @@ func hostForwardEnv(token string) map[string]string {
 // question they were written to answer, so running them here reports a pass the
 // sidecar never gave — the same false green as a failed creation, arrived at one
 // step later.
-func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, workdir, workDir string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, rec *eventlog.Recorder, streams iostream.Streams) (validate.Result, error) {
+func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID string, workdir, workDir, projectRoot string, envVars map[string]string, rc config.ResolvedConfig, cfg *config.ProjectConfig, rec *eventlog.Recorder, streams iostream.Streams) (validate.Result, error) {
 	remoteCfg, localCfg := splitByRemote(cfg)
 	if len(remoteCfg.Commands) > 0 {
 		rec.Status(iostream.LevelInfo, fmt.Sprintf("running on sidecar %s: %s", sidecarID, commandNames(remoteCfg.Commands)))
@@ -1217,14 +1260,14 @@ func runSplitCommands(ctx context.Context, client *circleci.Client, sidecarID st
 	if len(remoteCfg.Commands) > 0 {
 		// Probe with a plain exec fn so the workspace check never touches the
 		// recorder — there is no real command to attribute the probe's ID to.
-		probeExecFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, workDir, envVars, rc, nil, streams)
+		probeExecFn, dest, err := newExecFn(ctx, client, sidecarID, workdir, projectRoot, envVars, rc, nil, streams)
 		if err != nil {
 			return validate.Result{}, unreachableSidecar(sidecarID, commandNames(remoteCfg.Commands), err)
 		}
 		if wsErr := validate.WorkspaceExists(ctx, probeExecFn, dest); wsErr != nil {
 			return validate.Result{}, missingWorkspace(sidecarID, dest, commandNames(remoteCfg.Commands), wsErr)
 		}
-		execFn, _, err := newExecFn(ctx, client, sidecarID, workdir, workDir, envVars, rc, rec.SetCommandID, streams)
+		execFn, _, err := newExecFn(ctx, client, sidecarID, workdir, projectRoot, envVars, rc, rec.SetCommandID, streams)
 		if err != nil {
 			return validate.Result{}, unreachableSidecar(sidecarID, commandNames(remoteCfg.Commands), err)
 		}

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -987,3 +987,55 @@ func TestReportDelegatedValidatePrintsRiskOnlyWhenItMatters(t *testing.T) {
 	assert.Assert(t, strings.Contains(out, "2000 lines (60)"), "got %q", out)
 	assert.Assert(t, strings.Contains(out, "committing it in parts"), "got %q", out)
 }
+
+// A snapshot run validates a tree that was checked out from the state being
+// validated, so git sees nothing changed in it. The clean-tree skip must not
+// fire there: skipping would run no commands and report a pass, which is a
+// green light for code nothing looked at.
+//
+// This is the shape of a real bug. The unit tests around the daemon stub the
+// runner, so the skip lived below all of them and the first honest end-to-end
+// run reported "passed" having executed nothing.
+func TestASnapshotRunIsNotSkippedForBeingClean(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv(config.EnvXDGDataHome, t.TempDir())
+	t.Setenv(config.EnvCircleToken, "")
+	t.Setenv(config.EnvCircleCIToken, "")
+
+	// A clean repo: everything committed, exactly as a checked-out snapshot is.
+	dir := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "ran")
+	assert.NilError(t, config.SaveProjectConfig(dir, &config.ProjectConfig{
+		Commands: []config.Command{{Name: "test", Run: "touch " + marker}},
+	}))
+	for _, args := range [][]string{
+		{"init"}, {"config", "user.email", "t@t.co"}, {"config", "user.name", "t"},
+		{"add", "-A"}, {"commit", "-m", "init"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		assert.NilError(t, err, "git %v: %s", args, out)
+	}
+
+	run := func(extra ...string) {
+		var outBuf, errBuf bytes.Buffer
+		root := newTestRootCmd()
+		root.SetOut(&outBuf)
+		root.SetErr(&errBuf)
+		root.SetIn(strings.NewReader(hookPayload))
+		root.SetArgs(append([]string{"--insecure-storage", "validate", "--local", "--project", dir}, extra...))
+		_ = root.Execute()
+	}
+
+	// Without the attribution, a clean tree is skipped — the behaviour every
+	// ordinary hook run relies on.
+	run()
+	_, err := os.Stat(marker)
+	assert.Assert(t, err != nil, "a clean ordinary run should have been skipped")
+
+	// With it, the commands run.
+	run("--attribute-to", dir)
+	_, err = os.Stat(marker)
+	assert.NilError(t, err, "a snapshot run was skipped and reported without running anything")
+}

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -70,6 +70,13 @@ type ProjectConfig struct {
 	// AsyncValidateMaxLines overrides how large a change may be and still be
 	// validated in the background. Zero means the built-in default.
 	AsyncValidateMaxLines int `json:"asyncValidateMaxLines,omitempty"`
+	// AsyncValidateWorktree runs background checks in a checked-out snapshot
+	// instead of the live working tree, so editing while they run cannot make
+	// the answer describe code that has moved. Off by default: a snapshot holds
+	// nothing git was told to ignore, so a project whose checks need installed
+	// dependencies or a build cache would see environment failures reported as
+	// code failures.
+	AsyncValidateWorktree bool `json:"asyncValidateWorktree,omitempty"`
 }
 
 // LoadProjectConfig reads .chunk/config.json from workDir.

--- a/internal/filestate/filestate.go
+++ b/internal/filestate/filestate.go
@@ -1,0 +1,315 @@
+// Package filestate measures a working tree without asking git anything.
+//
+// It exists because git is not always there to ask. A repository with no
+// commits has no HEAD to diff against, and a directory that was never a
+// repository has nothing at all — and both are trees an agent can be working
+// in. More of them will be: keeping track of what changed without a commit
+// history is becoming its own problem, and a resident daemon watching a
+// filesystem is the shape of the answer.
+//
+// Where git can answer, it should: it knows what is ignored, and it knows how
+// much of a modified file an edit actually touched. This does not. See Changes
+// for what that costs and which way it errs.
+package filestate
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/changeset"
+	"github.com/CircleCI-Public/chunk-cli/internal/hashutil"
+)
+
+// Walk budgets. Past either of them Build fails rather than returning a partial
+// index, because a partial index measures a smaller change than the real one —
+// and a change that reads smaller than it is, is a change that gets waved
+// through. Failing makes the caller wait instead.
+var (
+	maxFiles       = 20000
+	maxBytes int64 = 64 << 20
+)
+
+// ErrWalkBudget reports that the tree holds more than the walk is willing to read.
+var ErrWalkBudget = errors.New("working tree exceeds the walk budget")
+
+// Entry is one file's contribution to the state of a tree.
+type Entry struct {
+	// Hash is the SHA-256 of the file's contents, which is what makes a
+	// modification detectable without keeping the contents themselves.
+	Hash string
+	// Lines is how many lines the file has. Binary content reports none.
+	Lines int
+}
+
+// Index is the state of a working tree: every file it holds, by path relative
+// to the root, in slash form on every platform.
+type Index map[string]Entry
+
+// Build walks the tree at root and hashes it.
+//
+// Skipping is deliberately minimal: .git, and whatever the root .gitignore
+// names in one of the three forms that cannot be misread — a bare name, a
+// directory, or *.ext. Anything it is unsure about is walked and counted. That
+// is the wrong way round for speed and the right way round for safety, since
+// every file wrongly skipped makes the change look smaller than it is. The
+// budgets above are what keep the honest version bounded.
+func Build(root string) (Index, error) {
+	// Checked before the walk, because WalkDir reports a missing root through the
+	// same callback as a missing file deep in the tree — and the tree's own
+	// absence must not come back as "nothing has changed here".
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", root, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("read %s: not a directory", root)
+	}
+
+	skip := loadIgnores(root)
+	idx := make(Index)
+
+	var (
+		files int
+		bytes int64
+	)
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// A directory that cannot be read is skipped rather than fatal: a
+			// permissions hole somewhere in a tree should not stop the rest of it
+			// being measured.
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil || rel == "." {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+
+		if d.IsDir() {
+			if skip.dir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() || skip.file(d.Name()) {
+			return nil
+		}
+
+		files++
+		if files > maxFiles {
+			return ErrWalkBudget
+		}
+		hash, lines, n, hashErr := hashAndCount(path, maxBytes-bytes)
+		if hashErr != nil {
+			return hashErr
+		}
+		bytes += n
+		idx[rel] = Entry{Hash: hash, Lines: lines}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk %s: %w", root, err)
+	}
+	return idx, nil
+}
+
+// Changes reports how far this index has moved from an earlier one. A nil
+// before means there is no earlier state, so the whole tree is the change.
+//
+// A modified file counts its whole length rather than the lines that actually
+// changed. Without the earlier contents there is no way to know how much of it
+// moved — only that it did — so it counts the most it could have, which
+// over-measures a one-line edit in a long file as the whole file. That is the
+// direction to be wrong in: an over-measured change is waited for, and an
+// under-measured one is waved through. Where git can answer, it answers better;
+// this is for the trees it cannot.
+func (i Index) Changes(before Index) changeset.Changes {
+	baseline := changeset.BaselineWholeTree
+	if before != nil {
+		baseline = "earlier state"
+	}
+	ch := changeset.Changes{Baseline: baseline}
+
+	for path, now := range i {
+		was, existed := before[path]
+		switch {
+		case !existed:
+			ch.Paths = append(ch.Paths, path)
+			ch.Lines += now.Lines
+		case was.Hash != now.Hash:
+			ch.Paths = append(ch.Paths, path)
+			ch.Lines += max(was.Lines, now.Lines)
+		}
+	}
+	for path, was := range before {
+		if _, still := i[path]; !still {
+			ch.Paths = append(ch.Paths, path)
+			ch.Lines += was.Lines
+		}
+	}
+	// Sorted so the same change always reports the same way: map order is
+	// random, and a path list that shuffles between runs is unreadable in output
+	// and untestable in a test.
+	sort.Strings(ch.Paths)
+	return ch
+}
+
+// Digest reduces an index to one value, so two states of a tree can be
+// compared without keeping either of them.
+//
+// It is the git-free equivalent of a worktree fingerprint, for the same use:
+// deciding whether a tree has moved while something else was looking away.
+// Paths are folded in sorted order, since map iteration is random and a digest
+// that depended on it would report every tree as changed.
+func (i Index) Digest() string {
+	paths := make([]string, 0, len(i))
+	for path := range i {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	h := sha256.New()
+	for _, path := range paths {
+		hashutil.WritePart(h, path)
+		hashutil.WritePart(h, i[path].Hash)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// hashAndCount reads path once, returning its content hash, its line count and
+// how many bytes it read.
+//
+// One pass for both, because the file is being read anyway and a second pass to
+// count lines would double the cost of every walk. Binary content reports no
+// lines, on git's own rule of thumb — a NUL byte near the start — since counting
+// newlines in a compiled object produces a number with no meaning.
+func hashAndCount(path string, remaining int64) (string, int, int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", 0, 0, nil // vanished between the walk and the read
+	}
+	if info.Size() > remaining {
+		return "", 0, 0, ErrWalkBudget
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return "", 0, 0, nil // unreadable: counted as absent rather than fatal
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	var (
+		buf      = make([]byte, 64<<10)
+		lines    int
+		read     int64
+		first    = true
+		binary   bool
+		lastByte byte
+	)
+	reader := bufio.NewReader(f)
+	for {
+		n, readErr := reader.Read(buf)
+		if n > 0 {
+			chunk := buf[:n]
+			_, _ = h.Write(chunk)
+			if first {
+				first = false
+				binary = bytes.IndexByte(chunk, 0) >= 0
+			}
+			if !binary {
+				lines += bytes.Count(chunk, []byte{'\n'})
+				lastByte = chunk[len(chunk)-1]
+			}
+			read += int64(n)
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+			return "", 0, read, readErr
+		}
+	}
+	if !binary && read > 0 && lastByte != '\n' {
+		lines++ // a final line with no newline after it is still a line
+	}
+	return hex.EncodeToString(h.Sum(nil)), lines, read, nil
+}
+
+// ignores is the small set of things a walk skips.
+type ignores struct {
+	dirs  map[string]bool
+	names map[string]bool
+	exts  map[string]bool
+}
+
+func (ig *ignores) dir(name string) bool {
+	return name == ".git" || ig.dirs[name]
+}
+
+func (ig *ignores) file(name string) bool {
+	return ig.names[name] || ig.exts[strings.ToLower(filepath.Ext(name))]
+}
+
+// loadIgnores reads the root .gitignore, taking only the patterns that cannot
+// be misread.
+//
+// Negations, anchors, nested .gitignore files and ** globs are all skipped
+// rather than half-implemented. A pattern understood wrongly either hides a
+// file that changed — which is the failure mode this package must not have — or
+// walks a directory it was told not to, which merely costs time.
+func loadIgnores(root string) *ignores {
+	ig := &ignores{
+		dirs:  make(map[string]bool),
+		names: make(map[string]bool),
+		exts:  make(map[string]bool),
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".gitignore"))
+	if err != nil {
+		return ig
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "!") {
+			continue
+		}
+		if strings.Contains(line, "**") || strings.Count(line, "/") > 1 {
+			continue
+		}
+		if after, ok := strings.CutSuffix(line, "/"); ok {
+			if !strings.Contains(after, "*") {
+				ig.dirs[strings.TrimPrefix(after, "/")] = true
+			}
+			continue
+		}
+		if strings.Contains(line, "/") {
+			continue
+		}
+		if ext, ok := strings.CutPrefix(line, "*"); ok {
+			if strings.HasPrefix(ext, ".") && !strings.Contains(ext, "*") {
+				ig.exts[strings.ToLower(ext)] = true
+			}
+			continue
+		}
+		if !strings.ContainsAny(line, "*?[") {
+			// A bare name is both a file name and a directory name in git, and it
+			// is read as both here.
+			ig.names[line] = true
+			ig.dirs[line] = true
+		}
+	}
+	return ig
+}

--- a/internal/filestate/filestate_test.go
+++ b/internal/filestate/filestate_test.go
@@ -1,0 +1,185 @@
+package filestate
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/changeset"
+)
+
+func write(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	path := filepath.Join(dir, filepath.FromSlash(rel))
+	assert.NilError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	assert.NilError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func build(t *testing.T, dir string) Index {
+	t.Helper()
+	idx, err := Build(dir)
+	assert.NilError(t, err)
+	return idx
+}
+
+func TestBuildIndexesEveryFile(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "main.go", "package main\n")
+	write(t, dir, "docs/guide.md", "one\ntwo\n")
+
+	idx := build(t, dir)
+	assert.Equal(t, len(idx), 2)
+	assert.Equal(t, idx["main.go"].Lines, 1)
+	assert.Equal(t, idx["docs/guide.md"].Lines, 2)
+	assert.Assert(t, idx["main.go"].Hash != "", "no content hash was recorded")
+}
+
+// No earlier state means the whole tree is the change: there is nothing it
+// could be smaller than.
+func TestChangesAgainstNothingIsTheWholeTree(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "a.txt", "one\ntwo\n")
+	write(t, dir, "b.txt", "three\n")
+
+	ch := build(t, dir).Changes(nil)
+	assert.DeepEqual(t, ch.Paths, []string{"a.txt", "b.txt"})
+	assert.Equal(t, ch.Lines, 3)
+	assert.Equal(t, ch.Baseline, changeset.BaselineWholeTree)
+	assert.Equal(t, ch.Incremental(), false)
+}
+
+func TestChangesReportsAddedRemovedAndModified(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "kept.txt", "one\n")
+	write(t, dir, "gone.txt", "one\ntwo\n")
+	before := build(t, dir)
+
+	assert.NilError(t, os.Remove(filepath.Join(dir, "gone.txt")))
+	write(t, dir, "new.txt", "three\n")
+
+	ch := build(t, dir).Changes(before)
+	assert.DeepEqual(t, ch.Paths, []string{"gone.txt", "new.txt"})
+	// The deleted file's two lines and the new file's one.
+	assert.Equal(t, ch.Lines, 3)
+	assert.Equal(t, ch.Incremental(), true)
+}
+
+// An unchanged tree is unchanged, however many files it has.
+func TestChangesIsEmptyForAnUntouchedTree(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "a.txt", "one\n")
+	before := build(t, dir)
+
+	assert.Equal(t, build(t, dir).Changes(before).Empty(), true)
+}
+
+// Without the earlier contents there is no telling how much of a modified file
+// moved, so it counts the most it could have. Over-measuring makes somebody
+// wait; under-measuring waves a change through.
+func TestAModifiedFileCountsItsWholeLength(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "main.go", strings.Repeat("// line\n", 100))
+	before := build(t, dir)
+
+	write(t, dir, "main.go", strings.Repeat("// line\n", 99)+"// edited\n")
+
+	ch := build(t, dir).Changes(before)
+	assert.DeepEqual(t, ch.Paths, []string{"main.go"})
+	assert.Equal(t, ch.Lines, 100, "a one-line edit must count the file, not the line")
+}
+
+func TestBuildSkipsTheGitDirectory(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, ".git/objects/ab/cdef", "blob")
+	write(t, dir, "main.go", "package main\n")
+
+	idx := build(t, dir)
+	assert.Equal(t, len(idx), 1)
+	assert.Assert(t, idx["main.go"].Hash != "")
+}
+
+func TestBuildHonoursTheSimplePartsOfGitignore(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, ".gitignore", "# comment\nnode_modules/\n*.log\nsecrets.env\n")
+	write(t, dir, "node_modules/pkg/index.js", "junk\n")
+	write(t, dir, "debug.log", "noise\n")
+	write(t, dir, "secrets.env", "TOKEN=x\n")
+	write(t, dir, "main.go", "package main\n")
+
+	idx := build(t, dir)
+	assert.Equal(t, len(idx), 2, "got %v", idx)
+	assert.Assert(t, idx["main.go"].Hash != "")
+	assert.Assert(t, idx[".gitignore"].Hash != "")
+}
+
+// A pattern this does not fully understand is walked rather than guessed at.
+// Counting a file that should have been ignored costs time; missing one that
+// changed is the failure this package must not have.
+func TestBuildWalksPatternsItDoesNotUnderstand(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, ".gitignore", "!keep.txt\nsrc/**/gen.go\ndeep/nested/path/thing\n")
+	write(t, dir, "keep.txt", "one\n")
+	write(t, dir, "src/a/gen.go", "package a\n")
+
+	idx := build(t, dir)
+	assert.Assert(t, idx["keep.txt"].Hash != "", "a negation was misread as an ignore")
+	assert.Assert(t, idx["src/a/gen.go"].Hash != "", "a ** pattern was misread as an ignore")
+}
+
+// Newlines in a binary file are not lines.
+func TestBinaryContentCountsNoLines(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "blob.bin", "\x00\x01\n\n\n")
+
+	assert.Equal(t, build(t, dir)["blob.bin"].Lines, 0)
+}
+
+// Past the budget it fails rather than returning a partial index, since a
+// partial index is a change that reads smaller than it is.
+func TestBuildRefusesATreeOverTheBudget(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"a.txt", "b.txt", "c.txt"} {
+		write(t, dir, name, "one\n")
+	}
+
+	original := maxFiles
+	maxFiles = 2
+	defer func() { maxFiles = original }()
+
+	_, err := Build(dir)
+	assert.Assert(t, errors.Is(err, ErrWalkBudget), "got %v", err)
+}
+
+func TestBuildNotADirectoryIsAnError(t *testing.T) {
+	_, err := Build(filepath.Join(t.TempDir(), "nope"))
+	assert.Assert(t, err != nil)
+}
+
+// Two equal digests are the same content, which is all the staleness check
+// needs of them.
+func TestDigestIsStableAndContentAddressed(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "a.txt", "one\n")
+	write(t, dir, "b/c.txt", "two\n")
+
+	first := build(t, dir).Digest()
+	assert.Equal(t, first, build(t, dir).Digest())
+
+	write(t, dir, "a.txt", "changed\n")
+	assert.Assert(t, build(t, dir).Digest() != first, "an edit did not change the digest")
+}
+
+// A file moved between two paths with the same contents is still a change: the
+// digest folds in the paths, not only what is in them.
+func TestDigestCoversPathsNotJustContents(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "a.txt", "one\n")
+	before := build(t, dir).Digest()
+
+	assert.NilError(t, os.Rename(filepath.Join(dir, "a.txt"), filepath.Join(dir, "b.txt")))
+	assert.Assert(t, build(t, dir).Digest() != before, "a rename did not change the digest")
+}

--- a/internal/gitutil/changes.go
+++ b/internal/gitutil/changes.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/changeset"
 )
 
 // maxCountBytes caps the total untracked content read to count lines. Untracked
@@ -22,35 +24,6 @@ var maxCountBytes int64 = 16 << 20
 // ErrCountBudget reports that the changed files hold more content than the line
 // count is willing to read.
 var ErrCountBudget = errors.New("changed files exceed the line count budget")
-
-// Changes summarises how far a working tree has moved from HEAD: which paths
-// changed, and how much of them.
-//
-// It answers a different question from Worktree. A fingerprint says whether the
-// tree is the same tree as before; this says how big the change is and what kind
-// of files it touched — which is what a caller deciding how much caution a
-// change deserves needs to know.
-type Changes struct {
-	// Paths is every path git reports as changed, relative to the repo root.
-	// Rename and copy entries name the destination only, since that is the file
-	// now on disk.
-	Paths []string
-	// Lines is how many lines the change touches: insertions plus deletions
-	// against the baseline for tracked files, and every line of an untracked
-	// file, all of which are new. Binary content contributes no lines — there
-	// are none to count — so a change can name paths and still report zero.
-	Lines int
-	// Baseline names what the change was measured against: "HEAD", or the SHA of
-	// an earlier snapshot. A caller reporting a number has to say what it is a
-	// number of, and the two answers mean different things — see ChangesBetween.
-	Baseline string
-}
-
-// BaselineHead is the Baseline of a change measured against the last commit.
-const BaselineHead = "HEAD"
-
-// Empty reports whether nothing has changed relative to the baseline.
-func (c Changes) Empty() bool { return len(c.Paths) == 0 }
 
 // WorkingChanges measures the working tree at dir against HEAD.
 //
@@ -65,10 +38,10 @@ func (c Changes) Empty() bool { return len(c.Paths) == 0 }
 // budget. The returned Changes is then the zero value, which reports no paths
 // and no lines — never mistake it for a small change, since it is the same
 // value a clean tree produces.
-func WorkingChanges(dir string) (Changes, error) {
+func WorkingChanges(dir string) (changeset.Changes, error) {
 	out, err := gitOut(dir, "rev-parse", "--show-toplevel")
 	if err != nil {
-		return Changes{}, fmt.Errorf("resolve repo root: %w", err)
+		return changeset.Changes{}, fmt.Errorf("resolve repo root: %w", err)
 	}
 	root := strings.TrimSpace(out)
 
@@ -77,14 +50,14 @@ func WorkingChanges(dir string) (Changes, error) {
 	// rather than collapsing a directory into a single entry.
 	status, err := gitOut(dir, "status", "--porcelain", "-z", "-uall")
 	if err != nil {
-		return Changes{}, fmt.Errorf("read git status: %w", err)
+		return changeset.Changes{}, fmt.Errorf("read git status: %w", err)
 	}
 	entries := parseStatus(status)
 	if len(entries) == 0 {
-		return Changes{Baseline: BaselineHead}, nil
+		return changeset.Changes{Baseline: changeset.BaselineHead}, nil
 	}
 
-	ch := Changes{Paths: make([]string, 0, len(entries)), Baseline: BaselineHead}
+	ch := changeset.Changes{Paths: make([]string, 0, len(entries)), Baseline: changeset.BaselineHead}
 	remaining := maxCountBytes
 	for _, e := range entries {
 		ch.Paths = append(ch.Paths, e.Path)
@@ -93,7 +66,7 @@ func WorkingChanges(dir string) (Changes, error) {
 		}
 		lines, read, err := countLines(filepath.Join(root, e.Path), remaining)
 		if err != nil {
-			return Changes{}, fmt.Errorf("count %s: %w", e.Path, err)
+			return changeset.Changes{}, fmt.Errorf("count %s: %w", e.Path, err)
 		}
 		remaining -= read
 		ch.Lines += lines
@@ -101,7 +74,7 @@ func WorkingChanges(dir string) (Changes, error) {
 
 	tracked, err := trackedLines(dir)
 	if err != nil {
-		return Changes{}, err
+		return changeset.Changes{}, err
 	}
 	ch.Lines += tracked
 	return ch, nil

--- a/internal/gitutil/changes_test.go
+++ b/internal/gitutil/changes_test.go
@@ -8,10 +8,12 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/changeset"
 )
 
 // changes asserts the tree could be measured and returns the measurement.
-func changes(t *testing.T, dir string) Changes {
+func changes(t *testing.T, dir string) changeset.Changes {
 	t.Helper()
 	ch, err := WorkingChanges(dir)
 	assert.NilError(t, err)
@@ -119,7 +121,7 @@ func TestWorkingChangesRefusesMoreUntrackedContentThanTheBudget(t *testing.T) {
 
 	ch, err := WorkingChanges(dir)
 	assert.Assert(t, errors.Is(err, ErrCountBudget), "got %v", err)
-	assert.DeepEqual(t, ch, Changes{})
+	assert.DeepEqual(t, ch, changeset.Changes{})
 }
 
 // A tree whose state cannot be established reports the zero value, which reads
@@ -128,7 +130,7 @@ func TestWorkingChangesRefusesMoreUntrackedContentThanTheBudget(t *testing.T) {
 func TestWorkingChangesNotARepoIsUnusable(t *testing.T) {
 	ch, err := WorkingChanges(t.TempDir())
 	assert.Assert(t, err != nil, "a non-repo dir must not produce a measurement")
-	assert.DeepEqual(t, ch, Changes{})
+	assert.DeepEqual(t, ch, changeset.Changes{})
 }
 
 func TestWorkingChangesRepoWithoutCommitsIsUnusable(t *testing.T) {

--- a/internal/gitutil/shadow.go
+++ b/internal/gitutil/shadow.go
@@ -1,0 +1,79 @@
+package gitutil
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// shadowIdentity is the author git needs to write a commit object. The commit
+// is a handle for a tree and nothing else — never pushed, never referenced,
+// collected by gc — so it carries chunk's name rather than the developer's,
+// which should never appear on an object they did not make.
+var shadowIdentity = []string{
+	"GIT_AUTHOR_NAME=chunk",
+	"GIT_AUTHOR_EMAIL=chunk@local",
+	"GIT_COMMITTER_NAME=chunk",
+	"GIT_COMMITTER_EMAIL=chunk@local",
+}
+
+// MaterializeTree checks out a tree snapshot into its own directory and returns
+// the path, along with a function that removes it.
+//
+// This is what lets checks run against a state that cannot move underneath
+// them. A run against the live working tree is racing the developer and the
+// agent: anything they edit while it runs makes its answer describe code that
+// is no longer there, and that answer then has to be thrown away. A run against
+// a checked-out snapshot is true about that snapshot however long it takes, and
+// stays true afterwards.
+//
+// What it does not carry is everything git was told to ignore. Dependencies,
+// build caches, local env files and anything else gitignored are absent, so
+// checks that need them fail here for reasons that have nothing to do with the
+// change. That is why the worktree mode is opt-in: for some projects it is
+// exactly right, and for others every run would report an environment failure
+// as a code failure.
+//
+// Unlike SnapshotTree this does touch repository metadata — git records the
+// worktree under .git/worktrees — which the cleanup removes. A daemon killed
+// before cleanup leaves an entry behind; `git worktree prune` clears those, and
+// the next cleanup runs it.
+func MaterializeTree(dir, tree string) (string, func(), error) {
+	if tree == "" {
+		return "", nil, fmt.Errorf("no snapshot to materialize")
+	}
+
+	commit, err := gitOutEnv(dir, append(os.Environ(), shadowIdentity...),
+		"commit-tree", tree, "-m", "chunk snapshot")
+	if err != nil {
+		return "", nil, fmt.Errorf("commit snapshot: %w", err)
+	}
+
+	path, err := os.MkdirTemp("", "chunk-shadow-")
+	if err != nil {
+		return "", nil, fmt.Errorf("create shadow dir: %w", err)
+	}
+	// Removed first: worktree add refuses a directory that already exists, and
+	// MkdirTemp has just made one. Taking the name rather than the directory is
+	// what keeps two concurrent runs from choosing the same path.
+	if err := os.Remove(path); err != nil {
+		return "", nil, fmt.Errorf("clear shadow dir: %w", err)
+	}
+
+	if _, err := gitOut(dir, "worktree", "add", "--detach", path, strings.TrimSpace(commit)); err != nil {
+		return "", nil, fmt.Errorf("add shadow worktree: %w", err)
+	}
+	return path, cleanupShadow(dir, path), nil
+}
+
+// cleanupShadow returns a function that removes a shadow worktree and the
+// metadata git recorded for it. Best-effort throughout: a leftover temp
+// directory is worth a warning, not a failed validate run.
+func cleanupShadow(dir, path string) func() {
+	return func() {
+		_, _ = gitOut(dir, "worktree", "remove", "--force", path)
+		_ = os.RemoveAll(path)
+		// Clears entries left by a daemon that died before its own cleanup ran.
+		_, _ = gitOut(dir, "worktree", "prune")
+	}
+}

--- a/internal/gitutil/shadow_test.go
+++ b/internal/gitutil/shadow_test.go
@@ -1,0 +1,117 @@
+package gitutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func materialize(t *testing.T, dir, tree string) string {
+	t.Helper()
+	path, cleanup, err := MaterializeTree(dir, tree)
+	assert.NilError(t, err)
+	t.Cleanup(cleanup)
+	return path
+}
+
+// Everything the snapshot held is there, committed or not: uncommitted work is
+// the whole reason for validating a snapshot rather than a commit.
+func TestMaterializeTreeCarriesUncommittedWork(t *testing.T) {
+	dir := setupRepo(t)
+	commitFile(t, dir, "tracked.txt", "committed\n")
+	writeFile(t, dir, "untracked.go", "package main\n")
+	writeFile(t, dir, "tracked.txt", "edited\n")
+
+	path := materialize(t, dir, snapshot(t, dir))
+
+	tracked, err := os.ReadFile(filepath.Join(path, "tracked.txt"))
+	assert.NilError(t, err)
+	assert.Equal(t, string(tracked), "edited\n")
+	_, err = os.Stat(filepath.Join(path, "untracked.go"))
+	assert.NilError(t, err, "untracked work did not reach the shadow")
+}
+
+// The point of the whole thing: the live tree can move as much as it likes and
+// the shadow does not.
+func TestTheShadowDoesNotMoveWithTheLiveTree(t *testing.T) {
+	dir := setupRepo(t)
+	writeFile(t, dir, "main.go", "before\n")
+	path := materialize(t, dir, snapshot(t, dir))
+
+	writeFile(t, dir, "main.go", "after\n")
+	writeFile(t, dir, "another.go", "new since\n")
+
+	shadowed, err := os.ReadFile(filepath.Join(path, "main.go"))
+	assert.NilError(t, err)
+	assert.Equal(t, string(shadowed), "before\n")
+	_, err = os.Stat(filepath.Join(path, "another.go"))
+	assert.Assert(t, err != nil, "a file created after the snapshot appeared in it")
+}
+
+// What it cannot carry, said out loud: gitignored content is absent, which is
+// why running checks in a shadow is opt-in.
+func TestMaterializeTreeLeavesIgnoredContentBehind(t *testing.T) {
+	dir := setupRepo(t)
+	writeFile(t, dir, ".gitignore", "node_modules/\n")
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "node_modules"), 0o755))
+	writeFile(t, dir, "node_modules/dep.js", "module.exports = 1\n")
+
+	path := materialize(t, dir, snapshot(t, dir))
+
+	_, err := os.Stat(filepath.Join(path, "node_modules"))
+	assert.Assert(t, err != nil, "ignored content reached the shadow")
+}
+
+// It is a real worktree, so tools that ask git about it get answers.
+func TestTheShadowIsAGitWorktree(t *testing.T) {
+	dir := setupRepo(t)
+	writeFile(t, dir, "main.go", "package main\n")
+	path := materialize(t, dir, snapshot(t, dir))
+
+	root, err := gitOut(path, "rev-parse", "--show-toplevel")
+	assert.NilError(t, err)
+	assert.Equal(t, strings.TrimSpace(root) != "", true)
+	// And it is clean, since it was checked out from exactly this state.
+	status, err := gitOut(path, "status", "--porcelain")
+	assert.NilError(t, err)
+	assert.Equal(t, strings.TrimSpace(status), "")
+}
+
+// Cleanup takes the directory and the metadata git recorded for it, so a repo
+// does not accumulate worktrees one background run at a time.
+func TestCleanupRemovesTheShadowAndItsMetadata(t *testing.T) {
+	dir := setupRepo(t)
+	writeFile(t, dir, "main.go", "package main\n")
+	tree := snapshot(t, dir)
+
+	path, cleanup, err := MaterializeTree(dir, tree)
+	assert.NilError(t, err)
+	before := gitRun(t, dir, "worktree", "list")
+	assert.Assert(t, strings.Contains(before, path), "the worktree was not registered: %s", before)
+
+	cleanup()
+
+	_, statErr := os.Stat(path)
+	assert.Assert(t, statErr != nil, "the shadow directory survived cleanup")
+	after := gitRun(t, dir, "worktree", "list")
+	assert.Assert(t, !strings.Contains(after, path), "metadata survived cleanup: %s", after)
+}
+
+// Two runs at once must not pick the same directory.
+func TestTwoShadowsOfTheSameTreeCoexist(t *testing.T) {
+	dir := setupRepo(t)
+	writeFile(t, dir, "main.go", "package main\n")
+	tree := snapshot(t, dir)
+
+	first := materialize(t, dir, tree)
+	second := materialize(t, dir, tree)
+	assert.Assert(t, first != second, "both runs got the same shadow directory")
+}
+
+func TestMaterializeTreeRefusesAnEmptySnapshot(t *testing.T) {
+	_, _, err := MaterializeTree(setupRepo(t), "")
+	assert.Assert(t, err != nil)
+}

--- a/internal/gitutil/snapshot.go
+++ b/internal/gitutil/snapshot.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/changeset"
 )
 
 // SnapshotTree captures the whole working state at dir as a git tree object and
@@ -74,18 +76,18 @@ func SnapshotTree(dir string) (string, error) {
 //
 // The error is non-nil when base cannot be diffed: it has been garbage collected,
 // or the tree cannot be snapshotted now. Callers fall back to WorkingChanges.
-func ChangesBetween(dir, base string) (Changes, error) {
+func ChangesBetween(dir, base string) (changeset.Changes, error) {
 	now, err := SnapshotTree(dir)
 	if err != nil {
-		return Changes{}, err
+		return changeset.Changes{}, err
 	}
 	if now == base {
-		return Changes{Baseline: base}, nil
+		return changeset.Changes{Baseline: base}, nil
 	}
 
 	names, err := gitOutEnv(dir, nil, "diff", "--name-only", "-z", base, now)
 	if err != nil {
-		return Changes{}, fmt.Errorf("diff %s: %w", base, err)
+		return changeset.Changes{}, fmt.Errorf("diff %s: %w", base, err)
 	}
 	var paths []string
 	for _, p := range strings.Split(names, "\x00") {
@@ -94,14 +96,14 @@ func ChangesBetween(dir, base string) (Changes, error) {
 		}
 	}
 	if len(paths) == 0 {
-		return Changes{Baseline: base}, nil
+		return changeset.Changes{Baseline: base}, nil
 	}
 
 	stat, err := gitOutEnv(dir, nil, "diff", "--shortstat", base, now)
 	if err != nil {
-		return Changes{}, fmt.Errorf("diff %s: %w", base, err)
+		return changeset.Changes{}, fmt.Errorf("diff %s: %w", base, err)
 	}
-	return Changes{Paths: paths, Lines: countShortstat(stat), Baseline: base}, nil
+	return changeset.Changes{Paths: paths, Lines: countShortstat(stat), Baseline: base}, nil
 }
 
 // gitOutEnv is gitOut with an explicit environment. A nil env inherits this

--- a/internal/gitutil/snapshot_test.go
+++ b/internal/gitutil/snapshot_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/CircleCI-Public/chunk-cli/internal/changeset"
 )
 
 func snapshot(t *testing.T, dir string) string {
@@ -17,7 +19,7 @@ func snapshot(t *testing.T, dir string) string {
 	return tree
 }
 
-func between(t *testing.T, dir, base string) Changes {
+func between(t *testing.T, dir, base string) changeset.Changes {
 	t.Helper()
 	ch, err := ChangesBetween(dir, base)
 	assert.NilError(t, err)

--- a/internal/watchd/asyncvalidate.go
+++ b/internal/watchd/asyncvalidate.go
@@ -97,7 +97,7 @@ func newTaskStore(parent context.Context) *taskStore {
 		parent:      parent,
 		tasks:       make(map[string]*taskEntry),
 		byProject:   make(map[string][]string),
-		fingerprint: gitutil.Fingerprint,
+		fingerprint: fingerprintTree,
 		now:         time.Now,
 	}
 }

--- a/internal/watchd/asyncvalidate.go
+++ b/internal/watchd/asyncvalidate.go
@@ -30,6 +30,11 @@ type TaskState struct {
 	// Stale reports that the working tree changed while the run was in flight,
 	// so the result describes code that is no longer on disk.
 	Stale bool `json:"stale"`
+	// Snapshot reports that the run validated a checked-out copy of the tree
+	// rather than the tree itself. Such a result is exact about the state it
+	// ran against whatever happened afterwards, so it is reported even when
+	// stale — qualified rather than thrown away.
+	Snapshot bool `json:"snapshot,omitempty"`
 }
 
 // Passed reports whether a finished task validated the tree successfully.
@@ -110,7 +115,7 @@ func newTaskStore(parent context.Context) *taskStore {
 // reported as if it described the current tree. Callers are expected to fall
 // back to running synchronously, where the answer reaches whoever asked for it
 // while it is still true.
-func (s *taskStore) start(root string, run runFn) (string, error) {
+func (s *taskStore) start(root string, snapshot bool, run runFn) (string, error) {
 	root = config.CanonicalProjectRoot(root)
 	start, err := s.fingerprint(root)
 	if err != nil {
@@ -125,6 +130,7 @@ func (s *taskStore) start(root string, run runFn) (string, error) {
 			ProjectRoot: root,
 			StartedAt:   s.now(),
 			Running:     true,
+			Snapshot:    snapshot,
 		},
 		start:  start,
 		cancel: cancel,
@@ -232,7 +238,16 @@ func (s *taskStore) collect(root string) []TaskState {
 		// because it has moved since the run ended. Both mean the same thing to
 		// whoever is about to read the result.
 		movedSince := unverifiable || now.Head != entry.start.Head || now.Digest != entry.start.Digest
-		if !entry.state.Stale && !movedSince {
+		switch {
+		case !entry.state.Stale && !movedSince:
+			out = append(out, entry.state)
+		case entry.state.Snapshot:
+			// A snapshot-backed run validated a copy that cannot move, so its
+			// answer is still exactly true about the state it ran against. It is
+			// reported with that said rather than discarded — the work was done,
+			// and "your code passed as of the end of that turn" is worth more than
+			// silence.
+			entry.state.Stale = true
 			out = append(out, entry.state)
 		}
 		delete(s.tasks, id)

--- a/internal/watchd/asyncvalidate.go
+++ b/internal/watchd/asyncvalidate.go
@@ -277,6 +277,56 @@ func (s *taskStore) inFlight(root string) []TaskState {
 	return out
 }
 
+// supersede stops the runs in flight for root that a new run makes pointless,
+// and reports how many it stopped.
+//
+// A run is released because the tree has moved — that is what made a new hook
+// fire — so a live-tree run already in flight is validating code that is no
+// longer on disk, and its result is going to be discarded the moment it
+// finishes. Stopping it frees the validate lock the new run is about to want,
+// instead of leaving two runs of the same commands queued behind each other for
+// an answer only one of them can give.
+//
+// Snapshot-backed runs are left alone. Their verdict stays true about the state
+// they were handed whatever the tree does afterwards, so that one will be
+// reported rather than thrown away — cancelling it would discard the only work
+// here that was going to survive.
+func (s *taskStore) supersede(root string) int {
+	root = config.CanonicalProjectRoot(root)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ids := s.byProject[root]
+	kept := make([]string, 0, len(ids))
+	stopped := 0
+	for _, id := range ids {
+		entry, ok := s.tasks[id]
+		if !ok {
+			continue
+		}
+		if !entry.state.Running || entry.state.Snapshot {
+			kept = append(kept, id)
+			continue
+		}
+		if entry.cancel != nil {
+			entry.cancel()
+		}
+		// Dropped here rather than left to report a cancellation. finish finds no
+		// task and records nothing, which is right: a run that was stopped has
+		// concluded nothing, and reporting it as a failure would owe the project a
+		// blocking run it never earned.
+		delete(s.tasks, id)
+		stopped++
+	}
+	if len(kept) == 0 {
+		delete(s.byProject, root)
+	} else {
+		s.byProject[root] = kept
+	}
+	return stopped
+}
+
 // evictLocked drops finished tasks until root is under MaxTasksPerProject.
 // A running task is never evicted: cancelling a run to make room would lose
 // work that is about to produce an answer.

--- a/internal/watchd/asyncvalidate_test.go
+++ b/internal/watchd/asyncvalidate_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -454,9 +455,11 @@ func TestAsyncValidateEndpointAcceptsAndCollects(t *testing.T) {
 // broken, this tree just cannot be validated asynchronously, and the caller is
 // meant to read that as "run it inline" instead of as a daemon failure.
 func TestAsyncValidateEndpointRefusesAnUnfingerprintableTree(t *testing.T) {
-	dir, err := os.MkdirTemp("", "notarepo")
-	assert.NilError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	// A path with nothing at it. Git cannot identify it and neither can hashing
+	// it, so there is no baseline to detect staleness against — which is the
+	// only condition that refuses a run now that a tree git has no answer for
+	// can be identified by its contents instead. See fingerprintTree.
+	dir := filepath.Join(t.TempDir(), "gone")
 
 	d := newTestDaemon()
 	t.Cleanup(d.tasks.stopAll)
@@ -469,6 +472,23 @@ func TestAsyncValidateEndpointRefusesAnUnfingerprintableTree(t *testing.T) {
 	rec := serve(d, asyncReq(t, dir))
 	assert.Equal(t, rec.Code, http.StatusConflict)
 	assert.Equal(t, ran, false, "a run started against a tree with no baseline")
+}
+
+// A directory that is not a repository used to be refused, because git had no
+// identity to give it and staleness would have been undetectable. Hashing it
+// gives the same guarantee, so it is tracked like any other tree.
+func TestAsyncValidateEndpointAcceptsATreeThatIsNotARepository(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0o644))
+
+	d := newTestDaemon()
+	t.Cleanup(d.tasks.stopAll)
+	d.runner = func(context.Context, []string, []string, io.Writer, io.Writer) int { return 0 }
+
+	rec := serve(d, asyncReq(t, dir))
+	assert.Equal(t, rec.Code, http.StatusAccepted)
+	waitFor(t, func() bool { return len(d.tasks.inFlight(dir)) == 0 }, "run never finished")
+	assert.Equal(t, len(d.tasks.collect(dir)), 1, "the result was not kept")
 }
 
 // A result that cannot be attributed to a project could never be collected, so

--- a/internal/watchd/asyncvalidate_test.go
+++ b/internal/watchd/asyncvalidate_test.go
@@ -81,7 +81,7 @@ func waitFor(t *testing.T, cond func() bool, msg string) {
 func TestCollectReturnsAResultForAnUnchangedTree(t *testing.T) {
 	s, _ := newFakeStore(t, tree("abc", "d1"))
 
-	_, err := s.start("/repo", func(context.Context) (int, string) {
+	_, err := s.start("/repo", false, func(context.Context) (int, string) {
 		return 0, "1/1 passed"
 	})
 	assert.NilError(t, err)
@@ -103,7 +103,7 @@ func TestAnEditDuringTheRunDiscardsTheResult(t *testing.T) {
 	s, fake := newFakeStore(t, tree("abc", "d1"))
 
 	release := make(chan struct{})
-	_, err := s.start("/repo", func(context.Context) (int, string) {
+	_, err := s.start("/repo", false, func(context.Context) (int, string) {
 		<-release
 		return 0, "1/1 passed"
 	})
@@ -127,7 +127,7 @@ func TestACommitDuringTheRunDiscardsTheResult(t *testing.T) {
 	s, fake := newFakeStore(t, tree("abc", "d1"))
 
 	release := make(chan struct{})
-	_, err := s.start("/repo", func(context.Context) (int, string) {
+	_, err := s.start("/repo", false, func(context.Context) (int, string) {
 		<-release
 		return 0, "ok"
 	})
@@ -145,7 +145,7 @@ func TestACommitDuringTheRunDiscardsTheResult(t *testing.T) {
 func TestAFailureIsCollectedToo(t *testing.T) {
 	s, _ := newFakeStore(t, tree("abc", "d1"))
 
-	_, err := s.start("/repo", func(context.Context) (int, string) {
+	_, err := s.start("/repo", false, func(context.Context) (int, string) {
 		return 1, "0/1 passed"
 	})
 	assert.NilError(t, err)
@@ -167,7 +167,7 @@ func TestStartRefusesATreeItCannotFingerprint(t *testing.T) {
 	fake.set(gitutil.Worktree{}, errors.New("not a git repository"))
 
 	var ran bool
-	_, err := s.start("/repo", func(context.Context) (int, string) {
+	_, err := s.start("/repo", false, func(context.Context) (int, string) {
 		ran = true
 		return 0, ""
 	})
@@ -183,7 +183,7 @@ func TestATreeThatCannotBeFingerprintedAtTheEndIsStale(t *testing.T) {
 	s, fake := newFakeStore(t, tree("abc", "d1"))
 
 	release := make(chan struct{})
-	_, err := s.start("/repo", func(context.Context) (int, string) {
+	_, err := s.start("/repo", false, func(context.Context) (int, string) {
 		<-release
 		return 0, "ok"
 	})
@@ -201,7 +201,7 @@ func TestATreeThatCannotBeFingerprintedAtTheEndIsStale(t *testing.T) {
 func TestCollectReportsAResultOnlyOnce(t *testing.T) {
 	s, _ := newFakeStore(t, tree("abc", "d1"))
 
-	_, err := s.start("/repo", func(context.Context) (int, string) { return 0, "ok" })
+	_, err := s.start("/repo", false, func(context.Context) (int, string) { return 0, "ok" })
 	assert.NilError(t, err)
 	waitFor(t, func() bool { return len(s.inFlight("/repo")) == 0 }, "run never finished")
 
@@ -215,7 +215,7 @@ func TestCollectLeavesRunningTasksAlone(t *testing.T) {
 	s, _ := newFakeStore(t, tree("abc", "d1"))
 
 	release := make(chan struct{})
-	_, err := s.start("/repo", func(context.Context) (int, string) {
+	_, err := s.start("/repo", false, func(context.Context) (int, string) {
 		<-release
 		return 0, "ok"
 	})
@@ -235,12 +235,12 @@ func TestTwoRunsInFlightAreTrackedSeparately(t *testing.T) {
 	s, _ := newFakeStore(t, tree("abc", "d1"))
 
 	release := make(chan struct{})
-	first, err := s.start("/repo", func(context.Context) (int, string) {
+	first, err := s.start("/repo", false, func(context.Context) (int, string) {
 		<-release
 		return 0, "first"
 	})
 	assert.NilError(t, err)
-	second, err := s.start("/repo", func(context.Context) (int, string) {
+	second, err := s.start("/repo", false, func(context.Context) (int, string) {
 		<-release
 		return 1, "second"
 	})
@@ -257,7 +257,7 @@ func TestTwoRunsInFlightAreTrackedSeparately(t *testing.T) {
 func TestTasksAreKeptPerProject(t *testing.T) {
 	s, _ := newFakeStore(t, tree("abc", "d1"))
 
-	_, err := s.start("/repo-a", func(context.Context) (int, string) { return 0, "a" })
+	_, err := s.start("/repo-a", false, func(context.Context) (int, string) { return 0, "a" })
 	assert.NilError(t, err)
 	waitFor(t, func() bool { return len(s.inFlight("/repo-a")) == 0 }, "run never finished")
 
@@ -274,7 +274,7 @@ func TestEvictionNeverDropsARunningTask(t *testing.T) {
 
 	release := make(chan struct{})
 	for i := 0; i < MaxTasksPerProject+5; i++ {
-		_, err := s.start("/repo", func(context.Context) (int, string) {
+		_, err := s.start("/repo", false, func(context.Context) (int, string) {
 			<-release
 			return 0, "ok"
 		})
@@ -293,7 +293,7 @@ func TestFinishedTasksAreEvictedOverTheCap(t *testing.T) {
 	s, _ := newFakeStore(t, tree("abc", "d1"))
 
 	for i := 0; i < MaxTasksPerProject+5; i++ {
-		_, err := s.start("/repo", func(context.Context) (int, string) { return 0, "ok" })
+		_, err := s.start("/repo", false, func(context.Context) (int, string) { return 0, "ok" })
 		assert.NilError(t, err)
 		waitFor(t, func() bool { return len(s.inFlight("/repo")) == 0 }, "run never finished")
 	}
@@ -306,7 +306,7 @@ func TestStopAllCancelsRunsInFlight(t *testing.T) {
 	s, _ := newFakeStore(t, tree("abc", "d1"))
 
 	cancelled := make(chan struct{})
-	_, err := s.start("/repo", func(ctx context.Context) (int, string) {
+	_, err := s.start("/repo", false, func(ctx context.Context) (int, string) {
 		<-ctx.Done()
 		close(cancelled)
 		return 1, "cancelled"
@@ -328,7 +328,7 @@ func TestStopAllCancelsRunsInFlight(t *testing.T) {
 func TestAnEditAfterTheRunFinishedDiscardsTheResult(t *testing.T) {
 	s, fake := newFakeStore(t, tree("abc", "d1"))
 
-	_, err := s.start("/repo", func(context.Context) (int, string) { return 0, "ok" })
+	_, err := s.start("/repo", false, func(context.Context) (int, string) { return 0, "ok" })
 	assert.NilError(t, err)
 	waitFor(t, func() bool { return len(s.inFlight("/repo")) == 0 }, "run never finished")
 
@@ -343,7 +343,7 @@ func TestAnEditAfterTheRunFinishedDiscardsTheResult(t *testing.T) {
 func TestACommitAfterTheRunFinishedDiscardsTheResult(t *testing.T) {
 	s, fake := newFakeStore(t, tree("abc", "d1"))
 
-	_, err := s.start("/repo", func(context.Context) (int, string) { return 0, "ok" })
+	_, err := s.start("/repo", false, func(context.Context) (int, string) { return 0, "ok" })
 	assert.NilError(t, err)
 	waitFor(t, func() bool { return len(s.inFlight("/repo")) == 0 }, "run never finished")
 
@@ -356,7 +356,7 @@ func TestACommitAfterTheRunFinishedDiscardsTheResult(t *testing.T) {
 func TestATreeThatCannotBeFingerprintedAtCollectReportsNothing(t *testing.T) {
 	s, fake := newFakeStore(t, tree("abc", "d1"))
 
-	_, err := s.start("/repo", func(context.Context) (int, string) { return 0, "ok" })
+	_, err := s.start("/repo", false, func(context.Context) (int, string) { return 0, "ok" })
 	assert.NilError(t, err)
 	waitFor(t, func() bool { return len(s.inFlight("/repo")) == 0 }, "run never finished")
 
@@ -370,7 +370,7 @@ func TestCollectReadsTheTreeOncePerCall(t *testing.T) {
 	s, fake := newFakeStore(t, tree("abc", "d1"))
 
 	for i := 0; i < 3; i++ {
-		_, err := s.start("/repo", func(context.Context) (int, string) { return 0, "ok" })
+		_, err := s.start("/repo", false, func(context.Context) (int, string) { return 0, "ok" })
 		assert.NilError(t, err)
 		waitFor(t, func() bool { return len(s.inFlight("/repo")) == 0 }, "run never finished")
 	}

--- a/internal/watchd/risk.go
+++ b/internal/watchd/risk.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/changeset"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
+	"github.com/CircleCI-Public/chunk-cli/internal/filestate"
 	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 )
 
@@ -112,9 +114,9 @@ type riskDecision struct {
 // deliberately lopsided. Anything it cannot measure, and anything that has
 // recently failed, is made to block — the direction that costs a developer time
 // rather than the direction that costs them a missed failure.
-func decideRisk(p asyncPolicy, owesBlockingRun bool, ch gitutil.Changes, chErr error, hist historyEvidence) riskDecision {
+func decideRisk(p asyncPolicy, owesBlockingRun bool, ch changeset.Changes, chErr error, hist historyEvidence) riskDecision {
 	since := ""
-	if ch.Baseline != "" && ch.Baseline != gitutil.BaselineHead {
+	if ch.Incremental() {
 		since = " since the last passing run"
 	}
 	limit := p.maxLines
@@ -207,17 +209,29 @@ func lineCount(n int) string {
 type riskMemory struct {
 	mu     sync.Mutex
 	failed map[string]bool // canonical project root → owes a blocking run
-	// green is the tree each project last passed its checks against, and what
-	// the next change is measured from. See recordGreen.
-	green map[string]string
+	// green is the state each project last passed its checks in, and what the
+	// next change is measured from. See recordGreen.
+	green map[string]treeState
 }
 
 func newRiskMemory() *riskMemory {
 	return &riskMemory{
 		failed: make(map[string]bool),
-		green:  make(map[string]string),
+		green:  make(map[string]treeState),
 	}
 }
+
+// treeState is what a project looked like at a point in time, kept so a later
+// change can be measured from it. At most one of its fields is set: a git tree
+// object where git could answer for the tree, and a hashed walk where it could
+// not — a repository with no commits, or a directory that is not one.
+type treeState struct {
+	tree  string
+	index filestate.Index
+}
+
+// known reports whether this is a state anything can be measured against.
+func (s treeState) known() bool { return s.tree != "" || s.index != nil }
 
 // record notes how a run for root ended.
 func (m *riskMemory) record(root string, passed bool) {
@@ -258,19 +272,19 @@ func (m *riskMemory) owesBlockingRun(root string) bool {
 // that is the state the run actually validated. Whether the working tree has
 // moved on since is a separate question, and the one the next measurement is
 // about to answer.
-func (m *riskMemory) recordGreen(root, tree string) {
-	if tree == "" {
+func (m *riskMemory) recordGreen(root string, state treeState) {
+	if !state.known() {
 		return
 	}
 	root = config.CanonicalProjectRoot(root)
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.green[root] = tree
+	m.green[root] = state
 }
 
-// baseline returns the tree root's changes should be measured against, or "" to
-// measure against HEAD.
-func (m *riskMemory) baseline(root string) string {
+// baseline returns the state root's changes should be measured against. An
+// unknown state means there is nothing to measure from yet.
+func (m *riskMemory) baseline(root string) treeState {
 	root = config.CanonicalProjectRoot(root)
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -296,14 +310,73 @@ func (d *daemon) assessRisk(root string) riskDecision {
 // started, or a project whose runs have never passed. Falling back rather than
 // refusing keeps the first run after a restart working; it measures a larger
 // change than the incremental one, which errs towards making somebody wait.
-func (d *daemon) measure(root string) (gitutil.Changes, error) {
-	if base := d.risk.baseline(root); base != "" {
-		ch, err := gitutil.ChangesBetween(root, base)
+func (d *daemon) measure(root string) (changeset.Changes, error) {
+	base := d.risk.baseline(root)
+	if base.tree != "" {
+		ch, err := gitutil.ChangesBetween(root, base.tree)
 		if err == nil {
 			return ch, nil
 		}
 		// The snapshot is gone — collected by git's gc, or the repo has moved
 		// under it. Measuring against HEAD is worse but still true.
 	}
-	return gitutil.WorkingChanges(root)
+	if base.index != nil {
+		if idx, err := filestate.Build(root); err == nil {
+			return idx.Changes(base.index), nil
+		}
+	}
+
+	ch, err := gitutil.WorkingChanges(root)
+	if err == nil {
+		return ch, nil
+	}
+	// Git cannot answer for this tree: no repository, or one with no commits
+	// yet. Measured by hand instead, against nothing, so that three files in a
+	// fresh repo read as three files rather than as an unmeasurable change that
+	// blocks every run for as long as the repo stays fresh.
+	if idx, buildErr := filestate.Build(root); buildErr == nil {
+		return idx.Changes(nil), nil
+	}
+	return ch, err
+}
+
+// fingerprintTree identifies the state of a working tree for the staleness
+// check, in a way that does not need git to be able to answer.
+//
+// It is what lets a repository with no commits be validated in the background
+// at all. Staleness is only detectable against a recorded identity, and the git
+// fingerprint has none to give for a tree with no HEAD — so the run would be
+// refused and held, however small the change. Hashing the tree gives the same
+// guarantee by other means: two equal digests are the same content.
+//
+// Git first where git can answer, because it reads only the files it reports as
+// changed rather than walking everything.
+func fingerprintTree(dir string) (gitutil.Worktree, error) {
+	wt, err := gitutil.Fingerprint(dir)
+	if err == nil {
+		return wt, nil
+	}
+	idx, buildErr := filestate.Build(dir)
+	if buildErr != nil {
+		// Git's error names the condition — no repo, no commits, a dirty
+		// submodule — and is the more useful of the two to report.
+		return gitutil.Worktree{}, err
+	}
+	return gitutil.Worktree{Digest: idx.Digest(), Clean: len(idx) == 0}, nil
+}
+
+// snapshotState captures what root looks like now, to be recorded as the
+// baseline if the run about to happen passes. An unknown state simply means the
+// next change is measured against HEAD.
+func (d *daemon) snapshotState(root string) treeState {
+	if root == "" {
+		return treeState{}
+	}
+	if tree, err := gitutil.SnapshotTree(root); err == nil {
+		return treeState{tree: tree}
+	}
+	if idx, err := filestate.Build(root); err == nil {
+		return treeState{index: idx}
+	}
+	return treeState{}
 }

--- a/internal/watchd/risk.go
+++ b/internal/watchd/risk.go
@@ -72,6 +72,8 @@ func allInert(paths []string) bool {
 type asyncPolicy struct {
 	mode     string
 	maxLines int
+	// worktree runs background checks in a snapshot rather than the live tree.
+	worktree bool
 }
 
 // policyFor reads root's async validation policy. A project with no config, or
@@ -90,6 +92,7 @@ func policyFor(root string) asyncPolicy {
 	if cfg.AsyncValidateMaxLines > 0 {
 		p.maxLines = cfg.AsyncValidateMaxLines
 	}
+	p.worktree = cfg.AsyncValidateWorktree
 	return p
 }
 

--- a/internal/watchd/risk_test.go
+++ b/internal/watchd/risk_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -16,15 +17,15 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/CircleCI-Public/chunk-cli/internal/changeset"
 	"github.com/CircleCI-Public/chunk-cli/internal/config"
-	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 )
 
 // auto is the policy a project with no configuration gets.
 var auto = asyncPolicy{mode: config.AsyncValidateAuto, maxLines: DefaultAsyncMaxLines}
 
-func sourceChange(lines int) gitutil.Changes {
-	return gitutil.Changes{Paths: []string{"internal/cmd/validate.go"}, Lines: lines}
+func sourceChange(lines int) changeset.Changes {
+	return changeset.Changes{Paths: []string{"internal/cmd/validate.go"}, Lines: lines}
 }
 
 func TestASmallChangeIsBackgrounded(t *testing.T) {
@@ -48,7 +49,7 @@ func TestAChangeOnTheLimitBlocks(t *testing.T) {
 // Size is only consulted for changes that could plausibly fail a check. A docs
 // rewrite is backgrounded however long it is.
 func TestADocsOnlyChangeIsBackgroundedAtAnySize(t *testing.T) {
-	ch := gitutil.Changes{Paths: []string{"README.md", "docs/CLI.md", "LICENSE"}, Lines: 5000}
+	ch := changeset.Changes{Paths: []string{"README.md", "docs/CLI.md", "LICENSE"}, Lines: 5000}
 	d := decideRisk(auto, false, ch, nil, historyEvidence{})
 	assert.Equal(t, d.async, true)
 	assert.Equal(t, d.reason, "only docs and text changed")
@@ -56,14 +57,14 @@ func TestADocsOnlyChangeIsBackgroundedAtAnySize(t *testing.T) {
 
 // One source file in among the docs is a source change.
 func TestOneSourceFileAmongTheDocsIsJudgedOnSize(t *testing.T) {
-	ch := gitutil.Changes{Paths: []string{"README.md", "internal/cmd/validate.go"}, Lines: 5000}
+	ch := changeset.Changes{Paths: []string{"README.md", "internal/cmd/validate.go"}, Lines: 5000}
 	assert.Equal(t, decideRisk(auto, false, ch, nil, historyEvidence{}).async, false, historyEvidence{})
 }
 
 // A tree that cannot be measured says nothing about how large the change is,
 // and guessing small is the one answer that could lose a failure.
 func TestAnUnmeasurableChangeBlocks(t *testing.T) {
-	d := decideRisk(auto, false, gitutil.Changes{}, errors.New("not a repo"), historyEvidence{})
+	d := decideRisk(auto, false, changeset.Changes{}, errors.New("not a repo"), historyEvidence{})
 	assert.Equal(t, d.async, false)
 	assert.Assert(t, strings.Contains(d.reason, "not a repo"), "reason was %q", d.reason)
 }
@@ -72,7 +73,7 @@ func TestAnUnmeasurableChangeBlocks(t *testing.T) {
 // task and a later report on a run that does no work, so it stays here — and
 // says nothing, because there is nothing a developer would want told.
 func TestACleanTreeIsNotBackgrounded(t *testing.T) {
-	d := decideRisk(auto, false, gitutil.Changes{}, nil, historyEvidence{})
+	d := decideRisk(auto, false, changeset.Changes{}, nil, historyEvidence{})
 	assert.Equal(t, d.async, false)
 	assert.Equal(t, d.reason, "")
 }
@@ -87,7 +88,7 @@ func TestAProjectThatOwesABlockingRunGetsOne(t *testing.T) {
 
 func TestModeNeverBlocksEvenADocsChange(t *testing.T) {
 	p := asyncPolicy{mode: config.AsyncValidateNever, maxLines: DefaultAsyncMaxLines}
-	ch := gitutil.Changes{Paths: []string{"README.md"}, Lines: 2}
+	ch := changeset.Changes{Paths: []string{"README.md"}, Lines: 2}
 	assert.Equal(t, decideRisk(p, false, ch, nil, historyEvidence{}).async, false, historyEvidence{})
 }
 
@@ -110,7 +111,7 @@ func TestModeAlwaysOutranksTheFailureDebt(t *testing.T) {
 // answer for a project that has already given one.
 func TestModeAlwaysBackgroundsAnUnmeasurableChange(t *testing.T) {
 	p := asyncPolicy{mode: config.AsyncValidateAlways, maxLines: DefaultAsyncMaxLines}
-	assert.Equal(t, decideRisk(p, false, gitutil.Changes{}, errors.New("nope"), historyEvidence{}).async, true, historyEvidence{})
+	assert.Equal(t, decideRisk(p, false, changeset.Changes{}, errors.New("nope"), historyEvidence{}).async, true, historyEvidence{})
 }
 
 func TestAProjectCanRaiseItsOwnLimit(t *testing.T) {
@@ -366,14 +367,14 @@ func TestAFailedRunDoesNotMoveTheBaseline(t *testing.T) {
 	m := newRiskMemory()
 	root := t.TempDir()
 
-	m.recordGreen(root, "tree-a")
+	m.recordGreen(root, treeState{tree: "tree-a"})
 	m.record(root, false)
-	assert.Equal(t, m.baseline(root), "tree-a")
+	assert.Equal(t, m.baseline(root).tree, "tree-a")
 }
 
 func TestRiskMemoryHasNoBaselineUntilARunPasses(t *testing.T) {
 	m := newRiskMemory()
-	assert.Equal(t, m.baseline(t.TempDir()), "")
+	assert.Equal(t, m.baseline(t.TempDir()).known(), false)
 }
 
 // A tree git has since collected is not a measurement error, just a worse
@@ -381,7 +382,7 @@ func TestRiskMemoryHasNoBaselineUntilARunPasses(t *testing.T) {
 func TestAnUnknownBaselineFallsBackToHead(t *testing.T) {
 	d, root, _ := riskDaemon(t, 0)
 	writeSource(t, root, 10)
-	d.risk.recordGreen(root, "0000000000000000000000000000000000000000")
+	d.risk.recordGreen(root, treeState{tree: "0000000000000000000000000000000000000000"})
 
 	resp := decodeValidate(t, serve(d, validateReq(t, ValidateRequest{
 		Args: []string{"validate"}, ProjectRoot: root, AllowAsync: true,
@@ -389,4 +390,65 @@ func TestAnUnknownBaselineFallsBackToHead(t *testing.T) {
 	assert.Assert(t, resp.TaskID != "", "a collected baseline stopped the assessment")
 	assert.Assert(t, !strings.Contains(resp.Reason, "since the last passing run"),
 		"the fallback claimed a baseline it could not read: %q", resp.Reason)
+}
+
+// A repository with no commits has no HEAD to diff against, and git cannot
+// answer for it at all. Before, that made every run unmeasurable and therefore
+// blocking, for as long as the repo stayed fresh.
+func TestAFreshRepoIsMeasuredWithoutGit(t *testing.T) {
+	root := t.TempDir()
+	gitInit(t, root)
+	d := newTestDaemon()
+	t.Cleanup(d.tasks.stopAll)
+	d.runner = func(context.Context, []string, []string, io.Writer, io.Writer) int { return 0 }
+	writeSource(t, root, 10)
+
+	resp := decodeValidate(t, serve(d, validateReq(t, ValidateRequest{
+		Args: []string{"validate"}, ProjectRoot: root, AllowAsync: true,
+	})))
+	assert.Assert(t, resp.TaskID != "", "a repo with no commits was held: %s", resp.Reason)
+	assert.Assert(t, strings.Contains(resp.Reason, "10 lines"), "reason was %q", resp.Reason)
+}
+
+// And it is still measured incrementally: the state that passed is remembered
+// as a hashed walk rather than a git tree, and the next change is read from it.
+func TestAFreshRepoIsMeasuredIncrementally(t *testing.T) {
+	root := t.TempDir()
+	gitInit(t, root)
+	d := newTestDaemon()
+	t.Cleanup(d.tasks.stopAll)
+	d.runner = func(context.Context, []string, []string, io.Writer, io.Writer) int { return 0 }
+
+	writeSource(t, root, 400)
+	first := decodeValidate(t, serve(d, validateReq(t, ValidateRequest{
+		Args: []string{"validate"}, ProjectRoot: root, AllowAsync: true,
+	})))
+	assert.Assert(t, first.TaskID != "", "held: %s", first.Reason)
+	waitFor(t, func() bool { return len(d.tasks.inFlight(root)) == 0 }, "run never finished")
+	assert.Assert(t, d.risk.baseline(root).index != nil, "no hashed baseline was kept")
+
+	// 400 more lines in a second file. Against the whole tree that is 800 and
+	// would block; against the state that just passed it is 400.
+	writeSourceNamed(t, root, "more.go", 400)
+	second := decodeValidate(t, serve(d, validateReq(t, ValidateRequest{
+		Args: []string{"validate"}, ProjectRoot: root, AllowAsync: true,
+	})))
+	assert.Assert(t, second.TaskID != "", "held: %s", second.Reason)
+	assert.Assert(t, strings.Contains(second.Reason, "400 lines"), "reason was %q", second.Reason)
+}
+
+// gitInit makes dir a repository with no commits, which is the state git cannot
+// measure a change in.
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	assert.NilError(t, err, "git init: %s", out)
+}
+
+func writeSourceNamed(t *testing.T, dir, name string, n int) {
+	t.Helper()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, name),
+		[]byte(strings.Repeat("// line\n", n)), 0o644))
 }

--- a/internal/watchd/score.go
+++ b/internal/watchd/score.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
+	"github.com/CircleCI-Public/chunk-cli/internal/changeset"
 )
 
 // Risk score bands. They exist so a caller can act on the score without
@@ -63,7 +63,7 @@ type RiskSummary struct {
 // should have been 52. What the score is for is the questions one bit cannot
 // answer — which of two changes is riskier, whether a change is unusual for this
 // repo, and whether there is anything worth advising about it.
-func scoreChange(limit int, owesBlockingRun bool, ch gitutil.Changes, chErr error, hist historyEvidence) RiskSummary {
+func scoreChange(limit int, owesBlockingRun bool, ch changeset.Changes, chErr error, hist historyEvidence) RiskSummary {
 	if chErr != nil {
 		// Nothing is known about this change. The top of the scale is the only
 		// honest answer, and it is the same direction decideRisk takes.
@@ -154,7 +154,7 @@ func band(score int) string {
 // one generated file, so a single-file change gets no suggestion rather than an
 // impossible one. Nothing is advised about a failing run or an unmeasurable
 // tree either: the run itself is about to say more than any advice could.
-func advise(limit int, ch gitutil.Changes, chErr error) string {
+func advise(limit int, ch changeset.Changes, chErr error) string {
 	if chErr != nil || ch.Lines < limit || len(ch.Paths) < 2 || allInert(ch.Paths) {
 		return ""
 	}

--- a/internal/watchd/score_test.go
+++ b/internal/watchd/score_test.go
@@ -7,11 +7,11 @@ import (
 
 	"gotest.tools/v3/assert"
 
-	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
+	"github.com/CircleCI-Public/chunk-cli/internal/changeset"
 )
 
-func change(lines int, paths ...string) gitutil.Changes {
-	return gitutil.Changes{Paths: paths, Lines: lines, Baseline: gitutil.BaselineHead}
+func change(lines int, paths ...string) changeset.Changes {
+	return changeset.Changes{Paths: paths, Lines: lines, Baseline: changeset.BaselineHead}
 }
 
 func TestScoreRisesWithSize(t *testing.T) {
@@ -59,13 +59,13 @@ func TestAFailedLastRunAddsToTheScore(t *testing.T) {
 // Nothing known means the top of the scale. It is the same direction the
 // release decision takes, for the same reason.
 func TestAnUnmeasurableChangeScoresHighest(t *testing.T) {
-	s := scoreChange(500, false, gitutil.Changes{}, errors.New("not a repo"), historyEvidence{})
+	s := scoreChange(500, false, changeset.Changes{}, errors.New("not a repo"), historyEvidence{})
 	assert.Equal(t, s.Score, 100)
 	assert.Equal(t, s.Band, BandHigh)
 }
 
 func TestAnEmptyChangeScoresZero(t *testing.T) {
-	s := scoreChange(500, false, gitutil.Changes{Baseline: gitutil.BaselineHead}, nil, historyEvidence{})
+	s := scoreChange(500, false, changeset.Changes{Baseline: changeset.BaselineHead}, nil, historyEvidence{})
 	assert.Equal(t, s.Score, 0)
 	assert.Equal(t, s.Band, BandLow)
 }
@@ -98,7 +98,7 @@ func TestAdviceOnlyWhereThereIsSomethingToDo(t *testing.T) {
 		"one file":      scoreChange(500, false, change(2000, "generated.go"), nil, historyEvidence{}),
 		"under limit":   scoreChange(500, false, change(100, "a.go", "b.go"), nil, historyEvidence{}),
 		"docs and text": scoreChange(500, false, change(5000, "a.md", "b.md"), nil, historyEvidence{}),
-		"unmeasurable":  scoreChange(500, false, gitutil.Changes{}, errors.New("nope"), historyEvidence{}),
+		"unmeasurable":  scoreChange(500, false, changeset.Changes{}, errors.New("nope"), historyEvidence{}),
 	} {
 		assert.Equal(t, s.Advice, "", "advice was given for %s", name)
 	}

--- a/internal/watchd/shadow_test.go
+++ b/internal/watchd/shadow_test.go
@@ -169,3 +169,104 @@ func TestTheLiveTreeIsUsedUnlessTheProjectAsksOtherwise(t *testing.T) {
 	got := <-args
 	assert.Equal(t, slices.Contains(got, "--attribute-to"), false, "args were %v", got)
 }
+
+// Two runs of the same commands queued behind each other can only ever produce
+// one useful answer, and it is the later one. The earlier is validating a tree
+// that has already moved — that is what made the second hook fire.
+func TestReleasingARunSupersedesTheOneInFlight(t *testing.T) {
+	d, root, _ := riskDaemon(t, 0)
+	writeSource(t, root, 10)
+
+	release := make(chan struct{})
+	started := make(chan struct{}, 2)
+	d.runner = func(ctx context.Context, _ []string, _ []string, _ io.Writer, _ io.Writer) int {
+		started <- struct{}{}
+		select {
+		case <-release:
+			return 0
+		case <-ctx.Done():
+			return 1
+		}
+	}
+
+	first := releaseRun(t, d, root)
+	<-started
+
+	writeSource(t, root, 20)
+	second := releaseRun(t, d, root)
+	assert.Assert(t, second.TaskID != first.TaskID)
+
+	// The first run's context is cancelled, so it stops holding the validate
+	// lock and the second one gets to work.
+	<-started
+	close(release)
+	waitFor(t, func() bool { return len(d.tasks.inFlight(root)) == 0 }, "run never finished")
+
+	got := d.tasks.collect(root)
+	assert.Equal(t, len(got), 1, "both runs reported: %d", len(got))
+	assert.Equal(t, got[0].ID, second.TaskID, "the superseded run reported instead of the live one")
+}
+
+// A superseded run concluded nothing, so it must not leave a failure behind:
+// that would owe the project a blocking run it never earned.
+func TestASupersededRunOwesNothing(t *testing.T) {
+	d, root, _ := riskDaemon(t, 0)
+	writeSource(t, root, 10)
+
+	release := make(chan struct{})
+	started := make(chan struct{}, 2)
+	d.runner = func(ctx context.Context, _ []string, _ []string, _ io.Writer, _ io.Writer) int {
+		started <- struct{}{}
+		select {
+		case <-release:
+			return 0
+		case <-ctx.Done():
+			return 1
+		}
+	}
+
+	releaseRun(t, d, root)
+	<-started
+	writeSource(t, root, 20)
+	releaseRun(t, d, root)
+	<-started
+	close(release)
+	waitFor(t, func() bool { return len(d.tasks.inFlight(root)) == 0 }, "run never finished")
+
+	assert.Equal(t, d.risk.owesBlockingRun(root), false,
+		"a cancelled run was recorded as a failure")
+}
+
+// A snapshot-backed run is left alone: its verdict stays true about the state
+// it was handed, so it is the one piece of work here that will survive being
+// overtaken.
+func TestASnapshotRunIsNotSuperseded(t *testing.T) {
+	d, root := worktreeProject(t)
+	writeSource(t, root, 10)
+
+	release := make(chan struct{})
+	started := make(chan struct{}, 2)
+	d.runner = func(ctx context.Context, _ []string, _ []string, _ io.Writer, _ io.Writer) int {
+		started <- struct{}{}
+		select {
+		case <-release:
+			return 0
+		case <-ctx.Done():
+			return 1
+		}
+	}
+
+	first := releaseRun(t, d, root)
+	<-started
+
+	writeSource(t, root, 20)
+	second := releaseRun(t, d, root)
+	close(release)
+	waitFor(t, func() bool { return len(d.tasks.inFlight(root)) == 0 }, "runs never finished")
+
+	got := d.tasks.collect(root)
+	assert.Equal(t, len(got), 2, "a snapshot-backed run was thrown away: %d results", len(got))
+	ids := []string{got[0].ID, got[1].ID}
+	assert.Assert(t, slices.Contains(ids, first.TaskID), "the first snapshot result was lost")
+	assert.Assert(t, slices.Contains(ids, second.TaskID), "the second result was lost")
+}

--- a/internal/watchd/shadow_test.go
+++ b/internal/watchd/shadow_test.go
@@ -1,0 +1,171 @@
+package watchd
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// worktreeProject returns a repo configured to run its background checks in a
+// snapshot, and a daemon to serve it.
+func worktreeProject(t *testing.T) (*daemon, string) {
+	t.Helper()
+	root := gitRepo(t)
+	assert.NilError(t, os.MkdirAll(filepath.Join(root, ".chunk"), 0o755))
+	assert.NilError(t, os.WriteFile(filepath.Join(root, ".chunk", "config.json"),
+		[]byte(`{"commands":[{"name":"test","run":"true"}],"asyncValidateWorktree":true}`), 0o644))
+
+	d := newTestDaemon()
+	t.Cleanup(d.tasks.stopAll)
+	return d, root
+}
+
+func releaseRun(t *testing.T, d *daemon, root string) ValidateResponse {
+	t.Helper()
+	resp := decodeValidate(t, serve(d, validateReq(t, ValidateRequest{
+		Args: []string{"validate"}, ProjectRoot: root, AllowAsync: true,
+	})))
+	assert.Assert(t, resp.TaskID != "", "the run was not released: %s", resp.Reason)
+	return resp
+}
+
+// The commands run in a copy of the tree, and the results still belong to the
+// real project — the copy is a detached HEAD in a temp directory that nobody is
+// watching for their validate output.
+func TestWorktreeModeRunsInASnapshotAndAttributesItBack(t *testing.T) {
+	d, root := worktreeProject(t)
+	writeSource(t, root, 10)
+
+	args := make(chan []string, 1)
+	d.runner = func(_ context.Context, a []string, _ []string, _ io.Writer, _ io.Writer) int {
+		args <- a
+		return 0
+	}
+
+	releaseRun(t, d, root)
+	got := <-args
+
+	i := slices.Index(got, "--project")
+	assert.Assert(t, i >= 0 && i+1 < len(got), "no --project in %v", got)
+	shadow := got[i+1]
+	assert.Assert(t, shadow != root, "the run happened in the live tree")
+
+	j := slices.Index(got, "--attribute-to")
+	assert.Assert(t, j >= 0 && j+1 < len(got), "no --attribute-to in %v", got)
+	assert.Equal(t, got[j+1], root)
+}
+
+// The payoff: an edit while the run is in flight no longer throws the answer
+// away. The run validated a copy that cannot move, so its verdict is still
+// exactly true about the state it ran against — and it is reported with that
+// said rather than discarded.
+func TestASnapshotResultSurvivesAnEditDuringTheRun(t *testing.T) {
+	d, root := worktreeProject(t)
+	writeSource(t, root, 10)
+
+	release := make(chan struct{})
+	shadowSeen := make(chan string, 1)
+	d.runner = func(_ context.Context, a []string, _ []string, _ io.Writer, _ io.Writer) int {
+		if i := slices.Index(a, "--project"); i >= 0 {
+			shadowSeen <- a[i+1]
+		}
+		<-release
+		return 0
+	}
+
+	releaseRun(t, d, root)
+	shadow := <-shadowSeen
+
+	// The live tree moves while the run is going. The snapshot does not.
+	writeSource(t, root, 900)
+	inShadow, err := os.ReadFile(filepath.Join(shadow, "main.go"))
+	assert.NilError(t, err)
+	assert.Equal(t, strings.Count(string(inShadow), "\n"), 10, "the snapshot followed the live tree")
+
+	close(release)
+	waitFor(t, func() bool { return len(d.tasks.inFlight(root)) == 0 }, "run never finished")
+
+	got := d.tasks.collect(root)
+	assert.Equal(t, len(got), 1, "a snapshot-backed result was thrown away")
+	assert.Equal(t, got[0].Passed(), true)
+	assert.Equal(t, got[0].Snapshot, true)
+	assert.Equal(t, got[0].Stale, true, "the result did not say the tree had moved on")
+}
+
+// A result about the live tree is still discarded when the tree moves: it
+// describes code that is no longer there, and nothing can qualify that into
+// being useful.
+func TestALiveTreeResultIsStillDiscardedAfterAnEdit(t *testing.T) {
+	d, root, _ := riskDaemon(t, 0)
+	writeSource(t, root, 10)
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	d.runner = func(context.Context, []string, []string, io.Writer, io.Writer) int {
+		close(started)
+		<-release
+		return 0
+	}
+
+	releaseRun(t, d, root)
+	<-started
+	writeSource(t, root, 900)
+	close(release)
+	waitFor(t, func() bool { return len(d.tasks.inFlight(root)) == 0 }, "run never finished")
+
+	assert.Equal(t, len(d.tasks.collect(root)), 0, "a result about replaced code was reported")
+}
+
+// One background run, one temp worktree, removed afterwards — a repo must not
+// accumulate them a turn at a time.
+func TestTheShadowIsRemovedWhenTheRunEnds(t *testing.T) {
+	d, root := worktreeProject(t)
+	writeSource(t, root, 10)
+
+	shadowSeen := make(chan string, 1)
+	d.runner = func(_ context.Context, a []string, _ []string, _ io.Writer, _ io.Writer) int {
+		if i := slices.Index(a, "--project"); i >= 0 {
+			shadowSeen <- a[i+1]
+		}
+		return 0
+	}
+
+	releaseRun(t, d, root)
+	shadow := <-shadowSeen
+	waitFor(t, func() bool { return len(d.tasks.inFlight(root)) == 0 }, "run never finished")
+	waitFor(t, func() bool {
+		_, err := os.Stat(shadow)
+		return err != nil
+	}, "the shadow directory was not removed")
+
+	cmd := exec.Command("git", "worktree", "list")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	assert.NilError(t, err)
+	assert.Assert(t, !strings.Contains(string(out), shadow), "worktree metadata was left behind: %s", out)
+}
+
+// Off by default. A snapshot holds nothing git was told to ignore, so for many
+// projects every run in one would report an environment failure as a code
+// failure.
+func TestTheLiveTreeIsUsedUnlessTheProjectAsksOtherwise(t *testing.T) {
+	d, root, _ := riskDaemon(t, 0)
+	writeSource(t, root, 10)
+
+	args := make(chan []string, 1)
+	d.runner = func(_ context.Context, a []string, _ []string, _ io.Writer, _ io.Writer) int {
+		args <- a
+		return 0
+	}
+
+	releaseRun(t, d, root)
+	got := <-args
+	assert.Equal(t, slices.Contains(got, "--attribute-to"), false, "args were %v", got)
+}

--- a/internal/watchd/validate.go
+++ b/internal/watchd/validate.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/envctx"
+	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
 )
 
@@ -140,7 +141,24 @@ func (d *daemon) startValidateTask(req ValidateRequest, risk *RiskSummary) (stri
 	// is measured against HEAD instead.
 	before := d.snapshotState(req.ProjectRoot)
 
-	return d.tasks.start(req.ProjectRoot, func(ctx context.Context) (int, string) {
+	// A project that has asked for it gets its checks run in a checked-out copy
+	// of that state, so editing while they run cannot make the answer describe
+	// code that has moved. Materialising can fail — no snapshot, no worktree
+	// support, no disk — and then the run happens in the live tree as usual,
+	// which is slower to be sure of but never wrong about what it ran.
+	shadow, cleanup := "", func() {}
+	if policyFor(req.ProjectRoot).worktree && before.tree != "" {
+		if path, remove, err := gitutil.MaterializeTree(req.ProjectRoot, before.tree); err == nil {
+			shadow, cleanup = path, remove
+			// The commands run in the copy; the results still belong to the real
+			// project, whose data directory and event log the developer is watching.
+			args = append(append([]string(nil), args...),
+				"--project", shadow, "--attribute-to", req.ProjectRoot)
+		}
+	}
+
+	taskID, err := d.tasks.start(req.ProjectRoot, shadow != "", func(ctx context.Context) (int, string) {
+		defer cleanup()
 		// Serialised against every other validate run, async or not: two runs of
 		// the same commands in one tree would race over whatever they build.
 		d.validateMu.Lock()
@@ -167,6 +185,14 @@ func (d *daemon) startValidateTask(req ValidateRequest, risk *RiskSummary) (stri
 		// sees what the developer would have seen.
 		return exitCode, stdout.String() + stderr.String()
 	})
+	if err != nil {
+		// The run never started, so nothing will ever reach the deferred cleanup
+		// above. A shadow left behind would be a temp directory and a worktree
+		// entry per refused run.
+		cleanup()
+		return "", err
+	}
+	return taskID, nil
 }
 
 // handleCollect returns the finished results for a project and forgets them.

--- a/internal/watchd/validate.go
+++ b/internal/watchd/validate.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log"
 	"net/http"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/envctx"
@@ -157,6 +158,12 @@ func (d *daemon) startValidateTask(req ValidateRequest, risk *RiskSummary) (stri
 		}
 	}
 
+	// Whatever was already running for this project is validating a tree that
+	// has since moved, which is why this run exists at all.
+	if stopped := d.tasks.supersede(req.ProjectRoot); stopped > 0 {
+		log.Printf("watchd: superseded %d in-flight validate run(s) for %s", stopped, req.ProjectRoot)
+	}
+
 	taskID, err := d.tasks.start(req.ProjectRoot, shadow != "", func(ctx context.Context) (int, string) {
 		defer cleanup()
 		// Serialised against every other validate run, async or not: two runs of
@@ -171,6 +178,13 @@ func (d *daemon) startValidateTask(req ValidateRequest, risk *RiskSummary) (stri
 
 		var stdout, stderr bytes.Buffer
 		exitCode := d.runner(ctx, args, env, &stdout, &stderr)
+		if ctx.Err() != nil {
+			// Superseded, or the daemon is shutting down. The run concluded
+			// nothing, so nothing is recorded: a cancelled run is not a failed one,
+			// and filing it as either a failure or a known-good state would be a
+			// verdict on work that never finished.
+			return exitCode, stdout.String() + stderr.String()
+		}
 		if exitCode == 0 {
 			// Recorded even if the tree has moved on since. Staleness decides
 			// whether this *result* can be reported, which is a different

--- a/internal/watchd/validate.go
+++ b/internal/watchd/validate.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/CircleCI-Public/chunk-cli/internal/envctx"
-	"github.com/CircleCI-Public/chunk-cli/internal/gitutil"
 	"github.com/CircleCI-Public/chunk-cli/internal/session"
 )
 
@@ -137,9 +136,9 @@ func (d *daemon) startValidateTask(req ValidateRequest, risk *RiskSummary) (stri
 	sessionID := session.IDFromSlice(req.Env)
 	args := req.Args
 	// Taken before the run, because this is the state the run is about to
-	// validate. A tree that cannot be snapshotted just means the next change is
-	// measured against HEAD instead.
-	before, _ := gitutil.SnapshotTree(req.ProjectRoot)
+	// validate. A tree that cannot be captured at all just means the next change
+	// is measured against HEAD instead.
+	before := d.snapshotState(req.ProjectRoot)
 
 	return d.tasks.start(req.ProjectRoot, func(ctx context.Context) (int, string) {
 		// Serialised against every other validate run, async or not: two runs of
@@ -237,10 +236,7 @@ func (d *daemon) handleValidate(w http.ResponseWriter, r *http.Request) {
 
 // runValidateNow runs req to completion while the caller waits.
 func (d *daemon) runValidateNow(ctx context.Context, req ValidateRequest, risk *RiskSummary) ValidateResponse {
-	var before string
-	if req.ProjectRoot != "" {
-		before, _ = gitutil.SnapshotTree(req.ProjectRoot)
-	}
+	before := d.snapshotState(req.ProjectRoot)
 
 	d.validateMu.Lock()
 	defer d.validateMu.Unlock()


### PR DESCRIPTION
<!-- stack -->
**Stack** – merge bottom-up; each diff is against the one above it:

1. #580 – Track async validation tasks and discard stale results
1. #581 – Add risk assessment to the daemon
1. #584 – Measure trees git can't answer for, and run checks in a snapshot  ← **this PR**
1. #589 – Make background validation thresholds configurable

---

## Summary

- **Measure a tree git can't answer for** – a repo with no commits has no `HEAD` to diff against, and a directory that was never a repo has nothing at all, so every run in them blocked. `internal/filestate` walks and hashes instead, with git still answering first where it can. Hashing counts a modified file whole, which over-measures and makes you wait, rather than under-measuring and waving a change through.
- **Keep a result the tree moved past** (`asyncValidateWorktree`, off by default) – checking the snapshot out into its own worktree means the copy can't move, so the verdict stays true about the state the turn produced. Off by default because a snapshot holds nothing gitignored, and those projects would see environment failures reported as code failures.
- **The trap, found by running it rather than testing it** – a fresh checkout is a *clean* tree, and the Stop hook skips clean trees, so the first honest run executed nothing and reported a pass. `--attribute-to` exempts it and keeps the event log under the real repo.
- **Stop wasting work on obsolete runs** – two runs for one project could be in flight at once, the first validating code that had already moved while holding the lock the second wanted. `taskStore.supersede` cancels it and records nothing, since a cancelled run concluded nothing and shouldn't owe a blocking run. Snapshot runs are exempt.
- **Known gap** – remote commands in a snapshot run register their output under the copy, so the `chunk watch` logs pane won't show it.

## Test plan

- [x] `task test` (`-race`) and `task lint` green.
- [x] `filestate`: whole-tree and incremental diffs, a modified file counting whole, `.git` skipped, simple gitignore forms honoured and unclear ones walked anyway, binary content, the budget, digest stability.
- [x] Snapshots: uncommitted work carried in, the copy not following the live tree, ignored content absent, cleanup of directory and git metadata; at the daemon, attributed back to the real project and a result surviving an edit mid-run while a live-tree result is still discarded.
- [x] Superseding: the in-flight run cancelled, nothing owed afterwards, snapshot runs left alone.
- [x] `TestASnapshotRunIsNotSkippedForBeingClean` confirmed to fail without the exemption.
- [x] By hand against a real daemon: `CWD=/tmp/chunk-shadow-…` with `CONTENT=ORIGINAL` while the live tree said `EDITED`, the failure reported and qualified, nothing left behind.





